### PR TITLE
MVP 11: CI pipeline, module path, and release hygiene

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+## Checks
+
+- [ ] `go test ./...`
+- [ ] `go test -race ./pkg/... ./cmd/...`
+- [ ] `go vet ./...`
+- [ ] `scripts/size-budget.sh`
+- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
+- [ ] VS Code extension compile, if `extensions/vscode-gox` changed
+
+## Notes

--- a/.github/workflows/ci-browser-smoke.yml
+++ b/.github/workflows/ci-browser-smoke.yml
@@ -1,0 +1,54 @@
+name: Browser Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  TINYGO_VERSION: 0.41.1
+
+jobs:
+  browser-smoke:
+    name: Todo browser smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y brotli zstd curl
+
+      - name: Install TinyGo
+        run: |
+          curl -fsSL -o /tmp/tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
+          sudo apt-get install -y /tmp/tinygo.deb
+          tinygo version
+
+      - name: Install goxc
+        run: go install ./cmd/goxc
+
+      - name: Browser smoke
+        env:
+          CHROME: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: scripts/browser-smoke.sh

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,0 +1,48 @@
+name: Core
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  go:
+    name: Go and GOX checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+
+      - name: Artifact gate
+        run: scripts/artifact-check.sh
+
+      - name: Module path gate
+        run: scripts/module-path-check.sh
+
+      - name: Format
+        run: |
+          go fmt ./...
+          git diff --exit-code
+
+      - name: Test
+        run: go test ./...
+
+      - name: Race test
+        run: go test -race ./pkg/... ./cmd/...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Debug-tag test
+        run: go test -tags=goframe_debug ./...
+
+      - name: GOX golden tests
+        run: go test ./pkg/gox -run 'TestGolden|TestErrorGolden'

--- a/.github/workflows/ci-vscode.yml
+++ b/.github/workflows/ci-vscode.yml
@@ -1,0 +1,40 @@
+name: VS Code Extension
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  extension:
+    name: Compile GOX extension
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: extensions/vscode-gox
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: extensions/vscode-gox/package-lock.json
+
+      - name: Validate JSON
+        run: |
+          node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('syntaxes/gox.tmLanguage.json','utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('snippets/gox.code-snippets','utf8'))"
+          node -e "JSON.parse(require('fs').readFileSync('language-configuration.json','utf8'))"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compile
+        run: npm run compile

--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -1,0 +1,59 @@
+name: WASM Size
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  TINYGO_VERSION: 0.41.1
+
+jobs:
+  tinygo-size:
+    name: TinyGo packages and size budgets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+
+      - name: Install compression tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y brotli zstd
+
+      - name: Install TinyGo
+        run: |
+          curl -fsSL -o /tmp/tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
+          sudo apt-get install -y /tmp/tinygo.deb
+          tinygo version
+
+      - name: Install goxc
+        run: go install ./cmd/goxc
+
+      - name: Package examples
+        run: |
+          goxc generate ./examples/counter
+          goxc package ./examples/counter --compiler=tinygo
+          goxc generate ./examples/components
+          goxc package ./examples/components --compiler=tinygo
+          goxc generate ./examples/todo
+          goxc package ./examples/todo --compiler=tinygo
+
+      - name: Size budgets
+        run: scripts/size-budget.sh | tee size-report.txt
+
+      - name: Upload size report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: wasm-size-report
+          path: size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
+  browser smoke, and VS Code extension compile checks.
+- Artifact and module path regression gates.
+- CI and release hygiene documentation.
+
+### Planned
+
+- CI pipeline tuning after the first public pull requests.
+- Release packaging decisions for `goxc`.
+- Dashboard-sized benchmark exploration.
+
+## v0.1.0-mvp10 - 2026-06-17
+
+### Added
+
+- GOX expression-oriented conditional rendering with
+  `{condition && <Node />}`.
+- GOX ternary rendering with `{condition ? <A /> : <B />}`.
+- Nested GOX markup in callback return expressions.
+- `Key={...}` pseudo-prop lowering.
+- Simplified `UseState` API returning `(value, setValue)`.
+- Simplified `UseEffect` API with optional `gf.Deps(...)` and
+  `gf.EveryRender()`.
+- `gf.Map` and `gf.MapIndexed` list helpers.
+- Compressed WASM size budgets for raw, gzip, brotli, and optional zstd.
+- Hardened browser smoke harness with dynamic ports and origin preflight.
+
+### Notes
+
+This is an internal MVP milestone tag, not a stable public release.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GoFrame Player     possible future host for portable .gfapp bundles
 Install the latest published toolchain:
 
 ```bash
-go install github.com/jin-wu/goframe/cmd/goxc@latest
+go install github.com/graybuton/goframe/cmd/goxc@latest
 ```
 
 Make sure `$(go env GOPATH)/bin` is in `PATH`, then verify the installation:

--- a/README.md
+++ b/README.md
@@ -500,6 +500,14 @@ npm install
 npm run compile
 ```
 
+## CI and regression gates
+
+GitHub Actions run core Go/GOX checks, TinyGo WASM size budgets, browser smoke,
+and VS Code extension compile checks. Local source gates also verify that build
+artifacts are not tracked and that the module path remains canonical.
+
+See [CI and regression gates](docs/ci.md) and [release hygiene](docs/release.md).
+
 ## License
 
 goframe is licensed under the Apache License, Version 2.0.

--- a/cmd/goxc/clean.go
+++ b/cmd/goxc/clean.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jin-wu/goframe/pkg/gox"
+	"github.com/graybuton/goframe/pkg/gox"
 )
 
 type cleanOptions struct {

--- a/cmd/goxc/generate.go
+++ b/cmd/goxc/generate.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/jin-wu/goframe/pkg/gox"
+	"github.com/graybuton/goframe/pkg/gox"
 )
 
 func generateCommand(args []string) error {

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,159 @@
+# CI and Regression Gates
+
+This repository keeps local scripts and GitHub Actions aligned. The goal is to
+make runtime, GOX, WASM size, browser smoke, and VS Code extension regressions
+visible before merge.
+
+## Workflows
+
+### Core
+
+`.github/workflows/ci-core.yml` runs on pull requests and pushes to `main`.
+
+It checks:
+
+- tracked artifact gate;
+- canonical module path gate;
+- `go fmt ./...` plus a clean diff check;
+- `go test ./...`;
+- `go test -race ./pkg/... ./cmd/...`;
+- `go vet ./...`;
+- `go test -tags=goframe_debug ./...`;
+- GOX golden tests.
+
+### WASM Size
+
+`.github/workflows/ci-wasm-size.yml` runs on pull requests, pushes to `main`,
+and manually through `workflow_dispatch`.
+
+It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
+counter, components, and todo examples with TinyGo and runs:
+
+```bash
+scripts/size-budget.sh
+```
+
+The workflow uploads the printed size report as an artifact.
+
+### Browser Smoke
+
+`.github/workflows/ci-browser-smoke.yml` runs on pull requests, pushes to
+`main`, and manually through `workflow_dispatch`.
+
+It installs Go, TinyGo `0.41.1`, Node.js 20, Chrome, and compression tools,
+then runs:
+
+```bash
+scripts/browser-smoke.sh
+```
+
+The smoke script chooses dynamic ports, verifies the expected app origin before
+storage cleanup, checks WASM MIME type, and separates harness failures from app
+failures.
+
+### VS Code Extension
+
+`.github/workflows/ci-vscode.yml` runs on pull requests and pushes to `main`.
+
+It validates extension JSON files, installs dependencies with `npm ci`, and
+runs:
+
+```bash
+npm run compile
+```
+
+## Local Checks
+
+Core local verification:
+
+```bash
+go fmt ./...
+go test ./...
+go test -race ./pkg/... ./cmd/...
+go vet ./...
+go test -tags=goframe_debug ./...
+go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
+```
+
+Full local gate, including TinyGo packaging and benchmarks:
+
+```bash
+scripts/check.sh
+scripts/perf-report.sh
+```
+
+Size budget only:
+
+```bash
+scripts/size-budget.sh
+```
+
+Browser smoke:
+
+```bash
+scripts/browser-smoke.sh
+```
+
+VS Code extension:
+
+```bash
+cd extensions/vscode-gox
+npm ci
+npm run compile
+```
+
+## Required Tools
+
+Local checks use:
+
+- Go 1.22 or newer;
+- TinyGo 0.41.1 for WASM size and browser smoke gates;
+- gzip;
+- brotli;
+- zstd, optional locally but installed in CI;
+- Node.js 20 or newer for browser smoke and extension checks;
+- Chrome or Chromium for browser smoke;
+- curl for smoke server readiness checks.
+
+Set `CHROME=/path/to/chrome` when Chrome is not available as `google-chrome`.
+
+## Size Budget Failures
+
+Do not loosen budgets by default. First identify whether the growth comes from:
+
+- production runtime imports;
+- debug code accidentally compiled into production;
+- example-level code;
+- TinyGo version changes;
+- compression tool changes.
+
+Run:
+
+```bash
+scripts/size-budget.sh
+scripts/perf-report.sh
+```
+
+Update budgets only when the increase is intentional and documented.
+
+## Browser Smoke Failures
+
+Treat smoke failures as either harness failures or app failures.
+
+Harness failures include server bind errors, wrong CDP target, wrong origin,
+missing Chrome, unavailable storage, or stale server state. App failures include
+DOM identity loss, render counter regressions, localStorage persistence issues,
+duplicate key diagnostics failures, or listener churn regressions.
+
+The smoke script must not continue against an unknown server or `about:blank`.
+
+## Artifact and Module Gates
+
+`scripts/artifact-check.sh` fails if tracked files include generated bundles,
+WASM files, `node_modules`, VSIX packages, or test binaries.
+
+`scripts/module-path-check.sh` enforces:
+
+- `module github.com/graybuton/goframe`;
+- no legacy repository path references;
+- README documents `go install github.com/graybuton/goframe/cmd/goxc@latest`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,70 @@
+# Release Hygiene
+
+goframe is still an experimental MVP project. The current tags are milestone
+tags, not stable public API releases.
+
+## Tag Style
+
+Current milestone tag:
+
+```text
+v0.1.0-mvp10
+```
+
+Future public experimental releases should use normal semantic tags such as:
+
+```text
+v0.1.0
+```
+
+Use annotated tags:
+
+```bash
+git tag -a v0.1.0-mvp10 -m "MVP 10: GOX expression ergonomics and public API cleanup"
+```
+
+Push tags explicitly:
+
+```bash
+git push origin v0.1.0-mvp10
+```
+
+## Pre-Release Checklist
+
+Before creating a tag:
+
+- working tree is clean;
+- `main` contains the intended merge commit;
+- module path is `github.com/graybuton/goframe`;
+- `go test ./...` passes;
+- `go test -race ./pkg/... ./cmd/...` passes;
+- `go vet ./...` passes;
+- `go test -tags=goframe_debug ./...` passes;
+- GOX golden tests pass;
+- `scripts/check.sh` passes locally or in CI;
+- `scripts/size-budget.sh` passes;
+- `scripts/browser-smoke.sh` passes on a machine with Chrome and localhost bind;
+- VS Code extension JSON validation and compile pass;
+- `scripts/artifact-check.sh` passes;
+- `scripts/module-path-check.sh` passes;
+- README, docs, and changelog are updated;
+- no `dist/`, `build/`, `.wasm`, `.wasm.gz`, `.wasm.br`, `.wasm.zst`,
+  `node_modules`, `.vsix`, or `.test` files are tracked.
+
+## Current Publishing Policy
+
+The project does not publish binaries yet.
+
+The VS Code extension is not published to the Marketplace yet. Local extension
+development remains under `extensions/vscode-gox`.
+
+The recommended install path for the CLI is:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@latest
+```
+
+## After Tagging
+
+For now, release notes can be drafted from `CHANGELOG.md`. Keep milestone notes
+clear about API instability and experimental status.

--- a/examples/components/app.gox
+++ b/examples/components/app.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type HeaderProps struct {
 	Title string

--- a/examples/components/app.gox.go
+++ b/examples/components/app.gox.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type HeaderProps struct {
 	Title string

--- a/examples/components/main.go
+++ b/examples/components/main.go
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func main() {
 	done := make(chan struct{})

--- a/examples/counter/app.gox
+++ b/examples/counter/app.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func App() gf.Node {
 	count, setCount := gf.UseState(0)

--- a/examples/counter/app.gox.go
+++ b/examples/counter/app.gox.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func App() gf.Node {
 	count, setCount := gf.UseState(0)

--- a/examples/counter/main.go
+++ b/examples/counter/main.go
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func main() {
 	done := make(chan struct{})

--- a/examples/todo/app.gox
+++ b/examples/todo/app.gox
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	gf "github.com/jin-wu/goframe/pkg/goframe"
+	gf "github.com/graybuton/goframe/pkg/goframe"
 )
 
 type Todo struct {

--- a/examples/todo/app.gox.go
+++ b/examples/todo/app.gox.go
@@ -5,7 +5,7 @@ package main
 import (
 	"strings"
 
-	gf "github.com/jin-wu/goframe/pkg/goframe"
+	gf "github.com/graybuton/goframe/pkg/goframe"
 )
 
 type Todo struct {

--- a/examples/todo/main.go
+++ b/examples/todo/main.go
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func main() {
 	done := make(chan struct{})

--- a/extensions/vscode-gox/samples/demo.gox
+++ b/extensions/vscode-gox/samples/demo.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Title    string

--- a/extensions/vscode-gox/snippets/gox.code-snippets
+++ b/extensions/vscode-gox/snippets/gox.code-snippets
@@ -5,7 +5,7 @@
     "body": [
       "package main",
       "",
-      "import gf \"github.com/jin-wu/goframe/pkg/goframe\"",
+      "import gf \"github.com/graybuton/goframe/pkg/goframe\"",
       "",
       "func App() gf.Node {",
       "\treturn (",

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/jin-wu/goframe
+module github.com/graybuton/goframe
 
 go 1.22

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -10,7 +10,7 @@ import (
 func TestGenerateCounter(t *testing.T) {
 	source := []byte(`package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func App() gf.Node {
 	count, setCount := gf.UseState(0)
@@ -53,7 +53,7 @@ func App() gf.Node {
 func TestGenerateIgnoresGoComparison(t *testing.T) {
 	source := []byte(`package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func App() gf.Node {
 	count, max := 1, 2

--- a/pkg/gox/testdata/component_children.golden.go
+++ b/pkg/gox/testdata/component_children.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Title    string

--- a/pkg/gox/testdata/component_children.gox
+++ b/pkg/gox/testdata/component_children.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Title    string

--- a/pkg/gox/testdata/component_helper_children.golden.go
+++ b/pkg/gox/testdata/component_helper_children.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Children []gf.Node

--- a/pkg/gox/testdata/component_helper_children.gox
+++ b/pkg/gox/testdata/component_helper_children.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Children []gf.Node

--- a/pkg/gox/testdata/component_props.golden.go
+++ b/pkg/gox/testdata/component_props.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type ButtonProps struct {
 	Label   string

--- a/pkg/gox/testdata/component_props.gox
+++ b/pkg/gox/testdata/component_props.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type ButtonProps struct {
 	Label   string

--- a/pkg/gox/testdata/conditional_and.golden.go
+++ b/pkg/gox/testdata/conditional_and.golden.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool, ready bool, active bool) gf.Node {
 	return gf.El("main", nil,

--- a/pkg/gox/testdata/conditional_and.gox
+++ b/pkg/gox/testdata/conditional_and.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool, ready bool, active bool) gf.Node {
 	return (

--- a/pkg/gox/testdata/conditional_helper.golden.go
+++ b/pkg/gox/testdata/conditional_helper.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool) gf.Node {
 	return gf.El("main", nil,

--- a/pkg/gox/testdata/conditional_helper.gox
+++ b/pkg/gox/testdata/conditional_helper.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool) gf.Node {
 	return (

--- a/pkg/gox/testdata/conditional_text_suffix.golden.go
+++ b/pkg/gox/testdata/conditional_text_suffix.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []int) gf.Node {
 	return gf.El("main", nil,

--- a/pkg/gox/testdata/conditional_text_suffix.gox
+++ b/pkg/gox/testdata/conditional_text_suffix.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []int) gf.Node {
 	return (

--- a/pkg/gox/testdata/errors/duplicate_key.gox
+++ b/pkg/gox/testdata/errors/duplicate_key.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(id int) gf.Node {
 	return <p Key={id} Key="again">Broken</p>

--- a/pkg/gox/testdata/errors/missing_ternary_colon.gox
+++ b/pkg/gox/testdata/errors/missing_ternary_colon.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool) gf.Node {
 	return <main>{show ? <p>Yes</p>}</main>

--- a/pkg/gox/testdata/errors/non_node_ternary_branch.gox
+++ b/pkg/gox/testdata/errors/non_node_ternary_branch.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(show bool) gf.Node {
 	return <main>{show ? "yes" : <p>No</p>}</main>

--- a/pkg/gox/testdata/fragment.golden.go
+++ b/pkg/gox/testdata/fragment.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View() gf.Node {
 	return gf.Fragment(

--- a/pkg/gox/testdata/fragment.gox
+++ b/pkg/gox/testdata/fragment.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View() gf.Node {
 	return (

--- a/pkg/gox/testdata/input_event.golden.go
+++ b/pkg/gox/testdata/input_event.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(value string, update func(string)) gf.Node {
 	return gf.El("input", gf.Props{

--- a/pkg/gox/testdata/input_event.gox
+++ b/pkg/gox/testdata/input_event.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(value string, update func(string)) gf.Node {
 	return (

--- a/pkg/gox/testdata/key_pseudo_props.golden.go
+++ b/pkg/gox/testdata/key_pseudo_props.golden.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type RowProps struct {
 	Label string

--- a/pkg/gox/testdata/key_pseudo_props.gox
+++ b/pkg/gox/testdata/key_pseudo_props.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type RowProps struct {
 	Label string

--- a/pkg/gox/testdata/keyed_component.golden.go
+++ b/pkg/gox/testdata/keyed_component.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type ItemProps struct {
 	Label string

--- a/pkg/gox/testdata/keyed_component.gox
+++ b/pkg/gox/testdata/keyed_component.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type ItemProps struct {
 	Label string

--- a/pkg/gox/testdata/keyed_items.golden.go
+++ b/pkg/gox/testdata/keyed_items.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []string) gf.Node {
 	return gf.El("ul", nil,

--- a/pkg/gox/testdata/keyed_items.gox
+++ b/pkg/gox/testdata/keyed_items.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []string) gf.Node {
 	return (

--- a/pkg/gox/testdata/list_helper.golden.go
+++ b/pkg/gox/testdata/list_helper.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []string) gf.Node {
 	return gf.El("ul", nil,

--- a/pkg/gox/testdata/list_helper.gox
+++ b/pkg/gox/testdata/list_helper.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(items []string) gf.Node {
 	return (

--- a/pkg/gox/testdata/nested_components.golden.go
+++ b/pkg/gox/testdata/nested_components.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Children []gf.Node

--- a/pkg/gox/testdata/nested_components.gox
+++ b/pkg/gox/testdata/nested_components.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type CardProps struct {
 	Children []gf.Node

--- a/pkg/gox/testdata/nested_markup_returns.golden.go
+++ b/pkg/gox/testdata/nested_markup_returns.golden.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type Item struct {
 	ID     int

--- a/pkg/gox/testdata/nested_markup_returns.gox
+++ b/pkg/gox/testdata/nested_markup_returns.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type Item struct {
 	ID     int

--- a/pkg/gox/testdata/normal_expression_suffix.golden.go
+++ b/pkg/gox/testdata/normal_expression_suffix.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(count int) gf.Node {
 	return gf.El("p", nil,

--- a/pkg/gox/testdata/normal_expression_suffix.gox
+++ b/pkg/gox/testdata/normal_expression_suffix.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(count int) gf.Node {
 	return <p>{count} item(s)</p>

--- a/pkg/gox/testdata/simple_element.golden.go
+++ b/pkg/gox/testdata/simple_element.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View() gf.Node {
 	return gf.El("main", gf.Props{

--- a/pkg/gox/testdata/simple_element.gox
+++ b/pkg/gox/testdata/simple_element.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View() gf.Node {
 	return (

--- a/pkg/gox/testdata/ternary_expression_suffix.golden.go
+++ b/pkg/gox/testdata/ternary_expression_suffix.golden.go
@@ -2,7 +2,7 @@
 
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(condition bool, count int) gf.Node {
 	return gf.El("section", nil,

--- a/pkg/gox/testdata/ternary_expression_suffix.gox
+++ b/pkg/gox/testdata/ternary_expression_suffix.gox
@@ -1,6 +1,6 @@
 package demo
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func View(condition bool, count int) gf.Node {
 	return (

--- a/pkg/gox/testdata/ternary_render.golden.go
+++ b/pkg/gox/testdata/ternary_render.golden.go
@@ -2,7 +2,7 @@
 
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type EmptyProps struct{}
 

--- a/pkg/gox/testdata/ternary_render.gox
+++ b/pkg/gox/testdata/ternary_render.gox
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 type EmptyProps struct{}
 

--- a/scripts/artifact-check.sh
+++ b/scripts/artifact-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+pattern='(^|/)(dist|build)/|\.wasm(\.gz|\.br|\.zst)?$|node_modules|\.vsix$|\.test$'
+tracked="$(git ls-files | grep -E "$pattern" || true)"
+
+if [[ -n "$tracked" ]]; then
+	echo "tracked build artifacts found:"
+	echo "$tracked"
+	exit 1
+fi
+
+echo "artifact check: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -10,11 +10,23 @@ export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
 export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/tmp/goframe-tinygo-cache}"
 mkdir -p "$GOCACHE" "$XDG_CACHE_HOME"
 
+echo "== Artifact gate =="
+scripts/artifact-check.sh
+
+echo "== Module path gate =="
+scripts/module-path-check.sh
+
 echo "== Go formatting =="
 go fmt ./...
 
 echo "== Go tests =="
 go test ./...
+
+echo "== Debug-tag tests =="
+go test -tags=goframe_debug ./...
+
+echo "== GOX golden tests =="
+go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
 
 echo "== Race tests =="
 go test -race ./pkg/... ./cmd/...

--- a/scripts/fixtures/duplicate-keys/main.go
+++ b/scripts/fixtures/duplicate-keys/main.go
@@ -1,6 +1,6 @@
 package main
 
-import gf "github.com/jin-wu/goframe/pkg/goframe"
+import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func App() gf.Node {
 	return gf.El("main", gf.Props{"id": "duplicate-key-fixture"},

--- a/scripts/module-path-check.sh
+++ b/scripts/module-path-check.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+canonical_module="github.com/graybuton/goframe"
+legacy_module="github.com/jin-wu"
+legacy_module="$legacy_module/goframe"
+
+if ! grep -qx "module $canonical_module" go.mod; then
+	echo "go.mod must declare: module $canonical_module"
+	exit 1
+fi
+
+legacy_matches="$(git grep -n "$legacy_module" -- . || true)"
+if [[ -n "$legacy_matches" ]]; then
+	echo "legacy module path references found:"
+	echo "$legacy_matches"
+	exit 1
+fi
+
+if ! grep -q "go install $canonical_module/cmd/goxc@latest" README.md; then
+	echo "README.md must document the canonical goxc install command"
+	exit 1
+fi
+
+echo "module path check: ok"


### PR DESCRIPTION
## Summary

Adds CI and release hygiene for the MVP 10 baseline.

## Changes

- Align module path to `github.com/graybuton/goframe`
- Add GitHub Actions workflows:
  - core Go/GOX checks
  - TinyGo WASM size budgets
  - browser smoke
  - VS Code extension compile
- Add artifact and module path gates
- Add CI and release docs
- Add changelog
- Add PR template

## Local checks

- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`

## Notes

Browser smoke requires localhost bind and headless browser support.