### PR TITLE
chore(deps): configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Helsinki"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/Helsinki"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(go)"
+    labels:
+      - "dependencies"
+      - "go"
+
+  - package-ecosystem: "npm"
+    directory: "/extensions/vscode-gox"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Helsinki"
+    open-pull-requests-limit: 3
+    groups:
+      vscode-extension-dev:
+        patterns:
+          - "*"
+        dependency-type: "development"
+        update-types:
+          - "patch"
+          - "minor"
+    commit-message:
+      prefix: "chore(vscode)"
+    labels:
+      - "dependencies"
+      - "vscode"
+      - "npm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Dependabot configuration for GitHub Actions, Go modules, and VS Code
+  extension npm dependencies.
 - Dashboard-sized pressure-test example with 300 deterministic issue rows,
   filters, keyed table sorting, detail panel updates, and smoke coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ npm run compile
 GitHub Actions run core Go/GOX checks, TinyGo WASM size budgets, browser smoke,
 and VS Code extension compile checks. Local source gates also verify that build
 artifacts are not tracked and that the module path remains canonical.
+Dependabot is configured for weekly dependency update PRs.
 
 See [CI and regression gates](docs/ci.md) and [release hygiene](docs/release.md).
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -63,6 +63,24 @@ runs:
 npm run compile
 ```
 
+## Dependabot
+
+Dependabot version updates are configured in `.github/dependabot.yml`.
+
+The project tracks:
+
+- GitHub Actions updates;
+- Go module updates;
+- VS Code extension npm dependency updates.
+
+Dependabot runs weekly on Monday in the Europe/Helsinki timezone. Dependabot
+PRs are not auto-merged; they must pass CI, including size budgets and browser
+smoke when relevant.
+
+Security alerts and security updates should be enabled from the GitHub
+repository security settings. Recommended labels are `dependencies`,
+`github-actions`, `go`, `vscode`, and `npm`.
+
 ## Local Checks
 
 Core local verification:


### PR DESCRIPTION
## Summary

Adds Dependabot version update configuration for:

- GitHub Actions
- Go modules
- VS Code extension npm dependencies

## Notes

- Weekly schedule, Monday, Europe/Helsinki
- Auto-merge is intentionally disabled
- npm dev dependency patch/minor updates are grouped
- Security alerts/security updates are documented as GitHub repository settings

## Checks

- `go test ./...`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`
- `scripts/check.sh`
- `npm ci`
- `npm run compile`