### PR TITLE
Foundation Audit III: harden package/export safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   deployment directories.
 - Packaging safety checks for export ownership, legacy clean migration, and
   clearer hidden-workspace module errors.
+- Foundation Audit III safety coverage for explicit package output ownership,
+  package asset path validation, legacy `manifest.json` cleanup markers, and
+  clean workspace CLI edge cases.
 - Dependabot configuration for GitHub Actions, Go modules, and VS Code
   extension npm dependencies.
 - Dashboard-sized pressure-test example with 300 deterministic issue rows,

--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ examples/counter/.goframe/package/standalone/
 
 Compiler-specific filenames are internal details. A packaged application uses
 `assets/bundle.wasm` and `assets/wasm_exec.js` for both Go and TinyGo.
+By default, package output stays under `.goframe/package/standalone`. If you
+explicitly pass `--out`, point it at an empty directory or a previous GoFrame
+package output; goxc treats that directory as tool-owned package output.
 
 Cache-safe release packaging can add content hashes, preload hints, and
 precompressed assets:
@@ -379,9 +382,10 @@ goxc export ./examples/counter --out ./dist
 
 The export directory is treated as tool-owned. If `--out` points at a
 non-empty directory that does not contain a previous GoFrame export marker
-(`goframe-package.json` or `asset-manifest.json`), `goxc export` fails instead
-of deleting a possibly user-owned `assets/` directory. Pass `--force` only when
-you intentionally want goxc to treat that directory as package output:
+(`goframe-package.json`, `asset-manifest.json`, or legacy `manifest.json`),
+`goxc export` fails instead of deleting a possibly user-owned `assets/`
+directory. Pass `--force` only when you intentionally want goxc to treat that
+directory as package output:
 
 ```bash
 goxc export ./examples/counter --out ./dist --force

--- a/cmd/goxc/clean_test.go
+++ b/cmd/goxc/clean_test.go
@@ -67,3 +67,23 @@ func TestCleanLegacyRemovesGoframeOwnedDist(t *testing.T) {
 		t.Fatalf("goframe-owned dist still exists: %v", err)
 	}
 }
+
+func TestCleanLegacyRemovesLegacyManifestDist(t *testing.T) {
+	appDir := t.TempDir()
+	dist := filepath.Join(appDir, "dist")
+	if err := os.Mkdir(dist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dist, legacyPackageManifest), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanApp(cleanOptions{appDir: appDir, legacy: true}); err != nil {
+		t.Fatalf("cleanApp(legacy) error: %v", err)
+	}
+	if _, err := os.Stat(dist); !os.IsNotExist(err) {
+		t.Fatalf("legacy manifest dist still exists: %v", err)
+	}
+}

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -55,6 +56,30 @@ func TestBuildLayoutDefaultsAndExternalWorkspace(t *testing.T) {
 	}
 }
 
+func TestBuildLayoutExternalWorkspaceAvoidsAppCollisions(t *testing.T) {
+	root := t.TempDir()
+	firstApp := filepath.Join(root, "one", "dashboard")
+	secondApp := filepath.Join(root, "two", "dashboard")
+	external := filepath.Join(t.TempDir(), "workspace")
+
+	first, err := newBuildLayout(layoutOptions{appDir: firstApp, workspace: external})
+	if err != nil {
+		t.Fatalf("newBuildLayout(first) error: %v", err)
+	}
+	second, err := newBuildLayout(layoutOptions{appDir: secondApp, workspace: external})
+	if err != nil {
+		t.Fatalf("newBuildLayout(second) error: %v", err)
+	}
+	if first.WorkspaceRoot == second.WorkspaceRoot {
+		t.Fatalf("external workspace roots collide: %q", first.WorkspaceRoot)
+	}
+	for _, layout := range []BuildLayout{first, second} {
+		if !strings.HasPrefix(layout.WorkspaceRoot, external+string(filepath.Separator)) {
+			t.Fatalf("workspace root %q is not below %q", layout.WorkspaceRoot, external)
+		}
+	}
+}
+
 func TestParsePackageOptionsCompression(t *testing.T) {
 	options, err := parsePackageOptions([]string{"app", "--asset-hash", "--preload", "--compress=gzip,br"})
 	if err != nil {
@@ -91,6 +116,21 @@ func TestLoadManifestDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
+func TestLoadManifestAcceptsLegacyMainWASM(t *testing.T) {
+	appDir := t.TempDir()
+	content := []byte(`{"wasm":"main.wasm"}`)
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest(main.wasm) error: %v", err)
+	}
+	if manifest.WASM != "main.wasm" {
+		t.Fatalf("WASM = %q, want main.wasm", manifest.WASM)
+	}
+}
+
 func TestManifestRejectsApplicationRootAsOutput(t *testing.T) {
 	appDir := t.TempDir()
 	content := []byte(`{"output":"."}`)
@@ -99,6 +139,29 @@ func TestManifestRejectsApplicationRootAsOutput(t *testing.T) {
 	}
 	if _, err := loadManifest(appDir); err == nil {
 		t.Fatal("loadManifest() accepted application root as output")
+	}
+}
+
+func TestManifestRejectsEscapingPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "entry", content: `{"entry":"../cmd"}`},
+		{name: "output", content: `{"output":"../dist"}`},
+		{name: "wasm", content: `{"wasm":"../bundle.wasm"}`},
+		{name: "asset", content: `{"assets":["../secret.css"]}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			appDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(test.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadManifest(appDir); err == nil {
+				t.Fatalf("loadManifest() accepted escaping %s path", test.name)
+			}
+		})
 	}
 }
 
@@ -189,10 +252,79 @@ func App() gf.Node {
 	}
 }
 
+func TestGenerateInPlaceWritesAdjacentFileAndWarns(t *testing.T) {
+	appDir := t.TempDir()
+	source := `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <div>Hello</div>
+}
+`
+	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := generatePath(generateOptions{path: appDir, inPlace: true}, true); err != nil {
+			t.Fatalf("generatePath(inPlace) error: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "--in-place writes generated compiler output into the source tree") {
+		t.Fatalf("missing --in-place warning in stderr: %q", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(appDir, "app.gox.go")); err != nil {
+		t.Fatalf("adjacent generated file missing: %v", err)
+	}
+}
+
 func TestSizeReportsHelpfulErrorForEmptyDirectory(t *testing.T) {
 	err := sizeCommand([]string{t.TempDir()})
 	if err == nil {
 		t.Fatal("sizeCommand() returned nil error")
+	}
+}
+
+func TestParseServeOptionsUsesWorkspacePackageDir(t *testing.T) {
+	appDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(`{"name":"demo"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	options, err := parseServeOptions([]string{appDir})
+	if err != nil {
+		t.Fatalf("parseServeOptions() error: %v", err)
+	}
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if options.dir != layout.PackageDir {
+		t.Fatalf("serve dir = %q, want %q", options.dir, layout.PackageDir)
+	}
+}
+
+func TestArtifactDirectoryPrefersWorkspacePackage(t *testing.T) {
+	appDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(`{"name":"demo"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(layout.PackageDir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(layout.PackageDir, "assets", "bundle.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := artifactDirectory(sizeOptions{path: appDir})
+	if err != nil {
+		t.Fatalf("artifactDirectory() error: %v", err)
+	}
+	if got != layout.PackageDir {
+		t.Fatalf("artifact dir = %q, want %q", got, layout.PackageDir)
 	}
 }
 
@@ -221,6 +353,26 @@ func TestCleanPackageArtifactsRemovesOldCompression(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(directory, name)); !os.IsNotExist(err) {
 			t.Fatalf("%s still exists: %v", name, err)
 		}
+	}
+}
+
+func TestValidatePackageDestinationRejectsUnownedNonEmptyDirectory(t *testing.T) {
+	outDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outDir, "notes.txt"), []byte("user"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePackageDestination(outDir); err == nil {
+		t.Fatal("validatePackageDestination() accepted non-empty unowned directory")
+	}
+}
+
+func TestValidatePackageDestinationAllowsPreviousGoFramePackage(t *testing.T) {
+	outDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outDir, packageMetadataName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePackageDestination(outDir); err != nil {
+		t.Fatalf("validatePackageDestination(previous package) error: %v", err)
 	}
 }
 
@@ -261,6 +413,20 @@ func TestPublishPackageArtifactsCopiesStagedTree(t *testing.T) {
 		if string(got) != want {
 			t.Fatalf("%s = %q, want %q", path, got, want)
 		}
+	}
+}
+
+func TestWritePackageAssetRejectsEscapingLogicalName(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "styles.css")
+	if err := os.WriteFile(source, []byte("body{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assetsDir := filepath.Join(t.TempDir(), "assets")
+	if _, err := writePackageAsset(source, assetsDir, "../styles.css", packageOptions{compress: map[string]bool{}}); err == nil {
+		t.Fatal("writePackageAsset() accepted escaping logical name")
+	}
+	if _, err := os.Stat(filepath.Join(assetsDir, "..", "styles.css")); !os.IsNotExist(err) {
+		t.Fatalf("escaping asset was written: %v", err)
 	}
 }
 
@@ -373,4 +539,31 @@ func TestHumanSize(t *testing.T) {
 	if got := humanSize(73_631); got != "71.9 KiB" {
 		t.Fatalf("humanSize() = %q, want 71.9 KiB", got)
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = old
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
 }

--- a/cmd/goxc/export.go
+++ b/cmd/goxc/export.go
@@ -103,11 +103,28 @@ func validateExportDestination(outDir string, force bool) error {
 	return fmt.Errorf("export output directory %s is not empty and does not look like a previous GoFrame export; pass --force to treat it as tool-owned and overwrite package artifacts", outDir)
 }
 
+func validatePackageDestination(outDir string) error {
+	entries, err := os.ReadDir(outDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect package output directory: %w", err)
+	}
+	if len(entries) == 0 || isGoframeOwnedExport(outDir) {
+		return nil
+	}
+	return fmt.Errorf("package output directory %s is not empty and does not look like a previous GoFrame package; use the default hidden workspace output, choose an empty directory, or export a package with `goxc export --force` when overwriting is intentional", outDir)
+}
+
 func isGoframeOwnedExport(directory string) bool {
 	if fileExists(filepath.Join(directory, packageMetadataName)) {
 		return true
 	}
 	if fileExists(filepath.Join(directory, assetManifestName)) {
+		return true
+	}
+	if fileExists(filepath.Join(directory, legacyPackageManifest)) {
 		return true
 	}
 	return false

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -182,7 +182,13 @@ func packageApp(options packageOptions) error {
 	if err != nil {
 		return err
 	}
+	explicitOutDir := options.outDir != ""
 	options.outDir = packageOutputDirectory(options, layout)
+	if explicitOutDir {
+		if err := validatePackageDestination(options.outDir); err != nil {
+			return err
+		}
+	}
 	workDir, err := prepareBuildWorkspace(layout, manifest)
 	if err != nil {
 		return fmt.Errorf("prepare package workspace: %w", err)
@@ -446,7 +452,10 @@ func replaceHTMLBlock(content, name, replacement string) (string, bool) {
 }
 
 func writePackageAsset(sourcePath, assetsDir, logicalName string, options packageOptions) (packageAsset, error) {
-	logicalName = path.Clean(filepath.ToSlash(logicalName))
+	logicalName, err := cleanPackageAssetName(logicalName)
+	if err != nil {
+		return packageAsset{}, err
+	}
 	content, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return packageAsset{}, fmt.Errorf("read %s: %w", sourcePath, err)
@@ -496,6 +505,14 @@ func writePackageAsset(sourcePath, assetsDir, logicalName string, options packag
 		}
 	}
 	return asset, nil
+}
+
+func cleanPackageAssetName(name string) (string, error) {
+	clean := path.Clean(filepath.ToSlash(name))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
+		return "", fmt.Errorf("package asset logical name %q must be a relative child path", name)
+	}
+	return clean, nil
 }
 
 func shortContentHash(content []byte) string {

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -5,6 +5,18 @@ import (
 	"testing"
 )
 
+func TestPrepareBuildWorkspaceRejectsUnsupportedEntry(t *testing.T) {
+	_, err := prepareBuildWorkspace(BuildLayout{}, projectManifest{Entry: "cmd/app"})
+	if err == nil {
+		t.Fatal("prepareBuildWorkspace() accepted unsupported entry")
+	}
+	for _, want := range []string{"entry", "not supported", `"."`, "single-package"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
 func TestWriteWorkspaceGoModFailsWithoutRepoRootOrVersion(t *testing.T) {
 	oldFind := findRepositoryRootForWorkspace
 	oldVersion := goframeModuleVersionForBuild

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,8 @@ deployment directory. Export is intentionally explicit so normal build/package
 commands do not create visible `dist/` output. Export destinations are treated
 as tool-owned: non-empty directories without GoFrame export manifests are
 rejected unless `--force` is passed.
+Explicit `goxc package --out <dir>` is also treated as package-owned output and
+is rejected when `<dir>` is a non-empty non-GoFrame directory.
 
 ### Serve
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,9 +36,16 @@ goxc export ./examples/todo --out ./dist
 
 Only the export step creates `./dist`.
 
+If you intentionally pass `goxc package --out <dir>`, that directory is also
+treated as package output owned by goxc. It must be empty or already contain a
+GoFrame package marker; otherwise package fails before removing any existing
+`assets/` directory. The recommended visible deployment flow remains
+`goxc package` followed by `goxc export`.
+
 The export directory is tool-owned. If `--out` already exists, is non-empty,
-and does not contain `goframe-package.json` or `asset-manifest.json` from a
-previous GoFrame export, `goxc export` fails before touching it:
+and does not contain `goframe-package.json`, `asset-manifest.json`, or legacy
+`manifest.json` from a previous GoFrame export, `goxc export` fails before
+touching it:
 
 ```bash
 goxc export ./examples/todo --out ./dist

--- a/docs/foundation-audit.md
+++ b/docs/foundation-audit.md
@@ -166,13 +166,18 @@ Fixed CLI issues:
   prepared artifacts into `.goframe/package/standalone`.
 - MVP 13 package publishing removes stale root bundle artifacts and the
   package-owned `assets/` directory before publishing the next staged bundle.
+- Explicit package/export output directories are treated as tool-owned. Non-empty
+  directories without GoFrame package markers are rejected before package-owned
+  `assets/` cleanup.
+- Legacy `manifest.json` is still recognized as a GoFrame-owned package marker
+  for migration cleanup.
 
 Remaining CLI risks:
 
 - `serve` is a local development server. It binds to `127.0.0.1` and is not a
   hardened production static server.
 - `--out` is intentionally user-directed and may point outside the application
-  directory.
+  directory, but non-empty unmarked package/export directories are rejected.
 - Compression remains an explicit package helper; production deployments should
   prefer web-server or CDN compression.
 
@@ -273,6 +278,10 @@ CLI:
 - `clean` removes `.goframe/work`, `.goframe/build`, and `.goframe/package` by
   default; `--generated` also removes `.goframe/gen` and legacy adjacent
   `.gox.go` files.
+- `clean --legacy` removes old `build/` and GoFrame-owned `dist/` output while
+  preserving user-owned `dist/` directories.
+- Package asset logical names are validated before writing into `assets/` so
+  package helpers cannot escape the package asset directory.
 - `serve` is localhost-only.
 
 Remaining safety risks:
@@ -327,6 +336,7 @@ Automated checks currently include:
 - CLI manifest and package staging tests.
 - Browser Todo smoke script.
 - Browser duplicate-key smoke script.
+- Browser dashboard smoke and dashboard pressure-test trace.
 - Size budget script.
 - Pure runtime benchmark script.
 - Component identity decision document.
@@ -335,10 +345,12 @@ Automated checks currently include:
 
 Recommended next hardening steps before new product features:
 
-1. Add debug duplicate-key source locations.
-2. Add ancestor dirty queue metrics in `goframe_debug`.
-3. Add CI wiring for TinyGo size budgets and browser smoke tests.
-4. Decide whether component identity should include function identity or a
-   generated stable type token.
-5. Keep context/router/Player work out of the project until the lifecycle
-   regression gates run reliably in CI.
+1. Use the dashboard pressure test to guide runtime optimization work with
+   before/after render, patch, and DOM operation metrics.
+2. Keep memoization, context, router, Player, SSR, hydration, and bundle
+   splitting out of scope until the current packaging/runtime gates stay green
+   through PR review.
+3. Decide whether component identity should include function identity or a
+   generated stable type token before adding larger component lifecycle features.
+4. Add debug duplicate-key source locations only if diagnostics need to become
+   developer-facing rather than smoke-test-facing.


### PR DESCRIPTION
## Summary

Performs a safety-focused cleanup pass after MVP 13.

## Changes

- Rejects explicit `goxc package --out` into non-GoFrame non-empty directories
- Keeps `goxc export` output ownership explicit with `--force`
- Treats legacy `manifest.json` as GoFrame-owned package marker
- Hardens package asset logical path validation
- Adds tests for package/export/clean/workspace safety edges
- Updates docs for packaging safety and clean workspace behavior

## Checks

- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`