### PR TITLE
MVP 14: explicit component memoization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   extension npm dependencies.
 - Dashboard-sized pressure-test example with 300 deterministic issue rows,
   filters, keyed table sorting, detail panel updates, and smoke coverage.
+- Explicit `MemoEqual`-based component memoization in runtime, with dashboard row
+  memo skip coverage and browser smoke assertions.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   filters, keyed table sorting, detail panel updates, and smoke coverage.
 - Explicit `MemoEqual`-based component memoization in runtime, with dashboard row
   memo skip coverage and browser smoke assertions.
+- Memoization safety coverage for dirty descendants and dashboard callback
+  freshness.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,8 @@ children by key. Dirty component updates start directly at their mounted
 subtree, so unrelated ancestors and siblings are not traversed. If a parent and
 child are both dirty in the same batch, ancestor pruning keeps only the parent
 update. Descendant components encountered inside an updated parent subtree
-rerender; there is no automatic props memoization.
+rerender. For selective subtree bailouts, define `MemoEqual` on props to opt
+in to explicit component memoization and skip stable re-renders.
 
 Duplicate sibling keys are a user error. Production builds keep the smallest
 behavior and do not diagnose them; `goframe_debug` builds record and warn about
@@ -546,8 +547,9 @@ required.
   stable.
 - Lifecycle/effects are minimal; no context, error boundaries, async effects,
   dependency inference, or priorities.
-- There is no automatic props memoization. Components encountered during a
-  parent subtree update rerender.
+- Memoization is explicit and opt-in today:
+  components can implement `MemoEqual` on their props type to skip renders when
+  prop shapes are unchanged and the component is otherwise clean.
 - Duplicate key diagnostics are debug-only and do not run in production builds.
 - GOX has JSX-like render expressions for `condition && <Node />` and
   `condition ? <A /> : <B />`, but no template-block `if`/`for`, spread props,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,7 +246,9 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 - Component state slots are positional and require stable call order.
 - Lifecycle/effects are minimal; there is no Fiber scheduler, context, or
   error-boundary model.
-- No automatic props memoization; descendants rerender with their parent.
+- No automatic props memoization; descendants rerender with their parent unless
+  components explicitly implement `MemoEqual` on their props and the framework can
+  perform a deterministic memoized bailout.
 - Duplicate key diagnostics are debug-only.
 - GOX has expression-oriented conditional rendering, but no template-block
   loops/conditionals, spread props, or component namespaces.

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -147,7 +147,8 @@ The Todo example uses effects to persist tasks:
 - No cleanup ordering guarantees beyond each component instance cleaning its
   own registered hooks.
 - No lifecycle hooks for before-render or before-patch.
-- No component memoization.
+- No automatic component memoization in the GOX compiler or runtime. Memoization is
+  explicit via `MemoEqual` on component props and is intentionally opt-in.
 - No context, router integration, SSR, hydration, or async component model.
 - Hook order changes are unsupported and may panic only when the slot type
   changes.

--- a/docs/foundation-audit.md
+++ b/docs/foundation-audit.md
@@ -71,7 +71,8 @@ Temporary decisions to keep visible:
 - Direct function component calls are valid Go but do not create runtime
   component identity.
 - State slots are component-scoped but still positional.
-- There is no automatic props memoization.
+- There is no automatic deep comparison memoization. Components may opt in to
+  explicit memo bailouts with `MemoEqual` on props when appropriate.
 - The browser runtime assumes it owns the mounted DOM subtree.
 
 These are acceptable now, but they are the areas most likely to be touched by a
@@ -313,7 +314,8 @@ Remaining safety risks:
   ordering.
 - Lifecycle/effects are intentionally minimal: no context, error boundaries,
   async effects, or priorities.
-- No props memoization exists; this is a size and correctness tradeoff.
+- Memoization is explicit and opt-in via `MemoEqual` on props. Automatic
+  memoization is intentionally avoided to keep runtime behavior predictable.
 - GOX parser remains a focused parser, not a full Go-aware frontend.
 
 ## Regression Gates

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -1,0 +1,55 @@
+# Component Memoization
+
+`goframe` supports **explicit, opt-in** component memoization.
+It is intentionally narrow for MVP 14: there is no automatic comparison,
+no reflection, and no deep equality by default.
+
+## API
+
+Implement this method on your props type:
+
+```go
+func (props MyRowProps) MemoEqual(next MyRowProps) bool {
+    return props.ID == next.ID &&
+        props.Selected == next.Selected &&
+        props.Status == next.Status
+}
+```
+
+Then `goframe` may skip rerendering that component when all of the following are true:
+
+- component name/key identity matches
+- the previous and next props satisfy `MemoEqual`
+- the component instance is not dirty from its own local state/effects
+
+## Why explicit only
+
+Automatic memoization is hard to predict and can create subtle behavior changes.
+MVP 14 uses explicit `MemoEqual` so authors decide the comparator semantics.
+
+## Function props
+
+`MemoEqual` is user-defined. If you intentionally ignore function props, event
+handlers may remain the previous callback until the component is rendered again.
+Design your comparators accordingly.
+
+## Limits today
+
+- No automatic memoization for all components.
+- No reflection-based comparison.
+- No `unsafe`, no generated equality wrappers, no deep auto-compare.
+- No context/selectors as part of memoization strategy.
+- No virtualization or router/Player integration in this stage.
+
+## Interaction with keys and identity
+
+Memoized skip applies within the same component identity boundary:
+component name + key + same instance. Key or component identity changes still
+remount/recreate as normal.
+
+## What memoization does not change
+
+- Dirty subtree scheduling and patch mechanics are unchanged.
+- Effects and unmount cleanups remain governed by component lifecycle.
+- Memoization does not override `UseState`-driven rerenders when a component
+  is marked dirty.

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -21,6 +21,7 @@ Then `goframe` may skip rerendering that component when all of the following are
 - component name/key identity matches
 - the previous and next props satisfy `MemoEqual`
 - the component instance is not dirty from its own local state/effects
+- no dirty descendant is waiting inside the component subtree
 
 ## Why explicit only
 
@@ -31,7 +32,22 @@ MVP 14 uses explicit `MemoEqual` so authors decide the comparator semantics.
 
 `MemoEqual` is user-defined. If you intentionally ignore function props, event
 handlers may remain the previous callback until the component is rendered again.
-Design your comparators accordingly.
+This is correct only when the ignored callback is stable or when another prop
+forces a rerender whenever the callback's captured data changes.
+
+Safe patterns:
+
+- include a callback/data version token in props and compare it in `MemoEqual`;
+- compare a stable command ID or owner version instead of comparing functions;
+- include data fields that the callback closes over.
+
+The dashboard example uses a `DataVersion` prop on `IssueRowProps`. Row
+selection keeps the same version, so unchanged rows can skip. Dataset changes
+from reset, simulate update, or toggle increment the version, so row handlers
+are refreshed before they can act on stale issue data.
+
+Do not ignore function props when the callback closes over changing data and no
+other compared prop tracks that data.
 
 ## Limits today
 
@@ -46,6 +62,23 @@ Design your comparators accordingly.
 Memoized skip applies within the same component identity boundary:
 component name + key + same instance. Key or component identity changes still
 remount/recreate as normal.
+
+## Dirty descendants
+
+A memoized component is not allowed to skip when a descendant component is dirty.
+This matters with dirty queue ancestor pruning:
+
+```txt
+Parent dirty
+  MemoChild props equal
+    GrandChild dirty from local state
+```
+
+The flush queue may prune `GrandChild` because `Parent` will patch its subtree.
+`MemoChild` must still render/patch through to the dirty grandchild, even though
+its own props compare equal. The runtime tracks dirty descendants on component
+ancestors and blocks the memo skip until those descendant updates are rendered
+or the subtree is unmounted.
 
 ## What memoization does not change
 

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -46,6 +46,11 @@ selection keeps the same version, so unchanged rows can skip. Dataset changes
 from reset, simulate update, or toggle increment the version, so row handlers
 are refreshed before they can act on stale issue data.
 
+That is an intentional tradeoff: dataset-changing actions invalidate row
+memoization broadly, even when only one row changed. This keeps callback
+correctness explicit until the runtime has a smaller primitive such as
+functional state updates, stable event callbacks, or selectors.
+
 Do not ignore function props when the callback closes over changing data and no
 other compared prop tracks that data.
 

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -278,7 +278,8 @@ The dependency-free headless Chrome probe verifies:
 - lifecycle/effects are minimal and have no priorities or async scheduler;
 - no context or error boundaries;
 - component identity uses the declared component name, not Go function identity;
-- no automatic props memoization;
+- explicit opt-in props memoization via `MemoEqual`; components still rerender
+  by default when props are not memoized.
 - dirty component scheduling has no priorities, interruption, or concurrency;
 - duplicate-key diagnostics are debug-only and do not include source locations;
 - no SSR or hydration;

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -98,11 +98,16 @@ the issue data and filters because metrics and the visible table derive from
 them. `IssueWorkspace` owns only row selection so selecting a row does not
 rerender `DashboardApp`, `MetricsGrid`, or `FilterBar`.
 
-Known remaining cost: without table virtualization,
-selection-related updates can still rerender visible rows, but `IssueRow`
-implements `MemoEqual` and dashboard smoke now expects row memo skips on
-selection. This is a useful pressure-test result, and a baseline for future
-runtime optimization.
+`IssueRow` implements `MemoEqual`, and dashboard smoke expects row selection to
+rerender only the rows whose selected state changed. Unchanged rows should
+record memo skips. Dataset-changing actions also pass a `DataVersion` prop so
+memoized rows refresh event handlers before they can close over stale issue
+data.
+
+Known remaining cost: without table virtualization, full-table actions such as
+search, status filtering, sorting, reset, and simulated dataset updates still
+visit or rerender many visible rows. That is an intentional baseline for future
+runtime optimization rather than a hidden runtime feature.
 
 ## Known Limitations
 

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -98,9 +98,11 @@ the issue data and filters because metrics and the visible table derive from
 them. `IssueWorkspace` owns only row selection so selecting a row does not
 rerender `DashboardApp`, `MetricsGrid`, or `FilterBar`.
 
-Known remaining cost: without props memoization or table virtualization,
-updates inside `IssueWorkspace` can still rerender the visible rows. This is a
-useful pressure-test result, not something hidden by the example.
+Known remaining cost: without table virtualization,
+selection-related updates can still rerender visible rows, but `IssueRow`
+implements `MemoEqual` and dashboard smoke now expects row memo skips on
+selection. This is a useful pressure-test result, and a baseline for future
+runtime optimization.
 
 ## Known Limitations
 
@@ -109,5 +111,5 @@ useful pressure-test result, not something hidden by the example.
 - There is no virtualization; all 300 rows are real DOM rows.
 - GOX has no spread props, style objects, namespaces, or template loops.
 - Timing numbers printed by smoke are informational, not CI performance budgets.
-- There is no row virtualization or memoization, so full-table state changes
-  still visit rendered rows.
+- There is no row virtualization, so full-table state changes still visit all
+  rendered rows.

--- a/examples/dashboard/app.gox
+++ b/examples/dashboard/app.gox
@@ -6,6 +6,7 @@ type DashboardAppProps struct{}
 
 func DashboardApp(props DashboardAppProps) gf.Node {
 	issues, setIssues := gf.UseState(resetDemoIssues())
+	dataVersion, setDataVersion := gf.UseState(0)
 	query, setQuery := gf.UseState("")
 	statusFilter, setStatusFilter := gf.UseState(StatusAll)
 	priorityFilter, setPriorityFilter := gf.UseState(PriorityAll)
@@ -27,6 +28,7 @@ func DashboardApp(props DashboardAppProps) gf.Node {
 
 	reset := func() {
 		setIssues(resetDemoIssues())
+		setDataVersion(dataVersion + 1)
 		setQuery("")
 		setStatusFilter(StatusAll)
 		setPriorityFilter(PriorityAll)
@@ -35,10 +37,12 @@ func DashboardApp(props DashboardAppProps) gf.Node {
 
 	toggleIssue := func(id int) {
 		setIssues(toggleIssueStatus(issues, id))
+		setDataVersion(dataVersion + 1)
 	}
 
 	simulateUpdate := func() {
 		setIssues(simulateIssueUpdate(issues))
+		setDataVersion(dataVersion + 1)
 	}
 
 	return (
@@ -60,6 +64,7 @@ func DashboardApp(props DashboardAppProps) gf.Node {
 			<IssueWorkspace
 				Items={visible}
 				AllItems={issues}
+				DataVersion={dataVersion}
 				Query={query}
 				OnToggle={toggleIssue}
 			/>

--- a/examples/dashboard/components_table.gox
+++ b/examples/dashboard/components_table.gox
@@ -5,6 +5,7 @@ import gf "github.com/graybuton/goframe/pkg/goframe"
 type IssueWorkspaceProps struct {
 	Items    []Issue
 	AllItems []Issue
+	DataVersion int
 	Query    string
 	OnToggle func(id int)
 }
@@ -25,6 +26,7 @@ func IssueWorkspace(props IssueWorkspaceProps) gf.Node {
 					<IssueTable
 						Items={props.Items}
 						SelectedID={selectedID}
+						DataVersion={props.DataVersion}
 						OnSelect={setSelectedID}
 						OnToggle={props.OnToggle}
 					/>
@@ -43,6 +45,7 @@ func IssueWorkspace(props IssueWorkspaceProps) gf.Node {
 type IssueTableProps struct {
 	Items      []Issue
 	SelectedID int
+	DataVersion int
 	OnSelect   func(id int)
 	OnToggle   func(id int)
 }
@@ -67,6 +70,7 @@ func IssueTable(props IssueTableProps) gf.Node {
 						Key={issue.ID}
 						Issue={issue}
 						Selected={issue.ID == props.SelectedID}
+						DataVersion={props.DataVersion}
 						OnSelect={props.OnSelect}
 						OnToggle={props.OnToggle}
 					/>
@@ -79,6 +83,7 @@ func IssueTable(props IssueTableProps) gf.Node {
 type IssueRowProps struct {
 	Issue    Issue
 	Selected bool
+	DataVersion int
 	OnSelect  func(id int)
 	OnToggle  func(id int)
 }
@@ -123,6 +128,7 @@ func (props IssueRowProps) MemoEqual(next IssueRowProps) bool {
 		props.Issue.UpdatedAt == next.Issue.UpdatedAt &&
 		props.Issue.Events == next.Issue.Events &&
 		props.Selected == next.Selected &&
+		props.DataVersion == next.DataVersion &&
 		props.Issue.Title == next.Issue.Title &&
 		props.Issue.Owner == next.Issue.Owner &&
 		props.Issue.Service == next.Issue.Service

--- a/examples/dashboard/components_table.gox
+++ b/examples/dashboard/components_table.gox
@@ -116,6 +116,18 @@ func IssueRow(props IssueRowProps) gf.Node {
 	)
 }
 
+func (props IssueRowProps) MemoEqual(next IssueRowProps) bool {
+	return props.Issue.ID == next.Issue.ID &&
+		props.Issue.Status == next.Issue.Status &&
+		props.Issue.Priority == next.Issue.Priority &&
+		props.Issue.UpdatedAt == next.Issue.UpdatedAt &&
+		props.Issue.Events == next.Issue.Events &&
+		props.Selected == next.Selected &&
+		props.Issue.Title == next.Issue.Title &&
+		props.Issue.Owner == next.Issue.Owner &&
+		props.Issue.Service == next.Issue.Service
+}
+
 type EmptyStateProps struct {
 	Query string
 }

--- a/examples/dashboard/index.html
+++ b/examples/dashboard/index.html
@@ -13,6 +13,7 @@
     <script>
         window.goframeComponentRenderCounts = {};
         window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
         window.goframeComponentRenderProbe = (name) => {
             window.goframeComponentRenderCounts[name] =
                 (window.goframeComponentRenderCounts[name] || 0) + 1;
@@ -20,6 +21,10 @@
         window.goframeComponentPatchProbe = (name) => {
             window.goframeComponentPatchCounts[name] =
                 (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
         };
     </script>
     <!-- goframe:runtime -->

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -56,21 +56,23 @@ func C[P any](name string, props P, render ComponentFunc[P]) Node {
 }
 
 type componentInstance struct {
-	name           string
-	key            string
-	parent         *componentInstance
-	node           ComponentNode
-	memoEqual      func(any, any) bool
-	stateSlots     []*stateSlot
-	stateIndex     int
-	effectSlots    []*effectSlot
-	effectIndex    int
-	unmountSlots   []*unmountSlot
-	unmountIndex   int
-	dirty          bool
-	active         bool
-	scheduleUpdate func(*componentInstance)
-	update         func()
+	name             string
+	key              string
+	parent           *componentInstance
+	node             ComponentNode
+	memoEqual        func(any, any) bool
+	stateSlots       []*stateSlot
+	stateIndex       int
+	effectSlots      []*effectSlot
+	effectIndex      int
+	unmountSlots     []*unmountSlot
+	unmountIndex     int
+	dirty            bool
+	dirtyCounted     bool
+	dirtyDescendants int
+	active           bool
+	scheduleUpdate   func(*componentInstance)
+	update           func()
 }
 
 var currentComponent *componentInstance
@@ -95,7 +97,7 @@ func shouldSkipComponentRender(instance *componentInstance, nextNode ComponentNo
 	if instance.key != nextKey {
 		return false
 	}
-	if instance.memoEqual == nil || instance.dirty || !instance.active {
+	if instance.memoEqual == nil || instance.dirty || instance.dirtyDescendants > 0 || !instance.active {
 		return false
 	}
 	return instance.memoEqual(instance.node.Props, nextNode.Props)
@@ -107,7 +109,7 @@ func renderComponentInstance(instance *componentInstance) Node {
 	instance.stateIndex = 0
 	instance.effectIndex = 0
 	instance.unmountIndex = 0
-	instance.dirty = false
+	clearComponentDirty(instance)
 	defer func() {
 		currentComponent = previous
 	}()
@@ -121,10 +123,31 @@ func markComponentDirty(instance *componentInstance) {
 	if instance == nil || !instance.active {
 		return
 	}
+	if !instance.dirtyCounted {
+		for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
+			ancestor.dirtyDescendants++
+		}
+		instance.dirtyCounted = true
+	}
 	instance.dirty = true
 	if instance.scheduleUpdate != nil {
 		instance.scheduleUpdate(instance)
 	}
+}
+
+func clearComponentDirty(instance *componentInstance) {
+	if instance == nil {
+		return
+	}
+	if instance.dirtyCounted {
+		for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
+			if ancestor.dirtyDescendants > 0 {
+				ancestor.dirtyDescendants--
+			}
+		}
+		instance.dirtyCounted = false
+	}
+	instance.dirty = false
 }
 
 func pruneDirtyComponents(dirty []*componentInstance) []*componentInstance {
@@ -176,7 +199,8 @@ func deactivateComponent(instance *componentInstance) {
 	} else {
 		instance.active = false
 	}
-	instance.dirty = false
+	clearComponentDirty(instance)
+	instance.dirtyDescendants = 0
 	instance.parent = nil
 	instance.update = nil
 	instance.stateSlots = nil

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -3,25 +3,51 @@ package goframe
 // ComponentFunc renders one typed component props value.
 type ComponentFunc[P any] func(P) Node
 
+type memoizedProps[P any] interface {
+	MemoEqual(next P) bool
+}
+
 // ComponentNode preserves a function component boundary until the runtime
 // creates or reuses its component instance.
 type ComponentNode struct {
-	Name   string
-	Props  any
-	render func() Node
+	Name      string
+	Props     any
+	render    func() Node
+	memoEqual func(any, any) bool
 }
 
 func (ComponentNode) isNode() {}
 
 // Component creates a runtime-visible typed function component boundary.
 func Component[P any](name string, props P, render ComponentFunc[P]) Node {
+	var memoEqual func(any, any) bool
+	if _, ok := any(props).(memoizedProps[P]); ok {
+		memoEqual = memoizeProps[P]
+	}
 	return ComponentNode{
-		Name:  name,
-		Props: props,
+		Name:      name,
+		Props:     props,
+		memoEqual: memoEqual,
 		render: func() Node {
 			return render(props)
 		},
 	}
+}
+
+func memoizeProps[P any](oldProps, nextProps any) bool {
+	oldValue, ok := oldProps.(P)
+	if !ok {
+		return false
+	}
+	nextValue, ok := nextProps.(P)
+	if !ok {
+		return false
+	}
+	memoizer, ok := any(oldValue).(memoizedProps[P])
+	if !ok {
+		return false
+	}
+	return memoizer.MemoEqual(nextValue)
 }
 
 // C is the short form of Component.
@@ -34,6 +60,7 @@ type componentInstance struct {
 	key            string
 	parent         *componentInstance
 	node           ComponentNode
+	memoEqual      func(any, any) bool
 	stateSlots     []*stateSlot
 	stateIndex     int
 	effectSlots    []*effectSlot
@@ -54,10 +81,24 @@ func newComponentInstance(node ComponentNode, key string, parent *componentInsta
 		key:            key,
 		parent:         parent,
 		node:           node,
+		memoEqual:      node.memoEqual,
 		dirty:          true,
 		active:         true,
 		scheduleUpdate: schedule,
 	}
+}
+
+func shouldSkipComponentRender(instance *componentInstance, nextNode ComponentNode, nextKey string) bool {
+	if instance == nil || instance.node.Name != nextNode.Name {
+		return false
+	}
+	if instance.key != nextKey {
+		return false
+	}
+	if instance.memoEqual == nil || instance.dirty || !instance.active {
+		return false
+	}
+	return instance.memoEqual(instance.node.Props, nextNode.Props)
 }
 
 func renderComponentInstance(instance *componentInstance) Node {

--- a/pkg/goframe/component_debug_js.go
+++ b/pkg/goframe/component_debug_js.go
@@ -18,6 +18,13 @@ func reportComponentPatch(name string) {
 	}
 }
 
+func reportComponentMemoSkip(name string) {
+	probe := js.Global().Get("goframeComponentMemoSkipProbe")
+	if probe.Type() == js.TypeFunction {
+		probe.Invoke(name)
+	}
+}
+
 func reportDuplicateSiblingNodeKeys(nodes []Node, owner string) {
 	keys := make([]string, 0, len(nodes))
 	for _, node := range nodes {

--- a/pkg/goframe/component_debug_stub.go
+++ b/pkg/goframe/component_debug_stub.go
@@ -6,6 +6,8 @@ func reportComponentRender(name string) {}
 
 func reportComponentPatch(name string) {}
 
+func reportComponentMemoSkip(name string) {}
+
 func reportDuplicateSiblingNodeKeys(nodes []Node, owner string) {}
 
 func reportDuplicateSiblingKeys(keys []string, owner string) {}

--- a/pkg/goframe/component_debug_tag_stub.go
+++ b/pkg/goframe/component_debug_tag_stub.go
@@ -6,6 +6,8 @@ func reportComponentRender(name string) {}
 
 func reportComponentPatch(name string) {}
 
+func reportComponentMemoSkip(name string) {}
+
 func reportDuplicateSiblingNodeKeys(nodes []Node, owner string) {}
 
 func reportDuplicateSiblingKeys(keys []string, owner string) {}

--- a/pkg/goframe/memoization_test.go
+++ b/pkg/goframe/memoization_test.go
@@ -96,6 +96,61 @@ func TestShouldSkipComponentRenderDoesNotSkipWhenDirty(t *testing.T) {
 	}
 }
 
+func TestShouldSkipComponentRenderDoesNotSkipWhenDescendantDirty(t *testing.T) {
+	parent := dirtyCleanInstance("Parent", nil)
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	child := newComponentInstance(node, "memo", parent, nil)
+	child.dirty = false
+	grandchild := dirtyCleanInstance("GrandChild", child)
+	next := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	markComponentDirty(grandchild)
+
+	if child.dirtyDescendants != 1 || parent.dirtyDescendants != 1 {
+		t.Fatalf("dirty descendants child=%d parent=%d, want 1 each", child.dirtyDescendants, parent.dirtyDescendants)
+	}
+	if shouldSkipComponentRender(child, next, "memo") {
+		t.Fatal("memoized component with dirty descendant must not skip")
+	}
+
+	renderComponentInstance(grandchild)
+
+	if child.dirtyDescendants != 0 || parent.dirtyDescendants != 0 {
+		t.Fatalf("dirty descendants after render child=%d parent=%d, want 0 each", child.dirtyDescendants, parent.dirtyDescendants)
+	}
+	if !shouldSkipComponentRender(child, next, "memo") {
+		t.Fatal("clean memoized component with equal props should skip after descendant update")
+	}
+}
+
+func TestDirtyQueuePruningDoesNotMakeMemoSkipLoseDirtyDescendant(t *testing.T) {
+	parent := dirtyCleanInstance("Parent", nil)
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	child := newComponentInstance(node, "memo", parent, nil)
+	child.dirty = false
+	grandchild := dirtyCleanInstance("GrandChild", child)
+	next := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	markComponentDirty(grandchild)
+	markComponentDirty(parent)
+
+	pruned := pruneDirtyComponents([]*componentInstance{parent, grandchild})
+	if len(pruned) != 1 || pruned[0] != parent {
+		t.Fatalf("pruned dirty queue = %v, want parent only", instanceNames(pruned))
+	}
+	if shouldSkipComponentRender(child, next, "memo") {
+		t.Fatal("memo skip would hide a grandchild pruned from dirty queue")
+	}
+}
+
 func TestMemoizePropsRejectsIncompatibleValues(t *testing.T) {
 	if memoizeProps[memoizedPropsFixture](memoizedPropsFixture{ID: 1}, memoizedPropsFixture{ID: 1}) != true {
 		t.Fatal("expected equal memoized props to compare true")
@@ -103,4 +158,13 @@ func TestMemoizePropsRejectsIncompatibleValues(t *testing.T) {
 	if memoizeProps[memoizedPropsFixture](memoizedPropsFixture{ID: 1}, memoizedPropsFixture{ID: 2}) != false {
 		t.Fatal("expected changed memoized props to compare false")
 	}
+}
+
+func dirtyCleanInstance(name string, parent *componentInstance) *componentInstance {
+	node := Component(name, struct{}{}, func(struct{}) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "", parent, nil)
+	instance.dirty = false
+	return instance
 }

--- a/pkg/goframe/memoization_test.go
+++ b/pkg/goframe/memoization_test.go
@@ -1,0 +1,106 @@
+package goframe
+
+import "testing"
+
+type memoizedPropsFixture struct {
+	ID      int
+	Version int
+	Label   string
+}
+
+func (props memoizedPropsFixture) MemoEqual(next memoizedPropsFixture) bool {
+	return props.ID == next.ID &&
+		props.Version == next.Version &&
+		props.Label == next.Label
+}
+
+func TestShouldSkipComponentRenderRequiresMemoizedProps(t *testing.T) {
+	node := Component("NoMemo", memoizedPropsFixture{ID: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = false
+	next := Component("NoMemo", memoizedPropsFixture{ID: 2}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	if shouldSkipComponentRender(instance, next, "row-1") {
+		t.Fatal("component without MemoEqual should not be skipped")
+	}
+}
+
+func TestShouldSkipComponentRenderSkipsWhenEqualAndClean(t *testing.T) {
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1, Label: "a"}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = false
+	next := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1, Label: "a"}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	if !shouldSkipComponentRender(instance, next, "row-1") {
+		t.Fatal("expected memoized component to skip render")
+	}
+}
+
+func TestShouldSkipComponentRenderSkipsOnlyWhenNameAndKeyMatch(t *testing.T) {
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 2}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = false
+
+	wrongKey := Component("Memo", memoizedPropsFixture{ID: 1, Version: 2}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	if shouldSkipComponentRender(instance, wrongKey, "row-2") {
+		t.Fatal("component with different key must not be skipped")
+	}
+
+	wrongName := Component("Other", memoizedPropsFixture{ID: 1, Version: 2}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	if shouldSkipComponentRender(instance, wrongName, "row-1") {
+		t.Fatal("component with different name must not be skipped")
+	}
+}
+
+func TestShouldSkipComponentRenderSkipsWhenNotDirtyAndDirtyPropsEqual(t *testing.T) {
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 2, Label: "a"}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = false
+	changed := Component("Memo", memoizedPropsFixture{ID: 1, Version: 3, Label: "a"}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	if shouldSkipComponentRender(instance, changed, "row-1") {
+		t.Fatal("memo comparator should block skip on changed props")
+	}
+}
+
+func TestShouldSkipComponentRenderDoesNotSkipWhenDirty(t *testing.T) {
+	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = true
+	next := Component("Memo", memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	if shouldSkipComponentRender(instance, next, "row-1") {
+		t.Fatal("dirty component must rerender")
+	}
+}
+
+func TestMemoizePropsRejectsIncompatibleValues(t *testing.T) {
+	if memoizeProps[memoizedPropsFixture](memoizedPropsFixture{ID: 1}, memoizedPropsFixture{ID: 1}) != true {
+		t.Fatal("expected equal memoized props to compare true")
+	}
+	if memoizeProps[memoizedPropsFixture](memoizedPropsFixture{ID: 1}, memoizedPropsFixture{ID: 2}) != false {
+		t.Fatal("expected changed memoized props to compare false")
+	}
+}

--- a/pkg/goframe/memoization_test.go
+++ b/pkg/goframe/memoization_test.go
@@ -2,6 +2,10 @@ package goframe
 
 import "testing"
 
+type plainPropsFixture struct {
+	ID int
+}
+
 type memoizedPropsFixture struct {
 	ID      int
 	Version int
@@ -14,18 +18,18 @@ func (props memoizedPropsFixture) MemoEqual(next memoizedPropsFixture) bool {
 		props.Label == next.Label
 }
 
-func TestShouldSkipComponentRenderRequiresMemoizedProps(t *testing.T) {
-	node := Component("NoMemo", memoizedPropsFixture{ID: 1}, func(memoizedPropsFixture) Node {
+func TestShouldSkipComponentRenderRequiresMemoEqual(t *testing.T) {
+	node := Component("NoMemo", plainPropsFixture{ID: 1}, func(plainPropsFixture) Node {
 		return Empty()
 	}).(ComponentNode)
 	instance := newComponentInstance(node, "row-1", nil, nil)
 	instance.dirty = false
-	next := Component("NoMemo", memoizedPropsFixture{ID: 2}, func(memoizedPropsFixture) Node {
+	next := Component("NoMemo", plainPropsFixture{ID: 1}, func(plainPropsFixture) Node {
 		return Empty()
 	}).(ComponentNode)
 
 	if shouldSkipComponentRender(instance, next, "row-1") {
-		t.Fatal("component without MemoEqual should not be skipped")
+		t.Fatal("component without MemoEqual must not skip even when props are equal")
 	}
 }
 
@@ -66,7 +70,7 @@ func TestShouldSkipComponentRenderSkipsOnlyWhenNameAndKeyMatch(t *testing.T) {
 	}
 }
 
-func TestShouldSkipComponentRenderSkipsWhenNotDirtyAndDirtyPropsEqual(t *testing.T) {
+func TestShouldSkipComponentRenderDoesNotSkipWhenMemoPropsChanged(t *testing.T) {
 	node := Component("Memo", memoizedPropsFixture{ID: 1, Version: 2, Label: "a"}, func(memoizedPropsFixture) Node {
 		return Empty()
 	}).(ComponentNode)

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -142,8 +142,13 @@ func patchComponent(document, parent js.Value, mounted *mountedNode, newNode Com
 	instance := mounted.component
 	reportComponentPatch(instance.name)
 	instance.parent = owner
+	if shouldSkipComponentRender(instance, newNode, mounted.key) {
+		instance.node = newNode
+		instance.dirty = false
+		reportComponentMemoSkip(instance.name)
+		return
+	}
 	instance.node = newNode
-
 	child := patchMounted(document, parent, mounted.componentChild, renderComponentInstance(instance), instance)
 	mounted.componentChild = child
 }

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -156,6 +156,7 @@ try {
     await wait(120);
     timings.push({ step: "selection-update", ms: Date.now() - selectStart });
     const selectReport = await finishScenario(client, "row-select");
+    await assertRowSelectionReport(client, selectReport);
     const selected = await client.evaluate(`(() => {
         const first = document.querySelector(".issue-row");
         return {
@@ -634,23 +635,28 @@ function installDashboardAuditExpression(names) {
                 this.baseline = snapshotCounts(componentNames);
             },
             finish(label) {
-                const next = snapshotCounts(componentNames);
-                const renderDeltas = {};
-                const patchDeltas = {};
-                for (const name of componentNames) {
-                    renderDeltas[name] = next.renders[name] - this.baseline.renders[name];
-                    patchDeltas[name] = next.patches[name] - this.baseline.patches[name];
-                }
-                return {
-                    label,
-                    durationMs: Math.round((performance.now() - this.startedAt) * 100) / 100,
-                    renderDeltas,
-                    patchDeltas,
-                    operations: { ...this.operations },
-                    mutations: { ...this.mutations },
-                    rows: document.querySelectorAll(".issue-row").length,
-                    summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
-                };
+            const next = snapshotCounts(componentNames);
+            const renderDeltas = {};
+            const patchDeltas = {};
+            for (const name of componentNames) {
+                renderDeltas[name] = next.renders[name] - this.baseline.renders[name];
+                patchDeltas[name] = next.patches[name] - this.baseline.patches[name];
+            }
+            const memoDeltas = {};
+            for (const name of componentNames) {
+                memoDeltas[name] = next.memoSkips[name] - this.baseline.memoSkips[name];
+            }
+            return {
+                label,
+                durationMs: Math.round((performance.now() - this.startedAt) * 100) / 100,
+                renderDeltas,
+                patchDeltas,
+                memoDeltas,
+                operations: { ...this.operations },
+                mutations: { ...this.mutations },
+                rows: document.querySelectorAll(".issue-row").length,
+                summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
+            };
             },
         };
 
@@ -727,13 +733,37 @@ function installDashboardAuditExpression(names) {
         function snapshotCounts(names) {
             const renderCounts = window.goframeComponentRenderCounts || {};
             const patchCounts = window.goframeComponentPatchCounts || {};
+            const memoSkips = window.goframeComponentMemoSkips || {};
             const renders = {};
             const patches = {};
+            const skips = {};
             for (const name of names) {
                 renders[name] = renderCounts[name] || 0;
                 patches[name] = patchCounts[name] || 0;
+                skips[name] = memoSkips[name] || 0;
             }
-            return { renders, patches };
+            return { renders, patches, memoSkips: skips };
         }
     })()`;
+}
+
+async function assertRowSelectionReport(client, report) {
+    const rows = await client.evaluate(`document.querySelectorAll(".issue-row").length`);
+    const allowed = Math.max(2, Math.floor(rows / 2));
+    if (report.renderDeltas.IssueRow > allowed) {
+        throw new Error(`APP FAILURE: IssueRow renders ${report.renderDeltas.IssueRow} for row selection (limit ${allowed})`);
+    }
+    if (report.memoDeltas.IssueRow <= 0) {
+        throw new Error(`APP FAILURE: IssueRow memo skips not observed on row selection: ${JSON.stringify(report.memoDeltas)}`);
+    }
+    if (report.renderDeltas.Header !== 0 || report.renderDeltas.FilterBar !== 0 || report.renderDeltas.MetricsGrid !== 0) {
+        throw new Error(`APP FAILURE: unrelated renders triggered by row selection: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    if (report.patchDeltas.Header !== 0 || report.patchDeltas.FilterBar !== 0 || report.patchDeltas.MetricsGrid !== 0) {
+        throw new Error(`APP FAILURE: unrelated patches triggered by row selection: ${JSON.stringify(report.patchDeltas)}`);
+    }
+    if (report.operations.addEventListener !== 0 || report.operations.removeEventListener !== 0) {
+        throw new Error(`APP FAILURE: listener churn during row selection: ${JSON.stringify(report.operations)}`);
+    }
+    console.log(`dashboard row-selection memo summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, memoDeltas: report.memoDeltas })}`);
 }

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -150,18 +150,25 @@ try {
         "dashboard search updates visible rows without replacing header/search",
     );
 
+    await client.evaluate(`document.querySelector(".issue-row .row-link").click()`);
+    await wait(120);
     await startScenario(client, "row-select");
     const selectStart = Date.now();
-    await client.evaluate(`document.querySelector(".issue-row .row-link").click()`);
+    await client.evaluate(`(() => {
+        const rows = document.querySelectorAll(".issue-row");
+        const links = document.querySelectorAll(".issue-row .row-link");
+        window.__dashboardSelectionTarget = rows[1].id.replace("issue-row-", "");
+        links[1].click();
+    })()`);
     await wait(120);
     timings.push({ step: "selection-update", ms: Date.now() - selectStart });
     const selectReport = await finishScenario(client, "row-select");
-    await assertRowSelectionReport(client, selectReport);
+    assertRowSelectionReport(selectReport);
     const selected = await client.evaluate(`(() => {
-        const first = document.querySelector(".issue-row");
+        const target = window.__dashboardSelectionTarget;
         return {
             selected: Boolean(document.querySelector(".issue-row-selected")),
-            detail: document.querySelector("[data-testid='detail-panel']")?.textContent.includes(first.id.replace("issue-row-", "")),
+            detail: document.querySelector("[data-testid='detail-panel']")?.textContent.includes(target),
             headerSame: window.__dashboardHeader === document.querySelector("[data-testid='dashboard-header']"),
             searchSame: window.__dashboardSearch === document.querySelector("#dashboard-search"),
         };
@@ -254,6 +261,21 @@ try {
     }
     console.log("dashboard simulate update changes metrics: ok");
 
+    await startScenario(client, "post-simulate-row-toggle");
+    const postSimulateToggleBefore = await firstRowStatus(client);
+    await client.evaluate(`document.querySelector(".issue-row .button").click()`);
+    await wait(120);
+    const postSimulateToggleReport = await finishScenario(client, "post-simulate-row-toggle");
+    const postSimulateToggleAfter = await firstRowStatus(client);
+    const eventsAfterPostSimulateToggle = await metricValue(client, "Events");
+    if (postSimulateToggleBefore === postSimulateToggleAfter) {
+        throw new Error(`APP FAILURE: post-simulate row toggle did not change first row status: ${postSimulateToggleBefore}`);
+    }
+    if (eventsAfterPostSimulateToggle !== afterEvents) {
+        throw new Error(`APP FAILURE: post-simulate row toggle used stale issue data: events after simulate ${afterEvents}, after toggle ${eventsAfterPostSimulateToggle}`);
+    }
+    console.log("dashboard post-simulate row toggle preserves simulated data: ok");
+
     await startScenario(client, "reset-final");
     await clickButtonByText(client, "Reset");
     await wait(120);
@@ -288,6 +310,7 @@ try {
         resetBeforeSimulateReport,
         toggleReport,
         simulateReport,
+        postSimulateToggleReport,
         resetReport,
     ])}`);
     console.log("Dashboard browser smoke: ok");
@@ -747,9 +770,8 @@ function installDashboardAuditExpression(names) {
     })()`;
 }
 
-async function assertRowSelectionReport(client, report) {
-    const rows = await client.evaluate(`document.querySelectorAll(".issue-row").length`);
-    const allowed = Math.max(2, Math.floor(rows / 2));
+function assertRowSelectionReport(report) {
+    const allowed = 2;
     if (report.renderDeltas.IssueRow > allowed) {
         throw new Error(`APP FAILURE: IssueRow renders ${report.renderDeltas.IssueRow} for row selection (limit ${allowed})`);
     }


### PR DESCRIPTION
## Summary

Adds explicit opt-in component memoization through props-level `MemoEqual`.

## Changes

- Adds typed `MemoEqual(next Props) bool` memoization support
- Skips clean component renders when name/key/props match
- Prevents memo skip over dirty descendants
- Adds debug memo-skip counters
- Memoizes dashboard `IssueRow`
- Adds dashboard smoke assertions for row-selection bailout
- Adds stale handler safety check through `DataVersion`
- Documents explicit memoization model and tradeoffs

## Dashboard proof

- Focus-only remains runtime-clean: render 0 / patch 0 / DOM ops 0
- Row selection:
  - `IssueRow` renders: 2
  - `IssueRow` memo skips: 35
  - Header/FilterBar/MetricsGrid renders: 0
  - listener churn: 0

## Tradeoffs

- Function props are user responsibility in `MemoEqual`
- Dashboard uses `DataVersion` to avoid stale handlers
- Dataset-changing actions intentionally invalidate row memoization more broadly
- No virtualization/context/selectors in this MVP

## Checks

- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`