### PR TITLE
Dashboard DOM pressure audit

### DIFF
--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -110,6 +110,25 @@ search, status filtering, sorting, reset, and simulated dataset updates still
 visit or rerender many visible rows. That is an intentional baseline for future
 runtime optimization rather than a hidden runtime feature.
 
+For DOM pressure audits, run:
+
+```bash
+node --experimental-websocket scripts/dashboard-dom-pressure.mjs
+```
+
+The pressure audit repeatedly switches the status filter from Open to All. On
+the current 300-row fixture, Open shows 72 rows and All restores 300 rows, so
+the All transition recreates 228 rows. In a debug TinyGo build that is roughly
+6,156 created DOM nodes and 456 event listeners reattached per All transition.
+The audit fails if the live DOM node count or net listener count grows across
+cycles. A stable live DOM count with growing DevTools/Performance `Nodes`
+should be treated as a detached-node/GC accounting signal to investigate, not
+as proof of a live DOM leak by itself.
+
+The expected next product-level answer to this pressure is row virtualization,
+not a hidden runtime heuristic. Virtualization is intentionally outside this
+example and outside the current runtime MVPs.
+
 ## Known Limitations
 
 - There is no router or URL state.

--- a/scripts/dashboard-dom-pressure.mjs
+++ b/scripts/dashboard-dom-pressure.mjs
@@ -1,0 +1,823 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(scriptDir, "..");
+const appDir = join(rootDir, "examples/dashboard");
+const appURLBase = process.env.GOFRAME_DASHBOARD_PRESSURE_URL ?? "http://127.0.0.1";
+const chrome = process.env.CHROME ?? "google-chrome";
+const cycles = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_CYCLES ?? "20");
+const settleFrames = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_SETTLE_FRAMES ?? "2");
+const postIdleMs = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_POST_IDLE_MS ?? "3000");
+const profile = await mkdtemp(join(tmpdir(), "goframe-dashboard-pressure-"));
+const componentNames = [
+    "App",
+    "Header",
+    "DashboardApp",
+    "DashboardShell",
+    "MetricsGrid",
+    "MetricCard",
+    "Card",
+    "FilterBar",
+    "SearchBox",
+    "IssueWorkspace",
+    "IssueTable",
+    "IssueRow",
+    "DetailPanel",
+    "EmptyDetail",
+    "Button",
+];
+
+let browser = null;
+let server = null;
+let browserError = "";
+let browserExit = null;
+
+try {
+    await prepareDashboardDebugPackage();
+
+    const serverPort = await pickFreePort();
+    const debugPort = await pickFreePort();
+    const appURL = `${appURLBase}:${serverPort}/?pressure=${Date.now()}`;
+    const expectedApp = new URL(appURL);
+
+    server = startServer(serverPort);
+    await waitForServer(serverPort, server);
+
+    browser = startChrome(debugPort);
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Performance.enable");
+    await client.call("HeapProfiler.enable").catch(() => {});
+
+    await navigateToApp(client, appURL);
+    await waitForAppPage(client, expectedApp, "initial navigation");
+    await collectGarbage(client);
+    await client.evaluate(installPressureAuditExpression(componentNames));
+
+    const initial = await samplePage(client, "initial", 0, "all");
+    if (initial.rows !== 300) {
+        throw new Error(`APP FAILURE: dashboard should start with 300 rows, got ${initial.rows}`);
+    }
+
+    const records = [];
+    for (let cycle = 1; cycle <= cycles; cycle++) {
+        records.push(await runTransition(client, cycle, "open", "Open"));
+        records.push(await runTransition(client, cycle, "all", "All"));
+    }
+
+    await wait(postIdleMs);
+    await collectGarbage(client);
+    const finalIdle = await samplePage(client, "post-idle-gc", cycles, "all");
+
+    printRecords(records);
+    const analysis = analyzeRecords(records, finalIdle);
+    printAnalysis(initial, finalIdle, analysis);
+    if (analysis.failures.length > 0) {
+        throw new Error(`APP FAILURE: dashboard DOM pressure leak guard failed:\n${analysis.failures.join("\n")}`);
+    }
+
+    client.close();
+    console.log("Dashboard DOM pressure audit: ok");
+} finally {
+    if (browser) {
+        const exited = new Promise((resolveExit) => browser.once("exit", resolveExit));
+        killProcessGroup(browser);
+        await Promise.race([exited, wait(2000)]);
+    }
+    if (server) {
+        const exited = new Promise((resolveExit) => server.once("exit", resolveExit));
+        killProcessGroup(server);
+        await Promise.race([exited, wait(2000)]);
+    }
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function prepareDashboardDebugPackage() {
+    console.log("== Dashboard pressure package ==");
+    await runGoxc(["package", "./examples/dashboard", "--compiler=tinygo"]);
+    await runCommand("tinygo", [
+        "build",
+        "-target=wasm",
+        "-no-debug",
+        "-panic=trap",
+        "-tags=goframe_debug",
+        "-o",
+        join(appDir, ".goframe/package/standalone/assets/bundle.wasm"),
+        ".",
+    ], {
+        cwd: join(appDir, ".goframe/work/dev"),
+    });
+}
+
+async function runGoxc(args) {
+    const configured = process.env.GOXC;
+    if (configured) {
+        await runCommand(configured, args, { cwd: rootDir });
+        return;
+    }
+    await runCommand("go", ["run", "./cmd/goxc", ...args], { cwd: rootDir });
+}
+
+async function runCommand(command, args, options = {}) {
+    await new Promise((resolveRun, rejectRun) => {
+        const child = spawn(command, args, {
+            cwd: options.cwd ?? rootDir,
+            stdio: "inherit",
+            env: process.env,
+        });
+        child.on("error", rejectRun);
+        child.on("exit", (code) => {
+            if (code === 0) {
+                resolveRun();
+                return;
+            }
+            rejectRun(new Error(`${command} ${args.join(" ")} exited with ${code}`));
+        });
+    });
+}
+
+async function pickFreePort() {
+    return await new Promise((resolvePort, rejectPort) => {
+        const probe = createServer();
+        probe.on("error", rejectPort);
+        probe.listen(0, "127.0.0.1", () => {
+            const address = probe.address();
+            probe.close(() => resolvePort(address.port));
+        });
+    });
+}
+
+function startServer(port) {
+    const child = spawnGoxc(["serve", "./examples/dashboard", `--port=${port}`], {
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true,
+    });
+    child.stdout.on("data", (chunk) => process.stdout.write(chunk));
+    child.stderr.on("data", (chunk) => process.stderr.write(chunk));
+    return child;
+}
+
+function spawnGoxc(args, options) {
+    const configured = process.env.GOXC;
+    if (configured) {
+        return spawn(configured, args, { cwd: rootDir, env: process.env, ...options });
+    }
+    return spawn("go", ["run", "./cmd/goxc", ...args], { cwd: rootDir, env: process.env, ...options });
+}
+
+async function waitForServer(port, child) {
+    for (let attempt = 0; attempt < 160; attempt++) {
+        if (child.exitCode !== null) {
+            throw new Error(`HARNESS FAILURE: goxc serve exited before becoming ready with code ${child.exitCode}`);
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/`);
+            if (response.ok) {
+                return;
+            }
+        } catch {}
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: goxc serve did not become ready on port ${port}`);
+}
+
+function startChrome(debugPort) {
+    const child = spawn(chrome, [
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        "--enable-precise-memory-info",
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profile}`,
+        "about:blank",
+    ], {
+        stdio: ["ignore", "ignore", "pipe"],
+        detached: true,
+    });
+    child.stderr.on("data", (chunk) => {
+        browserError += chunk;
+    });
+    child.on("exit", (code, signal) => {
+        browserExit = { code, signal };
+    });
+    return child;
+}
+
+async function waitForPage(port) {
+    let lastError;
+    for (let attempt = 0; attempt < 60; attempt++) {
+        if (browserExit) {
+            throw new Error(`HARNESS FAILURE: Chrome exited before CDP page was available: ${JSON.stringify(browserExit)}\n${browserError}`);
+        }
+        try {
+            const pages = await fetchTargets(port);
+            const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+            if (page) return page;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools did not become ready: ${lastError ?? browserError}`);
+}
+
+async function fetchTargets(port) {
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    if (!response.ok) {
+        throw new Error(`CDP /json returned HTTP ${response.status}`);
+    }
+    return await response.json();
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+}
+
+async function waitForAppPage(client, expected, label) {
+    let lastState = null;
+    for (let attempt = 0; attempt < 120; attempt++) {
+        lastState = await pageState(client);
+        if (lastState.href.startsWith("chrome-error://")) {
+            throw new Error(`HARNESS FAILURE: ${label}: Chrome loaded an error document: ${JSON.stringify(lastState)}`);
+        }
+        if (isExpectedAppState(lastState, expected) && lastState.root && lastState.appReady) {
+            return;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: ${label}: app page did not become ready: ${JSON.stringify(lastState)}`);
+}
+
+async function pageState(client) {
+    return await client.evaluate(`(() => ({
+        href: window.location.href,
+        origin: window.location.origin,
+        protocol: window.location.protocol,
+        readyState: document.readyState,
+        root: Boolean(document.querySelector("#root")),
+        appReady: Boolean(document.querySelector("#dashboard-search") && window.goframeComponentRenderCounts?.App),
+    }))()`);
+}
+
+function isExpectedAppState(state, expected) {
+    if (!state || (state.protocol !== "http:" && state.protocol !== "https:")) {
+        return false;
+    }
+    try {
+        const actual = new URL(state.href);
+        return actual.origin === expected.origin && actual.pathname === expected.pathname;
+    } catch {
+        return false;
+    }
+}
+
+async function runTransition(client, cycle, status, label) {
+    await collectGarbage(client);
+    const metricsBefore = await performanceMetrics(client);
+    await client.evaluate(`window.__dashboardPressure.start(${JSON.stringify(label)})`);
+    const tracePromise = startTrace(client);
+    await client.evaluate(`(() => {
+        const select = document.querySelector("#status-filter");
+        select.value = ${JSON.stringify(status)};
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+    })()`);
+    await settle(client);
+    const audit = await client.evaluate(`window.__dashboardPressure.finish(${JSON.stringify(label)})`);
+    const trace = await stopTrace(client, tracePromise);
+    const metricsAfter = await performanceMetrics(client);
+    await collectGarbage(client);
+    const afterGC = await samplePage(client, label, cycle, status);
+
+    return {
+        cycle,
+        transition: label,
+        status,
+        durationMs: audit.durationMs,
+        rows: audit.rows,
+        summary: audit.summary,
+        liveDOMNodes: audit.liveDOMNodes,
+        allNodesAfterGC: afterGC.liveDOMNodes,
+        cdpNodes: metricsAfter.Nodes ?? 0,
+        cdpNodesAfterGC: afterGC.metrics.Nodes ?? 0,
+        jsEventListeners: metricsAfter.JSEventListeners ?? 0,
+        jsEventListenersAfterGC: afterGC.metrics.JSEventListeners ?? 0,
+        jsHeapUsed: metricsAfter.JSHeapUsedSize ?? 0,
+        jsHeapUsedAfterGC: afterGC.metrics.JSHeapUsedSize ?? 0,
+        netListeners: audit.netListeners,
+        operations: audit.operations,
+        renderDeltas: audit.renderDeltas,
+        patchDeltas: audit.patchDeltas,
+        memoDeltas: audit.memoDeltas,
+        renderReports: audit.renderReports,
+        runtimeRenderMs: round(sumBy(audit.renderReports, (entry) => entry.duration || 0)),
+        performanceDeltas: diffMetrics(metricsBefore, metricsAfter),
+        trace,
+    };
+}
+
+async function settle(client) {
+    await client.evaluate(`new Promise((resolve) => {
+        let frames = ${settleFrames};
+        const tick = () => {
+            if (frames-- <= 0) {
+                setTimeout(resolve, 0);
+                return;
+            }
+            requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+    })`);
+}
+
+async function samplePage(client, label, cycle, status) {
+    const page = await client.evaluate(`(() => ({
+        label: ${JSON.stringify(label)},
+        cycle: ${cycle},
+        status: ${JSON.stringify(status)},
+        rows: document.querySelectorAll(".issue-row").length,
+        liveDOMNodes: document.querySelectorAll("*").length,
+        summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
+    }))()`);
+    return { ...page, metrics: await performanceMetrics(client) };
+}
+
+async function performanceMetrics(client) {
+    try {
+        const result = await client.call("Performance.getMetrics");
+        const metrics = {};
+        for (const entry of result.metrics || []) {
+            metrics[entry.name] = entry.value;
+        }
+        return metrics;
+    } catch {
+        return {};
+    }
+}
+
+function diffMetrics(before, after) {
+    const durationNames = [
+        "TaskDuration",
+        "ScriptDuration",
+        "LayoutDuration",
+        "RecalcStyleDuration",
+    ];
+    const countNames = [
+        "LayoutCount",
+        "RecalcStyleCount",
+    ];
+    const deltas = {};
+    for (const name of durationNames) {
+        deltas[name] = round(((after[name] ?? 0) - (before[name] ?? 0)) * 1000);
+    }
+    for (const name of countNames) {
+        deltas[name] = round((after[name] ?? 0) - (before[name] ?? 0));
+    }
+    return deltas;
+}
+
+async function collectGarbage(client) {
+    try {
+        await client.call("HeapProfiler.collectGarbage");
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function startTrace(client) {
+    const events = [];
+    let complete;
+    const completePromise = new Promise((resolveComplete) => {
+        complete = resolveComplete;
+    });
+    const offData = client.on("Tracing.dataCollected", (params) => {
+        events.push(...(params.value || []));
+    });
+    const offComplete = client.on("Tracing.tracingComplete", () => {
+        offData();
+        offComplete();
+        complete(events);
+    });
+    try {
+        await client.call("Tracing.start", {
+            categories: "devtools.timeline,disabled-by-default-devtools.timeline",
+            transferMode: "ReportEvents",
+        });
+        return { completePromise, available: true };
+    } catch {
+        offData();
+        offComplete();
+        complete([]);
+        return { completePromise, available: false };
+    }
+}
+
+async function stopTrace(client, tracePromise) {
+    if (!tracePromise.available) {
+        return { traceAvailable: false };
+    }
+    try {
+        await client.call("Tracing.end");
+        const events = await Promise.race([tracePromise.completePromise, wait(3000).then(() => [])]);
+        return summarizeTrace(events);
+    } catch {
+        return { traceAvailable: false };
+    }
+}
+
+function summarizeTrace(events) {
+    const totals = {
+        traceAvailable: events.length > 0,
+        functionCallMs: 0,
+        evaluateScriptMs: 0,
+        updateLayoutTreeMs: 0,
+        layoutMs: 0,
+        paintMs: 0,
+        compositeLayersMs: 0,
+    };
+    for (const event of events) {
+        if (event.ph !== "X" || typeof event.dur !== "number") continue;
+        const ms = event.dur / 1000;
+        switch (event.name) {
+        case "FunctionCall":
+            totals.functionCallMs += ms;
+            break;
+        case "EvaluateScript":
+            totals.evaluateScriptMs += ms;
+            break;
+        case "UpdateLayoutTree":
+        case "RecalculateStyles":
+            totals.updateLayoutTreeMs += ms;
+            break;
+        case "Layout":
+            totals.layoutMs += ms;
+            break;
+        case "Paint":
+            totals.paintMs += ms;
+            break;
+        case "CompositeLayers":
+            totals.compositeLayersMs += ms;
+            break;
+        }
+    }
+    for (const key of Object.keys(totals)) {
+        if (typeof totals[key] === "number") {
+            totals[key] = round(totals[key]);
+        }
+    }
+    return totals;
+}
+
+function installPressureAuditExpression(names) {
+    return `(() => {
+        if (window.__dashboardPressure) return true;
+
+        const componentNames = ${JSON.stringify(names)};
+        const operations = ${JSON.stringify(emptyOperations())};
+        let netListeners = 0;
+        const renderReports = [];
+        window.goframeRenderProbe = (phase, duration) => {
+            renderReports.push({ phase, duration });
+        };
+
+        const audit = {
+            baseline: null,
+            operationBaseline: null,
+            reportBaseline: 0,
+            startedAt: 0,
+            start(label) {
+                this.startedAt = performance.now();
+                this.baseline = snapshotCounts(componentNames);
+                this.operationBaseline = { ...operations, netListeners };
+                this.reportBaseline = renderReports.length;
+            },
+            finish(label) {
+                const next = snapshotCounts(componentNames);
+                const renderDeltas = {};
+                const patchDeltas = {};
+                const memoDeltas = {};
+                for (const name of componentNames) {
+                    renderDeltas[name] = next.renders[name] - this.baseline.renders[name];
+                    patchDeltas[name] = next.patches[name] - this.baseline.patches[name];
+                    memoDeltas[name] = next.memoSkips[name] - this.baseline.memoSkips[name];
+                }
+                const opDeltas = {};
+                for (const key of Object.keys(operations)) {
+                    opDeltas[key] = operations[key] - this.operationBaseline[key];
+                }
+                return {
+                    label,
+                    durationMs: Math.round((performance.now() - this.startedAt) * 100) / 100,
+                    rows: document.querySelectorAll(".issue-row").length,
+                    liveDOMNodes: document.querySelectorAll("*").length,
+                    summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
+                    netListeners,
+                    operations: opDeltas,
+                    renderDeltas,
+                    patchDeltas,
+                    memoDeltas,
+                    renderReports: renderReports.slice(this.reportBaseline),
+                };
+            },
+        };
+
+        const wrap = (owner, name, counter, after) => {
+            const original = owner[name];
+            owner[name] = function(...args) {
+                operations[counter]++;
+                if (after) after();
+                return original.apply(this, args);
+            };
+        };
+
+        wrap(Document.prototype, "createElement", "createElement");
+        wrap(Document.prototype, "createTextNode", "createTextNode");
+        wrap(Document.prototype, "createComment", "createComment");
+        wrap(Document.prototype, "createDocumentFragment", "createDocumentFragment");
+        wrap(Node.prototype, "appendChild", "appendChild");
+        wrap(Node.prototype, "removeChild", "removeChild");
+        wrap(Node.prototype, "replaceChild", "replaceChild");
+        wrap(Node.prototype, "insertBefore", "insertBefore");
+        wrap(Element.prototype, "setAttribute", "setAttribute");
+        wrap(Element.prototype, "removeAttribute", "removeAttribute");
+        wrap(EventTarget.prototype, "addEventListener", "addEventListener", () => { netListeners++; });
+        wrap(EventTarget.prototype, "removeEventListener", "removeEventListener", () => { netListeners--; });
+
+        const nodeValue = Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue");
+        Object.defineProperty(Node.prototype, "nodeValue", {
+            configurable: nodeValue.configurable,
+            enumerable: nodeValue.enumerable,
+            get: nodeValue.get,
+            set(value) {
+                operations.setTextNodeValue++;
+                return nodeValue.set.call(this, value);
+            },
+        });
+        const inputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+        Object.defineProperty(HTMLInputElement.prototype, "value", {
+            configurable: inputValue.configurable,
+            enumerable: inputValue.enumerable,
+            get: inputValue.get,
+            set(value) {
+                operations.setProperty++;
+                return inputValue.set.call(this, value);
+            },
+        });
+        const selectValue = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
+        Object.defineProperty(HTMLSelectElement.prototype, "value", {
+            configurable: selectValue.configurable,
+            enumerable: selectValue.enumerable,
+            get: selectValue.get,
+            set(value) {
+                operations.setProperty++;
+                return selectValue.set.call(this, value);
+            },
+        });
+
+        window.__dashboardPressure = audit;
+        return true;
+
+        function snapshotCounts(names) {
+            const renderCounts = window.goframeComponentRenderCounts || {};
+            const patchCounts = window.goframeComponentPatchCounts || {};
+            const memoSkips = window.goframeComponentMemoSkips || {};
+            const renders = {};
+            const patches = {};
+            const skips = {};
+            for (const name of names) {
+                renders[name] = renderCounts[name] || 0;
+                patches[name] = patchCounts[name] || 0;
+                skips[name] = memoSkips[name] || 0;
+            }
+            return { renders, patches, memoSkips: skips };
+        }
+    })()`;
+}
+
+function emptyOperations() {
+    return {
+        createElement: 0,
+        createTextNode: 0,
+        createComment: 0,
+        createDocumentFragment: 0,
+        appendChild: 0,
+        removeChild: 0,
+        replaceChild: 0,
+        insertBefore: 0,
+        setTextNodeValue: 0,
+        setAttribute: 0,
+        removeAttribute: 0,
+        setProperty: 0,
+        addEventListener: 0,
+        removeEventListener: 0,
+    };
+}
+
+function printRecords(records) {
+    const rows = records.map((record) => ({
+        cycle: record.cycle,
+        to: record.transition,
+        ms: record.durationMs,
+        rows: record.rows,
+        liveDOM: record.liveDOMNodes,
+        cdpNodesGC: record.cdpNodesAfterGC,
+        jsListenersGC: record.jsEventListenersAfterGC,
+        netListeners: record.netListeners,
+        create: record.operations.createElement + record.operations.createTextNode + record.operations.createComment,
+        insert: record.operations.insertBefore + record.operations.appendChild,
+        remove: record.operations.removeChild,
+        addEvt: record.operations.addEventListener,
+        remEvt: record.operations.removeEventListener,
+        rowRender: record.renderDeltas.IssueRow,
+        rowPatch: record.patchDeltas.IssueRow,
+        rowMemo: record.memoDeltas.IssueRow,
+        rtRenderMs: record.runtimeRenderMs,
+        scriptMs: record.performanceDeltas.ScriptDuration,
+        layoutMs: record.performanceDeltas.LayoutDuration,
+        recalcMs: record.performanceDeltas.RecalcStyleDuration,
+        fnMs: record.trace.functionCallMs ?? 0,
+        paintMs: (record.trace.paintMs ?? 0) + (record.trace.compositeLayersMs ?? 0),
+        heapGC: record.jsHeapUsedAfterGC,
+    }));
+    console.table(rows);
+}
+
+function analyzeRecords(records, finalIdle) {
+    const failures = [];
+    const warnings = [];
+    const allRecords = records.filter((record) => record.status === "all");
+    const openRecords = records.filter((record) => record.status === "open");
+    const expectedAllRows = 300;
+
+    for (const record of allRecords) {
+        if (record.rows !== expectedAllRows) {
+            failures.push(`cycle ${record.cycle} All rows=${record.rows}, want ${expectedAllRows}`);
+        }
+    }
+
+    checkStable(allRecords, "liveDOMNodes", "All live DOM nodes", 0, failures);
+    checkStable(allRecords, "netListeners", "All net listener delta", 0, failures);
+    checkStable(allRecords, "jsEventListenersAfterGC", "All CDP JS event listeners after GC", 2, failures);
+    checkStable(openRecords, "liveDOMNodes", "Open live DOM nodes", 0, failures);
+    checkStable(openRecords, "netListeners", "Open net listener delta", 0, failures);
+
+    const cdpNodeDrift = drift(allRecords.map((record) => record.cdpNodesAfterGC));
+    if (cdpNodeDrift > 5) {
+        warnings.push(`CDP Nodes after GC drifted by ${cdpNodeDrift}; live DOM stability decides leak failure.`);
+    }
+
+    const averageAllCreate = average(allRecords.map((record) =>
+        record.operations.createElement + record.operations.createTextNode + record.operations.createComment));
+    const averageAllRemove = average(allRecords.map((record) => record.operations.removeChild));
+    const averageAllDuration = average(allRecords.map((record) => record.durationMs));
+    const averageAllLayout = average(allRecords.map((record) => record.performanceDeltas.LayoutDuration));
+    const averageAllScript = average(allRecords.map((record) => record.performanceDeltas.ScriptDuration));
+    const averageAllRender = average(allRecords.map((record) => record.runtimeRenderMs));
+
+    return {
+        failures,
+        warnings,
+        summary: {
+            cycles,
+            allRows: expectedAllRows,
+            openRows: openRecords[0]?.rows ?? 0,
+            averageAllDuration: round(averageAllDuration),
+            averageAllCreateNodes: round(averageAllCreate),
+            averageAllRemoveNodes: round(averageAllRemove),
+            averageAllRuntimeRenderMs: round(averageAllRender),
+            averageAllScriptMs: round(averageAllScript),
+            averageAllLayoutMs: round(averageAllLayout),
+            maxAllDuration: Math.max(...allRecords.map((record) => record.durationMs)),
+            liveDOMAllStart: allRecords[0]?.liveDOMNodes ?? 0,
+            liveDOMAllEnd: allRecords.at(-1)?.liveDOMNodes ?? 0,
+            netListenersAllStart: allRecords[0]?.netListeners ?? 0,
+            netListenersAllEnd: allRecords.at(-1)?.netListeners ?? 0,
+            cdpNodesAllStart: allRecords[0]?.cdpNodesAfterGC ?? 0,
+            cdpNodesAllEnd: allRecords.at(-1)?.cdpNodesAfterGC ?? 0,
+            postIdleLiveDOMNodes: finalIdle.liveDOMNodes,
+            postIdleCDPNodes: finalIdle.metrics.Nodes ?? 0,
+            postIdleJSEventListeners: finalIdle.metrics.JSEventListeners ?? 0,
+            postIdleJSHeapUsed: finalIdle.metrics.JSHeapUsedSize ?? 0,
+        },
+    };
+}
+
+function printAnalysis(initial, finalIdle, analysis) {
+    console.log(`Dashboard DOM pressure initial: ${JSON.stringify(initial)}`);
+    console.log(`Dashboard DOM pressure post-idle GC: ${JSON.stringify(finalIdle)}`);
+    console.log(`Dashboard DOM pressure summary: ${JSON.stringify(analysis.summary)}`);
+    for (const warning of analysis.warnings) {
+        console.warn(`WARNING: ${warning}`);
+    }
+}
+
+function checkStable(records, field, label, tolerance, failures) {
+    if (records.length === 0) return;
+    const values = records.map((record) => record[field]);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const first = values[0];
+    const last = values.at(-1);
+    if (max - min > tolerance || last - first > tolerance) {
+        failures.push(`${label} grew or failed to stabilize: first=${first}, last=${last}, min=${min}, max=${max}, tolerance=${tolerance}`);
+    }
+}
+
+function average(values) {
+    if (values.length === 0) return 0;
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function drift(values) {
+    if (values.length === 0) return 0;
+    return Math.max(...values) - Math.min(...values);
+}
+
+function sumBy(values, pick) {
+    return values.reduce((sum, value) => sum + pick(value), 0);
+}
+
+function round(value) {
+    return Math.round(value * 100) / 100;
+}
+
+function killProcessGroup(child) {
+    try {
+        process.kill(-child.pid, "SIGTERM");
+        return;
+    } catch {}
+    try {
+        child.kill("SIGTERM");
+    } catch {}
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolveSocket, rejectSocket) => {
+        socket.addEventListener("open", resolveSocket, { once: true });
+        socket.addEventListener("error", rejectSocket, { once: true });
+    });
+
+    let nextID = 1;
+    const pending = new Map();
+    const listeners = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (message.id && pending.has(message.id)) {
+            const request = pending.get(message.id);
+            pending.delete(message.id);
+            if (message.error) {
+                request.reject(new Error(message.error.message));
+            } else {
+                request.resolve(message.result || {});
+            }
+            return;
+        }
+        const callbacks = listeners.get(message.method);
+        if (!callbacks) return;
+        for (const callback of callbacks) callback(message.params || {});
+    });
+
+    const call = (method, params = {}) =>
+        new Promise((resolveCall, rejectCall) => {
+            const id = nextID++;
+            pending.set(id, { resolve: resolveCall, reject: rejectCall });
+            socket.send(JSON.stringify({ id, method, params }));
+        });
+
+    return {
+        call,
+        close: () => socket.close(),
+        on: (method, callback) => {
+            if (!listeners.has(method)) listeners.set(method, new Set());
+            listeners.get(method).add(callback);
+            return () => listeners.get(method)?.delete(callback);
+        },
+        evaluate: async (expression) => {
+            const result = await call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+    };
+}
+
+function wait(duration) {
+    return new Promise((resolveWait) => setTimeout(resolveWait, duration));
+}


### PR DESCRIPTION
## Summary

Adds a dashboard DOM pressure audit script.

## Findings

- Open -> All mounts ~228 rows
- Creates ~6,156 DOM nodes
- Adds/removes ~456 listeners
- Average transition time ~140 ms
- Live DOM node count stabilizes
- Listener net count stabilizes
- No live DOM/listener leak confirmed
- DevTools Nodes growth appears to be detached/GC/accounting signal

## Next

Use this audit as baseline for virtualized table/list work.