### PR TITLE
MVP 16: context selectors

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -49,10 +49,13 @@ jobs:
           goxc package ./examples/todo --compiler=tinygo
           goxc generate ./examples/dashboard
           goxc package ./examples/dashboard --compiler=tinygo
+          goxc generate ./examples/context
+          goxc package ./examples/context --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/dashboard --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/context --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - `UseReducer` state dispatch that applies actions to the latest component
   state slot, used by the dashboard to remove the `DataVersion` memoization
   workaround.
+- Scoped context selectors with nearest-provider lookup, comparable selector
+  dirtying, and a focused context example plus browser smoke coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ goxc size ./examples/dashboard
 goxc serve ./examples/dashboard --port=8080
 ```
 
+The context example demonstrates scoped providers and selector consumers:
+
+```bash
+goxc package ./examples/context --compiler=tinygo
+goxc serve ./examples/context --port=8080
+```
+
 ## GOX component model
 
 Lowercase tags create HTML elements:
@@ -223,6 +230,23 @@ to the component instance currently rendering. State `Set` calls mark that
 owner dirty and are coalesced into one browser animation-frame update.
 `gf.UseReducer` uses the same slots, but dispatch reads the latest slot state
 at event time before applying a pure reducer action.
+
+Context is scoped by the component tree. Use selectors for performance-sensitive
+consumers:
+
+```go
+var PreferencesContext = gf.CreateContext(Preferences{})
+
+gf.ProvideContext(PreferencesContext, preferences)
+
+density := gf.UseContextSelector(PreferencesContext, func(value Preferences) string {
+    return value.Density
+})
+```
+
+`UseContext` returns the whole nearest value and subscribes broadly. Prefer
+`UseContextSelector` when only a comparable field should trigger a rerender.
+See [context selectors](docs/context.md).
 
 MVP 9 adds minimal lifecycle hooks for component-owned side effects. MVP 10
 cleans up the public effect API:
@@ -559,8 +583,9 @@ required.
 - One mounted app and one browser thread. State is component-scoped and
   positional within each component, so state/effect hook order must remain
   stable.
-- Lifecycle/effects are minimal; no context, error boundaries, async effects,
-  dependency inference, or priorities.
+- Lifecycle/effects are minimal; context is scoped and selector-based, but
+  there are no error boundaries, async effects, dependency inference, or
+  priorities.
 - Memoization is explicit and opt-in today:
   components can implement `MemoEqual` on their props type to skip renders when
   prop shapes are unchanged and the component is otherwise clean.
@@ -580,6 +605,7 @@ required.
 - [GOX language and component model](docs/gox-language.md)
 - [Runtime model](docs/runtime-model.md)
 - [Lifecycle and effects](docs/effects.md)
+- [Context selectors](docs/context.md)
 - [VS Code GOX extension](extensions/vscode-gox/README.md)
 - [Future GoFrame Player vision](docs/player-vision.md)
 - [Counter example](examples/counter/README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,7 @@ counter bundle.wasm     77,890 bytes
 components bundle.wasm  83,159 bytes
 todo bundle.wasm        109,483 bytes
 dashboard bundle.wasm   146,832 bytes
+context bundle.wasm     106,631 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -181,7 +182,7 @@ than Counter because it also demonstrates compact localStorage persistence.
 
 The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
-dashboard-sized pressure-test example.
+dashboard-sized pressure-test example and the context selector example.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.
@@ -217,6 +218,7 @@ The MVP runtime currently has:
 - component instances identified by name, key, and sibling position;
 - component-scoped positional state slots, including the root `App`;
 - reducer dispatch that applies actions to the latest component state slot;
+- scoped context providers with selector-based consumer dirtying;
 - component-scoped lifecycle/effect slots;
 - dirty component updates coalesced into one animation-frame flush;
 - direct dirty-owner subtree updates without root traversal;
@@ -245,8 +247,10 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 
 - Minimal reconciliation only; no Fiber, concurrent rendering, or priorities.
 - Component state slots are positional and require stable call order.
-- Lifecycle/effects are minimal; there is no Fiber scheduler, context, or
-  error-boundary model.
+- Lifecycle/effects are minimal; there is no Fiber scheduler or error-boundary
+  model.
+- Context is scoped and selector-based, but has no async/server bridge or
+  custom non-comparable selector equality.
 - No automatic props memoization; descendants rerender with their parent unless
   components explicitly implement `MemoEqual` on their props and the framework can
   perform a deterministic memoized bailout.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,8 +27,8 @@ It checks:
 and manually through `workflow_dispatch`.
 
 It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
-counter, components, todo, and dashboard examples with TinyGo. It also runs a
-release-style package pass with `--asset-hash --preload --compress=gzip,br`
+counter, components, todo, dashboard, and context examples with TinyGo. It also
+runs a release-style package pass with `--asset-hash --preload --compress=gzip,br`
 before checking:
 
 ```bash
@@ -56,7 +56,8 @@ scripts/browser-smoke.sh
 The smoke script chooses dynamic ports, verifies the expected app origin before
 storage cleanup, checks WASM MIME type, and separates harness failures from app
 failures. It currently covers Todo reconciliation, duplicate-key debug
-diagnostics, and dashboard-sized filtering/sorting/selection behavior.
+diagnostics, dashboard-sized filtering/sorting/selection behavior, and context
+selector rerender isolation.
 
 ### VS Code Extension
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -87,6 +87,12 @@ Consumers under nested providers subscribe to the inner provider, not the outer
 provider. Unmounted consumers unsubscribe, and unmounted providers detach their
 subscribers.
 
+Provider topology changes are observable. If a provider appears above an
+existing consumer, disappears, or a nearer nested provider appears between an
+outer provider and a consumer, affected consumers are marked dirty and resubscribe
+to the new nearest provider on their next render. This happens even when a
+selector's comparable result is equal, because the provider scope itself changed.
+
 ## Memoization Interaction
 
 Context selectors are designed to work with explicit `MemoEqual` bailouts.
@@ -94,6 +100,11 @@ Context selectors are designed to work with explicit `MemoEqual` bailouts.
 If a parent/provider rerenders, clean memoized descendants may skip. A context
 consumer whose selected value changed is marked dirty, so memoized ancestors
 above it cannot skip over the update.
+
+Memoized ancestors also cannot hide context topology changes. When a provider
+appears, is removed, or a nearer nested provider takes over, the runtime marks
+affected consumers dirty and updates dirty descendant accounting through any
+memoized wrappers above them.
 
 This means selector consumers should usually be component boundaries, and clean
 structural wrappers can use explicit `MemoEqual` where useful.

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,0 +1,127 @@
+# Context Selectors
+
+MVP 16 adds scoped context with selector-based consumption. It is not a global
+store, router context, Redux clone, or deep comparison system.
+
+## API
+
+```go
+type Context[T any]
+
+func CreateContext[T any](defaultValue T) *Context[T]
+func ProvideContext[T any](ctx *Context[T], value T)
+func UseContext[T any](ctx *Context[T]) T
+func UseContextSelector[T any, S comparable](
+    ctx *Context[T],
+    selector func(T) S,
+) S
+```
+
+## Provider Hook
+
+Providers are ordinary components that call `ProvideContext` during render:
+
+```go
+var PreferencesContext = gf.CreateContext(defaultPreferences())
+
+func PreferencesProvider(props PreferencesProviderProps) gf.Node {
+    preferences, dispatch := gf.UseReducer(defaultPreferences(), reducePreferences)
+
+    gf.ProvideContext(PreferencesContext, preferences)
+
+    return (
+        <section>
+            <PreferencesControls Dispatch={dispatch} />
+            {props.Children}
+        </section>
+    )
+}
+```
+
+This avoids a new GOX provider syntax. Scope follows the mounted component tree
+through parent links. Descendant consumers read the nearest provider. Nested
+providers override outer providers for their own descendants.
+
+`ProvideContext` must be called during component render. Calling it outside
+render panics with a focused message.
+
+## Selectors
+
+Use selectors when a consumer only needs one comparable part of the context:
+
+```go
+density := gf.UseContextSelector(PreferencesContext, func(value Preferences) string {
+    return value.Density
+})
+```
+
+The selector result type `S` must be `comparable`. The runtime compares the
+previous selected value and the next selected value with `==`. It does not use
+reflection, `unsafe`, or deep equality.
+
+Selectors should be deterministic and side-effect-free. They may close over
+stable values, but they should not mutate state or depend on changing external
+state.
+
+## Broad Consumers
+
+`UseContext(ctx)` returns the full nearest value. Because the runtime cannot
+compare arbitrary `T` without reflection or a user-provided equality function,
+`UseContext` subscribes broadly. Provider updates rerender broad consumers.
+
+Use it for low-frequency or simple consumers. Prefer `UseContextSelector` for
+components on hot update paths.
+
+## Update Mechanics
+
+Each provider component stores its current context values. Each consumer stores
+its context subscriptions in positional context slots. When a provider updates:
+
+1. The provider value is updated during provider render.
+2. Selector subscribers under that provider recompute their selected value.
+3. Only subscribers whose selected value changed are marked dirty.
+4. Dirty descendant accounting prevents memoized ancestors from hiding those
+   consumer updates.
+
+Consumers under nested providers subscribe to the inner provider, not the outer
+provider. Unmounted consumers unsubscribe, and unmounted providers detach their
+subscribers.
+
+## Memoization Interaction
+
+Context selectors are designed to work with explicit `MemoEqual` bailouts.
+
+If a parent/provider rerenders, clean memoized descendants may skip. A context
+consumer whose selected value changed is marked dirty, so memoized ancestors
+above it cannot skip over the update.
+
+This means selector consumers should usually be component boundaries, and clean
+structural wrappers can use explicit `MemoEqual` where useful.
+
+## Example
+
+`examples/context` demonstrates:
+
+- scoped provider hook;
+- density, accent, and counter selector consumers;
+- a broad `UseContext` consumer;
+- nested provider override;
+- memoized static leaves;
+- browser smoke assertions that only the selected consumer rerenders.
+
+Run it locally:
+
+```bash
+goxc package ./examples/context --compiler=tinygo
+goxc serve ./examples/context --port=8080
+```
+
+## Limitations
+
+- Selector results must be comparable.
+- There is no custom equality function for non-comparable selections yet.
+- Context is synchronous and render-time only.
+- No server context, async context, or context devtools.
+- Context is not a global store; provider scope is the component tree.
+- Context selectors do not replace reducer dispatch, explicit memoization,
+  virtualization, or future router design.

--- a/docs/foundation-audit.md
+++ b/docs/foundation-audit.md
@@ -312,8 +312,9 @@ Remaining safety risks:
 - Component identity does not include Go function identity.
 - State and lifecycle slots are positional and do not support conditional hook
   ordering.
-- Lifecycle/effects are intentionally minimal: no context, error boundaries,
-  async effects, or priorities.
+- Lifecycle/effects are intentionally minimal. Context is scoped and
+  selector-based, but there are still no error boundaries, async effects, or
+  priorities.
 - Memoization is explicit and opt-in via `MemoEqual` on props. Automatic
   memoization is intentionally avoided to keep runtime behavior predictable.
 - GOX parser remains a focused parser, not a full Go-aware frontend.

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -57,7 +57,8 @@ other compared prop tracks that data.
 - No automatic memoization for all components.
 - No reflection-based comparison.
 - No `unsafe`, no generated equality wrappers, no deep auto-compare.
-- No context/selectors as part of memoization strategy.
+- Context selectors can mark memoized descendants dirty when their selected
+  value changes, but memoization still requires explicit props `MemoEqual`.
 - No stable event callback hook yet; reducer dispatch covers state transitions
   that can be represented as pure actions.
 - No virtualization or router/Player integration in this stage.

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -50,6 +50,7 @@ component instance
   -> component name and optional key
   -> latest props
   -> component-scoped state slots
+  -> context provider values and selector subscriptions
   -> dirty flag
   -> mounted child subtree
 ```
@@ -109,6 +110,41 @@ time. This means an old event handler retained by a memoized child can still
 apply an action to current state rather than to a value captured during an
 older render. Reducers should be pure state transitions; they should not depend
 on mutable render-local captures unless that coupling is intentional.
+
+## Scoped context selectors
+
+Context values are scoped by component parent links:
+
+```go
+ctx := gf.CreateContext(defaultValue)
+
+gf.ProvideContext(ctx, value)
+selected := gf.UseContextSelector(ctx, func(value T) S {
+	return value.Field
+})
+```
+
+`ProvideContext` is a render-time hook on a normal component. It stores a typed
+value on that provider component instance for descendants. The nearest provider
+wins, and nested providers isolate their subscribers from outer provider
+updates.
+
+`UseContextSelector` stores a selector subscription in positional context slots.
+The selected result type must be `comparable`; the runtime uses `==` to decide
+whether the consumer should be marked dirty. There is no reflection, deep
+equality, or generated selector equality.
+
+`UseContext` returns the full nearest value and subscribes broadly. Since the
+runtime cannot compare arbitrary context values without reflection, broad
+consumers rerender on provider updates. Performance-sensitive code should use
+selectors.
+
+When a provider updates, selector consumers are checked immediately. Consumers
+whose selected value changed are marked dirty, and dirty-descendant accounting
+prevents memoized ancestors from skipping over those updates. Unmounted
+consumers unsubscribe, and unmounted providers detach their subscriber set.
+
+See [context selectors](context.md) for API guidance and limitations.
 
 ## Dirty subtree updates
 
@@ -292,7 +328,9 @@ The dependency-free headless Chrome probe verifies:
 - one mounted application and one browser thread;
 - positional state and lifecycle slots require stable hook call order;
 - lifecycle/effects are minimal and have no priorities or async scheduler;
-- no context or error boundaries;
+- context is scoped and selector-based, but has no async/server bridge or
+  custom non-comparable selector equality;
+- no error boundaries;
 - component identity uses the declared component name, not Go function identity;
 - explicit opt-in props memoization via `MemoEqual`; components still rerender
   by default when props are not memoized.

--- a/examples/context/README.md
+++ b/examples/context/README.md
@@ -1,0 +1,37 @@
+# Context Selectors Example
+
+This example demonstrates the scoped context API added for MVP 16.
+
+It is intentionally small. The dashboard remains the larger reducer and
+memoization pressure test; this app focuses on context semantics:
+
+- `gf.CreateContext` for a typed default value;
+- `gf.ProvideContext` as a render-time provider hook;
+- `gf.UseContextSelector` for comparable selected values;
+- `gf.UseContext` as a broad consumer;
+- nested providers;
+- memoized leaf components so clean selector consumers can bail out.
+
+## Run
+
+```bash
+goxc package ./examples/context --compiler=tinygo
+goxc serve ./examples/context --port=8080
+```
+
+For a cache-safe package:
+
+```bash
+goxc package ./examples/context --compiler=tinygo --asset-hash --preload --compress=gzip,br
+```
+
+## What To Check
+
+Changing density should rerender the density selector consumer, not the accent
+or counter consumers. Changing accent should rerender the accent selector
+consumer. Incrementing the counter should rerender the counter selector
+consumer. The broad `UseContext` consumer rerenders on provider updates by
+design.
+
+This is not a global store. Context is scoped by the component tree and nearest
+provider wins.

--- a/examples/context/app.gox
+++ b/examples/context/app.gox
@@ -1,0 +1,227 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+var preferencesContext = gf.CreateContext(defaultPreferences())
+
+type AppProps struct{}
+
+func App() gf.Node {
+	return (
+		<main class="context-page">
+			<header class="context-header" data-testid="context-header">
+				<p class="eyebrow">GoFrame context selectors</p>
+				<h1>Scoped context with selector consumers</h1>
+				<p>Each consumer subscribes to one comparable field.</p>
+			</header>
+			<PreferencesProvider>
+				<ConsumerGrid>
+					<DensityConsumer />
+					<AccentConsumer />
+					<CounterConsumer />
+					<BroadConsumer />
+					<StaticPanel />
+					<NestedAccentProvider />
+				</ConsumerGrid>
+			</PreferencesProvider>
+		</main>
+	)
+}
+
+type PreferencesProviderProps struct {
+	Children []gf.Node
+}
+
+func PreferencesProvider(props PreferencesProviderProps) gf.Node {
+	preferences, dispatch := gf.UseReducer(defaultPreferences(), reducePreferences)
+	gf.ProvideContext(preferencesContext, preferences)
+
+	return (
+		<section class={"preferences-provider density-" + preferences.Density + " accent-" + preferences.Accent} data-testid="preferences-provider">
+			<PreferencesControls Preferences={preferences} Dispatch={dispatch} />
+			{props.Children}
+		</section>
+	)
+}
+
+type PreferencesControlsProps struct {
+	Preferences Preferences
+	Dispatch    func(PreferenceAction)
+}
+
+func PreferencesControls(props PreferencesControlsProps) gf.Node {
+	setDensity := func(value string) {
+		props.Dispatch(PreferenceAction{Kind: PreferenceActionDensity, Value: value})
+	}
+	setAccent := func(value string) {
+		props.Dispatch(PreferenceAction{Kind: PreferenceActionAccent, Value: value})
+	}
+	increment := func() {
+		props.Dispatch(PreferenceAction{Kind: PreferenceActionIncrement})
+	}
+	reset := func() {
+		props.Dispatch(PreferenceAction{Kind: PreferenceActionReset})
+	}
+
+	return (
+		<section class="controls" data-testid="preferences-controls">
+			<label>
+				Density
+				<select id="density-select" value={props.Preferences.Density} OnChange={func(event gf.InputEvent) {
+					setDensity(event.Value())
+				}}>
+					<option value={DensityComfortable}>comfortable</option>
+					<option value={DensityCompact}>compact</option>
+				</select>
+			</label>
+			<label>
+				Accent
+				<select id="accent-select" value={props.Preferences.Accent} OnChange={func(event gf.InputEvent) {
+					setAccent(event.Value())
+				}}>
+					<option value={AccentBlue}>blue</option>
+					<option value={AccentGreen}>green</option>
+					<option value={AccentPurple}>purple</option>
+				</select>
+			</label>
+			<button Type="button" id="increment-counter" OnClick={increment}>Increment counter</button>
+			<button Type="button" id="reset-preferences" OnClick={reset}>Reset</button>
+		</section>
+	)
+}
+
+type ConsumerGridProps struct {
+	Children []gf.Node
+}
+
+func (props ConsumerGridProps) MemoEqual(next ConsumerGridProps) bool {
+	return true
+}
+
+func ConsumerGrid(props ConsumerGridProps) gf.Node {
+	return (
+		<section class="consumer-grid" data-testid="consumer-grid">
+			{props.Children}
+		</section>
+	)
+}
+
+type DensityConsumerProps struct{}
+
+func (props DensityConsumerProps) MemoEqual(next DensityConsumerProps) bool {
+	return true
+}
+
+func DensityConsumer(props DensityConsumerProps) gf.Node {
+	density := gf.UseContextSelector(preferencesContext, func(value Preferences) string {
+		return value.Density
+	})
+	return (
+		<article class="consumer-card" data-testid="density-consumer" data-value={density}>
+			<span>Density</span>
+			<strong>{density}</strong>
+		</article>
+	)
+}
+
+type AccentConsumerProps struct{}
+
+func (props AccentConsumerProps) MemoEqual(next AccentConsumerProps) bool {
+	return true
+}
+
+func AccentConsumer(props AccentConsumerProps) gf.Node {
+	accent := gf.UseContextSelector(preferencesContext, func(value Preferences) string {
+		return value.Accent
+	})
+	return (
+		<article class="consumer-card" data-testid="accent-consumer" data-value={accent}>
+			<span>Accent</span>
+			<strong>{accent}</strong>
+		</article>
+	)
+}
+
+type CounterConsumerProps struct{}
+
+func (props CounterConsumerProps) MemoEqual(next CounterConsumerProps) bool {
+	return true
+}
+
+func CounterConsumer(props CounterConsumerProps) gf.Node {
+	count := gf.UseContextSelector(preferencesContext, func(value Preferences) int {
+		return value.Count
+	})
+	return (
+		<article class="consumer-card" data-testid="counter-consumer" data-value={count}>
+			<span>Counter</span>
+			<strong>{count}</strong>
+		</article>
+	)
+}
+
+type BroadConsumerProps struct{}
+
+func (props BroadConsumerProps) MemoEqual(next BroadConsumerProps) bool {
+	return true
+}
+
+func BroadConsumer(props BroadConsumerProps) gf.Node {
+	preferences := gf.UseContext(preferencesContext)
+	return (
+		<article class="consumer-card broad" data-testid="broad-consumer">
+			<span>Broad consumer</span>
+			<strong>{preferences.Density} / {preferences.Accent} / {preferences.Count}</strong>
+		</article>
+	)
+}
+
+type StaticPanelProps struct{}
+
+func (props StaticPanelProps) MemoEqual(next StaticPanelProps) bool {
+	return true
+}
+
+func StaticPanel(props StaticPanelProps) gf.Node {
+	return (
+		<article class="consumer-card static" data-testid="static-panel">
+			<span>Static panel</span>
+			<strong>unchanged</strong>
+		</article>
+	)
+}
+
+type NestedAccentProviderProps struct{}
+
+func (props NestedAccentProviderProps) MemoEqual(next NestedAccentProviderProps) bool {
+	return true
+}
+
+func NestedAccentProvider(props NestedAccentProviderProps) gf.Node {
+	outer := gf.UseContext(preferencesContext)
+	inner := outer
+	inner.Accent = AccentPurple
+	gf.ProvideContext(preferencesContext, inner)
+
+	return (
+		<article class="consumer-card nested" data-testid="nested-provider">
+			<span>Nested provider</span>
+			<InnerAccentConsumer />
+		</article>
+	)
+}
+
+type InnerAccentConsumerProps struct{}
+
+func (props InnerAccentConsumerProps) MemoEqual(next InnerAccentConsumerProps) bool {
+	return true
+}
+
+func InnerAccentConsumer(props InnerAccentConsumerProps) gf.Node {
+	accent := gf.UseContextSelector(preferencesContext, func(value Preferences) string {
+		return value.Accent
+	})
+	return (
+		<strong data-testid="inner-accent-consumer" data-value={accent}>{accent}</strong>
+	)
+}

--- a/examples/context/goframe.json
+++ b/examples/context/goframe.json
@@ -1,0 +1,11 @@
+{
+  "name": "context",
+  "entry": ".",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css"
+  ]
+}

--- a/examples/context/index.html
+++ b/examples/context/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>goframe context selectors</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <script>
+        window.goframeComponentRenderCounts = {};
+        window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
+        window.goframeComponentRenderProbe = (name) => {
+            window.goframeComponentRenderCounts[name] =
+                (window.goframeComponentRenderCounts[name] || 0) + 1;
+        };
+        window.goframeComponentPatchProbe = (name) => {
+            window.goframeComponentPatchCounts[name] =
+                (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
+        };
+    </script>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance))
+            .catch((error) => {
+                console.error("[goframe] startup failed", error);
+                document.getElementById("root").textContent = "Failed to start goframe. See console.";
+            });
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/context/model.go
+++ b/examples/context/model.go
@@ -1,0 +1,52 @@
+package main
+
+type Preferences struct {
+	Density string
+	Accent  string
+	Count   int
+}
+
+const (
+	DensityComfortable = "comfortable"
+	DensityCompact     = "compact"
+
+	AccentBlue   = "blue"
+	AccentGreen  = "green"
+	AccentPurple = "purple"
+)
+
+type PreferenceActionKind int
+
+const (
+	PreferenceActionDensity PreferenceActionKind = iota
+	PreferenceActionAccent
+	PreferenceActionIncrement
+	PreferenceActionReset
+)
+
+type PreferenceAction struct {
+	Kind  PreferenceActionKind
+	Value string
+}
+
+func defaultPreferences() Preferences {
+	return Preferences{
+		Density: DensityComfortable,
+		Accent:  AccentBlue,
+		Count:   0,
+	}
+}
+
+func reducePreferences(state Preferences, action PreferenceAction) Preferences {
+	switch action.Kind {
+	case PreferenceActionDensity:
+		state.Density = action.Value
+	case PreferenceActionAccent:
+		state.Accent = action.Value
+	case PreferenceActionIncrement:
+		state.Count++
+	case PreferenceActionReset:
+		return defaultPreferences()
+	}
+	return state
+}

--- a/examples/context/styles.css
+++ b/examples/context/styles.css
@@ -1,0 +1,107 @@
+:root {
+    color-scheme: light;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #f6f7fb;
+    color: #172033;
+}
+
+button,
+select {
+    font: inherit;
+}
+
+.context-page {
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 32px;
+}
+
+.context-header {
+    margin-bottom: 24px;
+}
+
+.eyebrow {
+    margin: 0 0 8px;
+    color: #52627a;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.preferences-provider {
+    border: 1px solid #d9dfec;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 16px 40px rgba(23, 32, 51, 0.08);
+    padding: 20px;
+}
+
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: end;
+    margin-bottom: 20px;
+}
+
+.controls label {
+    display: grid;
+    gap: 4px;
+    color: #52627a;
+    font-size: 0.85rem;
+}
+
+.controls select,
+.controls button {
+    border: 1px solid #c9d2e3;
+    border-radius: 10px;
+    background: #fff;
+    color: #172033;
+    padding: 8px 10px;
+}
+
+.controls button {
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.consumer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 14px;
+}
+
+.consumer-card {
+    border: 1px solid #e1e6f0;
+    border-radius: 14px;
+    background: #fbfcff;
+    padding: 16px;
+}
+
+.consumer-card span {
+    display: block;
+    margin-bottom: 8px;
+    color: #52627a;
+    font-size: 0.82rem;
+}
+
+.consumer-card strong {
+    font-size: 1.1rem;
+}
+
+.accent-green .consumer-card {
+    border-color: #b9dfcc;
+}
+
+.accent-purple .consumer-card {
+    border-color: #d3c5f2;
+}
+
+.density-compact .consumer-card {
+    padding: 10px;
+}

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -67,6 +67,10 @@ type componentInstance struct {
 	effectIndex      int
 	unmountSlots     []*unmountSlot
 	unmountIndex     int
+	contextSlots     []*contextSubscription
+	contextIndex     int
+	contextProviders map[int]*contextProvider
+	providedContexts []int
 	dirty            bool
 	dirtyCounted     bool
 	dirtyDescendants int
@@ -109,6 +113,8 @@ func renderComponentInstance(instance *componentInstance) Node {
 	instance.stateIndex = 0
 	instance.effectIndex = 0
 	instance.unmountIndex = 0
+	instance.contextIndex = 0
+	instance.providedContexts = instance.providedContexts[:0]
 	clearComponentDirty(instance)
 	defer func() {
 		currentComponent = previous
@@ -116,6 +122,7 @@ func renderComponentInstance(instance *componentInstance) Node {
 
 	reportComponentRender(instance.name)
 	node := instance.node.render()
+	finishComponentContextRender(instance)
 	return Child(node)
 }
 
@@ -199,6 +206,8 @@ func deactivateComponent(instance *componentInstance) {
 	} else {
 		instance.active = false
 	}
+	releaseContextSubscriptions(instance)
+	releaseContextProviders(instance)
 	clearComponentDirty(instance)
 	instance.dirtyDescendants = 0
 	instance.parent = nil
@@ -206,4 +215,7 @@ func deactivateComponent(instance *componentInstance) {
 	instance.stateSlots = nil
 	instance.effectSlots = nil
 	instance.unmountSlots = nil
+	instance.contextSlots = nil
+	instance.contextProviders = nil
+	instance.providedContexts = nil
 }

--- a/pkg/goframe/context.go
+++ b/pkg/goframe/context.go
@@ -2,6 +2,11 @@ package goframe
 
 var nextContextID int
 
+// contextSubscriptionsByID lets provider appearance/removal recompute nearest
+// provider topology for consumers that were previously subscribed to default or
+// to an outer provider. Ordinary provider value updates use provider.subscribers.
+var contextSubscriptionsByID map[int]map[*contextSubscription]bool
+
 // Context carries a typed value through a scoped component subtree.
 type Context[T any] struct {
 	id           int
@@ -42,9 +47,13 @@ func ProvideContext[T any](ctx *Context[T], value T) {
 		panic("goframe: ProvideContext requires a context")
 	}
 	instance := requireCurrentComponent("ProvideContext")
-	provider := ensureContextProvider(instance, ctx.id, value)
+	provider, created := ensureContextProvider(instance, ctx.id, value)
 	provider.value = value
 	recordProvidedContext(instance, ctx.id)
+	if created {
+		refreshContextTopology(ctx.id)
+		return
+	}
 	notifyContextSubscribers(provider, value)
 }
 
@@ -96,7 +105,7 @@ func UseContextSelector[T any, S comparable](ctx *Context[T], selector func(T) S
 	return selected
 }
 
-func ensureContextProvider[T any](instance *componentInstance, contextID int, value T) *contextProvider {
+func ensureContextProvider[T any](instance *componentInstance, contextID int, value T) (*contextProvider, bool) {
 	if instance.contextProviders == nil {
 		instance.contextProviders = make(map[int]*contextProvider)
 	}
@@ -109,8 +118,9 @@ func ensureContextProvider[T any](instance *componentInstance, contextID int, va
 			subscribers: make(map[*contextSubscription]bool),
 		}
 		instance.contextProviders[contextID] = provider
+		return provider, true
 	}
-	return provider
+	return provider, false
 }
 
 func recordProvidedContext(instance *componentInstance, contextID int) {
@@ -129,7 +139,7 @@ func finishComponentContextRender(instance *componentInstance) {
 
 func releaseUnusedContextSubscriptions(instance *componentInstance) {
 	for index := instance.contextIndex; index < len(instance.contextSlots); index++ {
-		unsubscribeContext(instance.contextSlots[index])
+		releaseContextSubscription(instance.contextSlots[index])
 		instance.contextSlots[index] = nil
 	}
 	instance.contextSlots = instance.contextSlots[:instance.contextIndex]
@@ -190,6 +200,7 @@ func subscribeContext(
 			update:       update,
 		}
 		instance.contextSlots = append(instance.contextSlots, slot)
+		registerContextSubscription(slot)
 		setContextSubscriptionProvider(slot, provider)
 		return
 	}
@@ -205,6 +216,36 @@ func subscribeContext(
 	slot.defaultValue = defaultValue
 	slot.update = update
 	setContextSubscriptionProvider(slot, provider)
+}
+
+func registerContextSubscription(slot *contextSubscription) {
+	if slot == nil {
+		return
+	}
+	if contextSubscriptionsByID == nil {
+		contextSubscriptionsByID = make(map[int]map[*contextSubscription]bool)
+	}
+	slots := contextSubscriptionsByID[slot.contextID]
+	if slots == nil {
+		slots = make(map[*contextSubscription]bool)
+		contextSubscriptionsByID[slot.contextID] = slots
+	}
+	slots[slot] = true
+}
+
+func releaseContextSubscription(slot *contextSubscription) {
+	if slot == nil {
+		return
+	}
+	unsubscribeContext(slot)
+	if contextSubscriptionsByID == nil {
+		return
+	}
+	slots := contextSubscriptionsByID[slot.contextID]
+	delete(slots, slot)
+	if len(slots) == 0 {
+		delete(contextSubscriptionsByID, slot.contextID)
+	}
 }
 
 func setContextSubscriptionProvider(slot *contextSubscription, provider *contextProvider) {
@@ -233,7 +274,7 @@ func unsubscribeContext(slot *contextSubscription) {
 func notifyContextSubscribers(provider *contextProvider, value any) {
 	for slot := range provider.subscribers {
 		if slot == nil || slot.owner == nil || !slot.owner.active {
-			delete(provider.subscribers, slot)
+			releaseContextSubscription(slot)
 			continue
 		}
 		if slot.update(slot, value) {
@@ -243,21 +284,46 @@ func notifyContextSubscribers(provider *contextProvider, value any) {
 }
 
 func removeContextProvider(provider *contextProvider) {
-	for slot := range provider.subscribers {
-		if slot == nil {
-			continue
-		}
-		delete(provider.subscribers, slot)
-		slot.provider = nil
-		if slot.owner != nil && slot.owner.active && slot.update(slot, slot.defaultValue) {
-			markComponentDirty(slot.owner)
-		}
+	if provider == nil {
+		return
 	}
+	if provider.owner != nil && provider.owner.contextProviders != nil {
+		delete(provider.owner.contextProviders, provider.id)
+	}
+	refreshContextTopology(provider.id)
+}
+
+func refreshContextTopology(contextID int) {
+	if contextSubscriptionsByID == nil {
+		return
+	}
+	for slot := range contextSubscriptionsByID[contextID] {
+		refreshContextSubscription(slot)
+	}
+}
+
+func refreshContextSubscription(slot *contextSubscription) {
+	if slot == nil || slot.owner == nil || !slot.owner.active {
+		releaseContextSubscription(slot)
+		return
+	}
+	provider := findContextProvider(slot.owner.parent, slot.contextID)
+	if provider == slot.provider {
+		return
+	}
+
+	value := slot.defaultValue
+	if provider != nil {
+		value = provider.value
+	}
+	slot.update(slot, value)
+	setContextSubscriptionProvider(slot, provider)
+	markComponentDirty(slot.owner)
 }
 
 func releaseContextSubscriptions(instance *componentInstance) {
 	for _, slot := range instance.contextSlots {
-		unsubscribeContext(slot)
+		releaseContextSubscription(slot)
 	}
 }
 

--- a/pkg/goframe/context.go
+++ b/pkg/goframe/context.go
@@ -1,0 +1,268 @@
+package goframe
+
+var nextContextID int
+
+// Context carries a typed value through a scoped component subtree.
+type Context[T any] struct {
+	id           int
+	defaultValue T
+}
+
+// CreateContext creates a typed context with a default value used when no
+// provider exists above the current component.
+func CreateContext[T any](defaultValue T) *Context[T] {
+	nextContextID++
+	return &Context[T]{
+		id:           nextContextID,
+		defaultValue: defaultValue,
+	}
+}
+
+type contextProvider struct {
+	id          int
+	owner       *componentInstance
+	value       any
+	subscribers map[*contextSubscription]bool
+}
+
+type contextSubscription struct {
+	owner        *componentInstance
+	provider     *contextProvider
+	contextID    int
+	kind         string
+	selected     any
+	defaultValue any
+	update       func(*contextSubscription, any) bool
+}
+
+// ProvideContext provides value for descendant components of the current
+// component. It must be called during component render.
+func ProvideContext[T any](ctx *Context[T], value T) {
+	if ctx == nil {
+		panic("goframe: ProvideContext requires a context")
+	}
+	instance := requireCurrentComponent("ProvideContext")
+	provider := ensureContextProvider(instance, ctx.id, value)
+	provider.value = value
+	recordProvidedContext(instance, ctx.id)
+	notifyContextSubscribers(provider, value)
+}
+
+// UseContext returns the nearest provider value, or the context default when
+// no provider exists. It subscribes broadly; performance-sensitive consumers
+// should prefer UseContextSelector.
+func UseContext[T any](ctx *Context[T]) T {
+	if ctx == nil {
+		panic("goframe: UseContext requires a context")
+	}
+	instance := requireCurrentComponent("UseContext")
+	provider := findContextProvider(instance.parent, ctx.id)
+	value := ctx.defaultValue
+	if provider != nil {
+		value = provider.value.(T)
+	}
+	subscribeContext(instance, ctx.id, "UseContext", provider, value, ctx.defaultValue, func(slot *contextSubscription, raw any) bool {
+		slot.selected = raw
+		return true
+	})
+	return value
+}
+
+// UseContextSelector returns selector(nearest value). S must be comparable so
+// the runtime can dirty this consumer only when the selected value changes.
+func UseContextSelector[T any, S comparable](ctx *Context[T], selector func(T) S) S {
+	if ctx == nil {
+		panic("goframe: UseContextSelector requires a context")
+	}
+	if selector == nil {
+		panic("goframe: UseContextSelector requires a selector")
+	}
+	instance := requireCurrentComponent("UseContextSelector")
+	provider := findContextProvider(instance.parent, ctx.id)
+	value := ctx.defaultValue
+	if provider != nil {
+		value = provider.value.(T)
+	}
+	selected := selector(value)
+	subscribeContext(instance, ctx.id, "UseContextSelector", provider, selected, ctx.defaultValue, func(slot *contextSubscription, raw any) bool {
+		next := selector(raw.(T))
+		previous, ok := slot.selected.(S)
+		if ok && previous == next {
+			return false
+		}
+		slot.selected = next
+		return true
+	})
+	return selected
+}
+
+func ensureContextProvider[T any](instance *componentInstance, contextID int, value T) *contextProvider {
+	if instance.contextProviders == nil {
+		instance.contextProviders = make(map[int]*contextProvider)
+	}
+	provider := instance.contextProviders[contextID]
+	if provider == nil {
+		provider = &contextProvider{
+			id:          contextID,
+			owner:       instance,
+			value:       value,
+			subscribers: make(map[*contextSubscription]bool),
+		}
+		instance.contextProviders[contextID] = provider
+	}
+	return provider
+}
+
+func recordProvidedContext(instance *componentInstance, contextID int) {
+	for _, existing := range instance.providedContexts {
+		if existing == contextID {
+			return
+		}
+	}
+	instance.providedContexts = append(instance.providedContexts, contextID)
+}
+
+func finishComponentContextRender(instance *componentInstance) {
+	releaseUnusedContextSubscriptions(instance)
+	releaseUnprovidedContexts(instance)
+}
+
+func releaseUnusedContextSubscriptions(instance *componentInstance) {
+	for index := instance.contextIndex; index < len(instance.contextSlots); index++ {
+		unsubscribeContext(instance.contextSlots[index])
+		instance.contextSlots[index] = nil
+	}
+	instance.contextSlots = instance.contextSlots[:instance.contextIndex]
+}
+
+func releaseUnprovidedContexts(instance *componentInstance) {
+	if len(instance.contextProviders) == 0 {
+		return
+	}
+	for contextID, provider := range instance.contextProviders {
+		if contextWasProvided(instance, contextID) {
+			continue
+		}
+		removeContextProvider(provider)
+		delete(instance.contextProviders, contextID)
+	}
+}
+
+func contextWasProvided(instance *componentInstance, contextID int) bool {
+	for _, providedID := range instance.providedContexts {
+		if providedID == contextID {
+			return true
+		}
+	}
+	return false
+}
+
+func findContextProvider(instance *componentInstance, contextID int) *contextProvider {
+	for current := instance; current != nil; current = current.parent {
+		if current.contextProviders == nil {
+			continue
+		}
+		if provider := current.contextProviders[contextID]; provider != nil {
+			return provider
+		}
+	}
+	return nil
+}
+
+func subscribeContext(
+	instance *componentInstance,
+	contextID int,
+	kind string,
+	provider *contextProvider,
+	selected any,
+	defaultValue any,
+	update func(*contextSubscription, any) bool,
+) {
+	index := instance.contextIndex
+	instance.contextIndex++
+	if index == len(instance.contextSlots) {
+		slot := &contextSubscription{
+			owner:        instance,
+			contextID:    contextID,
+			kind:         kind,
+			selected:     selected,
+			defaultValue: defaultValue,
+			update:       update,
+		}
+		instance.contextSlots = append(instance.contextSlots, slot)
+		setContextSubscriptionProvider(slot, provider)
+		return
+	}
+
+	slot := instance.contextSlots[index]
+	if slot.kind != kind {
+		panic("goframe: context hook at slot " + ToString(index) + " changed from " + slot.kind + " to " + kind)
+	}
+	if slot.contextID != contextID {
+		panic("goframe: context hook at slot " + ToString(index) + " changed context")
+	}
+	slot.selected = selected
+	slot.defaultValue = defaultValue
+	slot.update = update
+	setContextSubscriptionProvider(slot, provider)
+}
+
+func setContextSubscriptionProvider(slot *contextSubscription, provider *contextProvider) {
+	if slot.provider == provider {
+		return
+	}
+	unsubscribeContext(slot)
+	slot.provider = provider
+	if provider == nil {
+		return
+	}
+	if provider.subscribers == nil {
+		provider.subscribers = make(map[*contextSubscription]bool)
+	}
+	provider.subscribers[slot] = true
+}
+
+func unsubscribeContext(slot *contextSubscription) {
+	if slot == nil || slot.provider == nil {
+		return
+	}
+	delete(slot.provider.subscribers, slot)
+	slot.provider = nil
+}
+
+func notifyContextSubscribers(provider *contextProvider, value any) {
+	for slot := range provider.subscribers {
+		if slot == nil || slot.owner == nil || !slot.owner.active {
+			delete(provider.subscribers, slot)
+			continue
+		}
+		if slot.update(slot, value) {
+			markComponentDirty(slot.owner)
+		}
+	}
+}
+
+func removeContextProvider(provider *contextProvider) {
+	for slot := range provider.subscribers {
+		if slot == nil {
+			continue
+		}
+		delete(provider.subscribers, slot)
+		slot.provider = nil
+		if slot.owner != nil && slot.owner.active && slot.update(slot, slot.defaultValue) {
+			markComponentDirty(slot.owner)
+		}
+	}
+}
+
+func releaseContextSubscriptions(instance *componentInstance) {
+	for _, slot := range instance.contextSlots {
+		unsubscribeContext(slot)
+	}
+}
+
+func releaseContextProviders(instance *componentInstance) {
+	for _, provider := range instance.contextProviders {
+		removeContextProvider(provider)
+	}
+}

--- a/pkg/goframe/context_test.go
+++ b/pkg/goframe/context_test.go
@@ -248,6 +248,150 @@ func TestContextProviderRemovalDirtiesConsumersForDefault(t *testing.T) {
 	}
 }
 
+func TestContextProviderAppearanceDirtiesDefaultConsumerThroughMemoAncestor(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 0})
+	providing := false
+	provider := contextTestInstance("Provider", nil, func() {
+		if providing {
+			ProvideContext(ctx, contextValueFixture{Count: 7})
+		}
+	})
+	renderComponentInstance(provider)
+
+	memoNode := Component("Memo", contextMemoPropsFixture{ID: 1}, func(contextMemoPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	memo := newComponentInstance(memoNode, "memo", provider, nil)
+	memo.dirty = false
+
+	got := -1
+	consumer := contextTestInstance("Consumer", memo, func() {
+		got = UseContextSelector(ctx, func(value contextValueFixture) int {
+			return value.Count
+		})
+	})
+	renderComponentInstance(consumer)
+	if got != 0 {
+		t.Fatalf("initial selected context value = %d, want default 0", got)
+	}
+
+	providing = true
+	renderComponentInstance(provider)
+
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirtied when provider appears above it")
+	}
+	if memo.dirtyDescendants != 1 {
+		t.Fatalf("memo dirty descendants = %d, want 1", memo.dirtyDescendants)
+	}
+	next := Component("Memo", contextMemoPropsFixture{ID: 1}, func(contextMemoPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	if shouldSkipComponentRender(memo, next, "memo") {
+		t.Fatal("memoized ancestor must not skip context provider appearance")
+	}
+
+	renderComponentInstance(consumer)
+	if got != 7 {
+		t.Fatalf("selected context value after provider appears = %d, want 7", got)
+	}
+}
+
+func TestContextInnerProviderAppearanceRebindsConsumerFromOuterProvider(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 0})
+	outer := contextProviderInstance("Outer", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(outer)
+
+	innerProviding := false
+	inner := contextTestInstance("Inner", outer, func() {
+		if innerProviding {
+			ProvideContext(ctx, contextValueFixture{Count: 2})
+		}
+	})
+	renderComponentInstance(inner)
+
+	got := -1
+	consumer := contextTestInstance("Consumer", inner, func() {
+		got = UseContextSelector(ctx, func(value contextValueFixture) int {
+			return value.Count
+		})
+	})
+	renderComponentInstance(consumer)
+	if got != 1 {
+		t.Fatalf("initial selected context value = %d, want outer 1", got)
+	}
+
+	innerProviding = true
+	renderComponentInstance(inner)
+
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirtied when inner provider appears")
+	}
+	renderComponentInstance(consumer)
+	if got != 2 {
+		t.Fatalf("selected context value after inner provider appears = %d, want inner 2", got)
+	}
+}
+
+func TestContextProviderTopologyChangeDirtiesConsumerWhenSelectionIsEqual(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 1})
+	providing := false
+	provider := contextTestInstance("Provider", nil, func() {
+		if providing {
+			ProvideContext(ctx, contextValueFixture{Count: 1})
+		}
+	})
+	renderComponentInstance(provider)
+
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+
+	providing = true
+	renderComponentInstance(provider)
+
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirtied when nearest provider changes even if selected value is equal")
+	}
+}
+
+func TestContextInnerProviderRemovalRebindsConsumerToOuterProvider(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 0})
+	outer := contextProviderInstance("Outer", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(outer)
+
+	innerProviding := true
+	inner := contextTestInstance("Inner", outer, func() {
+		if innerProviding {
+			ProvideContext(ctx, contextValueFixture{Count: 2})
+		}
+	})
+	renderComponentInstance(inner)
+
+	got := -1
+	consumer := contextTestInstance("Consumer", inner, func() {
+		got = UseContextSelector(ctx, func(value contextValueFixture) int {
+			return value.Count
+		})
+	})
+	renderComponentInstance(consumer)
+	if got != 2 {
+		t.Fatalf("initial selected context value = %d, want inner 2", got)
+	}
+
+	innerProviding = false
+	renderComponentInstance(inner)
+
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirtied when inner provider is removed")
+	}
+	renderComponentInstance(consumer)
+	if got != 1 {
+		t.Fatalf("selected context value after inner provider removal = %d, want outer 1", got)
+	}
+}
+
 func TestContextDirtyConsumerPreventsMemoAncestorSkip(t *testing.T) {
 	ctx := CreateContext(contextValueFixture{})
 	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})

--- a/pkg/goframe/context_test.go
+++ b/pkg/goframe/context_test.go
@@ -1,0 +1,345 @@
+package goframe
+
+import "testing"
+
+type contextValueFixture struct {
+	Count  int
+	Accent string
+}
+
+type contextMemoPropsFixture struct {
+	ID int
+}
+
+func (props contextMemoPropsFixture) MemoEqual(next contextMemoPropsFixture) bool {
+	return props.ID == next.ID
+}
+
+func TestUseContextReturnsDefaultWithoutProvider(t *testing.T) {
+	ctx := CreateContext("default")
+	got := ""
+	consumer := contextTestInstance("Consumer", nil, func() {
+		got = UseContext(ctx)
+	})
+
+	renderComponentInstance(consumer)
+
+	if got != "default" {
+		t.Fatalf("context value = %q, want default", got)
+	}
+}
+
+func TestProvideContextVisibleToDescendant(t *testing.T) {
+	ctx := CreateContext("default")
+	provider := contextProviderInstance("Provider", nil, ctx, "provided")
+	renderComponentInstance(provider)
+
+	got := ""
+	consumer := contextTestInstance("Consumer", provider, func() {
+		got = UseContext(ctx)
+	})
+	renderComponentInstance(consumer)
+
+	if got != "provided" {
+		t.Fatalf("context value = %q, want provided", got)
+	}
+}
+
+func TestNearestProviderWins(t *testing.T) {
+	ctx := CreateContext("default")
+	outer := contextProviderInstance("Outer", nil, ctx, "outer")
+	renderComponentInstance(outer)
+	inner := contextProviderInstance("Inner", outer, ctx, "inner")
+	renderComponentInstance(inner)
+
+	got := ""
+	consumer := contextTestInstance("Consumer", inner, func() {
+		got = UseContext(ctx)
+	})
+	renderComponentInstance(consumer)
+
+	if got != "inner" {
+		t.Fatalf("context value = %q, want inner", got)
+	}
+}
+
+func TestNestedProvidersIsolateSubscriptions(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 1, Accent: "outer"})
+	outer := contextProviderInstance("Outer", nil, ctx, contextValueFixture{Count: 1, Accent: "outer"})
+	renderComponentInstance(outer)
+	inner := contextProviderInstance("Inner", outer, ctx, contextValueFixture{Count: 2, Accent: "inner"})
+	renderComponentInstance(inner)
+
+	got := 0
+	consumer := contextTestInstance("Consumer", inner, func() {
+		got = UseContextSelector(ctx, func(value contextValueFixture) int {
+			return value.Count
+		})
+	})
+	renderComponentInstance(consumer)
+	if got != 2 {
+		t.Fatalf("selected context value = %d, want 2", got)
+	}
+
+	outer.node = Component("Outer", contextValueFixture{Count: 9, Accent: "outer"}, func(value contextValueFixture) Node {
+		ProvideContext(ctx, value)
+		return Empty()
+	}).(ComponentNode)
+	renderComponentInstance(outer)
+
+	if consumer.dirty {
+		t.Fatal("consumer under inner provider should not be dirtied by outer provider update")
+	}
+}
+
+func TestUseContextSelectorReturnsSelectedValue(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 1, Accent: "blue"})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 3, Accent: "green"})
+	renderComponentInstance(provider)
+
+	got := ""
+	consumer := contextTestInstance("Consumer", provider, func() {
+		got = UseContextSelector(ctx, func(value contextValueFixture) string {
+			return value.Accent
+		})
+	})
+	renderComponentInstance(consumer)
+
+	if got != "green" {
+		t.Fatalf("selected context value = %q, want green", got)
+	}
+}
+
+func TestContextSelectorDirtyWhenSelectedValueChanges(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1, Accent: "blue"})
+	renderComponentInstance(provider)
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+
+	updateContextProvider(provider, ctx, contextValueFixture{Count: 2, Accent: "blue"})
+
+	if !consumer.dirty {
+		t.Fatal("selector consumer should be dirty when selected value changes")
+	}
+}
+
+func TestContextSelectorCleanWhenSelectedValueUnchanged(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1, Accent: "blue"})
+	renderComponentInstance(provider)
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+
+	updateContextProvider(provider, ctx, contextValueFixture{Count: 1, Accent: "green"})
+
+	if consumer.dirty {
+		t.Fatal("selector consumer should stay clean when selected value is unchanged")
+	}
+}
+
+func TestContextOnlyChangedSelectedConsumersAreDirty(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1, Accent: "blue"})
+	renderComponentInstance(provider)
+	countConsumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	accentConsumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) string {
+		return value.Accent
+	})
+	sibling := dirtyCleanInstance("Sibling", provider)
+	renderComponentInstance(countConsumer)
+	renderComponentInstance(accentConsumer)
+
+	updateContextProvider(provider, ctx, contextValueFixture{Count: 2, Accent: "blue"})
+
+	if !countConsumer.dirty {
+		t.Fatal("count consumer should be dirty")
+	}
+	if accentConsumer.dirty {
+		t.Fatal("accent consumer should stay clean")
+	}
+	if sibling.dirty {
+		t.Fatal("unrelated sibling should stay clean")
+	}
+}
+
+func TestUseContextBroadConsumerRerendersOnProviderUpdate(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(provider)
+	consumer := contextTestInstance("Consumer", provider, func() {
+		_ = UseContext(ctx)
+	})
+	renderComponentInstance(consumer)
+
+	updateContextProvider(provider, ctx, contextValueFixture{Count: 2})
+
+	if !consumer.dirty {
+		t.Fatal("UseContext consumer should be dirtied by provider update")
+	}
+}
+
+func TestContextConsumerUnmountUnsubscribes(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(provider)
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+	providerSlot := provider.contextProviders[ctx.id]
+	if len(providerSlot.subscribers) != 1 {
+		t.Fatalf("subscribers = %d, want 1", len(providerSlot.subscribers))
+	}
+
+	deactivateComponent(consumer)
+
+	if len(providerSlot.subscribers) != 0 {
+		t.Fatalf("subscribers after unmount = %d, want 0", len(providerSlot.subscribers))
+	}
+}
+
+func TestContextProviderUnmountClearsSubscribers(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(provider)
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+	subscription := consumer.contextSlots[0]
+	providerSlot := provider.contextProviders[ctx.id]
+
+	deactivateComponent(provider)
+
+	if len(providerSlot.subscribers) != 0 {
+		t.Fatalf("provider subscribers after unmount = %d, want 0", len(providerSlot.subscribers))
+	}
+	if subscription.provider != nil {
+		t.Fatal("subscription should no longer point at unmounted provider")
+	}
+}
+
+func TestContextProviderRemovalDirtiesConsumersForDefault(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{Count: 0})
+	providing := true
+	provider := contextTestInstance("Provider", nil, func() {
+		if providing {
+			ProvideContext(ctx, contextValueFixture{Count: 1})
+		}
+	})
+	renderComponentInstance(provider)
+	consumer := contextSelectorConsumer(provider, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+
+	providing = false
+	renderComponentInstance(provider)
+
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirtied when provider is removed and default selection differs")
+	}
+}
+
+func TestContextDirtyConsumerPreventsMemoAncestorSkip(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})
+	renderComponentInstance(provider)
+	memoNode := Component("Memo", contextMemoPropsFixture{ID: 1}, func(contextMemoPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	memo := newComponentInstance(memoNode, "memo", provider, nil)
+	memo.dirty = false
+	consumer := contextSelectorConsumer(memo, ctx, func(value contextValueFixture) int {
+		return value.Count
+	})
+	renderComponentInstance(consumer)
+
+	updateContextProvider(provider, ctx, contextValueFixture{Count: 2})
+
+	if memo.dirtyDescendants != 1 {
+		t.Fatalf("memo dirty descendants = %d, want 1", memo.dirtyDescendants)
+	}
+	next := Component("Memo", contextMemoPropsFixture{ID: 1}, func(contextMemoPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	if shouldSkipComponentRender(memo, next, "memo") {
+		t.Fatal("memoized ancestor must not skip dirty context consumer")
+	}
+}
+
+func TestContextHooksOutsideComponentPanic(t *testing.T) {
+	ctx := CreateContext(0)
+	assertPanic(t, "goframe: ProvideContext must be called during component render", func() {
+		ProvideContext(ctx, 1)
+	})
+	assertPanic(t, "goframe: UseContext must be called during component render", func() {
+		UseContext(ctx)
+	})
+	assertPanic(t, "goframe: UseContextSelector must be called during component render", func() {
+		UseContextSelector(ctx, func(value int) int {
+			return value
+		})
+	})
+}
+
+func TestContextHookKindMismatchPanics(t *testing.T) {
+	ctx := CreateContext(contextValueFixture{})
+	useSelector := false
+	instance := contextTestInstance("Consumer", nil, func() {
+		if useSelector {
+			_ = UseContextSelector(ctx, func(value contextValueFixture) int {
+				return value.Count
+			})
+			return
+		}
+		_ = UseContext(ctx)
+	})
+	renderComponentInstance(instance)
+
+	useSelector = true
+	assertPanic(t, "goframe: context hook at slot 0 changed from UseContext to UseContextSelector", func() {
+		renderComponentInstance(instance)
+	})
+}
+
+func contextProviderInstance[T any](name string, parent *componentInstance, ctx *Context[T], value T) *componentInstance {
+	return contextTestInstance(name, parent, func() {
+		ProvideContext(ctx, value)
+	})
+}
+
+func contextSelectorConsumer[T any, S comparable](
+	parent *componentInstance,
+	ctx *Context[T],
+	selector func(T) S,
+) *componentInstance {
+	return contextTestInstance("Consumer", parent, func() {
+		_ = UseContextSelector(ctx, selector)
+	})
+}
+
+func contextTestInstance(name string, parent *componentInstance, render func()) *componentInstance {
+	node := Component(name, struct{}{}, func(struct{}) Node {
+		render()
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "", parent, nil)
+	instance.dirty = false
+	return instance
+}
+
+func updateContextProvider[T any](instance *componentInstance, ctx *Context[T], value T) {
+	instance.node = Component(instance.name, value, func(value T) Node {
+		ProvideContext(ctx, value)
+		return Empty()
+	}).(ComponentNode)
+	renderComponentInstance(instance)
+}

--- a/pkg/goframe/state.go
+++ b/pkg/goframe/state.go
@@ -4,6 +4,7 @@ type stateSlot struct {
 	value   any
 	owner   *componentInstance
 	reducer any
+	kind    string
 }
 
 type stateHandle[T any] struct {
@@ -71,9 +72,13 @@ func useStateSlot[T any](initial T, hookName string) stateHandle[T] {
 		instance.stateSlots = append(instance.stateSlots, &stateSlot{
 			value: initial,
 			owner: instance,
+			kind:  hookName,
 		})
 	}
 	slot := instance.stateSlots[index]
+	if slot.kind != hookName {
+		panic("goframe: hook at state slot " + ToString(index) + " changed from " + slot.kind + " to " + hookName)
+	}
 	if _, ok := slotValue[T](slot); !ok {
 		panic("goframe: " + hookName + " state type changed between component renders")
 	}

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -297,6 +297,48 @@ func TestUseReducerStateTypeMismatchPanics(t *testing.T) {
 	})
 }
 
+func TestStateHookKindMismatchPanics(t *testing.T) {
+	useReducer := false
+	instance := testComponentInstance("StateKind", func() Node {
+		if useReducer {
+			_, _ = UseReducer(0, func(state int, action int) int {
+				return state + action
+			})
+		} else {
+			_, _ = UseState(0)
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	useReducer = true
+
+	assertPanic(t, "goframe: hook at state slot 0 changed from UseState to UseReducer", func() {
+		renderComponentInstance(instance)
+	})
+}
+
+func TestReducerHookKindMismatchPanics(t *testing.T) {
+	useState := false
+	instance := testComponentInstance("ReducerKind", func() Node {
+		if useState {
+			_, _ = UseState(0)
+		} else {
+			_, _ = UseReducer(0, func(state int, action int) int {
+				return state + action
+			})
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	useState = true
+
+	assertPanic(t, "goframe: hook at state slot 0 changed from UseReducer to UseState", func() {
+		renderComponentInstance(instance)
+	})
+}
+
 func TestUseReducerReducerTypeMismatchPanics(t *testing.T) {
 	useStringAction := false
 	instance := testComponentInstance("Reducer", func() Node {

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -9,6 +9,7 @@ CHROME_BIN="${CHROME:-google-chrome}"
 TODO_SMOKE_URL_BASE="${GOFRAME_TODO_SMOKE_URL:-http://127.0.0.1}"
 DUPLICATE_SMOKE_URL_BASE="${GOFRAME_DUPLICATE_KEY_SMOKE_URL:-http://127.0.0.1}"
 DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
+CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -88,6 +89,11 @@ build_duplicate_smoke_url() {
 build_dashboard_smoke_url() {
 	local port="$1"
 	echo "${DASHBOARD_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_context_smoke_url() {
+	local port="$1"
+	echo "${CONTEXT_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -204,8 +210,24 @@ run_with_server ./examples/dashboard "$DASHBOARD_PORT" "$DASHBOARD_URL" \
 	node --experimental-websocket scripts/dashboard-browser-smoke.mjs
 
 echo
+echo "== Context debug browser smoke =="
+"$GOXC" package ./examples/context --compiler=tinygo
+(
+	cd ./examples/context/.goframe/work/dev
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/context/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+CONTEXT_PORT="$(resolve_port "${GOFRAME_CONTEXT_SMOKE_PORT:-}")"
+export GOFRAME_CONTEXT_CHROME_DEBUG_PORT="${GOFRAME_CONTEXT_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+CONTEXT_URL="$(build_context_smoke_url "$CONTEXT_PORT")"
+run_with_server ./examples/context "$CONTEXT_PORT" "$CONTEXT_URL" \
+	node --experimental-websocket scripts/context-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
+"$GOXC" package ./examples/context --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -50,6 +50,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" generate ./examples/dashboard
 "$GOXC" package ./examples/dashboard --compiler=tinygo
+"$GOXC" generate ./examples/context
+"$GOXC" package ./examples/context --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/context-browser-smoke.mjs
+++ b/scripts/context-browser-smoke.mjs
@@ -1,0 +1,523 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_CONTEXT_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_CONTEXT_CHROME_DEBUG_PORT ?? "19226");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-context-smoke-"));
+const expectedApp = new URL(appURL);
+const componentNames = [
+    "App",
+    "PreferencesProvider",
+    "PreferencesControls",
+    "ConsumerGrid",
+    "DensityConsumer",
+    "AccentConsumer",
+    "CounterConsumer",
+    "BroadConsumer",
+    "StaticPanel",
+    "NestedAccentProvider",
+    "InnerAccentConsumer",
+];
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+let browserExit = null;
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+browser.on("exit", (code, signal) => {
+    browserExit = { code, signal };
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL, "initial"));
+    await waitForAppPage(client, expectedApp, "initial navigation");
+
+    assertDeepEqual(
+        await contextState(client),
+        {
+            density: "comfortable",
+            accent: "blue",
+            counter: "0",
+            broad: "comfortable / blue / 0",
+            innerAccent: "purple",
+            staticText: "unchanged",
+            appRenders: 1,
+        },
+        "context initial render",
+    );
+
+    assertDeepEqual(
+        await client.evaluate(installContextAuditExpression(componentNames)),
+        { ready: true },
+        "context performance audit installed",
+    );
+
+    await startScenario(client, "density-compact");
+    await setSelectValue(client, "#density-select", "compact");
+    const densityReport = await finishScenario(client, "density-compact");
+    assertSelectorReport(densityReport, "DensityConsumer", "density change");
+    assertDeepEqual(
+        await contextState(client),
+        {
+            density: "compact",
+            accent: "blue",
+            counter: "0",
+            broad: "compact / blue / 0",
+            innerAccent: "purple",
+            staticText: "unchanged",
+            appRenders: 1,
+        },
+        "context density update",
+    );
+
+    await startScenario(client, "accent-green");
+    await setSelectValue(client, "#accent-select", "green");
+    const accentReport = await finishScenario(client, "accent-green");
+    assertSelectorReport(accentReport, "AccentConsumer", "accent change");
+    assertDeepEqual(
+        await contextState(client),
+        {
+            density: "compact",
+            accent: "green",
+            counter: "0",
+            broad: "compact / green / 0",
+            innerAccent: "purple",
+            staticText: "unchanged",
+            appRenders: 1,
+        },
+        "context accent update",
+    );
+
+    await startScenario(client, "counter-increment");
+    await client.evaluate(`document.querySelector("#increment-counter").click()`);
+    await wait(120);
+    const counterReport = await finishScenario(client, "counter-increment");
+    assertSelectorReport(counterReport, "CounterConsumer", "counter increment");
+    assertDeepEqual(
+        await contextState(client),
+        {
+            density: "compact",
+            accent: "green",
+            counter: "1",
+            broad: "compact / green / 1",
+            innerAccent: "purple",
+            staticText: "unchanged",
+            appRenders: 1,
+        },
+        "context counter update",
+    );
+
+    await startScenario(client, "reset");
+    await client.evaluate(`document.querySelector("#reset-preferences").click()`);
+    await wait(120);
+    const resetReport = await finishScenario(client, "reset");
+    assertResetReport(resetReport);
+    assertDeepEqual(
+        await contextState(client),
+        {
+            density: "comfortable",
+            accent: "blue",
+            counter: "0",
+            broad: "comfortable / blue / 0",
+            innerAccent: "purple",
+            staticText: "unchanged",
+            appRenders: 1,
+        },
+        "context reset",
+    );
+
+    client.close();
+    console.log("Context browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function contextState(client) {
+    return await client.evaluate(`(() => ({
+        density: document.querySelector("[data-testid='density-consumer'] strong")?.textContent.trim(),
+        accent: document.querySelector("[data-testid='accent-consumer'] strong")?.textContent.trim(),
+        counter: document.querySelector("[data-testid='counter-consumer'] strong")?.textContent.trim(),
+        broad: document.querySelector("[data-testid='broad-consumer'] strong")?.textContent.trim(),
+        innerAccent: document.querySelector("[data-testid='inner-accent-consumer']")?.textContent.trim(),
+        staticText: document.querySelector("[data-testid='static-panel'] strong")?.textContent.trim(),
+        appRenders: window.goframeComponentRenderCounts.App,
+    }))()`);
+}
+
+async function setSelectValue(client, selector, value) {
+    await client.evaluate(`(() => {
+        const select = document.querySelector(${JSON.stringify(selector)});
+        select.value = ${JSON.stringify(value)};
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+        return true;
+    })()`);
+    await wait(140);
+}
+
+async function startScenario(client, label) {
+    await client.evaluate(`(() => {
+        window.__contextAudit.start(${JSON.stringify(label)});
+        return true;
+    })()`);
+}
+
+async function finishScenario(client, label) {
+    const report = await client.evaluate(`(() => window.__contextAudit.finish(${JSON.stringify(label)}))()`);
+    console.log(`context perf ${label}: ${JSON.stringify(report)}`);
+    return report;
+}
+
+function assertSelectorReport(report, changedComponent, label) {
+    const selectorComponents = ["DensityConsumer", "AccentConsumer", "CounterConsumer"];
+    for (const name of selectorComponents) {
+        const renders = report.renderDeltas[name];
+        if (name === changedComponent) {
+            if (renders <= 0) {
+                throw new Error(`APP FAILURE: ${label} did not render ${changedComponent}: ${JSON.stringify(report)}`);
+            }
+            continue;
+        }
+        if (renders !== 0) {
+            throw new Error(`APP FAILURE: ${label} rendered unrelated ${name}: ${JSON.stringify(report.renderDeltas)}`);
+        }
+        if (report.memoDeltas[name] <= 0) {
+            throw new Error(`APP FAILURE: ${label} did not memo-skip clean ${name}: ${JSON.stringify(report.memoDeltas)}`);
+        }
+    }
+    if (report.renderDeltas.StaticPanel !== 0 || report.memoDeltas.StaticPanel <= 0) {
+        throw new Error(`APP FAILURE: ${label} touched static panel: ${JSON.stringify(report)}`);
+    }
+    if (report.renderDeltas.BroadConsumer <= 0) {
+        throw new Error(`APP FAILURE: ${label} did not rerender broad UseContext consumer: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    if (report.renderDeltas.InnerAccentConsumer !== 0) {
+        throw new Error(`APP FAILURE: ${label} rendered inner accent selector despite unchanged nested value: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    assertNoStructuralOrListenerChurn(report, label);
+}
+
+function assertResetReport(report) {
+    if (report.renderDeltas.DensityConsumer <= 0 || report.renderDeltas.AccentConsumer <= 0 || report.renderDeltas.CounterConsumer <= 0) {
+        throw new Error(`APP FAILURE: reset should render changed selector consumers: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    if (report.renderDeltas.StaticPanel !== 0 || report.memoDeltas.StaticPanel <= 0) {
+        throw new Error(`APP FAILURE: reset touched static panel: ${JSON.stringify(report)}`);
+    }
+    if (report.renderDeltas.BroadConsumer <= 0) {
+        throw new Error(`APP FAILURE: reset did not rerender broad UseContext consumer: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    assertNoStructuralOrListenerChurn(report, "reset");
+}
+
+function assertNoStructuralOrListenerChurn(report, label) {
+    const structural = ["createElement", "createTextNode", "appendChild", "removeChild", "replaceChild", "insertBefore"];
+    for (const key of structural) {
+        if (report.operations[key] !== 0) {
+            throw new Error(`APP FAILURE: structural DOM op during ${label}: ${JSON.stringify(report.operations)}`);
+        }
+    }
+    if (report.operations.addEventListener !== 0 || report.operations.removeEventListener !== 0) {
+        throw new Error(`APP FAILURE: listener churn during ${label}: ${JSON.stringify(report.operations)}`);
+    }
+}
+
+async function waitForPage(port) {
+    let lastError;
+    for (let attempt = 0; attempt < 50; attempt++) {
+        if (browserExit) {
+            throw new Error(`HARNESS FAILURE: Chrome exited before CDP page was available: ${JSON.stringify(browserExit)}\n${browserError}`);
+        }
+        try {
+            const pages = await fetchTargets(port);
+            const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+            if (page) {
+                return page;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools did not become ready: ${lastError ?? browserError}`);
+}
+
+async function fetchTargets(port) {
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    if (!response.ok) {
+        throw new Error(`CDP /json returned HTTP ${response.status}`);
+    }
+    return await response.json();
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+}
+
+async function waitForAppPage(client, expected, label) {
+    let lastState = null;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        lastState = await pageState(client);
+        if (lastState.href.startsWith("chrome-error://")) {
+            throw await harnessFailure(client, `${label}: Chrome loaded an error document`, lastState);
+        }
+        if (isExpectedAppState(lastState, expected) && lastState.root && lastState.appReady) {
+            return lastState;
+        }
+        await wait(100);
+    }
+    throw await harnessFailure(client, `${label}: app page did not become ready`, lastState);
+}
+
+async function pageState(client) {
+    return await client.evaluate(`(() => ({
+        href: window.location.href,
+        origin: window.location.origin,
+        protocol: window.location.protocol,
+        readyState: document.readyState,
+        root: Boolean(document.querySelector("#root")),
+        appReady: Boolean(document.querySelector("#density-select") && window.goframeComponentRenderCounts?.App),
+    }))()`);
+}
+
+function isExpectedAppState(state, expected) {
+    if (!state || (state.protocol !== "http:" && state.protocol !== "https:")) {
+        return false;
+    }
+    try {
+        const actual = new URL(state.href);
+        return actual.origin === expected.origin && actual.pathname === expected.pathname;
+    } catch {
+        return false;
+    }
+}
+
+async function harnessFailure(client, message, detail) {
+    const diagnostics = await collectDiagnostics(client);
+    return new Error(`HARNESS FAILURE: ${message}\n${JSON.stringify({ appURL, debugPort, detail, diagnostics }, null, 2)}`);
+}
+
+async function collectDiagnostics(client) {
+    const diagnostics = { targets: [], page: null };
+    try {
+        diagnostics.targets = (await fetchTargets(debugPort)).map((target) => ({
+            id: target.id,
+            type: target.type,
+            url: target.url,
+            title: target.title,
+        }));
+    } catch (error) {
+        diagnostics.targetsError = error.message;
+    }
+    if (client) {
+        try {
+            diagnostics.page = await pageState(client);
+        } catch (error) {
+            diagnostics.pageError = error.message;
+        }
+    }
+    if (browserExit) {
+        diagnostics.browserExit = browserExit;
+    }
+    if (browserError) {
+        diagnostics.browserStderr = browserError.slice(-4000);
+    }
+    return diagnostics;
+}
+
+function withSmokeParam(url, label) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", `${Date.now()}-${label}`);
+    return next.toString();
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result);
+        }
+    });
+
+    const call = (method, params = {}) =>
+        new Promise((resolve, reject) => {
+            const id = nextID++;
+            pending.set(id, { resolve, reject });
+            socket.send(JSON.stringify({ id, method, params }));
+        });
+
+    return {
+        call,
+        close: () => socket.close(),
+        evaluate: async (expression) => {
+            const result = await call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+    };
+}
+
+function installContextAuditExpression(names) {
+    return `(() => {
+        if (window.__contextAudit) return { ready: true };
+        const operations = ${JSON.stringify(emptyOperations())};
+        const componentNames = ${JSON.stringify(names)};
+        const audit = {
+            operations,
+            baseline: null,
+            startedAt: 0,
+            start(label) {
+                for (const key of Object.keys(this.operations)) this.operations[key] = 0;
+                this.baseline = snapshotCounts(componentNames);
+                this.startedAt = performance.now();
+            },
+            finish(label) {
+                const next = snapshotCounts(componentNames);
+                const renderDeltas = {};
+                const patchDeltas = {};
+                const memoDeltas = {};
+                for (const name of componentNames) {
+                    renderDeltas[name] = next.renders[name] - this.baseline.renders[name];
+                    patchDeltas[name] = next.patches[name] - this.baseline.patches[name];
+                    memoDeltas[name] = next.memoSkips[name] - this.baseline.memoSkips[name];
+                }
+                return {
+                    label,
+                    durationMs: Math.round((performance.now() - this.startedAt) * 100) / 100,
+                    renderDeltas,
+                    patchDeltas,
+                    memoDeltas,
+                    operations: { ...this.operations },
+                };
+            },
+        };
+        const wrap = (owner, name, counter) => {
+            const original = owner[name];
+            owner[name] = function(...args) {
+                operations[counter]++;
+                return original.apply(this, args);
+            };
+        };
+        wrap(Document.prototype, "createElement", "createElement");
+        wrap(Document.prototype, "createTextNode", "createTextNode");
+        wrap(Node.prototype, "appendChild", "appendChild");
+        wrap(Node.prototype, "removeChild", "removeChild");
+        wrap(Node.prototype, "replaceChild", "replaceChild");
+        wrap(Node.prototype, "insertBefore", "insertBefore");
+        wrap(Element.prototype, "setAttribute", "setAttribute");
+        wrap(Element.prototype, "removeAttribute", "removeAttribute");
+        wrap(EventTarget.prototype, "addEventListener", "addEventListener");
+        wrap(EventTarget.prototype, "removeEventListener", "removeEventListener");
+        const nodeValue = Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue");
+        Object.defineProperty(Node.prototype, "nodeValue", {
+            configurable: nodeValue.configurable,
+            enumerable: nodeValue.enumerable,
+            get: nodeValue.get,
+            set(value) {
+                operations.setTextNodeValue++;
+                return nodeValue.set.call(this, value);
+            },
+        });
+        const selectValue = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value");
+        Object.defineProperty(HTMLSelectElement.prototype, "value", {
+            configurable: selectValue.configurable,
+            enumerable: selectValue.enumerable,
+            get: selectValue.get,
+            set(value) {
+                operations.setProperty++;
+                return selectValue.set.call(this, value);
+            },
+        });
+        window.__contextAudit = audit;
+        return { ready: true };
+
+        function snapshotCounts(names) {
+            const renderCounts = window.goframeComponentRenderCounts || {};
+            const patchCounts = window.goframeComponentPatchCounts || {};
+            const memoSkips = window.goframeComponentMemoSkips || {};
+            const renders = {};
+            const patches = {};
+            const skips = {};
+            for (const name of names) {
+                renders[name] = renderCounts[name] || 0;
+                patches[name] = patchCounts[name] || 0;
+                skips[name] = memoSkips[name] || 0;
+            }
+            return { renders, patches, memoSkips: skips };
+        }
+    })()`;
+}
+
+function emptyOperations() {
+    return {
+        createElement: 0,
+        createTextNode: 0,
+        appendChild: 0,
+        removeChild: 0,
+        replaceChild: 0,
+        insertBefore: 0,
+        setTextNodeValue: 0,
+        setAttribute: 0,
+        removeAttribute: 0,
+        setProperty: 0,
+        addEventListener: 0,
+        removeEventListener: 0,
+    };
+}
+
+function assertDeepEqual(actual, expected, label) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+function wait(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -132,5 +132,6 @@ check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
 check_app "dashboard" "$(bundle_path dashboard)" 153600 53248 71680 61440 || status=1
+check_app "context" "$(bundle_path context)" 112640 36864 46080 40960 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adds scoped Context with selector-based subscriptions.

## Changes

- Add `gf.CreateContext`
- Add `gf.ProvideContext`
- Add `gf.UseContext`
- Add `gf.UseContextSelector`
- Add context subscription tracking and nearest-provider topology refresh
- Add hook-kind guards for context hooks
- Add `examples/context`
- Add context browser smoke
- Add context docs and size budget coverage

## Correctness

- Default context value works without provider
- Nearest provider wins
- Nested providers isolate consumers
- Selector consumers dirty only when selected value changes
- Broad `UseContext` consumers rerender on provider changes
- Provider appearance/removal/rebinding is handled
- Memoized ancestors cannot hide dirty context consumers

## Checks

- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/browser-smoke.sh`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`