### PR TITLE
MVP 17: virtualized collections

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -51,11 +51,14 @@ jobs:
           goxc package ./examples/dashboard --compiler=tinygo
           goxc generate ./examples/context
           goxc package ./examples/context --compiler=tinygo
+          goxc generate ./examples/virtualized
+          goxc package ./examples/virtualized --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/dashboard --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/context --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/virtualized --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   workaround.
 - Scoped context selectors with nearest-provider lookup, comparable selector
   dirtying, and a focused context example plus browser smoke coverage.
+- Fixed-height `VirtualList` and `VirtualTable` primitives, dashboard table
+  virtualization, and a focused virtualized collections example plus smoke
+  coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ goxc package ./examples/context --compiler=tinygo
 goxc serve ./examples/context --port=8080
 ```
 
+The virtualized collections example demonstrates framework-level fixed-height
+list and table virtualization with 10,000 logical rows but a bounded mounted
+DOM:
+
+```bash
+goxc package ./examples/virtualized --compiler=tinygo
+goxc serve ./examples/virtualized --port=8080
+```
+
 ## GOX component model
 
 Lowercase tags create HTML elements:
@@ -222,12 +231,14 @@ Browser props accept both lowercase and exported-style common names, including
 func()
 func(gf.Event)
 func(gf.InputEvent)
+func(gf.ScrollEvent)
 ```
 
 `gf.Event` provides `PreventDefault` and `StopPropagation`.
-`gf.InputEvent.Value()` supports controlled inputs. `gf.UseState` slots belong
-to the component instance currently rendering. State `Set` calls mark that
-owner dirty and are coalesced into one browser animation-frame update.
+`gf.InputEvent.Value()` supports controlled inputs. `gf.ScrollEvent.ScrollTop()`
+supports fixed-height virtualized collections. `gf.UseState` slots belong to
+the component instance currently rendering. State `Set` calls mark that owner
+dirty and are coalesced into one browser animation-frame update.
 `gf.UseReducer` uses the same slots, but dispatch reads the latest slot state
 at event time before applying a pure reducer action.
 
@@ -273,6 +284,12 @@ child are both dirty in the same batch, ancestor pruning keeps only the parent
 update. Descendant components encountered inside an updated parent subtree
 rerender. For selective subtree bailouts, define `MemoEqual` on props to opt
 in to explicit component memoization and skip stable re-renders.
+
+Large fixed-height collections should use `gf.VirtualList` or
+`gf.VirtualTable` instead of rendering hundreds of hidden or offscreen rows.
+Virtualization keeps the mounted DOM bounded to the visible window plus
+overscan; it is separate from memoization, which reduces render work for
+mounted components. See [virtualized collections](docs/virtualization.md).
 
 Duplicate sibling keys are a user error. Production builds keep the smallest
 behavior and do not diagnose them; `goframe_debug` builds record and warn about
@@ -534,9 +551,12 @@ Measured on June 16, 2026 with Go 1.24.4 and TinyGo 0.41.1:
 | Todo demo, TinyGo `bundle.wasm` | 109,483 | 106.9 KiB |
 | Todo demo, TinyGo `bundle.wasm.br` | 34,885 | 34.1 KiB |
 | Todo demo, TinyGo `bundle.wasm.gz` | 42,003 | 41.0 KiB |
-| Dashboard pressure test, TinyGo `bundle.wasm` | 146,832 | 143.4 KiB |
-| Dashboard pressure test, TinyGo `bundle.wasm.br` | 44,317 | 43.3 KiB |
-| Dashboard pressure test, TinyGo `bundle.wasm.gz` | 54,673 | 53.4 KiB |
+| Dashboard pressure test, TinyGo `bundle.wasm` | 162,773 | 159.0 KiB |
+| Dashboard pressure test, TinyGo `bundle.wasm.br` | 49,075 | 47.9 KiB |
+| Dashboard pressure test, TinyGo `bundle.wasm.gz` | 60,187 | 58.8 KiB |
+| Virtualized collections, TinyGo `bundle.wasm` | 118,546 | 115.8 KiB |
+| Virtualized collections, TinyGo `bundle.wasm.br` | 37,076 | 36.2 KiB |
+| Virtualized collections, TinyGo `bundle.wasm.gz` | 45,134 | 44.1 KiB |
 | Go `wasm_exec.js` | 16,992 | 16.6 KiB |
 | TinyGo `wasm_exec.js` | 16,715 | 16.3 KiB |
 
@@ -550,6 +570,9 @@ realistic 300-row interactive app.
 MVP 13 adds content-hashed release assets for cache-safe delivery. MVP 13.1
 keeps the app source tree clean by moving generated, build, and package
 outputs under `.goframe/`; use `goxc export` when you want a visible `dist/`.
+MVP 17 adds fixed-height virtualized list and table primitives; the dashboard
+now keeps physical issue rows bounded while preserving the 300-row logical
+fixture.
 
 ## Legacy CLI
 
@@ -589,6 +612,9 @@ required.
 - Memoization is explicit and opt-in today:
   components can implement `MemoEqual` on their props type to skip renders when
   prop shapes are unchanged and the component is otherwise clean.
+- Virtualized collections require fixed item/row heights and stable keys. They
+  bound mounted DOM work, but do not yet provide dynamic measurement, infinite
+  loading, or advanced keyboard navigation.
 - Duplicate key diagnostics are debug-only and do not run in production builds.
 - GOX has JSX-like render expressions for `condition && <Node />` and
   `condition ? <A /> : <B />`, but no template-block `if`/`for`, spread props,
@@ -606,12 +632,14 @@ required.
 - [Runtime model](docs/runtime-model.md)
 - [Lifecycle and effects](docs/effects.md)
 - [Context selectors](docs/context.md)
+- [Virtualized collections](docs/virtualization.md)
 - [VS Code GOX extension](extensions/vscode-gox/README.md)
 - [Future GoFrame Player vision](docs/player-vision.md)
 - [Counter example](examples/counter/README.md)
 - [Components example](examples/components/README.md)
 - [Todo example](examples/todo/README.md)
 - [Dashboard pressure-test example](examples/dashboard/README.md)
+- [Virtualized collections example](examples/virtualized/README.md)
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,11 +167,12 @@ TinyGo is the preferred lightweight experiment. It supports a smaller runtime
 surface but dramatically reduces the counter:
 
 ```text
-counter bundle.wasm     77,890 bytes
-components bundle.wasm  83,159 bytes
-todo bundle.wasm        109,483 bytes
-dashboard bundle.wasm   146,832 bytes
-context bundle.wasm     106,631 bytes
+counter bundle.wasm      81,233 bytes
+components bundle.wasm   86,608 bytes
+todo bundle.wasm        113,935 bytes
+dashboard bundle.wasm   162,773 bytes
+context bundle.wasm     111,440 bytes
+virtualized bundle.wasm 118,546 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -182,7 +183,8 @@ than Counter because it also demonstrates compact localStorage persistence.
 
 The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
-dashboard-sized pressure-test example and the context selector example.
+dashboard-sized pressure-test example, the context selector example, and the
+virtualized collections example.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.
@@ -200,9 +202,11 @@ measure of platform value because it contains almost no application behavior.
 `examples/dashboard` is the first dashboard-sized pressure test. It keeps all
 components in one Go package because GOX does not yet support component
 namespaces, but splits layout, metrics, filters, table, and detail components
-across multiple GOX files. It renders 300 deterministic rows and exercises
+across multiple GOX files. It models 300 deterministic rows and exercises
 search, filters, sorting, keyed row identity, selection, metric updates, and a
-small document-title effect.
+small document-title effect. The table is physically virtualized with
+`gf.VirtualTable`, so the logical row count can stay dashboard-sized while the
+mounted DOM remains bounded.
 
 Future editor-sized experiments should measure startup, update time, memory,
 compressed transfer size, and development ergonomics before broader conclusions
@@ -220,6 +224,7 @@ The MVP runtime currently has:
 - reducer dispatch that applies actions to the latest component state slot;
 - scoped context providers with selector-based consumer dirtying;
 - component-scoped lifecycle/effect slots;
+- fixed-height `VirtualList` and `VirtualTable` collection primitives;
 - dirty component updates coalesced into one animation-frame flush;
 - direct dirty-owner subtree updates without root traversal;
 - dirty queue ancestor pruning when parent and child are dirty in the same
@@ -251,6 +256,8 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
   model.
 - Context is scoped and selector-based, but has no async/server bridge or
   custom non-comparable selector equality.
+- Virtualized collections are fixed-height only; there is no dynamic
+  measurement, infinite loading, or advanced keyboard navigation yet.
 - No automatic props memoization; descendants rerender with their parent unless
   components explicitly implement `MemoEqual` on their props and the framework can
   perform a deterministic memoized bailout.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -27,9 +27,9 @@ It checks:
 and manually through `workflow_dispatch`.
 
 It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
-counter, components, todo, dashboard, and context examples with TinyGo. It also
-runs a release-style package pass with `--asset-hash --preload --compress=gzip,br`
-before checking:
+counter, components, todo, dashboard, context, and virtualized examples with
+TinyGo. It also runs a release-style package pass with
+`--asset-hash --preload --compress=gzip,br` before checking:
 
 ```bash
 scripts/size-budget.sh
@@ -56,8 +56,9 @@ scripts/browser-smoke.sh
 The smoke script chooses dynamic ports, verifies the expected app origin before
 storage cleanup, checks WASM MIME type, and separates harness failures from app
 failures. It currently covers Todo reconciliation, duplicate-key debug
-diagnostics, dashboard-sized filtering/sorting/selection behavior, and context
-selector rerender isolation.
+diagnostics, dashboard-sized filtering/sorting/selection behavior, context
+selector rerender isolation, and virtualized collection scroll/selection/toggle
+behavior.
 
 ### VS Code Extension
 
@@ -172,8 +173,8 @@ Treat smoke failures as either harness failures or app failures.
 Harness failures include server bind errors, wrong CDP target, wrong origin,
 missing Chrome, unavailable storage, or stale server state. App failures include
 DOM identity loss, render counter regressions, localStorage persistence issues,
-duplicate key diagnostics failures, dashboard filter/sort regressions, or
-listener churn regressions.
+duplicate key diagnostics failures, dashboard filter/sort regressions,
+virtualized collection window regressions, or listener churn regressions.
 
 The smoke script must not continue against an unknown server or `about:blank`.
 

--- a/docs/foundation-audit.md
+++ b/docs/foundation-audit.md
@@ -201,7 +201,9 @@ TinyGo size budgets:
 | Counter | 95 KiB |
 | Components | 105 KiB |
 | Todo | 120 KiB |
-| Dashboard | 150 KiB |
+| Dashboard | 165 KiB |
+| Context | 110 KiB |
+| Virtualized | 120 KiB |
 
 Run:
 
@@ -216,15 +218,19 @@ Measured during the foundation audit:
 
 | Example | TinyGo WASM |
 |---|---:|
-| Counter | 77,890 B |
-| Components | 83,159 B |
-| Todo | 109,483 B |
-| Dashboard pressure test | 146,832 B |
+| Counter | 81,233 B |
+| Components | 86,608 B |
+| Todo | 113,935 B |
+| Dashboard pressure test | 162,773 B |
+| Context selectors | 111,440 B |
+| Virtualized collections | 118,546 B |
 
-Counter and Components show the approximate runtime cost of MVP 9 lifecycle
-hooks. Todo includes example-level localStorage persistence and compact string
-encoding, so its increase is not purely runtime overhead. Dashboard is a
-larger example-level pressure test with 300 rows and sorting/filtering logic.
+Counter and Components show the approximate runtime cost of the shared runtime
+surface. Todo includes example-level localStorage persistence and compact
+string encoding, so its increase is not purely runtime overhead. Dashboard is a
+larger example-level pressure test with 300 logical rows, sorting/filtering
+logic, context/reducer/memoization-era runtime costs, and fixed-height table
+virtualization.
 
 ## Performance Review
 
@@ -262,6 +268,9 @@ Performance risks that remain:
 - Parent rerender always rerenders component descendants it reaches.
 - Paint Flashing is still checked indirectly through DOM operations and
   MutationObserver records, not direct browser paint metrics.
+- Virtualized collections currently require fixed item/row heights. Dynamic
+  measurement, infinite loading, keyboard navigation, and richer table
+  accessibility remain future work.
 
 ## Security/Safety Review
 
@@ -340,6 +349,8 @@ Automated checks currently include:
 - Browser Todo smoke script.
 - Browser duplicate-key smoke script.
 - Browser dashboard smoke and dashboard pressure-test trace.
+- Browser context selector smoke.
+- Browser virtualized collections smoke.
 - Size budget script.
 - Pure runtime benchmark script.
 - Component identity decision document.
@@ -348,11 +359,10 @@ Automated checks currently include:
 
 Recommended next hardening steps before new product features:
 
-1. Use the dashboard pressure test to guide runtime optimization work with
-   before/after render, patch, and DOM operation metrics.
-2. Keep memoization, context, router, Player, SSR, hydration, and bundle
-   splitting out of scope until the current packaging/runtime gates stay green
-   through PR review.
+1. Keep using the dashboard pressure test to guide runtime optimization work
+   with before/after render, patch, DOM operation, and listener metrics.
+2. Keep router, Player, SSR, hydration, and bundle splitting out of scope until
+   the current packaging/runtime gates stay green through PR review.
 3. Decide whether component identity should include function identity or a
    generated stable type token before adding larger component lifecycle features.
 4. Add debug duplicate-key source locations only if diagnostics need to become

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -61,7 +61,9 @@ other compared prop tracks that data.
   value changes, but memoization still requires explicit props `MemoEqual`.
 - No stable event callback hook yet; reducer dispatch covers state transitions
   that can be represented as pure actions.
-- No virtualization or router/Player integration in this stage.
+- Virtualization is a separate tool. Use `gf.VirtualList` or `gf.VirtualTable`
+  when offscreen collection items should not be mounted at all.
+- No router/Player integration in this stage.
 
 ## Interaction with keys and identity
 

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -217,6 +217,28 @@ cursor position. Stable-ID focus restoration remains a replacement fallback.
 its required reference. It calls `insertBefore` only when an actual move is
 needed.
 
+## Virtualized collections
+
+`gf.VirtualList` and `gf.VirtualTable` are framework-level fixed-height
+collection primitives. They keep the mounted DOM bounded to the visible window
+plus overscan while preserving a much larger logical item count.
+
+The virtual range stores the first visible row rather than raw scroll pixels.
+Scroll events that remain inside the same row boundary do not schedule another
+state update. When the row boundary changes, the virtualized component updates
+its range and keyed reconciliation mounts, unmounts, or moves only the window
+that should be present.
+
+Virtualization and memoization solve different costs. Memoization skips render
+and patch work for clean mounted components; virtualization avoids mounting
+offscreen components at all. The dashboard uses both: `IssueRow` remains
+memoized for row selection/toggle work, while `gf.VirtualTable` prevents
+filter transitions from creating hundreds of offscreen rows.
+
+The current virtualized model assumes fixed item or row height. Dynamic
+measurement, infinite loading, keyboard navigation, and richer table
+accessibility are future work. See [virtualized collections](virtualization.md).
+
 ## DOM stability regression
 
 DOM node replacement, component render, patch traversal, DOM mutation, and
@@ -330,6 +352,8 @@ The dependency-free headless Chrome probe verifies:
 - lifecycle/effects are minimal and have no priorities or async scheduler;
 - context is scoped and selector-based, but has no async/server bridge or
   custom non-comparable selector equality;
+- virtualized collections are fixed-height only and do not include dynamic
+  measurement, infinite loading, or keyboard navigation;
 - no error boundaries;
 - component identity uses the declared component name, not Go function identity;
 - explicit opt-in props memoization via `MemoEqual`; components still rerender

--- a/docs/virtualization.md
+++ b/docs/virtualization.md
@@ -85,8 +85,10 @@ The current range model is intentionally fixed-height:
 ```text
 visibleStart = scrollTop / itemHeight
 visibleCount = ceil(height / itemHeight)
-start = max(0, visibleStart - overscan)
-end = min(len(items), visibleStart + visibleCount + overscan)
+windowSize = min(len(items), visibleCount + 2 * overscan)
+rangeStart = clamp(visibleStart - overscan, 0, len(items) - windowSize)
+start = rangeStart
+end = start + windowSize
 topSpacer = start * itemHeight
 bottomSpacer = (len(items) - end) * itemHeight
 ```
@@ -94,9 +96,17 @@ bottomSpacer = (len(items) - end) * itemHeight
 Negative overscan is treated as zero. Invalid `Height` or `ItemHeight` values
 panic with a focused runtime message.
 
-Scroll handling stores the first visible row, not every raw pixel offset. If a
-scroll event stays within the same row boundary, the component does not schedule
-another state update.
+Scroll handling stores the rendered range start, not every raw pixel offset or
+every first visible row. At the top and bottom edges, the range keeps a full
+`visible + 2*overscan` window whenever enough items exist, so missing overscan
+on one side is compensated on the other side.
+
+During scroll, GoFrame first checks whether the current visible rows are still
+inside the already-rendered range. If so, it leaves component state alone and
+the DOM window stays mounted. A new range is scheduled only after the visible
+viewport leaves that buffer. Virtualized viewports and spacer rows disable
+browser scroll anchoring with `overflow-anchor:none` so spacer height changes do
+not fight the user's scroll position.
 
 ## Keys
 
@@ -121,13 +131,15 @@ than a classic leak.
 
 After moving the issue table to `gf.VirtualTable`, the dashboard still has 300
 logical issues, but the mounted `.issue-row` count stays bounded. A typical
-debug pressure run reports about 20 mounted rows, around 432 created nodes for
+debug pressure run reports about 28 mounted rows, bounded created nodes for
 `Open -> All`, stable live DOM count, and stable net listener count.
 
 The pressure script gates the important invariants:
 
 - mounted rows remain bounded;
 - top and bottom spacer rows keep stable DOM identity;
+- scroll inside the overscan buffer does not rerender or churn table rows;
+- continuous scroll renders `VirtualTable` far less often than scroll events;
 - live DOM count stabilizes across cycles;
 - net listener count stabilizes across cycles;
 - `Open -> All` no longer creates thousands of row nodes.

--- a/docs/virtualization.md
+++ b/docs/virtualization.md
@@ -41,6 +41,7 @@ gf.VirtualTable[Issue](gf.VirtualTableProps[Issue]{
 	Height:    560,
 	RowHeight: 48,
 	Overscan:  8,
+	ColumnCount: 7,
 	Key: func(issue Issue, index int) string {
 		return gf.ToString(issue.ID)
 	},
@@ -65,6 +66,11 @@ gf.VirtualTable[Issue](gf.VirtualTableProps[Issue]{
 spacer rows above and below the mounted window to preserve the logical scroll
 height. `VirtualRow.RowStyle` should be applied to the rendered `<tr>` so row
 height stays consistent.
+
+Set `ColumnCount` to the number of rendered columns in the table. GoFrame uses
+that value as the `colspan` for spacer and empty rows. If `ColumnCount <= 0`,
+the runtime falls back to `1`; examples should not rely on that fallback unless
+the table really has one column.
 
 ## Range Calculation
 

--- a/docs/virtualization.md
+++ b/docs/virtualization.md
@@ -1,0 +1,134 @@
+# Virtualized Collections
+
+`goframe` provides fixed-height collection virtualization for large lists and
+tables. Virtualization keeps only the visible window plus overscan mounted in
+the DOM. It is not the same as memoization: memoization skips render work for
+mounted components, while virtualization avoids mounting offscreen components
+at all.
+
+## VirtualList
+
+```go
+gf.VirtualList[Item](gf.VirtualListProps[Item]{
+	Items:      items,
+	Height:     360,
+	ItemHeight: 44,
+	Overscan:   8,
+	Key: func(item Item, index int) string {
+		return gf.ToString(item.ID)
+	},
+	RenderItem: func(item gf.VirtualItem[Item]) gf.Node {
+		return <ItemCard Key={item.Key} Item={item.Item} />
+	},
+	Class:  "items",
+	TestID: "items-list",
+})
+```
+
+`Height` is the scroll viewport height in pixels. `ItemHeight` is the fixed
+logical item height in pixels. `Overscan` renders extra rows above and below
+the visible window to avoid edge flicker during normal scrolling.
+
+`VirtualItem.Style` contains the absolute-position style for the item. The
+built-in `VirtualList` wrapper applies the positioning to a `gf-virtual-item`
+element before calling `RenderItem`.
+
+## VirtualTable
+
+```go
+gf.VirtualTable[Issue](gf.VirtualTableProps[Issue]{
+	Items:     issues,
+	Height:    560,
+	RowHeight: 48,
+	Overscan:  8,
+	Key: func(issue Issue, index int) string {
+		return gf.ToString(issue.ID)
+	},
+	Header: func() gf.Node {
+		return <IssueTableHeader />
+	},
+	RenderRow: func(row gf.VirtualRow[Issue]) gf.Node {
+		return <IssueRow
+			Key={row.Key}
+			Issue={row.Item}
+			Style={row.RowStyle}
+		/>
+	},
+	Empty: func() gf.Node {
+		return <EmptyState />
+	},
+	TestID: "issue-table",
+})
+```
+
+`VirtualTable` renders a scrollable viewport containing a normal table. It uses
+spacer rows above and below the mounted window to preserve the logical scroll
+height. `VirtualRow.RowStyle` should be applied to the rendered `<tr>` so row
+height stays consistent.
+
+## Range Calculation
+
+The current range model is intentionally fixed-height:
+
+```text
+visibleStart = scrollTop / itemHeight
+visibleCount = ceil(height / itemHeight)
+start = max(0, visibleStart - overscan)
+end = min(len(items), visibleStart + visibleCount + overscan)
+topSpacer = start * itemHeight
+bottomSpacer = (len(items) - end) * itemHeight
+```
+
+Negative overscan is treated as zero. Invalid `Height` or `ItemHeight` values
+panic with a focused runtime message.
+
+Scroll handling stores the first visible row, not every raw pixel offset. If a
+scroll event stays within the same row boundary, the component does not schedule
+another state update.
+
+## Keys
+
+Always prefer stable item IDs:
+
+```go
+Key: func(item Item, index int) string {
+	return gf.ToString(item.ID)
+}
+```
+
+If `Key` is nil, `goframe` falls back to index-based keys. That is acceptable
+for static append-only lists, but it is not recommended for filtered, sorted,
+or mutable data. The dashboard uses issue IDs as virtual row keys.
+
+## Dashboard Pressure
+
+Before virtualization, the dashboard `Open -> All` status transition mounted
+all 300 issue rows and created roughly 6k DOM nodes in the debug pressure audit.
+The live DOM and listener counts stabilized, so this was DOM pressure rather
+than a classic leak.
+
+After moving the issue table to `gf.VirtualTable`, the dashboard still has 300
+logical issues, but the mounted `.issue-row` count stays bounded. A typical
+debug pressure run reports about 20 mounted rows, around 432 created nodes for
+`Open -> All`, stable live DOM count, and stable net listener count.
+
+The pressure script gates the important invariants:
+
+- mounted rows remain bounded;
+- live DOM count stabilizes across cycles;
+- net listener count stabilizes across cycles;
+- `Open -> All` no longer creates thousands of row nodes.
+
+## Limitations
+
+- Fixed item and row heights only.
+- No dynamic measurement or variable-height layout engine yet.
+- No infinite loading or data-window fetching.
+- Table accessibility is basic; keyboard navigation is future work.
+- No SSR or hydration integration.
+- Hidden rows are not virtualization. Offscreen rows should not remain mounted
+  merely with `display:none` or `visibility:hidden`.
+
+Future work can add dynamic row-height measurement, richer table helpers,
+keyboard navigation, and infinite loading once the fixed-height model has more
+usage mileage.

--- a/docs/virtualization.md
+++ b/docs/virtualization.md
@@ -72,6 +72,12 @@ that value as the `colspan` for spacer and empty rows. If `ColumnCount <= 0`,
 the runtime falls back to `1`; examples should not rely on that fallback unless
 the table really has one column.
 
+The top and bottom spacer rows are internal keyed rows and remain mounted even
+when their height is `0px`. User row keys are namespaced internally before
+reconciliation, while `VirtualRow.Key` remains the user-facing item key passed
+to `RenderRow`. This prevents spacer rows and user rows from matching each
+other during scroll, filter, and sort updates.
+
 ## Range Calculation
 
 The current range model is intentionally fixed-height:
@@ -121,6 +127,7 @@ debug pressure run reports about 20 mounted rows, around 432 created nodes for
 The pressure script gates the important invariants:
 
 - mounted rows remain bounded;
+- top and bottom spacer rows keep stable DOM identity;
 - live DOM count stabilizes across cycles;
 - net listener count stabilizes across cycles;
 - `Open -> All` no longer creates thousands of row nodes.

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -111,7 +111,10 @@ logical issues and summaries still report the logical filtered count, but the
 mounted `.issue-row` elements stay bounded to the visible window plus overscan.
 The table passes `ColumnCount: 7` so spacer rows preserve the real dashboard
 columns: Issue, Status, Priority, Owner, Service, Events, and Action. This is
-real virtualization: offscreen rows are not hidden DOM nodes.
+real virtualization: offscreen rows are not hidden DOM nodes. The framework
+keeps top and bottom spacer rows keyed and mounted, including at `0px` height,
+so scroll/filter updates do not remount spacer `tr` nodes or match them against
+user rows.
 
 For DOM pressure audits, run:
 
@@ -131,6 +134,7 @@ With `gf.VirtualTable`, a typical debug run reports:
 - mounted issue rows: about 20, with a smoke bound of 70;
 - Open -> All average duration: about 47 ms in the local debug audit;
 - Open -> All created nodes: about 432;
+- virtual table spacer rows stable across filter and scroll cycles;
 - live DOM count stable across cycles;
 - net listener count stable across cycles.
 

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -10,6 +10,7 @@ The app models an operations dashboard with deterministic issue data. It tests:
 - derived filtered/sorted views;
 - metric cards;
 - keyed table rows and reorder/filter behavior;
+- fixed-height table virtualization through `gf.VirtualTable`;
 - row selection and detail panel updates;
 - a small document-title effect;
 - multi-file GOX components in one Go package.
@@ -20,7 +21,7 @@ The app models an operations dashboard with deterministic issue data. It tests:
 - `components_layout.gox` contains layout primitives.
 - `components_metrics.gox` contains metric cards.
 - `components_filters.gox` contains controlled inputs/selects.
-- `components_table.gox` contains keyed table rows.
+- `components_table.gox` contains the virtualized keyed issue table.
 - `components_detail.gox` contains the selected issue panel.
 - `model.go`, `data.go`, and `filters.go` contain pure app logic.
 
@@ -73,7 +74,7 @@ scripts/size-budget.sh
 
 Expected TinyGo size is dashboard-sized but still below the MVP budget:
 
-- raw <= 150 KiB;
+- raw <= 165 KiB;
 - gzip <= 70 KiB;
 - brotli <= 52 KiB;
 - zstd <= 60 KiB, when zstd is available.
@@ -105,10 +106,10 @@ event handlers dispatch actions against the latest issue state instead of a
 slice captured by an older render. That removes the earlier `DataVersion`
 workaround and keeps row memoization useful for single-row data changes.
 
-Known remaining cost: without table virtualization, full-table actions such as
-search, status filtering, sorting, reset, and simulated dataset updates still
-visit or rerender many visible rows. That is an intentional baseline for future
-runtime optimization rather than a hidden runtime feature.
+The table uses `gf.VirtualTable` with fixed-height rows. The app still has 300
+logical issues and summaries still report the logical filtered count, but the
+mounted `.issue-row` elements stay bounded to the visible window plus overscan.
+This is real virtualization: offscreen rows are not hidden DOM nodes.
 
 For DOM pressure audits, run:
 
@@ -116,25 +117,31 @@ For DOM pressure audits, run:
 node --experimental-websocket scripts/dashboard-dom-pressure.mjs
 ```
 
-The pressure audit repeatedly switches the status filter from Open to All. On
-the current 300-row fixture, Open shows 72 rows and All restores 300 rows, so
-the All transition recreates 228 rows. In a debug TinyGo build that is roughly
-6,156 created DOM nodes and 456 event listeners reattached per All transition.
-The audit fails if the live DOM node count or net listener count grows across
-cycles. A stable live DOM count with growing DevTools/Performance `Nodes`
-should be treated as a detached-node/GC accounting signal to investigate, not
-as proof of a live DOM leak by itself.
+The pressure audit repeatedly switches the status filter from Open to All. The
+pre-virtualization baseline created roughly 6,156 DOM nodes and reattached
+about 456 event listeners for the All transition, while live DOM and net
+listener counts still stabilized. That proved DOM pressure rather than a
+classic leak.
 
-The expected next product-level answer to this pressure is row virtualization,
-not a hidden runtime heuristic. Virtualization is intentionally outside this
-example and outside the current runtime MVPs.
+With `gf.VirtualTable`, a typical debug run reports:
+
+- logical All count: 300 issues;
+- mounted issue rows: about 20, with a smoke bound of 70;
+- Open -> All average duration: about 47 ms in the local debug audit;
+- Open -> All created nodes: about 432;
+- live DOM count stable across cycles;
+- net listener count stable across cycles.
+
+Exact timing remains informational and machine-dependent. The hard invariant is
+bounded mounted rows plus stable live DOM/listener counts.
 
 ## Known Limitations
 
 - There is no router or URL state.
-- There is no context API, so state is passed through typed props.
-- There is no virtualization; all 300 rows are real DOM rows.
+- State is still mostly passed through typed props; the dashboard intentionally
+  remains a reducer/memoization/virtualization pressure test rather than a
+  context example.
+- Virtualization requires fixed row height. There is no dynamic measurement,
+  infinite loading, or advanced keyboard navigation yet.
 - GOX has no spread props, style objects, namespaces, or template loops.
 - Timing numbers printed by smoke are informational, not CI performance budgets.
-- There is no row virtualization, so full-table state changes still visit all
-  rendered rows.

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -114,7 +114,10 @@ columns: Issue, Status, Priority, Owner, Service, Events, and Action. This is
 real virtualization: offscreen rows are not hidden DOM nodes. The framework
 keeps top and bottom spacer rows keyed and mounted, including at `0px` height,
 so scroll/filter updates do not remount spacer `tr` nodes or match them against
-user rows.
+user rows. Scroll state is buffered by rendered range start: scrolling within
+the existing overscan buffer should not rerender `VirtualTable` or remount
+`IssueRow` nodes, and range updates happen only after the visible viewport
+leaves that buffer.
 
 For DOM pressure audits, run:
 
@@ -131,10 +134,12 @@ classic leak.
 With `gf.VirtualTable`, a typical debug run reports:
 
 - logical All count: 300 issues;
-- mounted issue rows: about 20, with a smoke bound of 70;
+- mounted issue rows: about 28, with a smoke bound of 70;
 - Open -> All average duration: about 47 ms in the local debug audit;
-- Open -> All created nodes: about 432;
+- Open -> All created nodes remain bounded;
 - virtual table spacer rows stable across filter and scroll cycles;
+- continuous table scroll renders `VirtualTable` much less often than scroll
+  events;
 - live DOM count stable across cycles;
 - net listener count stable across cycles.
 

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -109,7 +109,9 @@ workaround and keeps row memoization useful for single-row data changes.
 The table uses `gf.VirtualTable` with fixed-height rows. The app still has 300
 logical issues and summaries still report the logical filtered count, but the
 mounted `.issue-row` elements stay bounded to the visible window plus overscan.
-This is real virtualization: offscreen rows are not hidden DOM nodes.
+The table passes `ColumnCount: 7` so spacer rows preserve the real dashboard
+columns: Issue, Status, Priority, Owner, Service, Events, and Action. This is
+real virtualization: offscreen rows are not hidden DOM nodes.
 
 For DOM pressure audits, run:
 

--- a/examples/dashboard/components_table.gox
+++ b/examples/dashboard/components_table.gox
@@ -53,6 +53,7 @@ func IssueTable(props IssueTableProps) gf.Node {
 		Height: dashboardTableHeight,
 		RowHeight: dashboardRowHeight,
 		Overscan: dashboardRowOverscan,
+		ColumnCount: dashboardTableColumnCount,
 		Key: func(issue Issue, index int) string {
 			return gf.ToString(issue.ID)
 		},

--- a/examples/dashboard/components_table.gox
+++ b/examples/dashboard/components_table.gox
@@ -48,37 +48,55 @@ type IssueTableProps struct {
 }
 
 func IssueTable(props IssueTableProps) gf.Node {
+	return gf.VirtualTable[Issue](gf.VirtualTableProps[Issue]{
+		Items: props.Items,
+		Height: dashboardTableHeight,
+		RowHeight: dashboardRowHeight,
+		Overscan: dashboardRowOverscan,
+		Key: func(issue Issue, index int) string {
+			return gf.ToString(issue.ID)
+		},
+		Header: func() gf.Node {
+			return <IssueTableHeader />
+		},
+		RenderRow: func(row gf.VirtualRow[Issue]) gf.Node {
+			issue := row.Item
+			return <IssueRow
+				Key={row.Key}
+				Issue={issue}
+				Selected={issue.ID == props.SelectedID}
+				Style={row.RowStyle}
+				OnSelect={props.OnSelect}
+				OnToggle={props.OnToggle}
+			/>
+		},
+		Class: "issue-table",
+		TestID: "issue-table",
+	})
+}
+
+type IssueTableHeaderProps struct{}
+
+func IssueTableHeader(props IssueTableHeaderProps) gf.Node {
 	return (
-		<table class="issue-table" data-testid="issue-table">
-			<thead>
-				<tr>
-					<th>Issue</th>
-					<th>Status</th>
-					<th>Priority</th>
-					<th>Owner</th>
-					<th>Service</th>
-					<th>Events</th>
-					<th>Action</th>
-				</tr>
-			</thead>
-			<tbody>
-				{gf.Map(props.Items, func(issue Issue) gf.Node {
-					return <IssueRow
-						Key={issue.ID}
-						Issue={issue}
-						Selected={issue.ID == props.SelectedID}
-						OnSelect={props.OnSelect}
-						OnToggle={props.OnToggle}
-					/>
-				})}
-			</tbody>
-		</table>
+		<thead>
+			<tr>
+				<th>Issue</th>
+				<th>Status</th>
+				<th>Priority</th>
+				<th>Owner</th>
+				<th>Service</th>
+				<th>Events</th>
+				<th>Action</th>
+			</tr>
+		</thead>
 	)
 }
 
 type IssueRowProps struct {
 	Issue    Issue
 	Selected bool
+	Style    string
 	OnSelect  func(id int)
 	OnToggle  func(id int)
 }
@@ -92,6 +110,7 @@ func IssueRow(props IssueRowProps) gf.Node {
 		<tr
 			ID={"issue-row-"+gf.ToString(props.Issue.ID)}
 			class={className}
+			style={props.Style}
 			data-testid={"issue-row-"+gf.ToString(props.Issue.ID)}
 		>
 			<td>
@@ -123,6 +142,7 @@ func (props IssueRowProps) MemoEqual(next IssueRowProps) bool {
 		props.Issue.UpdatedAt == next.Issue.UpdatedAt &&
 		props.Issue.Events == next.Issue.Events &&
 		props.Selected == next.Selected &&
+		props.Style == next.Style &&
 		props.Issue.Title == next.Issue.Title &&
 		props.Issue.Owner == next.Issue.Owner &&
 		props.Issue.Service == next.Issue.Service

--- a/examples/dashboard/model.go
+++ b/examples/dashboard/model.go
@@ -33,6 +33,7 @@ const dashboardItemCount = 300
 const dashboardTableHeight = 560
 const dashboardRowHeight = 48
 const dashboardRowOverscan = 8
+const dashboardTableColumnCount = 7
 
 type Issue struct {
 	ID         int

--- a/examples/dashboard/model.go
+++ b/examples/dashboard/model.go
@@ -30,6 +30,9 @@ const (
 )
 
 const dashboardItemCount = 300
+const dashboardTableHeight = 560
+const dashboardRowHeight = 48
+const dashboardRowOverscan = 8
 
 type Issue struct {
 	ID         int

--- a/examples/dashboard/styles.css
+++ b/examples/dashboard/styles.css
@@ -144,6 +144,7 @@ select:focus {
     width: 100%;
     border-collapse: collapse;
     font-size: 0.92rem;
+    table-layout: fixed;
 }
 
 .issue-table th,
@@ -158,6 +159,26 @@ select:focus {
     color: #667789;
     font-size: 0.75rem;
     text-transform: uppercase;
+}
+
+.gf-virtual-table-viewport {
+    border: 1px solid #e0e7ee;
+    border-radius: 0.7rem;
+}
+
+.gf-virtual-table .issue-row {
+    height: 48px;
+}
+
+.gf-virtual-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: white;
+}
+
+.gf-virtual-table-spacer td {
+    background: transparent;
 }
 
 .issue-row-selected { background: #edf8fb; }

--- a/examples/dashboard/styles.css
+++ b/examples/dashboard/styles.css
@@ -161,9 +161,28 @@ select:focus {
     text-transform: uppercase;
 }
 
+.issue-table th:nth-child(1),
+.issue-table td:nth-child(1) { width: 30%; }
+.issue-table th:nth-child(2),
+.issue-table td:nth-child(2) { width: 12%; }
+.issue-table th:nth-child(3),
+.issue-table td:nth-child(3) { width: 11%; }
+.issue-table th:nth-child(4),
+.issue-table td:nth-child(4) { width: 12%; }
+.issue-table th:nth-child(5),
+.issue-table td:nth-child(5) { width: 13%; }
+.issue-table th:nth-child(6),
+.issue-table td:nth-child(6) { width: 8%; }
+.issue-table th:nth-child(7),
+.issue-table td:nth-child(7) { width: 14%; }
+
 .gf-virtual-table-viewport {
     border: 1px solid #e0e7ee;
     border-radius: 0.7rem;
+}
+
+.gf-virtual-table {
+    width: 100%;
 }
 
 .gf-virtual-table .issue-row {

--- a/examples/virtualized/README.md
+++ b/examples/virtualized/README.md
@@ -1,0 +1,44 @@
+# Virtualized Collections Example
+
+This example demonstrates the reusable `gf.VirtualList` and `gf.VirtualTable`
+primitives. It creates 10,000 deterministic logical items while keeping the
+mounted DOM bounded to the visible window plus overscan.
+
+It is intentionally small. The dashboard remains the larger pressure test;
+this app is the focused proof that virtualization is framework-level API, not
+an example-local workaround.
+
+## What It Tests
+
+- `gf.VirtualList` fixed-height item windows.
+- `gf.VirtualTable` fixed-row-height table windows.
+- Stable item keys based on logical IDs.
+- Scroll-driven range updates.
+- Selection and toggle actions after scrolling.
+- Bounded DOM and listener counts despite a large logical collection.
+
+## Run
+
+```bash
+goxc generate ./examples/virtualized
+goxc package ./examples/virtualized --compiler=tinygo
+goxc serve ./examples/virtualized --port=8080
+```
+
+Then open <http://127.0.0.1:8080>.
+
+For cache-safe packaging:
+
+```bash
+goxc package ./examples/virtualized --compiler=tinygo --asset-hash --preload --compress=gzip,br
+goxc size ./examples/virtualized
+```
+
+## Limitations
+
+- Row and item heights are fixed.
+- There is no dynamic measurement engine yet.
+- Infinite loading, keyboard navigation, and advanced accessibility behavior are
+  future work.
+- Hidden rows are not used. Only the visible window plus overscan exists in the
+  DOM.

--- a/examples/virtualized/app.gox
+++ b/examples/virtualized/app.gox
@@ -1,0 +1,210 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <VirtualizedApp />
+}
+
+type VirtualizedAppProps struct{}
+
+func VirtualizedApp(props VirtualizedAppProps) gf.Node {
+	items, dispatch := gf.UseReducer(makeDemoItems(virtualizedItemCount), reduceDemoItems)
+	selectedID, setSelectedID := gf.UseState(1)
+	selected, found := findDemoItem(items, selectedID)
+
+	toggle := func(id int) {
+		dispatch(DemoAction{Kind: DemoActionToggle, ID: id})
+	}
+	reset := func() {
+		dispatch(DemoAction{Kind: DemoActionReset})
+		setSelectedID(1)
+	}
+
+	return (
+		<main class="virtual-page">
+			<header class="hero" data-testid="virtualized-header">
+				<p class="eyebrow">GoFrame virtualized collections</p>
+				<h1>10,000 logical rows, bounded DOM</h1>
+				<p data-testid="logical-count">{len(items)} logical items</p>
+			</header>
+
+			<section class="toolbar">
+				<button Type="button" id="reset-demo" OnClick={reset}>Reset demo data</button>
+				<p data-testid="selection-summary">
+					{found ? (
+						<>Selected #{selected.ID} · {enabledLabel(selected.Enabled)} · score {selected.Score}</>
+					) : (
+						<>No selection</>
+					)}
+				</p>
+			</section>
+
+			<section class="virtual-grid">
+				<VirtualListPanel
+					Items={items}
+					SelectedID={selectedID}
+					OnSelect={setSelectedID}
+					OnToggle={toggle}
+				/>
+				<VirtualTablePanel
+					Items={items}
+					SelectedID={selectedID}
+					OnSelect={setSelectedID}
+					OnToggle={toggle}
+				/>
+			</section>
+		</main>
+	)
+}
+
+type VirtualListPanelProps struct {
+	Items []DemoItem
+	SelectedID int
+	OnSelect func(id int)
+	OnToggle func(id int)
+}
+
+func VirtualListPanel(props VirtualListPanelProps) gf.Node {
+	return (
+		<section class="panel">
+			<h2>VirtualList</h2>
+			{gf.VirtualList[DemoItem](gf.VirtualListProps[DemoItem]{
+				Items: props.Items,
+				Height: virtualListHeight,
+				ItemHeight: virtualListItemHeight,
+				Overscan: virtualOverscan,
+				Key: func(item DemoItem, index int) string {
+					return gf.ToString(item.ID)
+				},
+				RenderItem: func(item gf.VirtualItem[DemoItem]) gf.Node {
+					value := item.Item
+					return <VirtualListItem
+						Key={item.Key}
+						Item={value}
+						Selected={value.ID == props.SelectedID}
+						OnSelect={props.OnSelect}
+						OnToggle={props.OnToggle}
+					/>
+				},
+				Class: "demo-list",
+				TestID: "virtual-list",
+			})}
+		</section>
+	)
+}
+
+type VirtualListItemProps struct {
+	Item DemoItem
+	Selected bool
+	OnSelect func(id int)
+	OnToggle func(id int)
+}
+
+func VirtualListItem(props VirtualListItemProps) gf.Node {
+	className := "list-card"
+	if props.Selected {
+		className += " selected"
+	}
+	return (
+		<div class={className} data-testid={"virtual-list-item-"+gf.ToString(props.Item.ID)}>
+			<button Type="button" class="item-main" OnClick={func() {
+				props.OnSelect(props.Item.ID)
+			}}>
+				<strong>#{props.Item.ID} {props.Item.Name}</strong>
+				<span>{props.Item.Group} · score {props.Item.Score}</span>
+			</button>
+			<button Type="button" class="tiny" OnClick={func() {
+				props.OnToggle(props.Item.ID)
+			}}>{enabledLabel(props.Item.Enabled)}</button>
+		</div>
+	)
+}
+
+type VirtualTablePanelProps struct {
+	Items []DemoItem
+	SelectedID int
+	OnSelect func(id int)
+	OnToggle func(id int)
+}
+
+func VirtualTablePanel(props VirtualTablePanelProps) gf.Node {
+	return (
+		<section class="panel">
+			<h2>VirtualTable</h2>
+			{gf.VirtualTable[DemoItem](gf.VirtualTableProps[DemoItem]{
+				Items: props.Items,
+				Height: virtualTableHeight,
+				RowHeight: virtualTableRowHeight,
+				Overscan: virtualOverscan,
+				Key: func(item DemoItem, index int) string {
+					return gf.ToString(item.ID)
+				},
+				Header: func() gf.Node {
+					return <VirtualTableHeader />
+				},
+				RenderRow: func(row gf.VirtualRow[DemoItem]) gf.Node {
+					item := row.Item
+					return <VirtualTableRow
+						Key={row.Key}
+						Item={item}
+						Selected={item.ID == props.SelectedID}
+						Style={row.RowStyle}
+						OnSelect={props.OnSelect}
+						OnToggle={props.OnToggle}
+					/>
+				},
+				Class: "demo-table",
+				TestID: "virtual-table",
+			})}
+		</section>
+	)
+}
+
+type VirtualTableHeaderProps struct{}
+
+func VirtualTableHeader(props VirtualTableHeaderProps) gf.Node {
+	return (
+		<thead>
+			<tr>
+				<th>Item</th>
+				<th>Group</th>
+				<th>Score</th>
+				<th>Status</th>
+				<th>Action</th>
+			</tr>
+		</thead>
+	)
+}
+
+type VirtualTableRowProps struct {
+	Item DemoItem
+	Selected bool
+	Style string
+	OnSelect func(id int)
+	OnToggle func(id int)
+}
+
+func VirtualTableRow(props VirtualTableRowProps) gf.Node {
+	className := "virtual-row"
+	if props.Selected {
+		className += " selected"
+	}
+	return (
+		<tr class={className} style={props.Style} data-testid={"virtual-row-"+gf.ToString(props.Item.ID)}>
+			<td>
+				<button Type="button" class="row-link" OnClick={func() {
+					props.OnSelect(props.Item.ID)
+				}}>#{props.Item.ID} {props.Item.Name}</button>
+			</td>
+			<td>{props.Item.Group}</td>
+			<td>{props.Item.Score}</td>
+			<td>{enabledLabel(props.Item.Enabled)}</td>
+			<td>
+				<button Type="button" class="tiny" OnClick={func() {
+					props.OnToggle(props.Item.ID)
+				}}>Toggle</button>
+			</td>
+		</tr>
+	)
+}

--- a/examples/virtualized/app.gox
+++ b/examples/virtualized/app.gox
@@ -137,6 +137,7 @@ func VirtualTablePanel(props VirtualTablePanelProps) gf.Node {
 				Height: virtualTableHeight,
 				RowHeight: virtualTableRowHeight,
 				Overscan: virtualOverscan,
+				ColumnCount: virtualTableColumnCount,
 				Key: func(item DemoItem, index int) string {
 					return gf.ToString(item.ID)
 				},

--- a/examples/virtualized/goframe.json
+++ b/examples/virtualized/goframe.json
@@ -1,0 +1,11 @@
+{
+  "name": "virtualized",
+  "entry": ".",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css"
+  ]
+}

--- a/examples/virtualized/index.html
+++ b/examples/virtualized/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>goframe virtualized collections</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <script>
+        window.goframeComponentRenderCounts = {};
+        window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
+        window.goframeComponentRenderProbe = (name) => {
+            window.goframeComponentRenderCounts[name] =
+                (window.goframeComponentRenderCounts[name] || 0) + 1;
+        };
+        window.goframeComponentPatchProbe = (name) => {
+            window.goframeComponentPatchCounts[name] =
+                (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
+        };
+    </script>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance))
+            .catch((error) => {
+                console.error("[goframe] startup failed", error);
+                document.getElementById("root").textContent = "Failed to start goframe. See console.";
+            });
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/examples/virtualized/main.go
+++ b/examples/virtualized/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/virtualized/model.go
+++ b/examples/virtualized/model.go
@@ -7,6 +7,7 @@ const virtualListHeight = 360
 const virtualListItemHeight = 44
 const virtualTableHeight = 420
 const virtualTableRowHeight = 40
+const virtualTableColumnCount = 5
 const virtualOverscan = 8
 
 type DemoItem struct {

--- a/examples/virtualized/model.go
+++ b/examples/virtualized/model.go
@@ -1,0 +1,109 @@
+package main
+
+import "strconv"
+
+const virtualizedItemCount = 10000
+const virtualListHeight = 360
+const virtualListItemHeight = 44
+const virtualTableHeight = 420
+const virtualTableRowHeight = 40
+const virtualOverscan = 8
+
+type DemoItem struct {
+	ID      int
+	Name    string
+	Group   string
+	Enabled bool
+	Score   int
+}
+
+type DemoActionKind int
+
+const (
+	DemoActionToggle DemoActionKind = iota
+	DemoActionReset
+)
+
+type DemoAction struct {
+	Kind DemoActionKind
+	ID   int
+}
+
+func makeDemoItems(count int) []DemoItem {
+	items := make([]DemoItem, 0, count)
+	for index := 0; index < count; index++ {
+		id := index + 1
+		items = append(items, DemoItem{
+			ID:      id,
+			Name:    "Item " + paddedNumber(id),
+			Group:   groupName(index),
+			Enabled: index%3 != 0,
+			Score:   (index*37 + 11) % 1000,
+		})
+	}
+	return items
+}
+
+func reduceDemoItems(items []DemoItem, action DemoAction) []DemoItem {
+	switch action.Kind {
+	case DemoActionToggle:
+		return toggleDemoItem(items, action.ID)
+	case DemoActionReset:
+		return makeDemoItems(virtualizedItemCount)
+	default:
+		return items
+	}
+}
+
+func toggleDemoItem(items []DemoItem, id int) []DemoItem {
+	next := append([]DemoItem(nil), items...)
+	for index := range next {
+		if next[index].ID == id {
+			next[index].Enabled = !next[index].Enabled
+			return next
+		}
+	}
+	return items
+}
+
+func findDemoItem(items []DemoItem, id int) (DemoItem, bool) {
+	for _, item := range items {
+		if item.ID == id {
+			return item, true
+		}
+	}
+	return DemoItem{}, false
+}
+
+func groupName(index int) string {
+	switch index % 4 {
+	case 0:
+		return "Alpha"
+	case 1:
+		return "Beta"
+	case 2:
+		return "Gamma"
+	default:
+		return "Delta"
+	}
+}
+
+func enabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+func paddedNumber(value int) string {
+	if value < 10 {
+		return "000" + strconv.Itoa(value)
+	}
+	if value < 100 {
+		return "00" + strconv.Itoa(value)
+	}
+	if value < 1000 {
+		return "0" + strconv.Itoa(value)
+	}
+	return strconv.Itoa(value)
+}

--- a/examples/virtualized/model_test.go
+++ b/examples/virtualized/model_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+func TestMakeDemoItemsIsDeterministic(t *testing.T) {
+	items := makeDemoItems(3)
+	if len(items) != 3 {
+		t.Fatalf("len = %d, want 3", len(items))
+	}
+	if items[0].ID != 1 || items[0].Name != "Item 0001" || items[1].Group != "Beta" {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+}
+
+func TestReduceDemoItemsToggleDoesNotMutateInput(t *testing.T) {
+	items := makeDemoItems(4)
+	before := items[1].Enabled
+	next := reduceDemoItems(items, DemoAction{Kind: DemoActionToggle, ID: 2})
+	if items[1].Enabled != before {
+		t.Fatalf("input mutated: got %v, want %v", items[1].Enabled, before)
+	}
+	if next[1].Enabled == before {
+		t.Fatalf("toggle did not change item 2")
+	}
+}
+
+func TestFindDemoItem(t *testing.T) {
+	items := makeDemoItems(4)
+	item, ok := findDemoItem(items, 3)
+	if !ok || item.ID != 3 {
+		t.Fatalf("find item = %#v, %v", item, ok)
+	}
+	if _, ok := findDemoItem(items, 99); ok {
+		t.Fatal("unexpected match for missing item")
+	}
+}

--- a/examples/virtualized/styles.css
+++ b/examples/virtualized/styles.css
@@ -1,0 +1,149 @@
+:root {
+    color: #172033;
+    background: #eef3f8;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; }
+button { font: inherit; }
+
+.virtual-page {
+    display: grid;
+    gap: 1rem;
+    max-width: 76rem;
+    margin: 0 auto 3rem;
+    padding: 1.25rem;
+}
+
+.hero {
+    color: white;
+    background: linear-gradient(135deg, #172033, #6e4cc8);
+    border-radius: 1rem;
+    padding: 2rem;
+}
+
+.hero h1,
+.hero p { margin: 0; }
+.hero h1 { margin-top: 0.35rem; }
+
+.eyebrow {
+    color: #d9d0ff;
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.toolbar,
+.panel {
+    background: white;
+    border: 1px solid #d9e3ec;
+    border-radius: 0.9rem;
+    box-shadow: 0 0.8rem 2rem rgb(23 32 51 / 7%);
+    padding: 1rem;
+}
+
+.toolbar {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.toolbar p { margin: 0; color: #526373; }
+
+button {
+    border: 0;
+    border-radius: 0.5rem;
+    color: white;
+    background: #176f8b;
+    cursor: pointer;
+    padding: 0.55rem 0.75rem;
+}
+
+.tiny {
+    font-size: 0.78rem;
+    padding: 0.35rem 0.55rem;
+}
+
+.virtual-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.panel h2 { margin: 0 0 0.8rem; }
+
+.gf-virtual-list,
+.gf-virtual-table-viewport {
+    border: 1px solid #d9e3ec;
+    border-radius: 0.7rem;
+    background: #f9fbfd;
+}
+
+.list-card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.75rem;
+    height: 44px;
+    border-bottom: 1px solid #e1e8ef;
+    padding: 0 0.6rem;
+}
+
+.item-main,
+.row-link {
+    display: grid;
+    gap: 0.12rem;
+    border: 0;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+    padding: 0;
+    text-align: left;
+}
+
+.item-main span {
+    color: #667789;
+    font-size: 0.78rem;
+}
+
+.selected {
+    background: #edf8fb;
+}
+
+.demo-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-size: 0.9rem;
+}
+
+.demo-table th,
+.demo-table td {
+    border-bottom: 1px solid #e1e8ef;
+    padding: 0.45rem 0.5rem;
+    text-align: left;
+}
+
+.demo-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: white;
+}
+
+.virtual-row {
+    height: 40px;
+}
+
+.gf-virtual-table-spacer td {
+    background: transparent;
+}
+
+@media (max-width: 58rem) {
+    .virtual-grid { grid-template-columns: 1fr; }
+    .toolbar { align-items: flex-start; flex-direction: column; }
+}

--- a/pkg/goframe/event.go
+++ b/pkg/goframe/event.go
@@ -34,3 +34,17 @@ func (event InputEvent) Value() string {
 	}
 	return event.value()
 }
+
+// ScrollEvent exposes the current scroll offset for scrollable elements.
+type ScrollEvent struct {
+	Event
+	scrollTop func() int
+}
+
+// ScrollTop returns the event target's vertical scroll offset in pixels.
+func (event ScrollEvent) ScrollTop() int {
+	if event.scrollTop == nil {
+		return 0
+	}
+	return event.scrollTop()
+}

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -325,6 +325,7 @@ func eventHandler(listener *mountedEvent) js.Func {
 		}
 		wrappedEvent := wrapEvent(rawEvent)
 		inputEvent := wrapInputEvent(rawEvent, wrappedEvent)
+		scrollEvent := wrapScrollEvent(rawEvent, wrappedEvent)
 		switch callback := listener.callback.(type) {
 		case func():
 			callback()
@@ -332,10 +333,12 @@ func eventHandler(listener *mountedEvent) js.Func {
 			callback(wrappedEvent)
 		case func(InputEvent):
 			callback(inputEvent)
+		case func(ScrollEvent):
+			callback(scrollEvent)
 		case func(js.Value):
 			callback(rawEvent)
 		default:
-			panic("goframe: event handler must be func(), func(goframe.Event), func(goframe.InputEvent), or func(js.Value)")
+			panic("goframe: event handler must be func(), func(goframe.Event), func(goframe.InputEvent), func(goframe.ScrollEvent), or func(js.Value)")
 		}
 		return nil
 	})
@@ -371,6 +374,26 @@ func wrapInputEvent(value js.Value, event Event) InputEvent {
 				return ""
 			}
 			return current.String()
+		},
+	}
+}
+
+func wrapScrollEvent(value js.Value, event Event) ScrollEvent {
+	return ScrollEvent{
+		Event: event,
+		scrollTop: func() int {
+			if value.IsUndefined() || value.IsNull() {
+				return 0
+			}
+			target := value.Get("target")
+			if target.IsUndefined() || target.IsNull() {
+				return 0
+			}
+			current := target.Get("scrollTop")
+			if current.IsUndefined() || current.IsNull() {
+				return 0
+			}
+			return current.Int()
 		},
 	}
 }

--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -80,8 +80,8 @@ func renderVirtualList[T any](props VirtualListProps[T]) Node {
 	if props.RenderItem == nil {
 		panic("goframe: VirtualList requires RenderItem")
 	}
-	visibleStart, setVisibleStart := UseState(0)
-	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.ItemHeight, props.Overscan, visibleStart)
+	rangeStart, setRangeStart := UseState(0)
+	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.ItemHeight, props.Overscan, rangeStart)
 
 	children := make([]Node, 0, rangeInfo.End-rangeInfo.Start)
 	for index := rangeInfo.Start; index < rangeInfo.End; index++ {
@@ -104,9 +104,9 @@ func renderVirtualList[T any](props VirtualListProps[T]) Node {
 		"class": joinVirtualClass("gf-virtual-list", props.Class),
 		"style": virtualViewportStyle(props.Height),
 		"OnScroll": func(event ScrollEvent) {
-			next := virtualVisibleStart(len(props.Items), props.ItemHeight, event.ScrollTop())
-			if next != visibleStart {
-				setVisibleStart(next)
+			next := virtualRangeStartAfterScroll(rangeInfo, rangeStart, len(props.Items), props.Height, props.ItemHeight, props.Overscan, event.ScrollTop())
+			if next != rangeStart {
+				setRangeStart(next)
 			}
 		},
 	}
@@ -117,7 +117,7 @@ func renderVirtualList[T any](props VirtualListProps[T]) Node {
 	return El("div", outerProps,
 		El("div", Props{
 			"class": "gf-virtual-list-spacer",
-			"style": "height:" + ToString(rangeInfo.TotalHeight) + "px;position:relative;",
+			"style": "height:" + ToString(rangeInfo.TotalHeight) + "px;position:relative;overflow-anchor:none;",
 		}, children...),
 	)
 }
@@ -127,8 +127,8 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 	if props.RenderRow == nil {
 		panic("goframe: VirtualTable requires RenderRow")
 	}
-	visibleStart, setVisibleStart := UseState(0)
-	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.RowHeight, props.Overscan, visibleStart)
+	rangeStart, setRangeStart := UseState(0)
+	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.RowHeight, props.Overscan, rangeStart)
 
 	bodyChildren := make([]Node, 0, rangeInfo.End-rangeInfo.Start+2)
 	if len(props.Items) == 0 {
@@ -166,9 +166,9 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 		"class": "gf-virtual-table-viewport",
 		"style": virtualViewportStyle(props.Height),
 		"OnScroll": func(event ScrollEvent) {
-			next := virtualVisibleStart(len(props.Items), props.RowHeight, event.ScrollTop())
-			if next != visibleStart {
-				setVisibleStart(next)
+			next := virtualRangeStartAfterScroll(rangeInfo, rangeStart, len(props.Items), props.Height, props.RowHeight, props.Overscan, event.ScrollTop())
+			if next != rangeStart {
+				setRangeStart(next)
 			}
 		},
 	}
@@ -190,10 +190,12 @@ func validateVirtualDimensions(name string, height int, itemHeight int, itemHeig
 }
 
 func calculateVirtualRange(length int, height int, itemHeight int, overscan int, scrollTop int) VirtualRange {
-	return calculateVirtualRangeFromStart(length, height, itemHeight, overscan, virtualVisibleStart(length, itemHeight, scrollTop))
+	visibleStart := virtualVisibleStart(length, itemHeight, scrollTop)
+	rangeStart := virtualRangeStartForVisibleStart(length, height, itemHeight, overscan, visibleStart)
+	return calculateVirtualRangeFromStart(length, height, itemHeight, overscan, rangeStart)
 }
 
-func calculateVirtualRangeFromStart(length int, height int, itemHeight int, overscan int, visibleStart int) VirtualRange {
+func calculateVirtualRangeFromStart(length int, height int, itemHeight int, overscan int, rangeStart int) VirtualRange {
 	validateVirtualDimensions("virtual range", height, itemHeight, "ItemHeight")
 	if length <= 0 {
 		return VirtualRange{}
@@ -201,23 +203,9 @@ func calculateVirtualRangeFromStart(length int, height int, itemHeight int, over
 	if overscan < 0 {
 		overscan = 0
 	}
-	visibleStart = clampInt(visibleStart, 0, length-1)
-	visibleCount := ceilDiv(height, itemHeight)
-	if visibleCount < 1 {
-		visibleCount = 1
-	}
-
-	start := visibleStart - overscan
-	if start < 0 {
-		start = 0
-	}
-	end := visibleStart + visibleCount + overscan
-	if end > length {
-		end = length
-	}
-	if end < start {
-		end = start
-	}
+	windowSize := virtualWindowSize(length, height, itemHeight, overscan)
+	start := clampInt(rangeStart, 0, length-windowSize)
+	end := start + windowSize
 
 	return VirtualRange{
 		Start:        start,
@@ -226,6 +214,63 @@ func calculateVirtualRangeFromStart(length int, height int, itemHeight int, over
 		BottomSpacer: (length - end) * itemHeight,
 		TotalHeight:  length * itemHeight,
 	}
+}
+
+func virtualVisibleCount(height int, itemHeight int) int {
+	if height <= 0 || itemHeight <= 0 {
+		return 0
+	}
+	count := ceilDiv(height, itemHeight)
+	if count < 1 {
+		return 1
+	}
+	return count
+}
+
+func virtualWindowSize(length int, height int, itemHeight int, overscan int) int {
+	if length <= 0 {
+		return 0
+	}
+	if overscan < 0 {
+		overscan = 0
+	}
+	windowSize := virtualVisibleCount(height, itemHeight) + 2*overscan
+	if windowSize < 1 {
+		windowSize = 1
+	}
+	if windowSize > length {
+		return length
+	}
+	return windowSize
+}
+
+func virtualRangeCoversVisible(rangeInfo VirtualRange, visibleStart int, visibleCount int) bool {
+	if visibleCount < 0 {
+		visibleCount = 0
+	}
+	visibleEnd := visibleStart + visibleCount
+	return visibleStart >= rangeInfo.Start && visibleEnd <= rangeInfo.End
+}
+
+func virtualRangeStartForVisibleStart(length int, height int, itemHeight int, overscan int, visibleStart int) int {
+	if length <= 0 {
+		return 0
+	}
+	if overscan < 0 {
+		overscan = 0
+	}
+	windowSize := virtualWindowSize(length, height, itemHeight, overscan)
+	visibleStart = clampInt(visibleStart, 0, length-1)
+	return clampInt(visibleStart-overscan, 0, length-windowSize)
+}
+
+func virtualRangeStartAfterScroll(rangeInfo VirtualRange, currentStart int, length int, height int, itemHeight int, overscan int, scrollTop int) int {
+	visibleStart := virtualVisibleStart(length, itemHeight, scrollTop)
+	visibleCount := virtualVisibleCount(height, itemHeight)
+	if virtualRangeCoversVisible(rangeInfo, visibleStart, visibleCount) {
+		return currentStart
+	}
+	return virtualRangeStartForVisibleStart(length, height, itemHeight, overscan, visibleStart)
 }
 
 func virtualVisibleStart(length int, itemHeight int, scrollTop int) int {
@@ -246,17 +291,17 @@ func virtualItemKey[T any](key func(T, int) string, item T, index int) string {
 }
 
 func virtualViewportStyle(height int) string {
-	return "height:" + ToString(height) + "px;overflow-y:auto;position:relative;"
+	return "height:" + ToString(height) + "px;overflow-y:auto;position:relative;overflow-anchor:none;"
 }
 
 func virtualTableSpacerRow(name string, height int, columnCount int) Node {
 	return El("tr", Props{
 		"class":       "gf-virtual-table-spacer gf-virtual-table-spacer-" + name,
 		"aria-hidden": "true",
-		"style":       "height:" + ToString(height) + "px;",
+		"style":       "height:" + ToString(height) + "px;overflow-anchor:none;",
 	}, El("td", Props{
 		"colspan": virtualTableColumnCount(columnCount),
-		"style":   "height:" + ToString(height) + "px;padding:0;border:0;line-height:0;font-size:0;",
+		"style":   "height:" + ToString(height) + "px;padding:0;border:0;line-height:0;font-size:0;overflow-anchor:none;",
 	}))
 }
 

--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -68,6 +68,13 @@ type VirtualRange struct {
 	TotalHeight  int
 }
 
+const (
+	virtualTableTopSpacerKey    = "goframe:virtual-table:spacer:top"
+	virtualTableBottomSpacerKey = "goframe:virtual-table:spacer:bottom"
+	virtualTableEmptyKey        = "goframe:virtual-table:empty"
+	virtualTableRowKeyPrefix    = "goframe:virtual-table:row:"
+)
+
 func renderVirtualList[T any](props VirtualListProps[T]) Node {
 	validateVirtualDimensions("VirtualList", props.Height, props.ItemHeight, "ItemHeight")
 	if props.RenderItem == nil {
@@ -126,12 +133,13 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 	bodyChildren := make([]Node, 0, rangeInfo.End-rangeInfo.Start+2)
 	if len(props.Items) == 0 {
 		if props.Empty != nil {
-			bodyChildren = append(bodyChildren, virtualTableContentRow(props.Empty(), props.ColumnCount))
+			bodyChildren = append(bodyChildren, Key(virtualTableEmptyKey, virtualTableContentRow(props.Empty(), props.ColumnCount)))
 		}
 	} else {
-		if rangeInfo.TopSpacer > 0 {
-			bodyChildren = append(bodyChildren, virtualTableSpacerRow("top", rangeInfo.TopSpacer, props.ColumnCount))
-		}
+		bodyChildren = append(bodyChildren, Key(
+			virtualTableTopSpacerKey,
+			virtualTableSpacerRow("top", rangeInfo.TopSpacer, props.ColumnCount),
+		))
 		for index := rangeInfo.Start; index < rangeInfo.End; index++ {
 			key := virtualItemKey(props.Key, props.Items[index], index)
 			row := VirtualRow[T]{
@@ -140,11 +148,12 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 				Key:      key,
 				RowStyle: "height:" + ToString(props.RowHeight) + "px;",
 			}
-			bodyChildren = append(bodyChildren, Key(key, props.RenderRow(row)))
+			bodyChildren = append(bodyChildren, Key(virtualTableRowKeyPrefix+key, props.RenderRow(row)))
 		}
-		if rangeInfo.BottomSpacer > 0 {
-			bodyChildren = append(bodyChildren, virtualTableSpacerRow("bottom", rangeInfo.BottomSpacer, props.ColumnCount))
-		}
+		bodyChildren = append(bodyChildren, Key(
+			virtualTableBottomSpacerKey,
+			virtualTableSpacerRow("bottom", rangeInfo.BottomSpacer, props.ColumnCount),
+		))
 	}
 
 	tableChildren := make([]Node, 0, 2)
@@ -247,7 +256,7 @@ func virtualTableSpacerRow(name string, height int, columnCount int) Node {
 		"style":       "height:" + ToString(height) + "px;",
 	}, El("td", Props{
 		"colspan": virtualTableColumnCount(columnCount),
-		"style":   "height:" + ToString(height) + "px;padding:0;border:0;",
+		"style":   "height:" + ToString(height) + "px;padding:0;border:0;line-height:0;font-size:0;",
 	}))
 }
 

--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -1,0 +1,279 @@
+package goframe
+
+// VirtualItem is passed to VirtualList item renderers.
+type VirtualItem[T any] struct {
+	Item  T
+	Index int
+	Key   string
+	Style string
+}
+
+// VirtualListProps configures a fixed-height virtualized list.
+type VirtualListProps[T any] struct {
+	Items      []T
+	Height     int
+	ItemHeight int
+	Overscan   int
+
+	Key        func(item T, index int) string
+	RenderItem func(item VirtualItem[T]) Node
+
+	Class  string
+	TestID string
+}
+
+// VirtualList renders only the visible window plus overscan for a fixed-height
+// list. Dynamic item measurement is intentionally out of scope.
+func VirtualList[T any](props VirtualListProps[T]) Node {
+	return Component("VirtualList", props, renderVirtualList[T])
+}
+
+// VirtualRow is passed to VirtualTable row renderers.
+type VirtualRow[T any] struct {
+	Item     T
+	Index    int
+	Key      string
+	RowStyle string
+}
+
+// VirtualTableProps configures a fixed-row-height virtualized table.
+type VirtualTableProps[T any] struct {
+	Items     []T
+	Height    int
+	RowHeight int
+	Overscan  int
+
+	Key       func(item T, index int) string
+	Header    func() Node
+	RenderRow func(row VirtualRow[T]) Node
+	Empty     func() Node
+
+	Class  string
+	TestID string
+}
+
+// VirtualTable renders a scrollable fixed-row-height table while keeping the
+// mounted row count bounded by the visible window plus overscan.
+func VirtualTable[T any](props VirtualTableProps[T]) Node {
+	return Component("VirtualTable", props, renderVirtualTable[T])
+}
+
+type VirtualRange struct {
+	Start        int
+	End          int
+	TopSpacer    int
+	BottomSpacer int
+	TotalHeight  int
+}
+
+func renderVirtualList[T any](props VirtualListProps[T]) Node {
+	validateVirtualDimensions("VirtualList", props.Height, props.ItemHeight, "ItemHeight")
+	if props.RenderItem == nil {
+		panic("goframe: VirtualList requires RenderItem")
+	}
+	visibleStart, setVisibleStart := UseState(0)
+	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.ItemHeight, props.Overscan, visibleStart)
+
+	children := make([]Node, 0, rangeInfo.End-rangeInfo.Start)
+	for index := rangeInfo.Start; index < rangeInfo.End; index++ {
+		key := virtualItemKey(props.Key, props.Items[index], index)
+		top := index * props.ItemHeight
+		style := "position:absolute;top:" + ToString(top) + "px;height:" + ToString(props.ItemHeight) + "px;width:100%;"
+		item := VirtualItem[T]{
+			Item:  props.Items[index],
+			Index: index,
+			Key:   key,
+			Style: style,
+		}
+		children = append(children, Key(key, El("div", Props{
+			"class": "gf-virtual-item",
+			"style": style,
+		}, props.RenderItem(item))))
+	}
+
+	outerProps := Props{
+		"class": joinVirtualClass("gf-virtual-list", props.Class),
+		"style": virtualViewportStyle(props.Height),
+		"OnScroll": func(event ScrollEvent) {
+			next := virtualVisibleStart(len(props.Items), props.ItemHeight, event.ScrollTop())
+			if next != visibleStart {
+				setVisibleStart(next)
+			}
+		},
+	}
+	if props.TestID != "" {
+		outerProps["data-testid"] = props.TestID
+	}
+
+	return El("div", outerProps,
+		El("div", Props{
+			"class": "gf-virtual-list-spacer",
+			"style": "height:" + ToString(rangeInfo.TotalHeight) + "px;position:relative;",
+		}, children...),
+	)
+}
+
+func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
+	validateVirtualDimensions("VirtualTable", props.Height, props.RowHeight, "RowHeight")
+	if props.RenderRow == nil {
+		panic("goframe: VirtualTable requires RenderRow")
+	}
+	visibleStart, setVisibleStart := UseState(0)
+	rangeInfo := calculateVirtualRangeFromStart(len(props.Items), props.Height, props.RowHeight, props.Overscan, visibleStart)
+
+	bodyChildren := make([]Node, 0, rangeInfo.End-rangeInfo.Start+2)
+	if len(props.Items) == 0 {
+		if props.Empty != nil {
+			bodyChildren = append(bodyChildren, virtualTableContentRow(props.Empty()))
+		}
+	} else {
+		if rangeInfo.TopSpacer > 0 {
+			bodyChildren = append(bodyChildren, virtualTableSpacerRow("top", rangeInfo.TopSpacer))
+		}
+		for index := rangeInfo.Start; index < rangeInfo.End; index++ {
+			key := virtualItemKey(props.Key, props.Items[index], index)
+			row := VirtualRow[T]{
+				Item:     props.Items[index],
+				Index:    index,
+				Key:      key,
+				RowStyle: "height:" + ToString(props.RowHeight) + "px;",
+			}
+			bodyChildren = append(bodyChildren, Key(key, props.RenderRow(row)))
+		}
+		if rangeInfo.BottomSpacer > 0 {
+			bodyChildren = append(bodyChildren, virtualTableSpacerRow("bottom", rangeInfo.BottomSpacer))
+		}
+	}
+
+	tableChildren := make([]Node, 0, 2)
+	if props.Header != nil {
+		tableChildren = append(tableChildren, props.Header())
+	}
+	tableChildren = append(tableChildren, El("tbody", Props{}, bodyChildren...))
+
+	outerProps := Props{
+		"class": "gf-virtual-table-viewport",
+		"style": virtualViewportStyle(props.Height),
+		"OnScroll": func(event ScrollEvent) {
+			next := virtualVisibleStart(len(props.Items), props.RowHeight, event.ScrollTop())
+			if next != visibleStart {
+				setVisibleStart(next)
+			}
+		},
+	}
+	if props.TestID != "" {
+		outerProps["data-testid"] = props.TestID
+	}
+
+	return El("div", outerProps,
+		El("table", Props{
+			"class": joinVirtualClass("gf-virtual-table", props.Class),
+		}, tableChildren...),
+	)
+}
+
+func validateVirtualDimensions(name string, height int, itemHeight int, itemHeightName string) {
+	if height <= 0 || itemHeight <= 0 {
+		panic("goframe: " + name + " requires positive Height and " + itemHeightName)
+	}
+}
+
+func calculateVirtualRange(length int, height int, itemHeight int, overscan int, scrollTop int) VirtualRange {
+	return calculateVirtualRangeFromStart(length, height, itemHeight, overscan, virtualVisibleStart(length, itemHeight, scrollTop))
+}
+
+func calculateVirtualRangeFromStart(length int, height int, itemHeight int, overscan int, visibleStart int) VirtualRange {
+	validateVirtualDimensions("virtual range", height, itemHeight, "ItemHeight")
+	if length <= 0 {
+		return VirtualRange{}
+	}
+	if overscan < 0 {
+		overscan = 0
+	}
+	visibleStart = clampInt(visibleStart, 0, length-1)
+	visibleCount := ceilDiv(height, itemHeight)
+	if visibleCount < 1 {
+		visibleCount = 1
+	}
+
+	start := visibleStart - overscan
+	if start < 0 {
+		start = 0
+	}
+	end := visibleStart + visibleCount + overscan
+	if end > length {
+		end = length
+	}
+	if end < start {
+		end = start
+	}
+
+	return VirtualRange{
+		Start:        start,
+		End:          end,
+		TopSpacer:    start * itemHeight,
+		BottomSpacer: (length - end) * itemHeight,
+		TotalHeight:  length * itemHeight,
+	}
+}
+
+func virtualVisibleStart(length int, itemHeight int, scrollTop int) int {
+	if length <= 0 || itemHeight <= 0 {
+		return 0
+	}
+	if scrollTop < 0 {
+		scrollTop = 0
+	}
+	return clampInt(scrollTop/itemHeight, 0, length-1)
+}
+
+func virtualItemKey[T any](key func(T, int) string, item T, index int) string {
+	if key != nil {
+		return key(item, index)
+	}
+	return "index-" + ToString(index)
+}
+
+func virtualViewportStyle(height int) string {
+	return "height:" + ToString(height) + "px;overflow-y:auto;position:relative;"
+}
+
+func virtualTableSpacerRow(name string, height int) Node {
+	return El("tr", Props{
+		"class":       "gf-virtual-table-spacer gf-virtual-table-spacer-" + name,
+		"aria-hidden": "true",
+		"style":       "height:" + ToString(height) + "px;",
+	}, El("td", Props{
+		"colspan": "999",
+		"style":   "height:" + ToString(height) + "px;padding:0;border:0;",
+	}))
+}
+
+func virtualTableContentRow(content Node) Node {
+	return El("tr", Props{
+		"class": "gf-virtual-table-content",
+	}, El("td", Props{
+		"colspan": "999",
+	}, content))
+}
+
+func joinVirtualClass(base string, extra string) string {
+	if extra == "" {
+		return base
+	}
+	return base + " " + extra
+}
+
+func ceilDiv(value int, divisor int) int {
+	return (value + divisor - 1) / divisor
+}
+
+func clampInt(value int, low int, high int) int {
+	if value < low {
+		return low
+	}
+	if value > high {
+		return high
+	}
+	return value
+}

--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -43,6 +43,8 @@ type VirtualTableProps[T any] struct {
 	RowHeight int
 	Overscan  int
 
+	ColumnCount int
+
 	Key       func(item T, index int) string
 	Header    func() Node
 	RenderRow func(row VirtualRow[T]) Node
@@ -124,11 +126,11 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 	bodyChildren := make([]Node, 0, rangeInfo.End-rangeInfo.Start+2)
 	if len(props.Items) == 0 {
 		if props.Empty != nil {
-			bodyChildren = append(bodyChildren, virtualTableContentRow(props.Empty()))
+			bodyChildren = append(bodyChildren, virtualTableContentRow(props.Empty(), props.ColumnCount))
 		}
 	} else {
 		if rangeInfo.TopSpacer > 0 {
-			bodyChildren = append(bodyChildren, virtualTableSpacerRow("top", rangeInfo.TopSpacer))
+			bodyChildren = append(bodyChildren, virtualTableSpacerRow("top", rangeInfo.TopSpacer, props.ColumnCount))
 		}
 		for index := rangeInfo.Start; index < rangeInfo.End; index++ {
 			key := virtualItemKey(props.Key, props.Items[index], index)
@@ -141,7 +143,7 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 			bodyChildren = append(bodyChildren, Key(key, props.RenderRow(row)))
 		}
 		if rangeInfo.BottomSpacer > 0 {
-			bodyChildren = append(bodyChildren, virtualTableSpacerRow("bottom", rangeInfo.BottomSpacer))
+			bodyChildren = append(bodyChildren, virtualTableSpacerRow("bottom", rangeInfo.BottomSpacer, props.ColumnCount))
 		}
 	}
 
@@ -238,23 +240,30 @@ func virtualViewportStyle(height int) string {
 	return "height:" + ToString(height) + "px;overflow-y:auto;position:relative;"
 }
 
-func virtualTableSpacerRow(name string, height int) Node {
+func virtualTableSpacerRow(name string, height int, columnCount int) Node {
 	return El("tr", Props{
 		"class":       "gf-virtual-table-spacer gf-virtual-table-spacer-" + name,
 		"aria-hidden": "true",
 		"style":       "height:" + ToString(height) + "px;",
 	}, El("td", Props{
-		"colspan": "999",
+		"colspan": virtualTableColumnCount(columnCount),
 		"style":   "height:" + ToString(height) + "px;padding:0;border:0;",
 	}))
 }
 
-func virtualTableContentRow(content Node) Node {
+func virtualTableContentRow(content Node, columnCount int) Node {
 	return El("tr", Props{
 		"class": "gf-virtual-table-content",
 	}, El("td", Props{
-		"colspan": "999",
+		"colspan": virtualTableColumnCount(columnCount),
 	}, content))
+}
+
+func virtualTableColumnCount(value int) string {
+	if value <= 0 {
+		value = 1
+	}
+	return ToString(value)
 }
 
 func joinVirtualClass(base string, extra string) string {

--- a/pkg/goframe/virtual_test.go
+++ b/pkg/goframe/virtual_test.go
@@ -161,6 +161,138 @@ func TestVirtualTableContentRowUsesColumnCount(t *testing.T) {
 	}
 }
 
+func TestVirtualTableUsesStableSpacerAndNamespacedRowKeys(t *testing.T) {
+	userKeys := []string{}
+	children := renderVirtualTableBodyChildrenForTest(VirtualTableProps[int]{
+		Items:       []int{1, 2, 3},
+		Height:      40,
+		RowHeight:   20,
+		Overscan:    0,
+		ColumnCount: 7,
+		Key: func(item int, index int) string {
+			if item == 1 {
+				return virtualTableTopSpacerKey
+			}
+			return "item-" + ToString(item)
+		},
+		RenderRow: func(row VirtualRow[int]) Node {
+			userKeys = append(userKeys, row.Key)
+			return Key(row.Key, El("tr", Props{"style": row.RowStyle}, El("td", Props{}, Text(ToString(row.Item)))))
+		},
+	})
+
+	if len(children) != 4 {
+		t.Fatalf("tbody child count = %d, want 4", len(children))
+	}
+	top := requireKeyedNode(t, children[0])
+	firstRow := requireKeyedNode(t, children[1])
+	secondRow := requireKeyedNode(t, children[2])
+	bottom := requireKeyedNode(t, children[3])
+
+	if top.Key != virtualTableTopSpacerKey {
+		t.Fatalf("top spacer key = %q, want %q", top.Key, virtualTableTopSpacerKey)
+	}
+	if bottom.Key != virtualTableBottomSpacerKey {
+		t.Fatalf("bottom spacer key = %q, want %q", bottom.Key, virtualTableBottomSpacerKey)
+	}
+	if firstRow.Key != virtualTableRowKeyPrefix+virtualTableTopSpacerKey {
+		t.Fatalf("first row internal key = %q, want namespaced user key", firstRow.Key)
+	}
+	if secondRow.Key != virtualTableRowKeyPrefix+"item-2" {
+		t.Fatalf("second row internal key = %q, want namespaced item key", secondRow.Key)
+	}
+	if firstRow.Key == top.Key || firstRow.Key == bottom.Key {
+		t.Fatalf("row internal key %q collided with spacer keys", firstRow.Key)
+	}
+	if len(userKeys) != 2 || userKeys[0] != virtualTableTopSpacerKey || userKeys[1] != "item-2" {
+		t.Fatalf("user-facing row keys = %#v, want original keys", userKeys)
+	}
+}
+
+func TestVirtualTableKeepsZeroHeightSpacersMounted(t *testing.T) {
+	children := renderVirtualTableBodyChildrenForTest(VirtualTableProps[int]{
+		Items:       []int{1, 2},
+		Height:      100,
+		RowHeight:   20,
+		Overscan:    0,
+		ColumnCount: 7,
+		RenderRow: func(row VirtualRow[int]) Node {
+			return El("tr", Props{"style": row.RowStyle}, El("td", Props{}, Text(ToString(row.Item))))
+		},
+	})
+
+	if len(children) != 4 {
+		t.Fatalf("tbody child count = %d, want top spacer, 2 rows, bottom spacer", len(children))
+	}
+	top := requireVNode(t, requireKeyedNode(t, children[0]).Node)
+	bottom := requireVNode(t, requireKeyedNode(t, children[3]).Node)
+	if got := top.Props["style"]; got != "height:0px;" {
+		t.Fatalf("top spacer style = %#v, want height:0px;", got)
+	}
+	if got := bottom.Props["style"]; got != "height:0px;" {
+		t.Fatalf("bottom spacer style = %#v, want height:0px;", got)
+	}
+	topCell := requireVNode(t, top.Children[0])
+	if got := topCell.Props["style"]; got != "height:0px;padding:0;border:0;line-height:0;font-size:0;" {
+		t.Fatalf("top spacer cell style = %#v, want zero-height style", got)
+	}
+}
+
+func TestVirtualTableKeysEmptyState(t *testing.T) {
+	children := renderVirtualTableBodyChildrenForTest(VirtualTableProps[int]{
+		Items:       nil,
+		Height:      100,
+		RowHeight:   20,
+		ColumnCount: 7,
+		RenderRow: func(row VirtualRow[int]) Node {
+			return El("tr", Props{}, El("td", Props{}, Text(ToString(row.Item))))
+		},
+		Empty: func() Node {
+			return Text("empty")
+		},
+	})
+
+	if len(children) != 1 {
+		t.Fatalf("empty tbody child count = %d, want 1", len(children))
+	}
+	empty := requireKeyedNode(t, children[0])
+	if empty.Key != virtualTableEmptyKey {
+		t.Fatalf("empty key = %q, want %q", empty.Key, virtualTableEmptyKey)
+	}
+	row := requireVNode(t, empty.Node)
+	cell := requireVNode(t, row.Children[0])
+	if got := cell.Props["colspan"]; got != "7" {
+		t.Fatalf("empty colspan = %#v, want 7", got)
+	}
+}
+
+func renderVirtualTableBodyChildrenForTest[T any](props VirtualTableProps[T]) []Node {
+	node := VirtualTable(props).(ComponentNode)
+	instance := newComponentInstance(node, "", nil, nil)
+	outer := renderComponentInstance(instance).(VNode)
+	table := outer.Children[0].(VNode)
+	tbody := table.Children[len(table.Children)-1].(VNode)
+	return tbody.Children
+}
+
+func requireKeyedNode(t *testing.T, node Node) KeyedNode {
+	t.Helper()
+	keyed, ok := node.(KeyedNode)
+	if !ok {
+		t.Fatalf("node = %#v, want KeyedNode", node)
+	}
+	return keyed
+}
+
+func requireVNode(t *testing.T, node Node) VNode {
+	t.Helper()
+	vnode, ok := node.(VNode)
+	if !ok {
+		t.Fatalf("node = %#v, want VNode", node)
+	}
+	return vnode
+}
+
 func assertPanics(t *testing.T, fn func()) {
 	t.Helper()
 	defer func() {

--- a/pkg/goframe/virtual_test.go
+++ b/pkg/goframe/virtual_test.go
@@ -129,6 +129,38 @@ func TestVirtualTableCreatesComponentBoundary(t *testing.T) {
 	}
 }
 
+func TestVirtualTableColumnCount(t *testing.T) {
+	tests := []struct {
+		value int
+		want  string
+	}{
+		{value: 0, want: "1"},
+		{value: -1, want: "1"},
+		{value: 7, want: "7"},
+	}
+	for _, test := range tests {
+		if got := virtualTableColumnCount(test.value); got != test.want {
+			t.Fatalf("column count %d = %q, want %q", test.value, got, test.want)
+		}
+	}
+}
+
+func TestVirtualTableSpacerRowUsesColumnCount(t *testing.T) {
+	row := virtualTableSpacerRow("top", 48, 7).(VNode)
+	cell := row.Children[0].(VNode)
+	if got := cell.Props["colspan"]; got != "7" {
+		t.Fatalf("spacer colspan = %#v, want 7", got)
+	}
+}
+
+func TestVirtualTableContentRowUsesColumnCount(t *testing.T) {
+	row := virtualTableContentRow(Text("empty"), 7).(VNode)
+	cell := row.Children[0].(VNode)
+	if got := cell.Props["colspan"]; got != "7" {
+		t.Fatalf("content colspan = %#v, want 7", got)
+	}
+}
+
 func assertPanics(t *testing.T, fn func()) {
 	t.Helper()
 	defer func() {

--- a/pkg/goframe/virtual_test.go
+++ b/pkg/goframe/virtual_test.go
@@ -1,0 +1,140 @@
+package goframe
+
+import "testing"
+
+func TestCalculateVirtualRangeEmpty(t *testing.T) {
+	got := calculateVirtualRange(0, 100, 20, 2, 0)
+	if got != (VirtualRange{}) {
+		t.Fatalf("range = %#v, want empty", got)
+	}
+}
+
+func TestCalculateVirtualRangeShortList(t *testing.T) {
+	got := calculateVirtualRange(3, 200, 40, 4, 0)
+	want := VirtualRange{Start: 0, End: 3, TopSpacer: 0, BottomSpacer: 0, TotalHeight: 120}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeTop(t *testing.T) {
+	got := calculateVirtualRange(100, 100, 20, 2, 0)
+	want := VirtualRange{Start: 0, End: 7, TopSpacer: 0, BottomSpacer: 1860, TotalHeight: 2000}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeMiddle(t *testing.T) {
+	got := calculateVirtualRange(100, 100, 20, 2, 440)
+	want := VirtualRange{Start: 20, End: 29, TopSpacer: 400, BottomSpacer: 1420, TotalHeight: 2000}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeBottom(t *testing.T) {
+	got := calculateVirtualRange(100, 100, 20, 2, 5000)
+	want := VirtualRange{Start: 97, End: 100, TopSpacer: 1940, BottomSpacer: 0, TotalHeight: 2000}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeOverscanClamps(t *testing.T) {
+	got := calculateVirtualRange(10, 90, 30, 20, 120)
+	want := VirtualRange{Start: 0, End: 10, TopSpacer: 0, BottomSpacer: 0, TotalHeight: 300}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeNegativeOverscan(t *testing.T) {
+	got := calculateVirtualRange(10, 90, 30, -2, 120)
+	want := VirtualRange{Start: 4, End: 7, TopSpacer: 120, BottomSpacer: 90, TotalHeight: 300}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeNegativeScroll(t *testing.T) {
+	got := calculateVirtualRange(10, 90, 30, 1, -100)
+	want := VirtualRange{Start: 0, End: 4, TopSpacer: 0, BottomSpacer: 180, TotalHeight: 300}
+	if got != want {
+		t.Fatalf("range = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalculateVirtualRangeRequiresPositiveDimensions(t *testing.T) {
+	assertPanics(t, func() {
+		calculateVirtualRange(10, 0, 30, 1, 0)
+	})
+	assertPanics(t, func() {
+		calculateVirtualRange(10, 90, 0, 1, 0)
+	})
+}
+
+func TestVirtualVisibleStartChangesOnlyOnRowBoundary(t *testing.T) {
+	if got := virtualVisibleStart(100, 30, 29); got != 0 {
+		t.Fatalf("visible start before row boundary = %d, want 0", got)
+	}
+	if got := virtualVisibleStart(100, 30, 30); got != 1 {
+		t.Fatalf("visible start at row boundary = %d, want 1", got)
+	}
+}
+
+func TestVirtualItemKey(t *testing.T) {
+	if got := virtualItemKey[int](nil, 42, 7); got != "index-7" {
+		t.Fatalf("fallback key = %q, want index-7", got)
+	}
+	got := virtualItemKey(func(item int, index int) string {
+		return "id-" + ToString(item) + "-" + ToString(index)
+	}, 42, 7)
+	if got != "id-42-7" {
+		t.Fatalf("stable key = %q", got)
+	}
+}
+
+func TestVirtualListCreatesComponentBoundary(t *testing.T) {
+	node, ok := VirtualList(VirtualListProps[int]{
+		Items:      []int{1, 2, 3},
+		Height:     100,
+		ItemHeight: 20,
+		RenderItem: func(item VirtualItem[int]) Node {
+			return Text(ToString(item.Item))
+		},
+	}).(ComponentNode)
+	if !ok {
+		t.Fatal("VirtualList did not create component boundary")
+	}
+	if node.Name != "VirtualList" {
+		t.Fatalf("component name = %q, want VirtualList", node.Name)
+	}
+}
+
+func TestVirtualTableCreatesComponentBoundary(t *testing.T) {
+	node, ok := VirtualTable(VirtualTableProps[int]{
+		Items:     []int{1, 2, 3},
+		Height:    100,
+		RowHeight: 20,
+		RenderRow: func(row VirtualRow[int]) Node {
+			return El("tr", Props{}, El("td", Props{}, Text(ToString(row.Item))))
+		},
+	}).(ComponentNode)
+	if !ok {
+		t.Fatal("VirtualTable did not create component boundary")
+	}
+	if node.Name != "VirtualTable" {
+		t.Fatalf("component name = %q, want VirtualTable", node.Name)
+	}
+}
+
+func assertPanics(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	fn()
+}

--- a/pkg/goframe/virtual_test.go
+++ b/pkg/goframe/virtual_test.go
@@ -19,7 +19,7 @@ func TestCalculateVirtualRangeShortList(t *testing.T) {
 
 func TestCalculateVirtualRangeTop(t *testing.T) {
 	got := calculateVirtualRange(100, 100, 20, 2, 0)
-	want := VirtualRange{Start: 0, End: 7, TopSpacer: 0, BottomSpacer: 1860, TotalHeight: 2000}
+	want := VirtualRange{Start: 0, End: 9, TopSpacer: 0, BottomSpacer: 1820, TotalHeight: 2000}
 	if got != want {
 		t.Fatalf("range = %#v, want %#v", got, want)
 	}
@@ -35,7 +35,7 @@ func TestCalculateVirtualRangeMiddle(t *testing.T) {
 
 func TestCalculateVirtualRangeBottom(t *testing.T) {
 	got := calculateVirtualRange(100, 100, 20, 2, 5000)
-	want := VirtualRange{Start: 97, End: 100, TopSpacer: 1940, BottomSpacer: 0, TotalHeight: 2000}
+	want := VirtualRange{Start: 91, End: 100, TopSpacer: 1820, BottomSpacer: 0, TotalHeight: 2000}
 	if got != want {
 		t.Fatalf("range = %#v, want %#v", got, want)
 	}
@@ -59,7 +59,7 @@ func TestCalculateVirtualRangeNegativeOverscan(t *testing.T) {
 
 func TestCalculateVirtualRangeNegativeScroll(t *testing.T) {
 	got := calculateVirtualRange(10, 90, 30, 1, -100)
-	want := VirtualRange{Start: 0, End: 4, TopSpacer: 0, BottomSpacer: 180, TotalHeight: 300}
+	want := VirtualRange{Start: 0, End: 5, TopSpacer: 0, BottomSpacer: 150, TotalHeight: 300}
 	if got != want {
 		t.Fatalf("range = %#v, want %#v", got, want)
 	}
@@ -80,6 +80,57 @@ func TestVirtualVisibleStartChangesOnlyOnRowBoundary(t *testing.T) {
 	}
 	if got := virtualVisibleStart(100, 30, 30); got != 1 {
 		t.Fatalf("visible start at row boundary = %d, want 1", got)
+	}
+}
+
+func TestVirtualVisibleCountUsesCeilDivision(t *testing.T) {
+	if got := virtualVisibleCount(100, 20); got != 5 {
+		t.Fatalf("exact visible count = %d, want 5", got)
+	}
+	if got := virtualVisibleCount(101, 20); got != 6 {
+		t.Fatalf("ceil visible count = %d, want 6", got)
+	}
+}
+
+func TestVirtualRangeCoversVisibleInsideBuffer(t *testing.T) {
+	rangeInfo := VirtualRange{Start: 10, End: 19}
+	if !virtualRangeCoversVisible(rangeInfo, 12, 5) {
+		t.Fatalf("range %#v should cover visible start 12 count 5", rangeInfo)
+	}
+}
+
+func TestVirtualRangeCoversVisibleOutsideBuffer(t *testing.T) {
+	rangeInfo := VirtualRange{Start: 10, End: 19}
+	if virtualRangeCoversVisible(rangeInfo, 15, 5) {
+		t.Fatalf("range %#v should not cover visible start 15 count 5", rangeInfo)
+	}
+}
+
+func TestVirtualRangeStartForVisibleStartRecentersWithOverscan(t *testing.T) {
+	if got := virtualRangeStartForVisibleStart(100, 100, 20, 2, 22); got != 20 {
+		t.Fatalf("middle range start = %d, want 20", got)
+	}
+	if got := virtualRangeStartForVisibleStart(100, 100, 20, 2, 1); got != 0 {
+		t.Fatalf("top range start = %d, want 0", got)
+	}
+	if got := virtualRangeStartForVisibleStart(100, 100, 20, 2, 99); got != 91 {
+		t.Fatalf("bottom range start = %d, want 91", got)
+	}
+}
+
+func TestVirtualRangeStartAfterScrollInsideBufferKeepsRangeStart(t *testing.T) {
+	rangeInfo := calculateVirtualRangeFromStart(100, 100, 20, 2, 0)
+	got := virtualRangeStartAfterScroll(rangeInfo, 0, 100, 100, 20, 2, 80)
+	if got != 0 {
+		t.Fatalf("range start after covered scroll = %d, want 0", got)
+	}
+}
+
+func TestVirtualRangeStartAfterScrollBeyondBufferUpdatesRangeStart(t *testing.T) {
+	rangeInfo := calculateVirtualRangeFromStart(100, 100, 20, 2, 0)
+	got := virtualRangeStartAfterScroll(rangeInfo, 0, 100, 100, 20, 2, 100)
+	if got != 3 {
+		t.Fatalf("range start after uncovered scroll = %d, want 3", got)
 	}
 }
 
@@ -226,14 +277,14 @@ func TestVirtualTableKeepsZeroHeightSpacersMounted(t *testing.T) {
 	}
 	top := requireVNode(t, requireKeyedNode(t, children[0]).Node)
 	bottom := requireVNode(t, requireKeyedNode(t, children[3]).Node)
-	if got := top.Props["style"]; got != "height:0px;" {
-		t.Fatalf("top spacer style = %#v, want height:0px;", got)
+	if got := top.Props["style"]; got != "height:0px;overflow-anchor:none;" {
+		t.Fatalf("top spacer style = %#v, want height:0px;overflow-anchor:none;", got)
 	}
-	if got := bottom.Props["style"]; got != "height:0px;" {
-		t.Fatalf("bottom spacer style = %#v, want height:0px;", got)
+	if got := bottom.Props["style"]; got != "height:0px;overflow-anchor:none;" {
+		t.Fatalf("bottom spacer style = %#v, want height:0px;overflow-anchor:none;", got)
 	}
 	topCell := requireVNode(t, top.Children[0])
-	if got := topCell.Props["style"]; got != "height:0px;padding:0;border:0;line-height:0;font-size:0;" {
+	if got := topCell.Props["style"]; got != "height:0px;padding:0;border:0;line-height:0;font-size:0;overflow-anchor:none;" {
 		t.Fatalf("top spacer cell style = %#v, want zero-height style", got)
 	}
 }

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -10,6 +10,7 @@ TODO_SMOKE_URL_BASE="${GOFRAME_TODO_SMOKE_URL:-http://127.0.0.1}"
 DUPLICATE_SMOKE_URL_BASE="${GOFRAME_DUPLICATE_KEY_SMOKE_URL:-http://127.0.0.1}"
 DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
+VIRTUALIZED_SMOKE_URL_BASE="${GOFRAME_VIRTUALIZED_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -94,6 +95,11 @@ build_dashboard_smoke_url() {
 build_context_smoke_url() {
 	local port="$1"
 	echo "${CONTEXT_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_virtualized_smoke_url() {
+	local port="$1"
+	echo "${VIRTUALIZED_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -225,9 +231,25 @@ run_with_server ./examples/context "$CONTEXT_PORT" "$CONTEXT_URL" \
 	node --experimental-websocket scripts/context-browser-smoke.mjs
 
 echo
+echo "== Virtualized debug browser smoke =="
+"$GOXC" package ./examples/virtualized --compiler=tinygo
+(
+	cd ./examples/virtualized/.goframe/work/dev
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/virtualized/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+VIRTUALIZED_PORT="$(resolve_port "${GOFRAME_VIRTUALIZED_SMOKE_PORT:-}")"
+export GOFRAME_VIRTUALIZED_CHROME_DEBUG_PORT="${GOFRAME_VIRTUALIZED_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+VIRTUALIZED_URL="$(build_virtualized_smoke_url "$VIRTUALIZED_PORT")"
+run_with_server ./examples/virtualized "$VIRTUALIZED_PORT" "$VIRTUALIZED_URL" \
+	node --experimental-websocket scripts/virtualized-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
 "$GOXC" package ./examples/context --compiler=tinygo
+"$GOXC" package ./examples/virtualized --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -52,6 +52,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/dashboard --compiler=tinygo
 "$GOXC" generate ./examples/context
 "$GOXC" package ./examples/context --compiler=tinygo
+"$GOXC" generate ./examples/virtualized
+"$GOXC" package ./examples/virtualized --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -237,6 +237,57 @@ try {
     assertWithinRowScrollReport(withinRowScrollReport, withinRowScrollBefore, withinRowScroll);
     await assertVirtualTableSpacerStability(client, "within-row scroll");
 
+    const insideBufferBefore = await captureVirtualTableDom(client, "__dashboardInsideBufferBefore");
+    await startScenario(client, "table-scroll-inside-buffer");
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 48 * 4;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(120);
+    const insideBufferReport = await finishScenario(client, "table-scroll-inside-buffer");
+    const insideBufferAfter = await readVirtualTableDom(client, "__dashboardInsideBufferBefore");
+    assertInsideBufferScrollReport(insideBufferReport, insideBufferBefore, insideBufferAfter);
+    await assertVirtualTableSpacerStability(client, "inside-buffer scroll");
+
+    const beyondBufferBefore = await captureVirtualTableDom(client, "__dashboardBeyondBufferBefore");
+    await startScenario(client, "table-scroll-beyond-buffer");
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 48 * 20;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+    const beyondBufferReport = await finishScenario(client, "table-scroll-beyond-buffer");
+    const beyondBufferAfter = await readVirtualTableDom(client, "__dashboardBeyondBufferBefore");
+    assertBeyondBufferScrollReport(beyondBufferReport, beyondBufferBefore, beyondBufferAfter);
+    await assertVirtualTableSpacerStability(client, "beyond-buffer scroll");
+
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+    const continuousBefore = await captureVirtualTableDom(client, "__dashboardContinuousBefore");
+    await startScenario(client, "table-continuous-scroll-buffered");
+    const continuousScrollSteps = await client.evaluate(`(async () => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        let steps = 0;
+        for (let top = 0; top <= 48 * 80; top += 12) {
+            viewport.scrollTop = top;
+            viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+            steps++;
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        return steps;
+    })()`);
+    await wait(240);
+    const continuousReport = await finishScenario(client, "table-continuous-scroll-buffered");
+    const continuousAfter = await readVirtualTableDom(client, "__dashboardContinuousBefore");
+    assertContinuousScrollReport(continuousReport, continuousScrollSteps, continuousBefore, continuousAfter);
+    await assertVirtualTableSpacerStability(client, "continuous buffered scroll");
+
     await startScenario(client, "table-scroll");
     await client.evaluate(`(() => {
         const viewport = document.querySelector("[data-testid='issue-table']");
@@ -416,6 +467,9 @@ try {
         selectReport,
         clearSearchReport,
         withinRowScrollReport,
+        insideBufferReport,
+        beyondBufferReport,
+        continuousReport,
         scrollReport,
         sortReport,
         statusReport,
@@ -638,6 +692,112 @@ function assertWithinRowScrollReport(report, beforeState, state) {
         throw new Error(`APP FAILURE: within-row scroll should not churn DOM: ${JSON.stringify(report.operations)}`);
     }
     console.log(`dashboard within-row scroll no-op summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations })}`);
+}
+
+async function captureVirtualTableDom(client, key) {
+    return await client.evaluate(`(() => {
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        const rows = [...document.querySelectorAll(".issue-row")];
+        window[${JSON.stringify(key)}] = {
+            top,
+            bottom,
+            rowIDs: rows.map((node) => node.id),
+            childCount: tbody?.children.length ?? 0,
+        };
+        return {
+            rowIDs: rows.map((node) => node.id),
+            rowCount: rows.length,
+            childCount: tbody?.children.length ?? 0,
+            spacerCount: tbody ? tbody.querySelectorAll(".gf-virtual-table-spacer").length : 0,
+            topExists: Boolean(top),
+            bottomExists: Boolean(bottom),
+        };
+    })()`);
+}
+
+async function readVirtualTableDom(client, key) {
+    return await client.evaluate(`(() => {
+        const before = window[${JSON.stringify(key)}] || {};
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        const rows = [...document.querySelectorAll(".issue-row")];
+        return {
+            rowIDs: rows.map((node) => node.id),
+            rowCount: rows.length,
+            childCount: tbody?.children.length ?? 0,
+            spacerCount: tbody ? tbody.querySelectorAll(".gf-virtual-table-spacer").length : 0,
+            topSame: Boolean(top && before.top === top),
+            bottomSame: Boolean(bottom && before.bottom === bottom),
+            rowIDsSame: JSON.stringify(before.rowIDs || []) === JSON.stringify(rows.map((node) => node.id)),
+            childCountSame: before.childCount === (tbody?.children.length ?? 0),
+        };
+    })()`);
+}
+
+function assertInsideBufferScrollReport(report, beforeState, state) {
+    assertMountedRowsBounded(state.rowCount, dashboardLogicalRows, "dashboard inside-buffer mounted rows");
+    if (!state.topSame || !state.bottomSame || state.spacerCount !== 2) {
+        throw new Error(`APP FAILURE: inside-buffer scroll changed spacer identity: ${JSON.stringify(state)}`);
+    }
+    if (!state.rowIDsSame || !state.childCountSame || beforeState.childCount !== state.childCount) {
+        throw new Error(`APP FAILURE: inside-buffer scroll changed mounted rows: before ${JSON.stringify(beforeState)}, after ${JSON.stringify(state)}`);
+    }
+    if (report.renderDeltas.VirtualTable !== 0 || report.renderDeltas.IssueRow !== 0) {
+        throw new Error(`APP FAILURE: inside-buffer scroll should not render VirtualTable/IssueRow: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    if (report.operations.createElement !== 0 || report.operations.removeChild !== 0 ||
+        report.operations.insertBefore !== 0 || report.operations.appendChild !== 0 ||
+        report.operations.addEventListener !== 0 || report.operations.removeEventListener !== 0) {
+        throw new Error(`APP FAILURE: inside-buffer scroll should not churn DOM/listeners: ${JSON.stringify(report.operations)}`);
+    }
+    console.log(`dashboard inside-buffer scroll no-op summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations })}`);
+}
+
+function assertBeyondBufferScrollReport(report, beforeState, state) {
+    assertMountedRowsBounded(state.rowCount, dashboardLogicalRows, "dashboard beyond-buffer mounted rows");
+    if (!state.topSame || !state.bottomSame || state.spacerCount !== 2) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll changed spacer identity: ${JSON.stringify(state)}`);
+    }
+    if (state.rowIDsSame) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll should update mounted row window: before ${JSON.stringify(beforeState)}, after ${JSON.stringify(state)}`);
+    }
+    if (report.renderDeltas.VirtualTable <= 0) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll should render VirtualTable: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    const created = report.operations.createElement + report.operations.createTextNode;
+    const inserted = report.operations.insertBefore + report.operations.appendChild;
+    if (created > 1200 || inserted > 160 || report.operations.removeChild > 160 ||
+        report.operations.addEventListener > 160 || report.operations.removeEventListener > 160) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll DOM churn is unbounded: ${JSON.stringify(report.operations)}`);
+    }
+    console.log(`dashboard beyond-buffer scroll bounded summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations, beforeRows: beforeState.rowCount, afterRows: state.rowCount })}`);
+}
+
+function assertContinuousScrollReport(report, scrollSteps, beforeState, state) {
+    assertMountedRowsBounded(state.rowCount, dashboardLogicalRows, "dashboard continuous-scroll mounted rows");
+    if (!state.topSame || !state.bottomSame || state.spacerCount !== 2) {
+        throw new Error(`APP FAILURE: continuous scroll changed spacer identity: ${JSON.stringify(state)}`);
+    }
+    const maxTableRenders = Math.ceil(scrollSteps / 4);
+    if (report.renderDeltas.VirtualTable > maxTableRenders) {
+        throw new Error(`APP FAILURE: continuous scroll rendered VirtualTable too often: renders=${report.renderDeltas.VirtualTable}, steps=${scrollSteps}, report=${JSON.stringify(report)}`);
+    }
+    if (report.renderDeltas.IssueRow > maxMountedRows * maxTableRenders) {
+        throw new Error(`APP FAILURE: continuous scroll rendered IssueRow too often: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    const created = report.operations.createElement + report.operations.createTextNode;
+    const inserted = report.operations.insertBefore + report.operations.appendChild;
+    if (created > maxMountedRows * maxTableRenders || inserted > maxMountedRows * maxTableRenders ||
+        report.operations.removeChild > maxMountedRows * maxTableRenders) {
+        throw new Error(`APP FAILURE: continuous scroll DOM churn is unbounded: ${JSON.stringify(report.operations)}`);
+    }
+    if (report.operations.addEventListener !== report.operations.removeEventListener) {
+        throw new Error(`APP FAILURE: continuous scroll listener net changed: ${JSON.stringify(report.operations)}`);
+    }
+    console.log(`dashboard continuous buffered scroll summary: ${JSON.stringify({ scrollSteps, tableRenders: report.renderDeltas.VirtualTable, rowRenders: report.renderDeltas.IssueRow, operations: report.operations, beforeRows: beforeState.rowCount, afterRows: state.rowCount })}`);
 }
 
 async function waitForPage(port) {

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -113,6 +113,7 @@ try {
         },
         "dashboard initial render",
     );
+    await assertDashboardTableLayout(client, "initial");
 
     assertDeepEqual(
         await client.evaluate(installDashboardAuditExpression(componentNames)),
@@ -308,6 +309,7 @@ try {
         { summary: `Showing ${filteredVisible} of 300 issues`, headerSame: true },
         "dashboard status filter updates table predictably",
     );
+    await assertDashboardTableLayout(client, "status filter");
 
     await startScenario(client, "reset-before-simulate");
     await clickButtonByText(client, "Reset");
@@ -375,6 +377,7 @@ try {
         },
         "dashboard reset restores deterministic view",
     );
+    await assertDashboardTableLayout(client, "reset");
 
     client.close();
     console.log(`Dashboard timing report: ${JSON.stringify(timings)}`);
@@ -512,6 +515,52 @@ function assertMountedRowsBounded(rows, logicalRows, label) {
     if (rows < 0 || rows > expectedLimit || (logicalRows > 0 && rows === 0)) {
         throw new Error(`APP FAILURE: ${label}: mounted rows ${rows}, logical rows ${logicalRows}, limit ${expectedLimit}`);
     }
+}
+
+async function assertDashboardTableLayout(client, label) {
+    const layout = await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        const table = viewport?.querySelector("table");
+        const headerCells = table ? [...table.querySelectorAll("thead th")] : [];
+        const firstRow = table?.querySelector("tbody tr.issue-row");
+        const firstRowCells = firstRow ? [...firstRow.querySelectorAll("td")] : [];
+        const rowLink = firstRow?.querySelector(".row-link");
+        const bounds = (node) => {
+            const rect = node.getBoundingClientRect();
+            return { width: Math.round(rect.width), height: Math.round(rect.height) };
+        };
+        return {
+            viewportWidth: viewport ? Math.round(viewport.getBoundingClientRect().width) : 0,
+            tableWidth: table ? Math.round(table.getBoundingClientRect().width) : 0,
+            headerCellCount: headerCells.length,
+            firstRowCellCount: firstRowCells.length,
+            headerWidths: headerCells.map((cell) => bounds(cell).width),
+            firstRowWidths: firstRowCells.map((cell) => bounds(cell).width),
+            rowLinkWidth: rowLink ? bounds(rowLink).width : 0,
+        };
+    })()`);
+    const failures = [];
+    if (layout.headerCellCount !== 7) failures.push(`header cells=${layout.headerCellCount}`);
+    if (layout.firstRowCellCount !== 7) failures.push(`row cells=${layout.firstRowCellCount}`);
+    if (!(layout.viewportWidth > 0 && layout.tableWidth >= layout.viewportWidth * 0.95)) {
+        failures.push(`table width ${layout.tableWidth}, viewport width ${layout.viewportWidth}`);
+    }
+    for (const [index, width] of layout.headerWidths.entries()) {
+        if (width <= 30) failures.push(`header width[${index}]=${width}`);
+    }
+    if ((layout.firstRowWidths[0] ?? 0) <= 100) {
+        failures.push(`issue column width=${layout.firstRowWidths[0] ?? 0}`);
+    }
+    if ((layout.firstRowWidths[6] ?? 0) <= 50) {
+        failures.push(`action column width=${layout.firstRowWidths[6] ?? 0}`);
+    }
+    if (layout.rowLinkWidth <= 100) {
+        failures.push(`row link width=${layout.rowLinkWidth}`);
+    }
+    if (failures.length > 0) {
+        throw new Error(`APP FAILURE: dashboard table layout collapsed during ${label}: ${failures.join("; ")} ${JSON.stringify(layout)}`);
+    }
+    console.log(`dashboard table layout ${label}: ok`);
 }
 
 async function waitForPage(port) {

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -288,6 +288,14 @@ try {
     assertContinuousScrollReport(continuousReport, continuousScrollSteps, continuousBefore, continuousAfter);
     await assertVirtualTableSpacerStability(client, "continuous buffered scroll");
 
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+    await assertVirtualTableSpacerStability(client, "before cross-row scroll");
+
     await startScenario(client, "table-scroll");
     await client.evaluate(`(() => {
         const viewport = document.querySelector("[data-testid='issue-table']");
@@ -767,13 +775,38 @@ function assertBeyondBufferScrollReport(report, beforeState, state) {
     if (report.renderDeltas.VirtualTable <= 0) {
         throw new Error(`APP FAILURE: beyond-buffer scroll should render VirtualTable: ${JSON.stringify(report.renderDeltas)}`);
     }
+    if (report.operations.addEventListener !== report.operations.removeEventListener) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll listener net changed: ${JSON.stringify(report.operations)}`);
+    }
+    const rowCount = Math.max(beforeState.rowCount, state.rowCount, 1);
+    const changedRows = Math.max(1, countRowWindowChanges(beforeState.rowIDs, state.rowIDs));
     const created = report.operations.createElement + report.operations.createTextNode;
     const inserted = report.operations.insertBefore + report.operations.appendChild;
-    if (created > 1200 || inserted > 160 || report.operations.removeChild > 160 ||
-        report.operations.addEventListener > 160 || report.operations.removeEventListener > 160) {
-        throw new Error(`APP FAILURE: beyond-buffer scroll DOM churn is unbounded: ${JSON.stringify(report.operations)}`);
+    const createdLimit = rowCount * 16;
+    const insertedLimit = rowCount * 16;
+    const removedLimit = rowCount * 4;
+    const listenerLimit = rowCount * 2;
+    if (created > createdLimit || inserted > insertedLimit || report.operations.removeChild > removedLimit ||
+        report.operations.addEventListener > listenerLimit || report.operations.removeEventListener > listenerLimit) {
+        throw new Error(`APP FAILURE: beyond-buffer scroll DOM churn is unbounded: ${JSON.stringify({
+            operations: report.operations,
+            rowCount,
+            changedRows,
+            limits: { createdLimit, insertedLimit, removedLimit, listenerLimit },
+        })}`);
     }
-    console.log(`dashboard beyond-buffer scroll bounded summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations, beforeRows: beforeState.rowCount, afterRows: state.rowCount })}`);
+    console.log(`dashboard beyond-buffer scroll bounded summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations, rowCount, changedRows, limits: { createdLimit, insertedLimit, removedLimit, listenerLimit }, beforeRows: beforeState.rowCount, afterRows: state.rowCount })}`);
+}
+
+function countRowWindowChanges(beforeIDs, afterIDs) {
+    const before = new Set(beforeIDs || []);
+    let changed = 0;
+    for (const id of afterIDs || []) {
+        if (!before.has(id)) {
+            changed++;
+        }
+    }
+    return changed;
 }
 
 function assertContinuousScrollReport(report, scrollSteps, beforeState, state) {

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -114,6 +114,7 @@ try {
         "dashboard initial render",
     );
     await assertDashboardTableLayout(client, "initial");
+    await assertVirtualTableSpacerStability(client, "initial");
 
     assertDeepEqual(
         await client.evaluate(installDashboardAuditExpression(componentNames)),
@@ -213,6 +214,29 @@ try {
         "APP FAILURE: dashboard reset before sort did not restore bounded mounted rows",
     );
 
+    const withinRowScrollBefore = await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+        window.__dashboardBeforeWithinRowScroll = [...document.querySelectorAll(".issue-row")].map((node) => node.id);
+        return window.__dashboardBeforeWithinRowScroll;
+    })()`);
+    await wait(120);
+    await assertVirtualTableSpacerStability(client, "before within-row scroll");
+    await startScenario(client, "table-scroll-within-row");
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 10;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(120);
+    const withinRowScrollReport = await finishScenario(client, "table-scroll-within-row");
+    const withinRowScroll = await client.evaluate(`(() => ({
+        rowIDs: [...document.querySelectorAll(".issue-row")].map((node) => node.id),
+    }))()`);
+    assertWithinRowScrollReport(withinRowScrollReport, withinRowScrollBefore, withinRowScroll);
+    await assertVirtualTableSpacerStability(client, "within-row scroll");
+
     await startScenario(client, "table-scroll");
     await client.evaluate(`(() => {
         const viewport = document.querySelector("[data-testid='issue-table']");
@@ -236,6 +260,7 @@ try {
     if (!scrolled.changed || !scrolled.target) {
         throw new Error(`APP FAILURE: dashboard scroll should change visible row window: ${JSON.stringify(scrolled)}`);
     }
+    await assertVirtualTableSpacerStability(client, "cross-row scroll");
     await client.evaluate(`(() => {
         const target = document.querySelector("#issue-row-" + window.__dashboardScrolledTarget + " .row-link");
         target.click();
@@ -257,6 +282,7 @@ try {
         viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
     })()`);
     await wait(160);
+    await assertVirtualTableSpacerStability(client, "scroll back to top");
     await client.evaluate(`(() => {
         const before = [...document.querySelectorAll(".issue-row")].slice(0, 8).map((node) => node.id);
         window.__dashboardBeforeSort = before;
@@ -287,6 +313,7 @@ try {
         { changed: true, headerSame: true, overlapPreserved: true },
         "dashboard sort updates virtual row window without replacing visible survivors",
     );
+    await assertVirtualTableSpacerStability(client, "sort");
 
     await startScenario(client, "status-blocked");
     await setSelectValue(client, "#status-filter", "blocked");
@@ -310,6 +337,7 @@ try {
         "dashboard status filter updates table predictably",
     );
     await assertDashboardTableLayout(client, "status filter");
+    await assertVirtualTableSpacerStability(client, "status filter");
 
     await startScenario(client, "reset-before-simulate");
     await clickButtonByText(client, "Reset");
@@ -378,6 +406,7 @@ try {
         "dashboard reset restores deterministic view",
     );
     await assertDashboardTableLayout(client, "reset");
+    await assertVirtualTableSpacerStability(client, "reset");
 
     client.close();
     console.log(`Dashboard timing report: ${JSON.stringify(timings)}`);
@@ -386,6 +415,7 @@ try {
         searchReport,
         selectReport,
         clearSearchReport,
+        withinRowScrollReport,
         scrollReport,
         sortReport,
         statusReport,
@@ -561,6 +591,53 @@ async function assertDashboardTableLayout(client, label) {
         throw new Error(`APP FAILURE: dashboard table layout collapsed during ${label}: ${failures.join("; ")} ${JSON.stringify(layout)}`);
     }
     console.log(`dashboard table layout ${label}: ok`);
+}
+
+async function assertVirtualTableSpacerStability(client, label) {
+    const state = await client.evaluate(`(() => {
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        const spacers = tbody ? [...tbody.querySelectorAll(".gf-virtual-table-spacer")] : [];
+        if (top && !window.__dashboardSpacerTop) window.__dashboardSpacerTop = top;
+        if (bottom && !window.__dashboardSpacerBottom) window.__dashboardSpacerBottom = bottom;
+        return {
+            spacerCount: spacers.length,
+            topExists: Boolean(top),
+            bottomExists: Boolean(bottom),
+            topSame: Boolean(top && window.__dashboardSpacerTop === top),
+            bottomSame: Boolean(bottom && window.__dashboardSpacerBottom === bottom),
+            childCount: tbody?.children.length ?? 0,
+            rowCount: document.querySelectorAll(".issue-row").length,
+        };
+    })()`);
+    const failures = [];
+    if (state.spacerCount !== 2) failures.push(`spacer count=${state.spacerCount}`);
+    if (!state.topExists) failures.push("top spacer missing");
+    if (!state.bottomExists) failures.push("bottom spacer missing");
+    if (!state.topSame) failures.push("top spacer node identity changed");
+    if (!state.bottomSame) failures.push("bottom spacer node identity changed");
+    assertMountedRowsBounded(state.rowCount, dashboardLogicalRows, `dashboard spacer stability ${label} mounted rows`);
+    if (failures.length > 0) {
+        throw new Error(`APP FAILURE: virtual table spacers unstable during ${label}: ${failures.join("; ")} ${JSON.stringify(state)}`);
+    }
+    console.log(`dashboard virtual table spacers ${label}: ok`);
+}
+
+function assertWithinRowScrollReport(report, beforeState, state) {
+    const before = JSON.stringify(beforeState);
+    const current = JSON.stringify(state.rowIDs);
+    if (before !== current) {
+        throw new Error(`APP FAILURE: within-row scroll changed mounted row IDs: before ${before}, after ${current}`);
+    }
+    if (report.renderDeltas.VirtualTable !== 0 || report.renderDeltas.IssueRow !== 0) {
+        throw new Error(`APP FAILURE: within-row scroll should not render VirtualTable/IssueRow: ${JSON.stringify(report.renderDeltas)}`);
+    }
+    if (report.operations.createElement !== 0 || report.operations.removeChild !== 0 ||
+        report.operations.insertBefore !== 0 || report.operations.appendChild !== 0) {
+        throw new Error(`APP FAILURE: within-row scroll should not churn DOM: ${JSON.stringify(report.operations)}`);
+    }
+    console.log(`dashboard within-row scroll no-op summary: ${JSON.stringify({ renderDeltas: report.renderDeltas, operations: report.operations })}`);
 }
 
 async function waitForPage(port) {

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -14,6 +14,8 @@ const profile = await mkdtemp(join(tmpdir(), "goframe-dashboard-smoke-"));
 const expectedApp = new URL(appURL);
 const timings = [];
 const performanceReports = [];
+const dashboardLogicalRows = 300;
+const maxMountedRows = 70;
 const componentNames = [
     "App",
     "Header",
@@ -26,6 +28,8 @@ const componentNames = [
     "SearchBox",
     "IssueWorkspace",
     "IssueTable",
+    "VirtualTable",
+    "IssueTableHeader",
     "IssueRow",
     "DetailPanel",
     "EmptyDetail",
@@ -66,8 +70,7 @@ try {
     await navigateToApp(client, withSmokeParam(appURL, "clean"));
     await waitForAppPage(client, expectedApp, "post-clean navigation");
 
-    assertDeepEqual(
-        await client.evaluate(`(() => {
+    const initialState = await client.evaluate(`(() => {
             window.__dashboardHeader = document.querySelector("[data-testid='dashboard-header']");
             window.__dashboardSearch = document.querySelector("#dashboard-search");
             window.__dashboardMetrics = document.querySelector("[data-testid='metrics-grid']");
@@ -85,14 +88,25 @@ try {
                 appRenders: window.goframeComponentRenderCounts.App,
                 headerRenders: window.goframeComponentRenderCounts.Header,
             };
-        })()`),
+        })()`);
+    assertMountedRowsBounded(initialState.rows, dashboardLogicalRows, "dashboard initial mounted rows");
+    assertDeepEqual(
+        {
+            header: initialState.header,
+            search: initialState.search,
+            metrics: initialState.metrics,
+            table: initialState.table,
+            detail: initialState.detail,
+            summary: initialState.summary,
+            appRenders: initialState.appRenders,
+            headerRenders: initialState.headerRenders,
+        },
         {
             header: true,
             search: true,
             metrics: true,
             table: true,
             detail: true,
-            rows: 300,
             summary: "Showing 300 of 300 issues",
             appRenders: 1,
             headerRenders: 1,
@@ -129,22 +143,22 @@ try {
             headerRenders: window.goframeComponentRenderCounts.Header,
         };
     })()`);
-    if (!(searchState.rows > 0 && searchState.rows < 300)) {
+    const searchVisible = parseSummary(searchState.summary).visible;
+    assertMountedRowsBounded(searchState.rows, searchVisible, "dashboard search mounted rows");
+    if (!(searchVisible > 0 && searchVisible < 300)) {
         throw new Error(`APP FAILURE: search should narrow rows: ${JSON.stringify(searchState)}`);
     }
     assertDeepEqual(
         {
-            summary: searchState.summary,
             headerSame: searchState.headerSame,
             searchSame: searchState.searchSame,
             metricsVisible: searchState.metricsVisible,
             headerRenders: searchState.headerRenders,
         },
         {
-            summary: `Showing ${searchState.rows} of 300 issues`,
             headerSame: true,
             searchSame: true,
-            metricsVisible: searchState.rows,
+            metricsVisible: searchVisible,
             headerRenders: 1,
         },
         "dashboard search updates visible rows without replacing header/search",
@@ -188,11 +202,68 @@ try {
             window.__dashboardRow1 = document.querySelector("#issue-row-1");
             const before = [...document.querySelectorAll(".issue-row")].slice(0, 8).map((node) => node.id);
             window.__dashboardBeforeSort = before;
+            window.__dashboardBeforeSortNodes = {};
+            for (const node of document.querySelectorAll(".issue-row")) {
+                window.__dashboardBeforeSortNodes[node.id] = node;
+            }
             return { rows: document.querySelectorAll(".issue-row").length, row1: Boolean(window.__dashboardRow1) };
         })()`),
-        (value) => value.rows === 300 && value.row1,
-        "APP FAILURE: dashboard reset before sort did not restore 300 visible rows",
+        (value) => value.rows > 0 && value.rows <= maxMountedRows && value.row1,
+        "APP FAILURE: dashboard reset before sort did not restore bounded mounted rows",
     );
+
+    await startScenario(client, "table-scroll");
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        window.__dashboardBeforeScroll = [...document.querySelectorAll(".issue-row")].map((node) => node.id);
+        viewport.scrollTop = 48 * 80;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+    const scrollReport = await finishScenario(client, "table-scroll");
+    const scrolled = await client.evaluate(`(() => {
+        const after = [...document.querySelectorAll(".issue-row")].map((node) => node.id);
+        const target = after[2] || after[0] || "";
+        window.__dashboardScrolledTarget = target.replace("issue-row-", "");
+        return {
+            rows: after.length,
+            changed: JSON.stringify(after) !== JSON.stringify(window.__dashboardBeforeScroll),
+            target: window.__dashboardScrolledTarget,
+        };
+    })()`);
+    assertMountedRowsBounded(scrolled.rows, dashboardLogicalRows, "dashboard scrolled mounted rows");
+    if (!scrolled.changed || !scrolled.target) {
+        throw new Error(`APP FAILURE: dashboard scroll should change visible row window: ${JSON.stringify(scrolled)}`);
+    }
+    await client.evaluate(`(() => {
+        const target = document.querySelector("#issue-row-" + window.__dashboardScrolledTarget + " .row-link");
+        target.click();
+    })()`);
+    await wait(120);
+    const scrolledSelection = await client.evaluate(`(() => ({
+        detail: document.querySelector("[data-testid='detail-panel']")?.textContent.includes(window.__dashboardScrolledTarget),
+        rows: document.querySelectorAll(".issue-row").length,
+    }))()`);
+    assertMountedRowsBounded(scrolledSelection.rows, dashboardLogicalRows, "dashboard scrolled selection mounted rows");
+    if (!scrolledSelection.detail) {
+        throw new Error(`APP FAILURE: selecting after scroll did not update detail: ${JSON.stringify(scrolledSelection)}`);
+    }
+    console.log("dashboard virtual scroll selection updates detail: ok");
+
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+    await client.evaluate(`(() => {
+        const before = [...document.querySelectorAll(".issue-row")].slice(0, 8).map((node) => node.id);
+        window.__dashboardBeforeSort = before;
+        window.__dashboardBeforeSortNodes = {};
+        for (const node of document.querySelectorAll(".issue-row")) {
+            window.__dashboardBeforeSortNodes[node.id] = node;
+        }
+    })()`);
 
     await startScenario(client, "sort-priority");
     const sortStart = Date.now();
@@ -201,17 +272,19 @@ try {
     const sortReport = await finishScenario(client, "sort-priority");
     const sorted = await client.evaluate(`(() => {
         const after = [...document.querySelectorAll(".issue-row")].slice(0, 8).map((node) => node.id);
+        const overlap = after.find((id) => window.__dashboardBeforeSort.includes(id));
         return {
             rows: document.querySelectorAll(".issue-row").length,
-            row1Same: window.__dashboardRow1 === document.querySelector("#issue-row-1"),
             changed: JSON.stringify(after) !== JSON.stringify(window.__dashboardBeforeSort),
             headerSame: window.__dashboardHeader === document.querySelector("[data-testid='dashboard-header']"),
+            overlapPreserved: overlap ? window.__dashboardBeforeSortNodes[overlap] === document.querySelector("#" + overlap) : true,
         };
     })()`);
+    assertMountedRowsBounded(sorted.rows, dashboardLogicalRows, "dashboard sorted mounted rows");
     assertDeepEqual(
-        sorted,
-        { rows: 300, row1Same: true, changed: true, headerSame: true },
-        "dashboard sort reorders keyed rows without replacing survivors",
+        { changed: sorted.changed, headerSame: sorted.headerSame, overlapPreserved: sorted.overlapPreserved },
+        { changed: true, headerSame: true, overlapPreserved: true },
+        "dashboard sort updates virtual row window without replacing visible survivors",
     );
 
     await startScenario(client, "status-blocked");
@@ -225,12 +298,14 @@ try {
             headerSame: window.__dashboardHeader === document.querySelector("[data-testid='dashboard-header']"),
         };
     })()`);
-    if (!(filtered.rows > 0 && filtered.rows < 300)) {
+    const filteredVisible = parseSummary(filtered.summary).visible;
+    assertMountedRowsBounded(filtered.rows, filteredVisible, "dashboard status mounted rows");
+    if (!(filteredVisible > 0 && filteredVisible < 300)) {
         throw new Error(`APP FAILURE: status filter should narrow rows: ${JSON.stringify(filtered)}`);
     }
     assertDeepEqual(
         { summary: filtered.summary, headerSame: filtered.headerSame },
-        { summary: `Showing ${filtered.rows} of 300 issues`, headerSame: true },
+        { summary: `Showing ${filteredVisible} of 300 issues`, headerSame: true },
         "dashboard status filter updates table predictably",
     );
 
@@ -283,7 +358,7 @@ try {
     await clickButtonByText(client, "Reset");
     await wait(120);
     const resetReport = await finishScenario(client, "reset-final");
-    assertDeepEqual(
+    windowlessAssert(
         await client.evaluate(`(() => ({
             rows: document.querySelectorAll(".issue-row").length,
             summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim(),
@@ -291,12 +366,12 @@ try {
             headerSame: window.__dashboardHeader === document.querySelector("[data-testid='dashboard-header']"),
             searchSame: window.__dashboardSearch === document.querySelector("#dashboard-search"),
         }))()`),
-        {
-            rows: 300,
-            summary: "Showing 300 of 300 issues",
-            title: "GoFrame Dashboard · 300 visible",
-            headerSame: true,
-            searchSame: true,
+        (value) => {
+            assertMountedRowsBounded(value.rows, dashboardLogicalRows, "dashboard reset mounted rows");
+            return value.summary === "Showing 300 of 300 issues" &&
+                value.title === "GoFrame Dashboard · 300 visible" &&
+                value.headerSame &&
+                value.searchSame;
         },
         "dashboard reset restores deterministic view",
     );
@@ -308,6 +383,7 @@ try {
         searchReport,
         selectReport,
         clearSearchReport,
+        scrollReport,
         sortReport,
         statusReport,
         resetBeforeSimulateReport,
@@ -421,6 +497,21 @@ function assertFocusOnlyReport(report) {
         throw new Error(`APP FAILURE: focus-only should not trigger runtime work: ${JSON.stringify(report)}`);
     }
     console.log("dashboard focus-only does not trigger runtime work: ok");
+}
+
+function parseSummary(summary) {
+    const match = /^Showing (\d+) of (\d+) issues$/.exec(summary || "");
+    if (!match) {
+        throw new Error(`APP FAILURE: unexpected dashboard summary: ${summary}`);
+    }
+    return { visible: Number(match[1]), total: Number(match[2]) };
+}
+
+function assertMountedRowsBounded(rows, logicalRows, label) {
+    const expectedLimit = Math.min(maxMountedRows, Math.max(0, logicalRows));
+    if (rows < 0 || rows > expectedLimit || (logicalRows > 0 && rows === 0)) {
+        throw new Error(`APP FAILURE: ${label}: mounted rows ${rows}, logical rows ${logicalRows}, limit ${expectedLimit}`);
+    }
 }
 
 async function waitForPage(port) {

--- a/scripts/dashboard-dom-pressure.mjs
+++ b/scripts/dashboard-dom-pressure.mjs
@@ -19,6 +19,7 @@ const settleFrames = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_SETTLE_FRAMES
 const postIdleMs = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_POST_IDLE_MS ?? "3000");
 const profile = await mkdtemp(join(tmpdir(), "goframe-dashboard-pressure-"));
 const expectedAllRows = 300;
+const expectedTableColumns = 7;
 const maxMountedRows = 70;
 const maxAllCreateNodes = 2500;
 const maxAllEventAdds = 160;
@@ -75,6 +76,7 @@ try {
     if (initial.logicalRows !== expectedAllRows || initial.rows <= 0 || initial.rows > maxMountedRows) {
         throw new Error(`APP FAILURE: dashboard should start with ${expectedAllRows} logical rows and bounded mounted rows: ${JSON.stringify(initial)}`);
     }
+    await assertDashboardTableLayout(client, "initial");
 
     const records = [];
     for (let cycle = 1; cycle <= cycles; cycle++) {
@@ -304,6 +306,9 @@ async function runTransition(client, cycle, status, label) {
     const metricsAfter = await performanceMetrics(client);
     await collectGarbage(client);
     const afterGC = await samplePage(client, label, cycle, status);
+    if (status === "all") {
+        await assertDashboardTableLayout(client, `${label} cycle ${cycle}`);
+    }
 
     return {
         cycle,
@@ -361,6 +366,47 @@ async function samplePage(client, label, cycle, status) {
     page.logicalRows = parsed.visible;
     page.totalRows = parsed.total;
     return { ...page, metrics: await performanceMetrics(client) };
+}
+
+async function assertDashboardTableLayout(client, label) {
+    const layout = await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        const table = viewport?.querySelector("table");
+        const headerCells = table ? [...table.querySelectorAll("thead th")] : [];
+        const firstRow = table?.querySelector("tbody tr.issue-row");
+        const firstRowCells = firstRow ? [...firstRow.querySelectorAll("td")] : [];
+        const rowLink = firstRow?.querySelector(".row-link");
+        return {
+            viewportWidth: viewport ? Math.round(viewport.getBoundingClientRect().width) : 0,
+            tableWidth: table ? Math.round(table.getBoundingClientRect().width) : 0,
+            headerCellCount: headerCells.length,
+            firstRowCellCount: firstRowCells.length,
+            headerWidths: headerCells.map((cell) => Math.round(cell.getBoundingClientRect().width)),
+            firstRowWidths: firstRowCells.map((cell) => Math.round(cell.getBoundingClientRect().width)),
+            rowLinkWidth: rowLink ? Math.round(rowLink.getBoundingClientRect().width) : 0,
+        };
+    })()`);
+    const failures = [];
+    if (layout.headerCellCount !== expectedTableColumns) failures.push(`header cells=${layout.headerCellCount}`);
+    if (layout.firstRowCellCount !== expectedTableColumns) failures.push(`row cells=${layout.firstRowCellCount}`);
+    if (!(layout.viewportWidth > 0 && layout.tableWidth >= layout.viewportWidth * 0.95)) {
+        failures.push(`table width ${layout.tableWidth}, viewport width ${layout.viewportWidth}`);
+    }
+    for (const [index, width] of layout.headerWidths.entries()) {
+        if (width <= 30) failures.push(`header width[${index}]=${width}`);
+    }
+    if ((layout.firstRowWidths[0] ?? 0) <= 100) {
+        failures.push(`issue column width=${layout.firstRowWidths[0] ?? 0}`);
+    }
+    if ((layout.firstRowWidths[6] ?? 0) <= 50) {
+        failures.push(`action column width=${layout.firstRowWidths[6] ?? 0}`);
+    }
+    if (layout.rowLinkWidth <= 100) {
+        failures.push(`row link width=${layout.rowLinkWidth}`);
+    }
+    if (failures.length > 0) {
+        throw new Error(`APP FAILURE: dashboard table layout collapsed during ${label}: ${failures.join("; ")} ${JSON.stringify(layout)}`);
+    }
 }
 
 async function performanceMetrics(client) {

--- a/scripts/dashboard-dom-pressure.mjs
+++ b/scripts/dashboard-dom-pressure.mjs
@@ -90,13 +90,16 @@ try {
         records.push(await runTransition(client, cycle, "all", "All"));
     }
 
+    const continuousScrollRecord = await runContinuousScrollAudit(client);
+
     await wait(postIdleMs);
     await collectGarbage(client);
     const finalIdle = await samplePage(client, "post-idle-gc", cycles, "all");
 
     printRecords(records);
     printScrollRecords(scrollRecords);
-    const analysis = analyzeRecords(records, finalIdle);
+    printContinuousScrollRecord(continuousScrollRecord);
+    const analysis = analyzeRecords(records, finalIdle, continuousScrollRecord);
     printAnalysis(initial, finalIdle, analysis);
     if (analysis.failures.length > 0) {
         throw new Error(`APP FAILURE: dashboard DOM pressure leak guard failed:\n${analysis.failures.join("\n")}`);
@@ -371,6 +374,78 @@ async function runScrollStability(client, label, scrollTop) {
         spacerCount: spacerState.spacerCount,
         spacerTopStable: spacerState.topSame,
         spacerBottomStable: spacerState.bottomSame,
+    };
+}
+
+async function runContinuousScrollAudit(client) {
+    const label = "continuous-scroll-buffered";
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = 0;
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await settle(client);
+    const before = await client.evaluate(`(() => {
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        window.__dashboardPressureContinuousTop = top;
+        window.__dashboardPressureContinuousBottom = bottom;
+        return {
+            rows: document.querySelectorAll(".issue-row").length,
+            childCount: tbody?.children.length ?? 0,
+            spacerCount: tbody ? tbody.querySelectorAll(".gf-virtual-table-spacer").length : 0,
+        };
+    })()`);
+    await client.evaluate(`window.__dashboardPressure.start(${JSON.stringify(label)})`);
+    const scrollSummary = await client.evaluate(`(async () => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        let steps = 0;
+        let maxRows = document.querySelectorAll(".issue-row").length;
+        for (let top = 0; top <= 48 * 80; top += 12) {
+            viewport.scrollTop = top;
+            viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+            steps++;
+            maxRows = Math.max(maxRows, document.querySelectorAll(".issue-row").length);
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+            maxRows = Math.max(maxRows, document.querySelectorAll(".issue-row").length);
+        }
+        return { steps, maxRows };
+    })()`);
+    await settle(client);
+    const audit = await client.evaluate(`window.__dashboardPressure.finish(${JSON.stringify(label)})`);
+    const spacerState = await assertVirtualTableSpacerStability(client, label);
+    const after = await client.evaluate(`(() => {
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        return {
+            rows: document.querySelectorAll(".issue-row").length,
+            childCount: tbody?.children.length ?? 0,
+            spacerCount: tbody ? tbody.querySelectorAll(".gf-virtual-table-spacer").length : 0,
+            topSame: Boolean(top && window.__dashboardPressureContinuousTop === top),
+            bottomSame: Boolean(bottom && window.__dashboardPressureContinuousBottom === bottom),
+        };
+    })()`);
+    const mountedRowsMax = Math.max(before.rows, scrollSummary.maxRows, after.rows);
+    return {
+        label,
+        scrollSteps: scrollSummary.steps,
+        durationMs: audit.durationMs,
+        rows: audit.rows,
+        mountedRowsMax,
+        operations: audit.operations,
+        renderDeltas: audit.renderDeltas,
+        patchDeltas: audit.patchDeltas,
+        memoDeltas: audit.memoDeltas,
+        netListeners: audit.netListeners,
+        listenerNetDelta: audit.operations.addEventListener - audit.operations.removeEventListener,
+        renderScrollRatio: round(audit.renderDeltas.VirtualTable / scrollSummary.steps),
+        spacerCount: spacerState.spacerCount,
+        spacerTopStable: spacerState.topSame && after.topSame,
+        spacerBottomStable: spacerState.bottomSame && after.bottomSame,
+        childCountBefore: before.childCount,
+        childCountAfter: after.childCount,
     };
 }
 
@@ -805,7 +880,23 @@ function printScrollRecords(records) {
     })));
 }
 
-function analyzeRecords(records, finalIdle) {
+function printContinuousScrollRecord(record) {
+    console.log(`Dashboard DOM pressure continuous scroll: ${JSON.stringify({
+        scrollSteps: record.scrollSteps,
+        virtualTableRenders: record.renderDeltas.VirtualTable,
+        issueRowRenders: record.renderDeltas.IssueRow,
+        renderScrollRatio: record.renderScrollRatio,
+        createElement: record.operations.createElement,
+        removeChild: record.operations.removeChild,
+        insertBefore: record.operations.insertBefore,
+        appendChild: record.operations.appendChild,
+        listenerNetDelta: record.listenerNetDelta,
+        spacersStable: record.spacerCount === 2 && record.spacerTopStable && record.spacerBottomStable,
+        mountedRowsMax: record.mountedRowsMax,
+    })}`);
+}
+
+function analyzeRecords(records, finalIdle, continuousScrollRecord) {
     const failures = [];
     const warnings = [];
     const allRecords = records.filter((record) => record.status === "all");
@@ -863,6 +954,31 @@ function analyzeRecords(records, finalIdle) {
         warnings.push(`average All transition duration ${round(averageAllDuration)}ms remains high despite bounded DOM.`);
     }
 
+    if (continuousScrollRecord) {
+        const maxTableRenders = Math.ceil(continuousScrollRecord.scrollSteps / 4);
+        const createdNodes = continuousScrollRecord.operations.createElement +
+            continuousScrollRecord.operations.createTextNode +
+            continuousScrollRecord.operations.createComment;
+        const insertedNodes = continuousScrollRecord.operations.insertBefore +
+            continuousScrollRecord.operations.appendChild;
+        const maxChurn = maxMountedRows * maxTableRenders;
+        if (continuousScrollRecord.renderDeltas.VirtualTable > maxTableRenders) {
+            failures.push(`continuous scroll VirtualTable renders=${continuousScrollRecord.renderDeltas.VirtualTable}, scroll steps=${continuousScrollRecord.scrollSteps}, limit=${maxTableRenders}`);
+        }
+        if (continuousScrollRecord.mountedRowsMax <= 0 || continuousScrollRecord.mountedRowsMax > maxMountedRows) {
+            failures.push(`continuous scroll mounted rows max=${continuousScrollRecord.mountedRowsMax}, limit=${maxMountedRows}`);
+        }
+        if (continuousScrollRecord.spacerCount !== 2 || !continuousScrollRecord.spacerTopStable || !continuousScrollRecord.spacerBottomStable) {
+            failures.push(`continuous scroll spacer instability: count=${continuousScrollRecord.spacerCount}, top=${continuousScrollRecord.spacerTopStable}, bottom=${continuousScrollRecord.spacerBottomStable}`);
+        }
+        if (continuousScrollRecord.listenerNetDelta !== 0) {
+            failures.push(`continuous scroll listener net delta=${continuousScrollRecord.listenerNetDelta}`);
+        }
+        if (createdNodes > maxChurn || insertedNodes > maxChurn || continuousScrollRecord.operations.removeChild > maxChurn) {
+            failures.push(`continuous scroll DOM churn unbounded: create=${createdNodes}, insert=${insertedNodes}, remove=${continuousScrollRecord.operations.removeChild}, limit=${maxChurn}`);
+        }
+    }
+
     return {
         failures,
         warnings,
@@ -891,6 +1007,15 @@ function analyzeRecords(records, finalIdle) {
             postIdleJSHeapUsed: finalIdle.metrics.JSHeapUsedSize ?? 0,
             spacerTopStable: allRecords.every((record) => record.spacerTopStable),
             spacerBottomStable: allRecords.every((record) => record.spacerBottomStable),
+            continuousScrollSteps: continuousScrollRecord?.scrollSteps ?? 0,
+            continuousVirtualTableRenders: continuousScrollRecord?.renderDeltas.VirtualTable ?? 0,
+            continuousIssueRowRenders: continuousScrollRecord?.renderDeltas.IssueRow ?? 0,
+            continuousRenderScrollRatio: continuousScrollRecord?.renderScrollRatio ?? 0,
+            continuousSpacersStable: continuousScrollRecord ?
+                continuousScrollRecord.spacerCount === 2 && continuousScrollRecord.spacerTopStable && continuousScrollRecord.spacerBottomStable :
+                false,
+            continuousMountedRowsMax: continuousScrollRecord?.mountedRowsMax ?? 0,
+            continuousListenerNetDelta: continuousScrollRecord?.listenerNetDelta ?? 0,
         },
     };
 }

--- a/scripts/dashboard-dom-pressure.mjs
+++ b/scripts/dashboard-dom-pressure.mjs
@@ -18,6 +18,10 @@ const cycles = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_CYCLES ?? "20");
 const settleFrames = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_SETTLE_FRAMES ?? "2");
 const postIdleMs = Number(process.env.GOFRAME_DASHBOARD_PRESSURE_POST_IDLE_MS ?? "3000");
 const profile = await mkdtemp(join(tmpdir(), "goframe-dashboard-pressure-"));
+const expectedAllRows = 300;
+const maxMountedRows = 70;
+const maxAllCreateNodes = 2500;
+const maxAllEventAdds = 160;
 const componentNames = [
     "App",
     "Header",
@@ -30,6 +34,8 @@ const componentNames = [
     "SearchBox",
     "IssueWorkspace",
     "IssueTable",
+    "VirtualTable",
+    "IssueTableHeader",
     "IssueRow",
     "DetailPanel",
     "EmptyDetail",
@@ -66,8 +72,8 @@ try {
     await client.evaluate(installPressureAuditExpression(componentNames));
 
     const initial = await samplePage(client, "initial", 0, "all");
-    if (initial.rows !== 300) {
-        throw new Error(`APP FAILURE: dashboard should start with 300 rows, got ${initial.rows}`);
+    if (initial.logicalRows !== expectedAllRows || initial.rows <= 0 || initial.rows > maxMountedRows) {
+        throw new Error(`APP FAILURE: dashboard should start with ${expectedAllRows} logical rows and bounded mounted rows: ${JSON.stringify(initial)}`);
     }
 
     const records = [];
@@ -305,6 +311,8 @@ async function runTransition(client, cycle, status, label) {
         status,
         durationMs: audit.durationMs,
         rows: audit.rows,
+        logicalRows: audit.logicalRows,
+        totalRows: audit.totalRows,
         summary: audit.summary,
         liveDOMNodes: audit.liveDOMNodes,
         allNodesAfterGC: afterGC.liveDOMNodes,
@@ -349,6 +357,9 @@ async function samplePage(client, label, cycle, status) {
         liveDOMNodes: document.querySelectorAll("*").length,
         summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
     }))()`);
+    const parsed = parseSummary(page.summary);
+    page.logicalRows = parsed.visible;
+    page.totalRows = parsed.total;
     return { ...page, metrics: await performanceMetrics(client) };
 }
 
@@ -516,12 +527,16 @@ function installPressureAuditExpression(names) {
                 for (const key of Object.keys(operations)) {
                     opDeltas[key] = operations[key] - this.operationBaseline[key];
                 }
+                const summary = document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "";
+                const match = /^Showing (\\d+) of (\\d+) issues$/.exec(summary);
                 return {
                     label,
                     durationMs: Math.round((performance.now() - this.startedAt) * 100) / 100,
                     rows: document.querySelectorAll(".issue-row").length,
+                    logicalRows: match ? Number(match[1]) : -1,
+                    totalRows: match ? Number(match[2]) : -1,
                     liveDOMNodes: document.querySelectorAll("*").length,
-                    summary: document.querySelector("[data-testid='visible-summary']")?.textContent.trim() || "",
+                    summary,
                     netListeners,
                     operations: opDeltas,
                     renderDeltas,
@@ -630,6 +645,7 @@ function printRecords(records) {
         to: record.transition,
         ms: record.durationMs,
         rows: record.rows,
+        logical: record.logicalRows,
         liveDOM: record.liveDOMNodes,
         cdpNodesGC: record.cdpNodesAfterGC,
         jsListenersGC: record.jsEventListenersAfterGC,
@@ -658,11 +674,28 @@ function analyzeRecords(records, finalIdle) {
     const warnings = [];
     const allRecords = records.filter((record) => record.status === "all");
     const openRecords = records.filter((record) => record.status === "open");
-    const expectedAllRows = 300;
 
     for (const record of allRecords) {
-        if (record.rows !== expectedAllRows) {
-            failures.push(`cycle ${record.cycle} All rows=${record.rows}, want ${expectedAllRows}`);
+        if (record.logicalRows !== expectedAllRows) {
+            failures.push(`cycle ${record.cycle} All logical rows=${record.logicalRows}, want ${expectedAllRows}`);
+        }
+        if (record.rows <= 0 || record.rows > maxMountedRows) {
+            failures.push(`cycle ${record.cycle} All mounted rows=${record.rows}, limit ${maxMountedRows}`);
+        }
+        const createdNodes = record.operations.createElement + record.operations.createTextNode + record.operations.createComment;
+        if (createdNodes > maxAllCreateNodes) {
+            failures.push(`cycle ${record.cycle} All created DOM nodes=${createdNodes}, limit ${maxAllCreateNodes}`);
+        }
+        if (record.operations.addEventListener > maxAllEventAdds) {
+            failures.push(`cycle ${record.cycle} All addEventListener delta=${record.operations.addEventListener}, limit ${maxAllEventAdds}`);
+        }
+    }
+    for (const record of openRecords) {
+        if (record.logicalRows <= 0 || record.logicalRows >= expectedAllRows) {
+            failures.push(`cycle ${record.cycle} Open logical rows=${record.logicalRows}, expected filtered subset`);
+        }
+        if (record.rows <= 0 || record.rows > maxMountedRows) {
+            failures.push(`cycle ${record.cycle} Open mounted rows=${record.rows}, limit ${maxMountedRows}`);
         }
     }
 
@@ -684,14 +717,19 @@ function analyzeRecords(records, finalIdle) {
     const averageAllLayout = average(allRecords.map((record) => record.performanceDeltas.LayoutDuration));
     const averageAllScript = average(allRecords.map((record) => record.performanceDeltas.ScriptDuration));
     const averageAllRender = average(allRecords.map((record) => record.runtimeRenderMs));
+    if (averageAllDuration > 150) {
+        warnings.push(`average All transition duration ${round(averageAllDuration)}ms remains high despite bounded DOM.`);
+    }
 
     return {
         failures,
         warnings,
         summary: {
             cycles,
-            allRows: expectedAllRows,
-            openRows: openRecords[0]?.rows ?? 0,
+            allRowsLogical: expectedAllRows,
+            allRowsMountedMax: Math.max(...allRecords.map((record) => record.rows)),
+            openRowsLogical: openRecords[0]?.logicalRows ?? 0,
+            openRowsMountedMax: Math.max(...openRecords.map((record) => record.rows)),
             averageAllDuration: round(averageAllDuration),
             averageAllCreateNodes: round(averageAllCreate),
             averageAllRemoveNodes: round(averageAllRemove),
@@ -742,6 +780,14 @@ function average(values) {
 function drift(values) {
     if (values.length === 0) return 0;
     return Math.max(...values) - Math.min(...values);
+}
+
+function parseSummary(summary) {
+    const match = /^Showing (\d+) of (\d+) issues$/.exec(summary || "");
+    if (!match) {
+        return { visible: -1, total: -1 };
+    }
+    return { visible: Number(match[1]), total: Number(match[2]) };
 }
 
 function sumBy(values, pick) {

--- a/scripts/dashboard-dom-pressure.mjs
+++ b/scripts/dashboard-dom-pressure.mjs
@@ -77,6 +77,12 @@ try {
         throw new Error(`APP FAILURE: dashboard should start with ${expectedAllRows} logical rows and bounded mounted rows: ${JSON.stringify(initial)}`);
     }
     await assertDashboardTableLayout(client, "initial");
+    await assertVirtualTableSpacerStability(client, "initial");
+    const scrollRecords = [
+        await runScrollStability(client, "scroll-within-row", 10),
+        await runScrollStability(client, "scroll-cross-row", 48 * 8 + 10),
+        await runScrollStability(client, "scroll-back-top", 0),
+    ];
 
     const records = [];
     for (let cycle = 1; cycle <= cycles; cycle++) {
@@ -89,6 +95,7 @@ try {
     const finalIdle = await samplePage(client, "post-idle-gc", cycles, "all");
 
     printRecords(records);
+    printScrollRecords(scrollRecords);
     const analysis = analyzeRecords(records, finalIdle);
     printAnalysis(initial, finalIdle, analysis);
     if (analysis.failures.length > 0) {
@@ -306,6 +313,7 @@ async function runTransition(client, cycle, status, label) {
     const metricsAfter = await performanceMetrics(client);
     await collectGarbage(client);
     const afterGC = await samplePage(client, label, cycle, status);
+    const spacerState = await assertVirtualTableSpacerStability(client, `${label} cycle ${cycle}`);
     if (status === "all") {
         await assertDashboardTableLayout(client, `${label} cycle ${cycle}`);
     }
@@ -335,7 +343,34 @@ async function runTransition(client, cycle, status, label) {
         renderReports: audit.renderReports,
         runtimeRenderMs: round(sumBy(audit.renderReports, (entry) => entry.duration || 0)),
         performanceDeltas: diffMetrics(metricsBefore, metricsAfter),
+        spacerCount: spacerState.spacerCount,
+        spacerTopStable: spacerState.topSame,
+        spacerBottomStable: spacerState.bottomSame,
         trace,
+    };
+}
+
+async function runScrollStability(client, label, scrollTop) {
+    await client.evaluate(`window.__dashboardPressure.start(${JSON.stringify(label)})`);
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector("[data-testid='issue-table']");
+        viewport.scrollTop = ${scrollTop};
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await settle(client);
+    const audit = await client.evaluate(`window.__dashboardPressure.finish(${JSON.stringify(label)})`);
+    const spacerState = await assertVirtualTableSpacerStability(client, label);
+    return {
+        label,
+        scrollTop,
+        rows: audit.rows,
+        operations: audit.operations,
+        renderDeltas: audit.renderDeltas,
+        patchDeltas: audit.patchDeltas,
+        memoDeltas: audit.memoDeltas,
+        spacerCount: spacerState.spacerCount,
+        spacerTopStable: spacerState.topSame,
+        spacerBottomStable: spacerState.bottomSame,
     };
 }
 
@@ -407,6 +442,38 @@ async function assertDashboardTableLayout(client, label) {
     if (failures.length > 0) {
         throw new Error(`APP FAILURE: dashboard table layout collapsed during ${label}: ${failures.join("; ")} ${JSON.stringify(layout)}`);
     }
+}
+
+async function assertVirtualTableSpacerStability(client, label) {
+    const state = await client.evaluate(`(() => {
+        const tbody = document.querySelector("[data-testid='issue-table'] tbody");
+        const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
+        const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
+        const spacers = tbody ? [...tbody.querySelectorAll(".gf-virtual-table-spacer")] : [];
+        if (top && !window.__dashboardPressureSpacerTop) window.__dashboardPressureSpacerTop = top;
+        if (bottom && !window.__dashboardPressureSpacerBottom) window.__dashboardPressureSpacerBottom = bottom;
+        return {
+            spacerCount: spacers.length,
+            topExists: Boolean(top),
+            bottomExists: Boolean(bottom),
+            topSame: Boolean(top && window.__dashboardPressureSpacerTop === top),
+            bottomSame: Boolean(bottom && window.__dashboardPressureSpacerBottom === bottom),
+            rowCount: document.querySelectorAll(".issue-row").length,
+        };
+    })()`);
+    const failures = [];
+    if (state.spacerCount !== 2) failures.push(`spacer count=${state.spacerCount}`);
+    if (!state.topExists) failures.push("top spacer missing");
+    if (!state.bottomExists) failures.push("bottom spacer missing");
+    if (!state.topSame) failures.push("top spacer identity changed");
+    if (!state.bottomSame) failures.push("bottom spacer identity changed");
+    if (state.rowCount <= 0 || state.rowCount > maxMountedRows) {
+        failures.push(`mounted rows=${state.rowCount}, limit ${maxMountedRows}`);
+    }
+    if (failures.length > 0) {
+        throw new Error(`APP FAILURE: virtual table spacers unstable during ${label}: ${failures.join("; ")} ${JSON.stringify(state)}`);
+    }
+    return state;
 }
 
 async function performanceMetrics(client) {
@@ -704,6 +771,9 @@ function printRecords(records) {
         rowRender: record.renderDeltas.IssueRow,
         rowPatch: record.patchDeltas.IssueRow,
         rowMemo: record.memoDeltas.IssueRow,
+        spacers: record.spacerCount,
+        topStable: record.spacerTopStable,
+        bottomStable: record.spacerBottomStable,
         rtRenderMs: record.runtimeRenderMs,
         scriptMs: record.performanceDeltas.ScriptDuration,
         layoutMs: record.performanceDeltas.LayoutDuration,
@@ -713,6 +783,26 @@ function printRecords(records) {
         heapGC: record.jsHeapUsedAfterGC,
     }));
     console.table(rows);
+}
+
+function printScrollRecords(records) {
+    console.table(records.map((record) => ({
+        label: record.label,
+        scrollTop: record.scrollTop,
+        rows: record.rows,
+        create: record.operations.createElement + record.operations.createTextNode + record.operations.createComment,
+        insert: record.operations.insertBefore + record.operations.appendChild,
+        remove: record.operations.removeChild,
+        addEvt: record.operations.addEventListener,
+        remEvt: record.operations.removeEventListener,
+        tableRender: record.renderDeltas.VirtualTable,
+        rowRender: record.renderDeltas.IssueRow,
+        rowPatch: record.patchDeltas.IssueRow,
+        rowMemo: record.memoDeltas.IssueRow,
+        spacers: record.spacerCount,
+        topStable: record.spacerTopStable,
+        bottomStable: record.spacerBottomStable,
+    })));
 }
 
 function analyzeRecords(records, finalIdle) {
@@ -735,6 +825,9 @@ function analyzeRecords(records, finalIdle) {
         if (record.operations.addEventListener > maxAllEventAdds) {
             failures.push(`cycle ${record.cycle} All addEventListener delta=${record.operations.addEventListener}, limit ${maxAllEventAdds}`);
         }
+        if (record.spacerCount !== 2 || !record.spacerTopStable || !record.spacerBottomStable) {
+            failures.push(`cycle ${record.cycle} All spacer instability: count=${record.spacerCount}, top=${record.spacerTopStable}, bottom=${record.spacerBottomStable}`);
+        }
     }
     for (const record of openRecords) {
         if (record.logicalRows <= 0 || record.logicalRows >= expectedAllRows) {
@@ -742,6 +835,9 @@ function analyzeRecords(records, finalIdle) {
         }
         if (record.rows <= 0 || record.rows > maxMountedRows) {
             failures.push(`cycle ${record.cycle} Open mounted rows=${record.rows}, limit ${maxMountedRows}`);
+        }
+        if (record.spacerCount !== 2 || !record.spacerTopStable || !record.spacerBottomStable) {
+            failures.push(`cycle ${record.cycle} Open spacer instability: count=${record.spacerCount}, top=${record.spacerTopStable}, bottom=${record.spacerBottomStable}`);
         }
     }
 
@@ -793,6 +889,8 @@ function analyzeRecords(records, finalIdle) {
             postIdleCDPNodes: finalIdle.metrics.Nodes ?? 0,
             postIdleJSEventListeners: finalIdle.metrics.JSEventListeners ?? 0,
             postIdleJSHeapUsed: finalIdle.metrics.JSHeapUsedSize ?? 0,
+            spacerTopStable: allRecords.every((record) => record.spacerTopStable),
+            spacerBottomStable: allRecords.every((record) => record.spacerBottomStable),
         },
     };
 }

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -131,7 +131,8 @@ status=0
 check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
-check_app "dashboard" "$(bundle_path dashboard)" 153600 53248 71680 61440 || status=1
+check_app "dashboard" "$(bundle_path dashboard)" 168960 53248 71680 61440 || status=1
 check_app "context" "$(bundle_path context)" 112640 36864 46080 40960 || status=1
+check_app "virtualized" "$(bundle_path virtualized)" 122880 40960 49152 44032 || status=1
 
 exit "$status"

--- a/scripts/virtualized-browser-smoke.mjs
+++ b/scripts/virtualized-browser-smoke.mjs
@@ -1,0 +1,443 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_VIRTUALIZED_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_VIRTUALIZED_CHROME_DEBUG_PORT ?? "19227");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-virtualized-smoke-"));
+const expectedApp = new URL(appURL);
+const logicalItems = 10000;
+const maxMountedListItems = 40;
+const maxMountedTableRows = 40;
+const componentNames = [
+    "App",
+    "VirtualizedApp",
+    "VirtualListPanel",
+    "VirtualList",
+    "VirtualListItem",
+    "VirtualTablePanel",
+    "VirtualTable",
+    "VirtualTableHeader",
+    "VirtualTableRow",
+];
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+let browserExit = null;
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+browser.on("exit", (code, signal) => {
+    browserExit = { code, signal };
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL, "initial"));
+    await waitForAppPage(client, expectedApp, "initial navigation");
+    assertDeepEqual(await client.evaluate(installVirtualizedAuditExpression(componentNames)), { ready: true }, "virtualized audit installed");
+
+    const initial = await virtualizedState(client);
+    assertVirtualizedState(initial, "initial");
+    assertDeepEqual(
+        {
+            logical: initial.logical,
+            appRenders: initial.appRenders,
+            header: initial.header,
+        },
+        { logical: "10000 logical items", appRenders: 1, header: true },
+        "virtualized initial render",
+    );
+
+    await startScenario(client, "scroll-list");
+    await scrollTo(client, "[data-testid='virtual-list']", 44 * 500);
+    const listReport = await finishScenario(client, "scroll-list");
+    const listScrolled = await virtualizedState(client);
+    assertVirtualizedState(listScrolled, "list scroll");
+    if (JSON.stringify(initial.listIDs) === JSON.stringify(listScrolled.listIDs)) {
+        throw new Error(`APP FAILURE: VirtualList scroll did not change visible IDs: ${JSON.stringify(listScrolled.listIDs)}`);
+    }
+    assertMountedCountsInReport(listReport, "VirtualList scroll");
+    console.log("virtualized list scroll: ok");
+
+    await startScenario(client, "scroll-table");
+    await scrollTo(client, "[data-testid='virtual-table']", 40 * 800);
+    const tableReport = await finishScenario(client, "scroll-table");
+    const tableScrolled = await virtualizedState(client);
+    assertVirtualizedState(tableScrolled, "table scroll");
+    if (JSON.stringify(initial.tableIDs) === JSON.stringify(tableScrolled.tableIDs)) {
+        throw new Error(`APP FAILURE: VirtualTable scroll did not change visible IDs: ${JSON.stringify(tableScrolled.tableIDs)}`);
+    }
+    assertMountedCountsInReport(tableReport, "VirtualTable scroll");
+    console.log("virtualized table scroll: ok");
+
+    const targetID = tableScrolled.tableIDs[2] ?? tableScrolled.tableIDs[0];
+    if (!targetID) {
+        throw new Error("APP FAILURE: no virtual table row target after scroll");
+    }
+    await client.evaluate(`document.querySelector("[data-testid='virtual-row-${targetID}'] .row-link").click()`);
+    await wait(120);
+    const selected = await virtualizedState(client);
+    if (!selected.selection.includes(`#${targetID}`)) {
+        throw new Error(`APP FAILURE: selecting row ${targetID} after scroll failed: ${JSON.stringify(selected)}`);
+    }
+    console.log("virtualized table selection after scroll: ok");
+
+    const beforeToggle = selected.selection.includes("enabled") ? "enabled" : "disabled";
+    await startScenario(client, "toggle-after-scroll");
+    await client.evaluate(`document.querySelector("[data-testid='virtual-row-${targetID}'] .tiny").click()`);
+    await wait(120);
+    const toggleReport = await finishScenario(client, "toggle-after-scroll");
+    const afterToggle = await virtualizedState(client);
+    const afterLabel = afterToggle.selection.includes("enabled") ? "enabled" : "disabled";
+    if (beforeToggle === afterLabel) {
+        throw new Error(`APP FAILURE: toggling row ${targetID} after scroll did not update selection summary: ${JSON.stringify(afterToggle)}`);
+    }
+    assertVirtualizedState(afterToggle, "toggle after scroll");
+    assertNoListenerNetGrowth(toggleReport, "toggle after scroll");
+    console.log("virtualized toggle after scroll: ok");
+
+    await startScenario(client, "scroll-stability");
+    for (let index = 0; index < 6; index++) {
+        await scrollTo(client, "[data-testid='virtual-table']", 40 * (index % 2 === 0 ? 1200 : 300));
+    }
+    const stabilityReport = await finishScenario(client, "scroll-stability");
+    const stable = await virtualizedState(client);
+    assertVirtualizedState(stable, "scroll stability");
+    assertNoListenerNetGrowth(stabilityReport, "repeated virtual table scroll");
+    console.log("virtualized repeated scroll listener stability: ok");
+
+    client.close();
+    console.log("Virtualized browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function virtualizedState(client) {
+    return await client.evaluate(`(() => ({
+        header: Boolean(document.querySelector("[data-testid='virtualized-header']")),
+        logical: document.querySelector("[data-testid='logical-count']")?.textContent.trim() || "",
+        selection: document.querySelector("[data-testid='selection-summary']")?.textContent.replace(/\\s+/g, " ").trim() || "",
+        listItems: document.querySelectorAll("[data-testid^='virtual-list-item-']").length,
+        tableRows: document.querySelectorAll("[data-testid^='virtual-row-']").length,
+        listIDs: [...document.querySelectorAll("[data-testid^='virtual-list-item-']")].map((node) => node.getAttribute("data-testid").replace("virtual-list-item-", "")),
+        tableIDs: [...document.querySelectorAll("[data-testid^='virtual-row-']")].map((node) => node.getAttribute("data-testid").replace("virtual-row-", "")),
+        liveDOM: document.querySelectorAll("*").length,
+        appRenders: window.goframeComponentRenderCounts.App,
+    }))()`);
+}
+
+function assertVirtualizedState(state, label) {
+    if (state.logical !== `${logicalItems} logical items`) {
+        throw new Error(`APP FAILURE: ${label}: logical count mismatch: ${JSON.stringify(state)}`);
+    }
+    if (state.listItems <= 0 || state.listItems > maxMountedListItems) {
+        throw new Error(`APP FAILURE: ${label}: mounted list items ${state.listItems}, limit ${maxMountedListItems}`);
+    }
+    if (state.tableRows <= 0 || state.tableRows > maxMountedTableRows) {
+        throw new Error(`APP FAILURE: ${label}: mounted table rows ${state.tableRows}, limit ${maxMountedTableRows}`);
+    }
+}
+
+function assertNoListenerNetGrowth(report, label) {
+    if (report.netListeners !== 0) {
+        throw new Error(`APP FAILURE: ${label}: listener net changed: ${JSON.stringify(report)}`);
+    }
+}
+
+function assertMountedCountsInReport(report, label) {
+    if (report.listItems <= 0 || report.listItems > maxMountedListItems ||
+        report.tableRows <= 0 || report.tableRows > maxMountedTableRows) {
+        throw new Error(`APP FAILURE: ${label}: mounted count exceeded bounds: ${JSON.stringify(report)}`);
+    }
+}
+
+async function scrollTo(client, selector, scrollTop) {
+    await client.evaluate(`(() => {
+        const viewport = document.querySelector(${JSON.stringify(selector)});
+        viewport.scrollTop = ${scrollTop};
+        viewport.dispatchEvent(new Event("scroll", { bubbles: true }));
+    })()`);
+    await wait(160);
+}
+
+async function startScenario(client, label) {
+    await client.evaluate(`window.__virtualizedAudit.start(${JSON.stringify(label)})`);
+}
+
+async function finishScenario(client, label) {
+    const report = await client.evaluate(`window.__virtualizedAudit.finish(${JSON.stringify(label)})`);
+    console.log(`virtualized perf ${label}: ${JSON.stringify(report)}`);
+    return report;
+}
+
+function installVirtualizedAuditExpression(names) {
+    return `(() => {
+        if (window.__virtualizedAudit) return { ready: true };
+        const componentNames = ${JSON.stringify(names)};
+        const operations = ${JSON.stringify(emptyOperations())};
+        let netListeners = 0;
+        const audit = {
+            baseline: null,
+            operationBaseline: null,
+            netBaseline: 0,
+            start(label) {
+                this.baseline = snapshotCounts(componentNames);
+                this.operationBaseline = { ...operations };
+                this.netBaseline = netListeners;
+            },
+            finish(label) {
+                const next = snapshotCounts(componentNames);
+                const renderDeltas = {};
+                const patchDeltas = {};
+                const memoDeltas = {};
+                for (const name of componentNames) {
+                    renderDeltas[name] = next.renders[name] - this.baseline.renders[name];
+                    patchDeltas[name] = next.patches[name] - this.baseline.patches[name];
+                    memoDeltas[name] = next.memoSkips[name] - this.baseline.memoSkips[name];
+                }
+                const opDeltas = {};
+                for (const key of Object.keys(operations)) {
+                    opDeltas[key] = operations[key] - this.operationBaseline[key];
+                }
+                return {
+                    label,
+                    renderDeltas,
+                    patchDeltas,
+                    memoDeltas,
+                    operations: opDeltas,
+                    netListeners: netListeners - this.netBaseline,
+                    listItems: document.querySelectorAll("[data-testid^='virtual-list-item-']").length,
+                    tableRows: document.querySelectorAll("[data-testid^='virtual-row-']").length,
+                    liveDOM: document.querySelectorAll("*").length,
+                };
+            },
+        };
+        const wrap = (owner, name, counter, after) => {
+            const original = owner[name];
+            owner[name] = function(...args) {
+                operations[counter]++;
+                if (after) after();
+                return original.apply(this, args);
+            };
+        };
+        wrap(Document.prototype, "createElement", "createElement");
+        wrap(Document.prototype, "createTextNode", "createTextNode");
+        wrap(Node.prototype, "appendChild", "appendChild");
+        wrap(Node.prototype, "removeChild", "removeChild");
+        wrap(Node.prototype, "insertBefore", "insertBefore");
+        wrap(EventTarget.prototype, "addEventListener", "addEventListener", () => { netListeners++; });
+        wrap(EventTarget.prototype, "removeEventListener", "removeEventListener", () => { netListeners--; });
+        window.__virtualizedAudit = audit;
+        return { ready: true };
+
+        function snapshotCounts(names) {
+            const renderCounts = window.goframeComponentRenderCounts || {};
+            const patchCounts = window.goframeComponentPatchCounts || {};
+            const memoSkips = window.goframeComponentMemoSkips || {};
+            const renders = {};
+            const patches = {};
+            const skips = {};
+            for (const name of names) {
+                renders[name] = renderCounts[name] || 0;
+                patches[name] = patchCounts[name] || 0;
+                skips[name] = memoSkips[name] || 0;
+            }
+            return { renders, patches, memoSkips: skips };
+        }
+    })()`;
+}
+
+function emptyOperations() {
+    return {
+        createElement: 0,
+        createTextNode: 0,
+        appendChild: 0,
+        removeChild: 0,
+        insertBefore: 0,
+        addEventListener: 0,
+        removeEventListener: 0,
+    };
+}
+
+async function waitForPage(port) {
+    let lastError;
+    for (let attempt = 0; attempt < 50; attempt++) {
+        if (browserExit) {
+            throw new Error(`HARNESS FAILURE: Chrome exited before CDP page was available: ${JSON.stringify(browserExit)}\n${browserError}`);
+        }
+        try {
+            const pages = await fetchTargets(port);
+            const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+            if (page) return page;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools did not become ready: ${lastError ?? browserError}`);
+}
+
+async function fetchTargets(port) {
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    if (!response.ok) {
+        throw new Error(`CDP /json returned HTTP ${response.status}`);
+    }
+    return await response.json();
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+}
+
+async function waitForAppPage(client, expected, label) {
+    let lastState = null;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        lastState = await pageState(client);
+        if (lastState.href.startsWith("chrome-error://")) {
+            throw await harnessFailure(client, `${label}: Chrome loaded an error document`, lastState);
+        }
+        if (isExpectedAppState(lastState, expected) && lastState.root && lastState.appReady) {
+            return lastState;
+        }
+        await wait(100);
+    }
+    throw await harnessFailure(client, `${label}: app page did not become ready`, lastState);
+}
+
+async function pageState(client) {
+    return await client.evaluate(`(() => ({
+        href: window.location.href,
+        origin: window.location.origin,
+        protocol: window.location.protocol,
+        readyState: document.readyState,
+        root: Boolean(document.querySelector("#root")),
+        appReady: Boolean(document.querySelector("[data-testid='virtualized-header']") && window.goframeComponentRenderCounts?.App),
+    }))()`);
+}
+
+function isExpectedAppState(state, expected) {
+    if (!state || (state.protocol !== "http:" && state.protocol !== "https:")) {
+        return false;
+    }
+    try {
+        const actual = new URL(state.href);
+        return actual.origin === expected.origin && actual.pathname === expected.pathname;
+    } catch {
+        return false;
+    }
+}
+
+async function harnessFailure(client, message, detail) {
+    const diagnostics = await collectDiagnostics(client);
+    return new Error(`HARNESS FAILURE: ${message}\n${JSON.stringify({ appURL, debugPort, detail, diagnostics }, null, 2)}`);
+}
+
+async function collectDiagnostics(client) {
+    const diagnostics = { targets: [], page: null };
+    try {
+        diagnostics.targets = (await fetchTargets(debugPort)).map((target) => ({
+            id: target.id,
+            type: target.type,
+            url: target.url,
+            title: target.title,
+        }));
+    } catch (error) {
+        diagnostics.targetsError = error.message;
+    }
+    if (client) {
+        try {
+            diagnostics.page = await pageState(client);
+        } catch (error) {
+            diagnostics.pageError = error.message;
+        }
+    }
+    if (browserExit) diagnostics.browserExit = browserExit;
+    if (browserError) diagnostics.browserStderr = browserError.slice(-4000);
+    return diagnostics;
+}
+
+function withSmokeParam(url, label) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", `${Date.now()}-${label}`);
+    return next.toString();
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) return;
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result);
+        }
+    });
+
+    const call = (method, params = {}) =>
+        new Promise((resolve, reject) => {
+            const id = nextID++;
+            pending.set(id, { resolve, reject });
+            socket.send(JSON.stringify({ id, method, params }));
+        });
+
+    return {
+        call,
+        close: () => socket.close(),
+        evaluate: async (expression) => {
+            const result = await call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+    };
+}
+
+function assertDeepEqual(actual, expected, label) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+function wait(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}


### PR DESCRIPTION
## Summary

Adds framework-level fixed-height virtualization primitives and migrates the dashboard issue table to `gf.VirtualTable`.

## Changes

- Add `gf.VirtualList`
- Add `gf.VirtualTable`
- Add `gf.ScrollEvent`
- Add fixed-height virtual range calculation
- Add buffered range updates so scroll inside the rendered overscan window does not schedule Go state updates
- Add stable internal keys for virtual table spacer, empty, and row nodes
- Add explicit `ColumnCount` support for virtual table spacer/content rows
- Virtualize the dashboard issue table
- Add `examples/virtualized` with 10,000 logical items
- Update dashboard smoke tests for bounded mounted rows, layout sanity, spacer stability, and scroll behavior
- Update dashboard DOM pressure audit for virtualized table behavior
- Add virtualization docs and size budget coverage

## Dashboard DOM Pressure

Before virtualization:

- Open -> All average duration: ~140 ms
- Created DOM nodes: ~6,156
- Event listeners: +456
- Mounted rows: 300
- Live DOM/listener leak was not confirmed, but the update caused visible DOM pressure

After virtualization:

- Open -> All average duration: ~51 ms
- Mounted rows max: 28
- Live DOM remains stable
- Net listeners remain stable
- Spacer rows remain stable
- Table layout remains readable
- Scroll inside the already-rendered buffer does not trigger VirtualTable or IssueRow renders

## Runtime Model

`VirtualList` and `VirtualTable` use a fixed item/row height model:

- `Height` defines the viewport height
- `ItemHeight` / `RowHeight` defines the fixed item size
- `Overscan` keeps extra rows mounted around the visible window
- `Key` provides stable logical item identity
- The mounted DOM is bounded to the visible window plus overscan
- Dynamic measurement is intentionally out of scope for this MVP

## Dashboard Proof

The dashboard still models 300 logical issues, but the DOM now mounts only the visible virtual window.

Covered scenarios:

- Initial render keeps mounted rows bounded
- Search/filter keeps mounted rows bounded
- Open -> All no longer mounts hundreds of rows
- Slow scroll keeps spacer identity stable
- Scroll inside the buffered range does not trigger row churn
- Scroll beyond the buffer updates the row window within bounded limits
- Continuous scroll renders far less often than raw scroll events
- Row selection after scroll updates the detail panel
- Toggle after scroll updates the correct row
- Sort/reset keep table layout and row bounds stable

## New Example

Adds `examples/virtualized`:

- Demonstrates `gf.VirtualList`
- Demonstrates `gf.VirtualTable`
- Uses 10,000 logical items
- Keeps mounted DOM bounded
- Covers scroll, selection, and toggle behavior after scroll

## Stabilization Notes

This branch also includes targeted fixes found during browser/manual review:

- Replaced magic `colspan=999` with explicit `ColumnCount`
- Added dashboard table layout assertions
- Added stable internal keys for virtual table spacers and rows
- Render top/bottom spacers consistently for non-empty virtual tables
- Switched virtual range state from visible row to buffered range start
- Added `overflow-anchor:none` to virtualized viewports/spacers
- Added strict inside-buffer scroll no-op gates
- Scaled beyond-buffer DOM churn gates to mounted row window size

## Checks

- `go fmt ./...`
- `git diff --check`
- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- `go test ./examples/dashboard`
- `go test ./examples/context`
- `go test ./examples/virtualized`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `node --experimental-websocket scripts/dashboard-dom-pressure.mjs`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`

## Size Report

- counter: raw 81,350 B, gzip 32,477 B, br 27,098 B, zstd 29,282 B
- components: raw 86,725 B, gzip 34,131 B, br 28,324 B, zstd 30,555 B
- todo: raw 113,935 B, gzip 43,622 B, br 36,285 B, zstd 39,263 B
- dashboard: raw 163,897 B, gzip 61,217 B, br 49,482 B, zstd 53,454 B
- context: raw 111,440 B, gzip 42,093 B, br 34,413 B, zstd 37,111 B
- virtualized: raw 119,729 B, gzip 45,575 B, br 37,524 B, zstd 40,759 B

## Limits

- Fixed item/row height only
- No dynamic measurement yet
- No infinite loading yet
- Basic table accessibility and keyboard behavior
- No advanced table helper layer yet
- CDP Nodes may still drift during pressure runs, but live DOM and listener counts remain stable