### PR TITLE
MVP 19: component identity v2 prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - MVP 18 runtime and benchmark baseline documentation, including performance
   hard/informational gate policy, API stability tiers, component identity next
   steps, and symlink/file safety policy.
+- Component identity v2 prototype with `gf.NewComponentType`, `gf.ComponentT`,
+  generated GOX component tokens, and legacy `gf.Component` compatibility.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ type ButtonProps struct {
 The generated Go keeps the component visible to the runtime:
 
 ```go
-gf.Component("Button", ButtonProps{
+var _goxComponent_app_Button = gf.NewComponentType("main.Button", "Button")
+
+gf.ComponentT(_goxComponent_app_Button, ButtonProps{
 	Label:   "Increment",
 	OnClick: increment,
 }, Button)
@@ -217,9 +219,9 @@ gf.Map(items, func(item Item) gf.Node { ... })
 gf.MapIndexed(items, func(index int, item Item) gf.Node { ... })
 ```
 
-Low-level helpers such as `gf.Component`, `gf.El`, `gf.Child`, `gf.Key`,
-`gf.If`, `gf.IfElse`, `gf.For`, and `gf.ForIndexed` remain exported because
-generated `.gox.go` files use the public runtime package. Treat them as
+Low-level helpers such as `gf.Component`, `gf.ComponentT`, `gf.El`, `gf.Child`,
+`gf.Key`, `gf.If`, `gf.IfElse`, `gf.For`, and `gf.ForIndexed` remain exported
+because generated `.gox.go` files use the public runtime package. Treat them as
 runtime/compiler primitives unless you are writing generated-code-like Go by
 hand. In normal projects, `.gox.go` files live under `.goframe/gen` or an
 explicit `--out` directory and should not be committed.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -55,6 +55,8 @@ Runtime:
 - `gf.Key`
 - `gf.Component`
 - `gf.C`
+- `gf.NewComponentType`
+- `gf.ComponentT`
 - `gf.UseState`
 - `gf.UseReducer`
 - `gf.UseEffect`
@@ -92,7 +94,7 @@ exact shapes can still change before public preview.
 - Context topology behavior and selector limitations.
 - Virtualization details such as fixed-height range buffering and table spacer
   structure.
-- Component identity model.
+- Component identity id format for generated GOX component tokens.
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands and snippets.
@@ -140,8 +142,7 @@ Not stable:
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
 - multi-package app support;
-- component identity beyond name/key/position;
-- generated component tokens;
+- final component identity scheme for multi-package apps;
 - dynamic virtualization measurement;
 - infinite loading;
 - advanced accessibility/keyboard model for tables;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,8 @@ and TinyGo compilers can consume.
 The MVP component model deliberately delegates type checking to Go:
 
 - lowercase tags generate `gf.El`;
-- capitalized tags generate `gf.Component` boundaries using `<Name>Props`;
+- capitalized tags generate `gf.ComponentT` boundaries using generated
+  `gf.ComponentType` tokens and `<Name>Props`;
 - component children populate `Children []gf.Node`;
 - fragments generate `gf.Fragment`;
 - child expressions generate `gf.Child`.
@@ -244,8 +245,9 @@ The MVP runtime currently has:
 
 Direct function calls remain possible but do not create a component boundary.
 The single-thread assumption must be revisited before worker-driven updates.
-See [component identity](component-identity.md) for the current name/key/position
-strategy and the generated-token migration option.
+See [component identity](component-identity.md) for the typed generated-token
+strategy, legacy string identity compatibility, and remaining package-aware
+identity questions.
 See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 
 ## Limitations

--- a/docs/component-identity-next.md
+++ b/docs/component-identity-next.md
@@ -2,30 +2,39 @@
 
 ## Current Model
 
-GoFrame currently reuses component instances by:
+GoFrame's legacy path reuses component instances by:
 
 ```text
 component name + key/position
 ```
 
-GOX capitalized tags generate a string name:
+Older handwritten code and older generated output can still use a string name:
 
 ```go
 gf.Component("Header", HeaderProps{}, Header)
 ```
 
+MVP 19 adds a typed identity path:
+
+```go
+var _goxComponent_app_Header = gf.NewComponentType("main.Header", "Header")
+
+gf.ComponentT(_goxComponent_app_Header, HeaderProps{}, Header)
+```
+
 The runtime preserves state, effects, context subscriptions, and memoization
-metadata when the component name and sibling identity match. Keys override
-positional matching for reorderable siblings.
+metadata when the component identity and sibling identity match. Keys override
+positional matching for reorderable siblings. The debug name remains readable,
+but it does not define typed identity.
 
 ## Why It Works Today
 
-The current examples keep all application components in one Go package and use
-unique component names. That makes string identity small, readable in debug
-output, and TinyGo-friendly.
+The current examples keep all application components in one Go package. MVP 19
+uses the Go package name plus component name for generated GOX component ids,
+for example `main.Header`.
 
-It also keeps generated code simple. Direct Go function calls remain ordinary
-calls, while `gf.Component` marks the runtime boundary.
+Direct Go function calls remain ordinary calls. `gf.Component` and
+`gf.ComponentT` mark runtime component boundaries.
 
 ## Where It Becomes Risky
 
@@ -33,7 +42,7 @@ String names become risky when the project grows toward reusable packages or
 multi-package applications:
 
 - different packages can define components with the same name;
-- generated GOX code currently does not encode package identity;
+- generated GOX code currently encodes package name, not full import path;
 - moving a component between packages could accidentally preserve or reset
   state incorrectly depending on the generated name;
 - direct function calls and `gf.Component` boundaries remain behaviorally
@@ -100,10 +109,10 @@ Cons:
 
 ## Option C: Compiler-Generated Component Tokens
 
-GOX could generate stable package-aware tokens:
+GOX now generates prototype component tokens:
 
 ```go
-var _goxHeaderType = gf.ComponentType("main.Header")
+var _goxHeaderType = gf.NewComponentType("main.Header", "Header")
 
 gf.ComponentT(_goxHeaderType, HeaderProps{}, Header)
 ```
@@ -115,11 +124,11 @@ Pros:
 - avoids function identity and reflection;
 - gives the compiler a future place for metadata.
 
-Cons:
+Remaining cons:
 
-- requires a new runtime entry point;
-- changes generated code;
-- needs migration and size measurements;
+- current generated ids use package name rather than full import path;
+- token variable names include source-file context and are not public API;
+- full multi-package support still needs an import-path/package-token decision;
 - token lifetime and initialization must stay simple for TinyGo.
 
 ## Option D: Explicit User Tokens
@@ -185,15 +194,17 @@ A conservative path:
 
 ## Recommendation
 
-Do not implement generated identity in MVP 18. Before multi-package app
-support, prototype compiler-generated or package-aware identity and compare
-runtime size, generated code size, and migration cost.
+MVP 19 prototypes compiler-generated component tokens while preserving legacy
+`gf.Component` compatibility. Before multi-package app support, GoFrame still
+needs a package-aware identity decision that is stronger than package-name-only
+ids for `main` packages and reusable libraries.
 
 The current recommendation is:
 
 ```text
-single-package apps: keep name + key
-multi-package apps: require package-aware or compiler-generated identity first
+single-package apps: use generated ComponentT tokens
+handwritten/raw Go: gf.Component remains compatible; ComponentT is available
+multi-package apps: require package-aware identity before support is claimed
 ```
 
 ## Open Questions

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -1,11 +1,13 @@
 # Component Identity
 
-This document records the current component identity strategy and the options
-considered during Foundation Hardening II.
+This document records the component identity strategy and the options
+considered during Foundation Hardening II through MVP 19.
 
 ## Current Model
 
-`goframe` currently identifies component instances by:
+`goframe` has two compatible component identity paths.
+
+Legacy handwritten components identify instances by:
 
 ```text
 component name + key/position
@@ -19,9 +21,19 @@ gf.Component("Header", HeaderProps{
 }, Header)
 ```
 
+Generated GOX now uses explicit component identity tokens:
+
+```go
+var _goxComponent_app_Header = gf.NewComponentType("main.Header", "Header")
+
+gf.ComponentT(_goxComponent_app_Header, HeaderProps{
+	Title: "Demo",
+}, Header)
+```
+
 The mounted runtime reuses an existing component instance when:
 
-- the component name is the same;
+- the component identity is the same;
 - the key is the same when a key is present;
 - otherwise the sibling position is the same.
 
@@ -63,10 +75,10 @@ This remains the current strategy.
 
 ## Alternative B: Generated Stable Type Token
 
-GOX codegen could generate package-aware component tokens:
+GOX codegen now emits prototype component tokens:
 
 ```go
-var _goxComponentHeader = gf.ComponentType("main.Header")
+var _goxComponentHeader = gf.NewComponentType("main.Header", "Header")
 
 gf.ComponentT(_goxComponentHeader, HeaderProps{
 	Title: "Demo",
@@ -80,16 +92,16 @@ Pros:
 - does not require comparing Go function values;
 - can preserve readable names for debug output.
 
-Cons:
+Remaining cons:
 
-- changes generated code;
-- introduces another public or semi-public runtime API;
-- needs a migration story from `gf.Component`;
+- current ids use package name plus component name, not full import path;
+- token variable names are generated-code details;
+- full multi-package support still needs a package-aware identity decision;
 - may increase bundle size if token metadata grows.
 
-Recommendation: this is the most promising next identity improvement, but it
-should be introduced as an optional, non-breaking foundation after current
-regression gates are stable.
+Recommendation: keep the MVP 19 token path as the generated default while
+retaining `gf.Component` as compatibility API. Do not claim multi-package
+component identity until package-aware ids are designed.
 
 ## Alternative C: Function Identity
 
@@ -106,31 +118,29 @@ bad fits for this project:
 
 ## Recommendation
 
-Stay with name/key/position for now, with these hardening rules:
+Use generated typed identity for GOX, with these hardening rules:
 
-- keep component names stable and unique within an application;
+- keep generated identity ids stable within an application;
 - use keys for reordered lists;
 - treat duplicate keys as a bug;
 - keep duplicate-key diagnostics in `goframe_debug` builds only;
-- revisit generated stable type tokens before adding reusable component package
+- revisit package-aware identity before adding reusable component package
   workflows.
 
 ## Migration Plan For Tokens
 
-If generated type tokens become necessary:
+The current migration path:
 
-1. Add a small optional token API while keeping `gf.Component`:
+1. Keep the optional token API while keeping `gf.Component`:
 
    ```go
-   type ComponentType struct {
-   	name string
-   }
+   gf.NewComponentType("main.Header", "Header")
    ```
 
-2. Add `gf.ComponentT` or a compatible overload-style helper.
-3. Update GOX codegen to emit tokens behind a feature gate or versioned mode.
-4. Keep string-based `gf.Component` as a compatibility API.
-5. Measure TinyGo sizes before making token codegen the default.
+2. Use `gf.ComponentT` in generated GOX output.
+3. Keep string-based `gf.Component` as a compatibility API.
+4. Measure TinyGo sizes after token codegen changes.
+5. Design import-path or compiler package tokens before multi-package apps.
 
 ## Size Considerations
 

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -102,7 +102,7 @@ paths:
 - a conditional component disappears;
 - a keyed component is removed from a list;
 - a component key changes;
-- a component name changes;
+- a component identity changes;
 - a fragment subtree containing a component is removed;
 - a mounted application is replaced.
 

--- a/docs/foundation-audit-iv.md
+++ b/docs/foundation-audit-iv.md
@@ -423,7 +423,7 @@ Before the next runtime feature:
 1. Keep Foundation Audit IV green through CI after PR.
 2. Add CI `shellcheck` if the project wants shell portability enforcement.
 3. Decide whether symlink policy needs explicit documentation and tests.
-4. Consider a design note for compiler-generated component identity before
-   larger component systems.
+4. Continue the MVP 19 component identity prototype into a package-aware
+   identity design before larger component systems.
 5. Keep dynamic virtualization measurement, accessibility hardening, and stable
    callback hooks as separate design tasks rather than audit cleanup.

--- a/docs/foundation-audit.md
+++ b/docs/foundation-audit.md
@@ -57,7 +57,8 @@ pseudo-prop, and keeps low-level constructors as generated-code primitives.
 The current separation of responsibilities is good for an MVP platform:
 
 - Runtime code does not import the GOX compiler or CLI.
-- GOX codegen knows the public runtime API (`gf.El`, `gf.Component`, `gf.Child`)
+- GOX codegen knows the public runtime API (`gf.El`, `gf.ComponentT`,
+  `gf.Child`)
   but does not know browser DOM implementation details.
 - CLI code owns build/package/serve concerns and keeps compression out of
   `build`.
@@ -66,8 +67,9 @@ The current separation of responsibilities is good for an MVP platform:
 
 Temporary decisions to keep visible:
 
-- Component identity is based on component name plus key/position, not Go
-  function identity.
+- Generated component identity uses explicit component type tokens plus
+  key/position; legacy handwritten `gf.Component` still uses string identity.
+  Neither path uses Go function identity.
 - Direct function component calls are valid Go but do not create runtime
   component identity.
 - State slots are component-scoped but still positional.
@@ -123,7 +125,8 @@ Runtime risks that remain:
 GOX remains deliberately small:
 
 - Lowercase tags generate `gf.El`.
-- Capitalized tags generate `gf.Component`.
+- Capitalized tags generate `gf.ComponentT` with generated component type
+  tokens.
 - Props follow `<ComponentName>Props`.
 - Children become `Children: []gf.Node{...}`.
 - Expressions become `gf.Child(expr)`.

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -59,7 +59,9 @@ func Button(props ButtonProps) gf.Node {
 Generated component node:
 
 ```go
-gf.Component("Button", ButtonProps{
+var _goxComponent_app_Button = gf.NewComponentType("main.Button", "Button")
+
+gf.ComponentT(_goxComponent_app_Button, ButtonProps{
     Label:   "Increment",
     OnClick: increment,
 }, Button)
@@ -73,14 +75,16 @@ without attributes:
 ```
 
 ```go
-gf.Component("Status", StatusProps{}, Status)
+gf.ComponentT(_goxComponent_app_Status, StatusProps{}, Status)
 ```
 
 Component prop names must be valid Go field names. Go's type checker reports
 unknown fields and incompatible prop values after generation.
 
 The boundary gives the runtime a component instance, scoped state slots, and a
-mounted subtree that can be updated independently of ancestors and siblings. Calling
+mounted subtree that can be updated independently of ancestors and siblings.
+Generated GOX code uses `gf.NewComponentType`/`gf.ComponentT` so the runtime has
+an explicit identity token separate from the short debug name. Calling
 `Button(ButtonProps{...})` directly is still valid Go, but it is an ordinary
 function call without separate component identity.
 
@@ -104,7 +108,7 @@ type CardProps struct {
 Generated shape:
 
 ```go
-gf.Component("Card", CardProps{
+gf.ComponentT(_goxComponent_app_Card, CardProps{
     Title: "Stats",
     Children: []gf.Node{
         gf.El("p", nil,
@@ -214,7 +218,7 @@ two JSX-like render expressions inside child expression braces.
 Generated shape:
 
 ```go
-gf.If(ready, gf.Component("ReadyView", ReadyViewProps{}, ReadyView))
+gf.If(ready, gf.ComponentT(_goxComponent_app_ReadyView, ReadyViewProps{}, ReadyView))
 ```
 
 Ordinary Go boolean expressions remain ordinary child expressions when the
@@ -243,8 +247,8 @@ Generated shape:
 ```go
 gf.IfElse(
     len(items) == 0,
-    gf.Component("EmptyState", EmptyStateProps{}, EmptyState),
-    gf.Component("ItemList", ItemListProps{Items: items}, ItemList),
+    gf.ComponentT(_goxComponent_app_EmptyState, EmptyStateProps{}, EmptyState),
+    gf.ComponentT(_goxComponent_app_ItemList, ItemListProps{Items: items}, ItemList),
 )
 ```
 
@@ -288,12 +292,12 @@ Generated code wraps the node:
 
 ```go
 gf.Key(gf.ToString(todo.ID),
-    gf.Component("TodoItem", TodoItemProps{Todo: todo}, TodoItem),
+    gf.ComponentT(_goxComponent_app_TodoItem, TodoItemProps{Todo: todo}, TodoItem),
 )
 ```
 
 Keys provide stable sibling identity to the minimal DOM patch and component
-layers. A key around a `gf.Component` preserves that component instance,
+layers. A key around a generated component boundary preserves that component instance,
 scoped state, and compatible mounted DOM range across removal and reorder.
 
 ## Events and controlled inputs

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -18,7 +18,7 @@ func (props MyRowProps) MemoEqual(next MyRowProps) bool {
 
 Then `goframe` may skip rerendering that component when all of the following are true:
 
-- component name/key identity matches
+- component identity/key matches
 - the previous and next props satisfy `MemoEqual`
 - the component instance is not dirty from its own local state/effects
 - no dirty descendant is waiting inside the component subtree
@@ -68,8 +68,8 @@ other compared prop tracks that data.
 ## Interaction with keys and identity
 
 Memoized skip applies within the same component identity boundary:
-component name + key + same instance. Key or component identity changes still
-remount/recreate as normal.
+component identity + key + same instance. Key or component identity changes
+still remount/recreate as normal.
 
 ## Dirty descendants
 

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -117,6 +117,23 @@ TinyGo packaged WASM sizes:
 The authoritative gate remains `scripts/size-budget.sh`. This table is a
 snapshot, not a second budget file.
 
+MVP 19 component identity v2 added explicit generated component tokens. After
+trimming the runtime identity representation, the measured TinyGo size impact
+remained small but pushed the context raw bundle 56 B past its previous 110 KiB
+budget. The context raw budget was therefore moved to 111 KiB while compressed
+budgets stayed unchanged.
+
+MVP 19 measured sizes:
+
+| Example | Raw | gzip | br | zstd |
+|---|---:|---:|---:|---:|
+| counter | 82097 | 32854 | 27459 | 29666 |
+| components | 87609 | 34584 | 28768 | 30945 |
+| todo | 115033 | 44236 | 36835 | 39763 |
+| dashboard | 165558 | 61887 | 50065 | 54160 |
+| context | 112696 | 42437 | 34935 | 37622 |
+| virtualized | 120917 | 46609 | 38128 | 41346 |
+
 ## Browser / DOM Baseline
 
 `scripts/browser-smoke.sh` currently covers:

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -25,17 +25,26 @@ five costs outside the dirty component subtree.
 
 ## ComponentNode
 
-GOX capitalized tags generate `gf.Component` nodes:
+GOX capitalized tags generate typed `gf.ComponentT` nodes:
 
 ```go
-gf.Component("Header", HeaderProps{
+var _goxComponent_app_Header = gf.NewComponentType("main.Header", "Header")
+
+gf.ComponentT(_goxComponent_app_Header, HeaderProps{
 	Title: "Demo",
 }, Header)
 ```
 
-A `ComponentNode` stores the component name, props, and deferred render
-function. The function is not called until the runtime mounts or rerenders the
-component. Lowercase tags still generate `gf.El`.
+`gf.ComponentT` receives a `ComponentType` identity token plus props and a
+deferred render function. The debug name remains human-readable for probes,
+but the runtime reuse decision uses the typed identity token. The function is
+not called until the runtime mounts or rerenders the component. Lowercase tags
+still generate `gf.El`.
+
+The legacy `gf.Component(name, props, render)` helper remains supported for
+handwritten Go and older generated code. Its identity is namespaced separately
+from typed identities, so `gf.Component("Header", ...)` does not accidentally
+reuse `gf.ComponentT(gf.NewComponentType("Header", "Header"), ...)`.
 
 Direct Go calls such as `Header(HeaderProps{...})` remain valid, but they
 execute immediately and do not create component identity or a separate state
@@ -47,7 +56,7 @@ Each mounted component boundary owns a component instance:
 
 ```text
 component instance
-  -> component name and optional key
+  -> component identity, debug name, and optional key
   -> latest props
   -> component-scoped state slots
   -> context provider values and selector subscriptions
@@ -55,13 +64,18 @@ component instance
   -> mounted child subtree
 ```
 
-An instance is reused when the component name matches and its sibling identity
-matches. Unkeyed components use position. `gf.Key` or `gf.WithKey` gives a
-component stable keyed identity across sibling reorder and removal. Changing a
-component name or key creates a new instance and unmounts the old subtree.
+An instance is reused when the component identity matches and its sibling
+identity matches. Unkeyed components use position. `gf.Key` or `gf.WithKey`
+gives a component stable keyed identity across sibling reorder and removal.
+Changing a component identity or key creates a new instance and unmounts the
+old subtree.
 
-Component names should be unique for distinct component implementations. MVP 8
-does not compare Go function identities.
+GOX-generated identity currently uses the Go package name plus component name,
+such as `main.Header`. This is a prototype path for component identity v2. It
+does not claim full multi-package application support yet; a future design must
+decide whether identity should use import paths, generated package tokens, or
+another package-aware scheme. The runtime does not compare Go function
+identities.
 
 Component boundaries use stable start and end comment anchors. Their mounted
 range therefore remains valid even if a component changes its rendered root
@@ -208,7 +222,7 @@ Component subtree updates reuse the MVP 7 mounted DOM patcher:
 - unkeyed children patch by position;
 - keyed children reuse and move mounted DOM ranges;
 - fragments and component boundaries use start and end comment anchors;
-- incompatible node kinds, tags, component names, or keys are replaced.
+- incompatible node kinds, tags, component identities, or keys are replaced.
 
 Stable input DOM identity means controlled typing normally preserves focus and
 cursor position. Stable-ID focus restoration remains a replacement fallback.
@@ -355,7 +369,8 @@ The dependency-free headless Chrome probe verifies:
 - virtualized collections are fixed-height only and do not include dynamic
   measurement, infinite loading, or keyboard navigation;
 - no error boundaries;
-- component identity uses the declared component name, not Go function identity;
+- GOX-generated component identity uses a typed token derived from package name
+  and component name, while legacy `gf.Component` still uses string identity;
 - explicit opt-in props memoization via `MemoEqual`; components still rerender
   by default when props are not memoized.
 - dirty component scheduling has no priorities, interruption, or concurrency;

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -7,11 +7,41 @@ type memoizedProps[P any] interface {
 	MemoEqual(next P) bool
 }
 
+type componentIdentity struct {
+	typed bool
+	id    string
+}
+
+// ComponentType is an explicit component identity token.
+//
+// It separates runtime identity from the human-readable debug name. Use
+// NewComponentType to create values; the zero value is not valid for
+// ComponentT.
+type ComponentType struct {
+	identity  componentIdentity
+	debugName string
+}
+
+// NewComponentType creates an explicit component identity token.
+func NewComponentType(id string, debugName string) ComponentType {
+	if id == "" {
+		panic("goframe: empty component id")
+	}
+	if debugName == "" {
+		debugName = id
+	}
+	return ComponentType{
+		identity:  typedComponentIdentity(id),
+		debugName: debugName,
+	}
+}
+
 // ComponentNode preserves a function component boundary until the runtime
 // creates or reuses its component instance.
 type ComponentNode struct {
 	Name      string
 	Props     any
+	identity  componentIdentity
 	render    func() Node
 	memoEqual func(any, any) bool
 }
@@ -20,6 +50,19 @@ func (ComponentNode) isNode() {}
 
 // Component creates a runtime-visible typed function component boundary.
 func Component[P any](name string, props P, render ComponentFunc[P]) Node {
+	return componentNode(name, legacyComponentIdentity(name), props, render)
+}
+
+// ComponentT creates a runtime-visible component boundary with an explicit
+// component identity token.
+func ComponentT[P any](componentType ComponentType, props P, render ComponentFunc[P]) Node {
+	if componentType.identity.id == "" {
+		panic("goframe: invalid component type")
+	}
+	return componentNode(componentType.debugName, componentType.identity, props, render)
+}
+
+func componentNode[P any](name string, identity componentIdentity, props P, render ComponentFunc[P]) Node {
 	var memoEqual func(any, any) bool
 	if _, ok := any(props).(memoizedProps[P]); ok {
 		memoEqual = memoizeProps[P]
@@ -27,6 +70,7 @@ func Component[P any](name string, props P, render ComponentFunc[P]) Node {
 	return ComponentNode{
 		Name:      name,
 		Props:     props,
+		identity:  identity,
 		memoEqual: memoEqual,
 		render: func() Node {
 			return render(props)
@@ -57,6 +101,7 @@ func C[P any](name string, props P, render ComponentFunc[P]) Node {
 
 type componentInstance struct {
 	name             string
+	identity         componentIdentity
 	key              string
 	parent           *componentInstance
 	node             ComponentNode
@@ -84,6 +129,7 @@ var currentComponent *componentInstance
 func newComponentInstance(node ComponentNode, key string, parent *componentInstance, schedule func(*componentInstance)) *componentInstance {
 	return &componentInstance{
 		name:           node.Name,
+		identity:       nodeComponentIdentity(node),
 		key:            key,
 		parent:         parent,
 		node:           node,
@@ -95,7 +141,7 @@ func newComponentInstance(node ComponentNode, key string, parent *componentInsta
 }
 
 func shouldSkipComponentRender(instance *componentInstance, nextNode ComponentNode, nextKey string) bool {
-	if instance == nil || instance.node.Name != nextNode.Name {
+	if instance == nil || instance.identity != nodeComponentIdentity(nextNode) {
 		return false
 	}
 	if instance.key != nextKey {
@@ -194,6 +240,28 @@ func ownerDebugName(owner *componentInstance) string {
 		return "<root>"
 	}
 	return "<" + owner.name + ">"
+}
+
+func legacyComponentIdentity(name string) componentIdentity {
+	return componentIdentity{
+		id: name,
+	}
+}
+
+func typedComponentIdentity(id string) componentIdentity {
+	return componentIdentity{
+		typed: true,
+		id:    id,
+	}
+}
+
+func nodeComponentIdentity(node ComponentNode) componentIdentity {
+	if node.identity.id != "" {
+		return node.identity
+	}
+	return componentIdentity{
+		id: node.Name,
+	}
 }
 
 func deactivateComponent(instance *componentInstance) {

--- a/pkg/goframe/component_identity_test.go
+++ b/pkg/goframe/component_identity_test.go
@@ -1,0 +1,125 @@
+package goframe
+
+import "testing"
+
+func TestNewComponentTypeRequiresID(t *testing.T) {
+	assertPanic(t, "goframe: empty component id", func() {
+		NewComponentType("", "Header")
+	})
+}
+
+func TestNewComponentTypeUsesIDAsDebugFallback(t *testing.T) {
+	componentType := NewComponentType("main.Header", "")
+	node := ComponentT(componentType, 1, func(int) Node { return Empty() }).(ComponentNode)
+
+	if node.Name != "main.Header" {
+		t.Fatalf("debug name = %q, want id fallback", node.Name)
+	}
+	if got := nodeComponentIdentity(node); got != typedComponentIdentity("main.Header") {
+		t.Fatalf("identity = %q, want typed main.Header", componentIdentityString(got))
+	}
+}
+
+func TestComponentTPreservesDebugNameAndTypedIdentity(t *testing.T) {
+	componentType := NewComponentType("main.Number", "Number")
+	node := ComponentT(componentType, 42, func(value int) Node {
+		return Text(ToString(value))
+	}).(ComponentNode)
+
+	if node.Name != "Number" || node.Props != 42 {
+		t.Fatalf("component = %#v", node)
+	}
+	if got := nodeComponentIdentity(node); got != typedComponentIdentity("main.Number") {
+		t.Fatalf("identity = %q, want typed main.Number", componentIdentityString(got))
+	}
+	if text := node.render().(TextNode); text.Value != "42" {
+		t.Fatalf("rendered text = %q, want 42", text.Value)
+	}
+}
+
+func TestComponentTRejectsZeroComponentType(t *testing.T) {
+	assertPanic(t, "goframe: invalid component type", func() {
+		ComponentT(ComponentType{}, 0, func(int) Node { return Empty() })
+	})
+}
+
+func TestTypedComponentIdentityUsesIDAndKey(t *testing.T) {
+	render := func(value int) Node { return Text(ToString(value)) }
+	header := NewComponentType("main.Header", "Header")
+	otherHeader := NewComponentType("other.Header", "Header")
+
+	first := ComponentT(header, 1, render)
+	second := ComponentT(header, 2, render)
+	other := ComponentT(otherHeader, 1, render)
+
+	if !sameNodeIdentity(first, second) {
+		t.Fatal("same typed component id should preserve identity")
+	}
+	if sameNodeIdentity(first, other) {
+		t.Fatal("different typed component ids must replace identity even with same debug name")
+	}
+	if matches := matchChildIndices([]string{"one"}, []string{"one"}); matches[0] != 0 {
+		t.Fatalf("keyed component match = %v", matches)
+	}
+}
+
+func TestLegacyAndTypedComponentIdentitiesDoNotCollide(t *testing.T) {
+	render := func(value int) Node { return Text(ToString(value)) }
+	legacy := Component("Header", 1, render)
+	typed := ComponentT(NewComponentType("Header", "Header"), 1, render)
+
+	if sameNodeIdentity(legacy, typed) {
+		t.Fatal("legacy string identity must not collide with typed identity using the same id text")
+	}
+}
+
+func TestTypedComponentMemoizationUsesTypedIdentity(t *testing.T) {
+	componentType := NewComponentType("main.Memo", "Memo")
+	node := ComponentT(componentType, memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	instance := newComponentInstance(node, "row-1", nil, nil)
+	instance.dirty = false
+	next := ComponentT(componentType, memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	if !shouldSkipComponentRender(instance, next, "row-1") {
+		t.Fatal("expected clean typed memoized component with equal props to skip")
+	}
+
+	otherType := NewComponentType("other.Memo", "Memo")
+	other := ComponentT(otherType, memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	if shouldSkipComponentRender(instance, other, "row-1") {
+		t.Fatal("typed memoized component must not skip across different type ids")
+	}
+}
+
+func TestTypedMemoizedComponentDoesNotSkipDirtyDescendant(t *testing.T) {
+	parent := dirtyCleanInstance("Parent", nil)
+	componentType := NewComponentType("main.Memo", "Memo")
+	node := ComponentT(componentType, memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+	child := newComponentInstance(node, "memo", parent, nil)
+	child.dirty = false
+	grandchild := dirtyCleanInstance("GrandChild", child)
+	next := ComponentT(componentType, memoizedPropsFixture{ID: 1, Version: 1}, func(memoizedPropsFixture) Node {
+		return Empty()
+	}).(ComponentNode)
+
+	markComponentDirty(grandchild)
+
+	if shouldSkipComponentRender(child, next, "memo") {
+		t.Fatal("typed memoized component with dirty descendant must not skip")
+	}
+}
+
+func componentIdentityString(identity componentIdentity) string {
+	if identity.typed {
+		return "type:" + identity.id
+	}
+	return "legacy:" + identity.id
+}

--- a/pkg/goframe/reconcile.go
+++ b/pkg/goframe/reconcile.go
@@ -44,7 +44,7 @@ func sameNodeIdentity(oldNode, newNode Node) bool {
 		return ok
 	case ComponentNode:
 		newNode, ok := newNode.(ComponentNode)
-		return ok && oldNode.Name == newNode.Name
+		return ok && nodeComponentIdentity(oldNode) == nodeComponentIdentity(newNode)
 	default:
 		return false
 	}

--- a/pkg/gox/codegen.go
+++ b/pkg/gox/codegen.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
@@ -12,22 +13,80 @@ import (
 // Codegen turns a parsed GOX node into calls to the goframe runtime. The MVP
 // expects the runtime package to be imported with the name gf.
 func Codegen(node Node) (string, error) {
+	ctx := newCodegenContext("gox", "inline", false)
+	return ctx.codegen(node)
+}
+
+type codegenContext struct {
+	packageName           string
+	sourceName            string
+	declareComponentTypes bool
+	componentTypes        map[string]string
+	componentOrder        []string
+}
+
+func newCodegenContext(packageName string, sourceName string, declareComponentTypes bool) *codegenContext {
+	if packageName == "" {
+		packageName = "main"
+	}
+	sourceName = strings.TrimSuffix(filepath.Base(sourceName), filepath.Ext(sourceName))
+	if sourceName == "" || sourceName == "." {
+		sourceName = "gox"
+	}
+	return &codegenContext{
+		packageName:           packageName,
+		sourceName:            sanitizeIdentifierPart(sourceName),
+		declareComponentTypes: declareComponentTypes,
+		componentTypes:        make(map[string]string),
+	}
+}
+
+func (ctx *codegenContext) codegen(node Node) (string, error) {
 	var output bytes.Buffer
-	if err := writeNode(&output, node, 0); err != nil {
+	if err := ctx.writeNode(&output, node, 0); err != nil {
 		return "", err
 	}
 	return output.String(), nil
 }
 
-func writeNode(output *bytes.Buffer, node Node, depth int) error {
+func (ctx *codegenContext) componentTypeExpression(tag string) string {
+	id := ctx.packageName + "." + tag
+	if !ctx.declareComponentTypes {
+		return fmt.Sprintf("gf.NewComponentType(%q, %q)", id, tag)
+	}
+	if name, ok := ctx.componentTypes[tag]; ok {
+		return name
+	}
+	name := "_goxComponent_" + ctx.sourceName + "_" + sanitizeIdentifierPart(tag)
+	ctx.componentTypes[tag] = name
+	ctx.componentOrder = append(ctx.componentOrder, tag)
+	return name
+}
+
+func (ctx *codegenContext) declarations() string {
+	if len(ctx.componentOrder) == 0 {
+		return ""
+	}
+	var output bytes.Buffer
+	output.WriteString("var (\n")
+	for _, tag := range ctx.componentOrder {
+		name := ctx.componentTypes[tag]
+		id := ctx.packageName + "." + tag
+		fmt.Fprintf(&output, "\t%s = gf.NewComponentType(%q, %q)\n", name, id, tag)
+	}
+	output.WriteString(")\n")
+	return output.String()
+}
+
+func (ctx *codegenContext) writeNode(output *bytes.Buffer, node Node, depth int) error {
 	switch node := node.(type) {
 	case *Element:
 		if isComponent(node.Tag) {
-			return writeComponent(output, node, depth)
+			return ctx.writeComponent(output, node, depth)
 		}
-		return writeElement(output, node, depth)
+		return ctx.writeElement(output, node, depth)
 	case *Fragment:
-		return writeFragment(output, node.Children, depth)
+		return ctx.writeFragment(output, node.Children, depth)
 	case *Text:
 		value := normalizeText(node.Value)
 		if value == "" {
@@ -40,13 +99,13 @@ func writeNode(output *bytes.Buffer, node Node, depth int) error {
 		if code == "" {
 			return fmt.Errorf("gox: empty child expression")
 		}
-		return writeChildExpression(output, code, depth)
+		return ctx.writeChildExpression(output, code, depth)
 	default:
 		return fmt.Errorf("gox: unsupported AST node %T", node)
 	}
 }
 
-func writeComponent(output *bytes.Buffer, component *Element, depth int) error {
+func (ctx *codegenContext) writeComponent(output *bytes.Buffer, component *Element, depth int) error {
 	if !validGoIdentifier(component.Tag) {
 		return fmt.Errorf("gox: invalid component name %q", component.Tag)
 	}
@@ -57,7 +116,7 @@ func writeComponent(output *bytes.Buffer, component *Element, depth int) error {
 
 	var body bytes.Buffer
 
-	fmt.Fprintf(&body, "gf.Component(%q, %sProps{\n", component.Tag, component.Tag)
+	fmt.Fprintf(&body, "gf.ComponentT(%s, %sProps{\n", ctx.componentTypeExpression(component.Tag), component.Tag)
 	for _, attribute := range attributes {
 		if !validGoIdentifier(attribute.Name) {
 			return fmt.Errorf("gox: component prop %q must be a Go field name", attribute.Name)
@@ -72,7 +131,7 @@ func writeComponent(output *bytes.Buffer, component *Element, depth int) error {
 	if hasRenderableChildren(component.Children) {
 		writeIndent(&body, depth+1)
 		body.WriteString("Children: []gf.Node{\n")
-		if err := writeChildren(&body, component.Children, depth+2); err != nil {
+		if err := ctx.writeChildren(&body, component.Children, depth+2); err != nil {
 			return err
 		}
 		writeIndent(&body, depth+1)
@@ -83,7 +142,7 @@ func writeComponent(output *bytes.Buffer, component *Element, depth int) error {
 	return writeKeyed(output, key, body.Bytes(), depth)
 }
 
-func writeElement(output *bytes.Buffer, element *Element, depth int) error {
+func (ctx *codegenContext) writeElement(output *bytes.Buffer, element *Element, depth int) error {
 	key, attributes, err := splitKeyAttribute(element.Attributes)
 	if err != nil {
 		return err
@@ -109,7 +168,7 @@ func writeElement(output *bytes.Buffer, element *Element, depth int) error {
 
 	if hasRenderableChildren(element.Children) {
 		body.WriteString(",\n")
-		if err := writeChildren(&body, element.Children, depth+1); err != nil {
+		if err := ctx.writeChildren(&body, element.Children, depth+1); err != nil {
 			return err
 		}
 	} else {
@@ -120,11 +179,11 @@ func writeElement(output *bytes.Buffer, element *Element, depth int) error {
 	return writeKeyed(output, key, body.Bytes(), depth)
 }
 
-func writeFragment(output *bytes.Buffer, children []Node, depth int) error {
+func (ctx *codegenContext) writeFragment(output *bytes.Buffer, children []Node, depth int) error {
 	output.WriteString("gf.Fragment(")
 	if hasRenderableChildren(children) {
 		output.WriteString("\n")
-		if err := writeChildren(output, children, depth+1); err != nil {
+		if err := ctx.writeChildren(output, children, depth+1); err != nil {
 			return err
 		}
 	}
@@ -133,10 +192,10 @@ func writeFragment(output *bytes.Buffer, children []Node, depth int) error {
 	return nil
 }
 
-func writeChildren(output *bytes.Buffer, children []Node, depth int) error {
+func (ctx *codegenContext) writeChildren(output *bytes.Buffer, children []Node, depth int) error {
 	for _, child := range children {
 		var childOutput bytes.Buffer
-		if err := writeNode(&childOutput, child, depth); err != nil {
+		if err := ctx.writeNode(&childOutput, child, depth); err != nil {
 			return err
 		}
 		if childOutput.Len() == 0 {
@@ -166,15 +225,15 @@ func writeAttributeValue(output *bytes.Buffer, attribute Attribute) error {
 	return nil
 }
 
-func writeChildExpression(output *bytes.Buffer, code string, depth int) error {
-	if rendered, ok, err := lowerRenderExpression(code, depth); err != nil {
+func (ctx *codegenContext) writeChildExpression(output *bytes.Buffer, code string, depth int) error {
+	if rendered, ok, err := ctx.lowerRenderExpression(code, depth); err != nil {
 		return err
 	} else if ok {
 		output.WriteString(rendered)
 		return nil
 	}
 
-	rewritten, err := rewriteMarkupInGo(code)
+	rewritten, err := ctx.rewriteMarkupInGo(code)
 	if err != nil {
 		return err
 	}
@@ -182,15 +241,15 @@ func writeChildExpression(output *bytes.Buffer, code string, depth int) error {
 	return nil
 }
 
-func lowerRenderExpression(code string, depth int) (string, bool, error) {
+func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string, bool, error) {
 	if condition, thenCode, elseCode, ok, err := splitTernaryExpression(code); err != nil {
 		return "", false, err
 	} else if ok {
-		thenNode, thenOK, err := codegenNodeExpression(thenCode, depth)
+		thenNode, thenOK, err := ctx.codegenNodeExpression(thenCode, depth)
 		if err != nil {
 			return "", false, err
 		}
-		elseNode, elseOK, err := codegenNodeExpression(elseCode, depth)
+		elseNode, elseOK, err := ctx.codegenNodeExpression(elseCode, depth)
 		if err != nil {
 			return "", false, err
 		}
@@ -201,7 +260,7 @@ func lowerRenderExpression(code string, depth int) (string, bool, error) {
 	}
 
 	if condition, nodeCode, ok := splitRenderAndExpression(code); ok {
-		node, nodeOK, err := codegenNodeExpression(nodeCode, depth)
+		node, nodeOK, err := ctx.codegenNodeExpression(nodeCode, depth)
 		if err != nil {
 			return "", false, err
 		}
@@ -212,13 +271,13 @@ func lowerRenderExpression(code string, depth int) (string, bool, error) {
 	return "", false, nil
 }
 
-func codegenNodeExpression(code string, depth int) (string, bool, error) {
+func (ctx *codegenContext) codegenNodeExpression(code string, depth int) (string, bool, error) {
 	code = strings.TrimSpace(code)
 	if code == "" {
 		return "", false, nil
 	}
 	if inner, ok := unwrapOuterParens(code); ok {
-		return codegenNodeExpression(inner, depth)
+		return ctx.codegenNodeExpression(inner, depth)
 	}
 	if code[0] != '<' {
 		return "", false, nil
@@ -232,13 +291,13 @@ func codegenNodeExpression(code string, depth int) (string, bool, error) {
 		return "", false, fmt.Errorf("gox: unexpected text after GOX node expression")
 	}
 	var output bytes.Buffer
-	if err := writeNode(&output, node, depth); err != nil {
+	if err := ctx.writeNode(&output, node, depth); err != nil {
 		return "", false, err
 	}
 	return output.String(), true, nil
 }
 
-func rewriteMarkupInGo(code string) (string, error) {
+func (ctx *codegenContext) rewriteMarkupInGo(code string) (string, error) {
 	var output bytes.Buffer
 	cursor := 0
 	searchFrom := 0
@@ -252,7 +311,7 @@ func rewriteMarkupInGo(code string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		generated, err := Codegen(node)
+		generated, err := ctx.codegen(node)
 		if err != nil {
 			return "", err
 		}
@@ -348,6 +407,25 @@ func validGoIdentifier(value string) bool {
 		}
 	}
 	return true
+}
+
+func sanitizeIdentifierPart(value string) string {
+	var output strings.Builder
+	for index, character := range value {
+		if unicode.IsLetter(character) || character == '_' || index > 0 && unicode.IsDigit(character) {
+			output.WriteRune(character)
+			continue
+		}
+		output.WriteByte('_')
+	}
+	if output.Len() == 0 {
+		return "gox"
+	}
+	result := output.String()
+	if first := []rune(result)[0]; !unicode.IsLetter(first) && first != '_' {
+		return "_" + result
+	}
+	return result
 }
 
 func writeIndent(output *bytes.Buffer, depth int) {

--- a/pkg/gox/generate.go
+++ b/pkg/gox/generate.go
@@ -20,6 +20,7 @@ func Generate(source []byte) ([]byte, error) {
 // GenerateNamed transpiles GOX source and includes filename in diagnostics.
 func GenerateNamed(filename string, source []byte) ([]byte, error) {
 	input := string(source)
+	ctx := newCodegenContext(packageNameFromSource(input), filename, true)
 	var output bytes.Buffer
 	cursor := 0
 	searchFrom := 0
@@ -36,7 +37,7 @@ func GenerateNamed(filename string, source []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		code, err := Codegen(element)
+		code, err := ctx.codegen(element)
 		if err != nil {
 			return nil, diagnosticError(filename, line, column, err.Error(), sourceLine(input, start))
 		}
@@ -49,12 +50,16 @@ func GenerateNamed(filename string, source []byte) ([]byte, error) {
 		generated++
 	}
 	output.WriteString(input[cursor:])
+	generatedSource := output.String()
+	if declarations := ctx.declarations(); declarations != "" {
+		generatedSource = insertGeneratedDeclarations(generatedSource, declarations)
+	}
 
 	if generated == 0 {
 		return nil, fmt.Errorf("%s: no GOX markup elements found", filename)
 	}
 
-	formatted, err := format.Source(append([]byte(generatedHeader), output.Bytes()...))
+	formatted, err := format.Source(append([]byte(generatedHeader), []byte(generatedSource)...))
 	if err != nil {
 		return nil, fmt.Errorf("%s: generated Go source is invalid: %w", filename, err)
 	}
@@ -207,4 +212,87 @@ func nextNonSpace(input string, from int) int {
 		}
 	}
 	return -1
+}
+
+func packageNameFromSource(input string) string {
+	for _, line := range strings.Split(input, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "package ") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && validGoIdentifier(fields[1]) {
+			return fields[1]
+		}
+	}
+	return "main"
+}
+
+func insertGeneratedDeclarations(input string, declarations string) string {
+	position := declarationInsertionPoint(input)
+	return input[:position] + "\n" + declarations + input[position:]
+}
+
+func declarationInsertionPoint(input string) int {
+	packageIndex := strings.Index(input, "package ")
+	if packageIndex < 0 {
+		return 0
+	}
+	packageLineEnd := strings.IndexByte(input[packageIndex:], '\n')
+	if packageLineEnd < 0 {
+		return len(input)
+	}
+	position := packageIndex + packageLineEnd + 1
+	importStart := skipWhitespace(input, position)
+	if !strings.HasPrefix(input[importStart:], "import") || !isKeywordBoundary(input, importStart+len("import")) {
+		return position
+	}
+
+	index := skipWhitespace(input, importStart+len("import"))
+	if index >= len(input) {
+		return len(input)
+	}
+	if input[index] == '(' {
+		depth := 0
+		for index < len(input) {
+			switch input[index] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					index++
+					return lineEnd(input, index)
+				}
+			}
+			index++
+		}
+		return len(input)
+	}
+	return lineEnd(input, index)
+}
+
+func skipWhitespace(input string, index int) int {
+	for index < len(input) && unicode.IsSpace(rune(input[index])) {
+		index++
+	}
+	return index
+}
+
+func isKeywordBoundary(input string, index int) bool {
+	if index >= len(input) {
+		return true
+	}
+	character := rune(input[index])
+	return !unicode.IsLetter(character) && !unicode.IsDigit(character) && character != '_'
+}
+
+func lineEnd(input string, index int) int {
+	for index < len(input) && input[index] != '\n' {
+		index++
+	}
+	if index < len(input) {
+		index++
+	}
+	return index
 }

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -73,6 +73,66 @@ func App() gf.Node {
 	}
 }
 
+func TestCodegenComponentUsesInlineComponentType(t *testing.T) {
+	node, _, err := ParseElement(`<Button Label="Save" />`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generated, err := Codegen(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		`gf.ComponentT(gf.NewComponentType("gox.Button", "Button"), ButtonProps{`,
+		`Label: "Save"`,
+		`}, Button)`,
+	} {
+		if !strings.Contains(generated, want) {
+			t.Fatalf("generated component does not contain %q:\n%s", want, generated)
+		}
+	}
+}
+
+func TestGenerateDeclaresComponentTypeOncePerTag(t *testing.T) {
+	source := []byte(`package demo
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type ButtonProps struct { Label string }
+
+func Button(props ButtonProps) gf.Node {
+	return <button>{props.Label}</button>
+}
+
+func View() gf.Node {
+	return (
+		<div>
+			<Button Label="One" />
+			<Button Label="Two" />
+		</div>
+	)
+}
+`)
+
+	generated, err := GenerateNamed("testdata/repeated_button.gox", source)
+	if err != nil {
+		t.Fatalf("GenerateNamed() error: %v", err)
+	}
+	text := string(generated)
+	if got := strings.Count(text, `gf.NewComponentType("demo.Button", "Button")`); got != 1 {
+		t.Fatalf("component type declarations = %d, want 1:\n%s", got, text)
+	}
+	if got := strings.Count(text, `gf.ComponentT(_goxComponent_repeated_button_Button`); got != 2 {
+		t.Fatalf("ComponentT uses = %d, want 2:\n%s", got, text)
+	}
+	if typeIndex := strings.Index(text, `_goxComponent_repeated_button_Button = gf.NewComponentType`); typeIndex < 0 {
+		t.Fatalf("missing component type declaration:\n%s", text)
+	} else if importIndex := strings.Index(text, `import gf "github.com/graybuton/goframe/pkg/goframe"`); importIndex < 0 || typeIndex < importIndex {
+		t.Fatalf("component type declaration should be after import:\n%s", text)
+	}
+}
+
 func TestParseElementReportsMismatchedTag(t *testing.T) {
 	_, _, err := ParseElement("<div><span></div>")
 	if err == nil || !strings.Contains(err.Error(), "expected closing tag </span>, got </div>") {

--- a/pkg/gox/testdata/component_children.golden.go
+++ b/pkg/gox/testdata/component_children.golden.go
@@ -4,6 +4,10 @@ package demo
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_component_children_Card = gf.NewComponentType("demo.Card", "Card")
+)
+
 type CardProps struct {
 	Title    string
 	Children []gf.Node
@@ -21,7 +25,7 @@ func Card(props CardProps) gf.Node {
 }
 
 func View() gf.Node {
-	return gf.Component("Card", CardProps{
+	return gf.ComponentT(_goxComponent_component_children_Card, CardProps{
 		Title: "Stats",
 		Children: []gf.Node{
 			gf.El("p", nil,

--- a/pkg/gox/testdata/component_helper_children.golden.go
+++ b/pkg/gox/testdata/component_helper_children.golden.go
@@ -4,6 +4,10 @@ package demo
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_component_helper_children_Card = gf.NewComponentType("demo.Card", "Card")
+)
+
 type CardProps struct {
 	Children []gf.Node
 }
@@ -15,7 +19,7 @@ func Card(props CardProps) gf.Node {
 }
 
 func View(show bool) gf.Node {
-	return gf.Component("Card", CardProps{
+	return gf.ComponentT(_goxComponent_component_helper_children_Card, CardProps{
 		Children: []gf.Node{
 			gf.Child(gf.If(show, gf.Text("Visible"))),
 		},

--- a/pkg/gox/testdata/component_props.golden.go
+++ b/pkg/gox/testdata/component_props.golden.go
@@ -4,6 +4,10 @@ package demo
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_component_props_Button = gf.NewComponentType("demo.Button", "Button")
+)
+
 type ButtonProps struct {
 	Label   string
 	OnClick func()
@@ -18,7 +22,7 @@ func Button(props ButtonProps) gf.Node {
 }
 
 func View() gf.Node {
-	return gf.Component("Button", ButtonProps{
+	return gf.ComponentT(_goxComponent_component_props_Button, ButtonProps{
 		Label:   "Increment",
 		OnClick: func() {},
 	}, Button)

--- a/pkg/gox/testdata/key_pseudo_props.golden.go
+++ b/pkg/gox/testdata/key_pseudo_props.golden.go
@@ -4,6 +4,10 @@ package main
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_key_pseudo_props_Row = gf.NewComponentType("main.Row", "Row")
+)
+
 type RowProps struct {
 	Label string
 }
@@ -22,7 +26,7 @@ func View(id int, label string) gf.Node {
 			),
 		),
 		gf.Key("static-row",
-			gf.Component("Row", RowProps{
+			gf.ComponentT(_goxComponent_key_pseudo_props_Row, RowProps{
 				Label: label,
 			}, Row),
 		),

--- a/pkg/gox/testdata/keyed_component.golden.go
+++ b/pkg/gox/testdata/keyed_component.golden.go
@@ -4,6 +4,10 @@ package demo
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_keyed_component_Item = gf.NewComponentType("demo.Item", "Item")
+)
+
 type ItemProps struct {
 	Label string
 }
@@ -15,7 +19,7 @@ func Item(props ItemProps) gf.Node {
 }
 
 func View() gf.Node {
-	return gf.Key("item-1", gf.Component("Item", ItemProps{
+	return gf.Key("item-1", gf.ComponentT(_goxComponent_keyed_component_Item, ItemProps{
 		Label: "One",
 	}, Item))
 }

--- a/pkg/gox/testdata/nested_components.golden.go
+++ b/pkg/gox/testdata/nested_components.golden.go
@@ -4,6 +4,11 @@ package demo
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_nested_components_Card   = gf.NewComponentType("demo.Card", "Card")
+	_goxComponent_nested_components_Button = gf.NewComponentType("demo.Button", "Button")
+)
+
 type CardProps struct {
 	Children []gf.Node
 }
@@ -25,9 +30,9 @@ func Button(props ButtonProps) gf.Node {
 }
 
 func View() gf.Node {
-	return gf.Component("Card", CardProps{
+	return gf.ComponentT(_goxComponent_nested_components_Card, CardProps{
 		Children: []gf.Node{
-			gf.Component("Button", ButtonProps{
+			gf.ComponentT(_goxComponent_nested_components_Button, ButtonProps{
 				Label: "Nested",
 			}, Button),
 		},

--- a/pkg/gox/testdata/nested_markup_returns.golden.go
+++ b/pkg/gox/testdata/nested_markup_returns.golden.go
@@ -4,6 +4,10 @@ package main
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_nested_markup_returns_ItemRow = gf.NewComponentType("main.ItemRow", "ItemRow")
+)
+
 type Item struct {
 	ID     int
 	Label  string
@@ -27,7 +31,7 @@ func View(items []Item) gf.Node {
 				return gf.Fragment()
 			}
 			return gf.Key(gf.ToString(item.ID),
-				gf.Component("ItemRow", ItemRowProps{
+				gf.ComponentT(_goxComponent_nested_markup_returns_ItemRow, ItemRowProps{
 					Item: item,
 				}, ItemRow),
 			)

--- a/pkg/gox/testdata/ternary_render.golden.go
+++ b/pkg/gox/testdata/ternary_render.golden.go
@@ -4,6 +4,11 @@ package main
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	_goxComponent_ternary_render_Empty = gf.NewComponentType("main.Empty", "Empty")
+	_goxComponent_ternary_render_List  = gf.NewComponentType("main.List", "List")
+)
+
 type EmptyProps struct{}
 
 func Empty(props EmptyProps) gf.Node {
@@ -22,7 +27,7 @@ func List(props ListProps) gf.Node {
 
 func View(items []string) gf.Node {
 	return gf.El("section", nil,
-		gf.IfElse(len(items) == 0, gf.Component("Empty", EmptyProps{}, Empty), gf.Component("List", ListProps{
+		gf.IfElse(len(items) == 0, gf.ComponentT(_goxComponent_ternary_render_Empty, EmptyProps{}, Empty), gf.ComponentT(_goxComponent_ternary_render_List, ListProps{
 			Items: items,
 		}, List)),
 	)

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -132,7 +132,7 @@ check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
 check_app "dashboard" "$(bundle_path dashboard)" 168960 53248 71680 61440 || status=1
-check_app "context" "$(bundle_path context)" 112640 36864 46080 40960 || status=1
+check_app "context" "$(bundle_path context)" 113664 36864 46080 40960 || status=1
 check_app "virtualized" "$(bundle_path virtualized)" 122880 40960 49152 44032 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adds a typed component identity prototype while preserving legacy string-name component identity.

## Changes

- Add `gf.ComponentType`
- Add `gf.NewComponentType`
- Add `gf.ComponentT`
- Preserve existing `gf.Component`
- Separate legacy and typed identity namespaces
- Compare component identity instead of debug name in reconciliation/memoization
- Update GOX codegen to emit `gf.ComponentT`
- Add generated component type declarations
- Update GOX golden tests
- Update component identity docs and API stability docs

## Semantics

- Legacy `gf.Component("Header", ...)` remains compatible
- Typed `ComponentT(NewComponentType("main.Header", "Header"), ...)` uses explicit identity
- Debug name remains readable but does not define typed identity
- Different typed ids remount even if debug names match
- Legacy and typed identities do not collide

## Limits

- This is not full multi-package app support
- Generated ids currently use package name + component name, not full import path
- A package-aware/import-path-aware identity decision is still required before multi-package apps

## Checks

- `go fmt ./...`
- `git diff --check`
- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `node --experimental-websocket scripts/dashboard-dom-pressure.mjs`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`