### PR TITLE
MVP 21: GOX diagnostics and parser hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@
 - Multi-package GOX workspace support for `entry: "."` apps, including hidden
   workspace materialization for child packages, import-path-aware generated
   component identities, and a focused multipackage example plus browser smoke.
+- GOX diagnostic hardening with structured source diagnostics, clearer
+  unsupported namespace/spread errors, stricter parser-side validation for
+  empty expressions and `Key`, and multi-package source-path error coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/cmd/goxc/generate.go
+++ b/cmd/goxc/generate.go
@@ -90,7 +90,7 @@ func generatePath(options generateOptions, requireFiles bool) error {
 				PackageIdentity: packageIdentityForFile(appDir, file),
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("generate failed for %s: %w", file, err)
 			}
 			fmt.Printf("generated %s -> %s\n", file, output)
 		}
@@ -121,7 +121,7 @@ func generatePath(options generateOptions, requireFiles bool) error {
 			PackageIdentity: packageIdentityForFile(appDir, file),
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("generate failed for %s: %w", file, err)
 		}
 		fmt.Printf("generated %s -> %s\n", file, output)
 	}

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -100,7 +100,7 @@ func generateIntoDirectory(sourceRoot, destinationRoot string, requireFiles bool
 			Filename:        file,
 			PackageIdentity: packageIdentityForFile(sourceRoot, file),
 		}); err != nil {
-			return err
+			return fmt.Errorf("generate failed for %s: %w", file, err)
 		}
 	}
 	return nil

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -142,6 +142,45 @@ func View() gf.Node {
 	}
 }
 
+func TestGenerateIntoDirectoryReportsOriginalGOXSource(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/example/root\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	appDir := filepath.Join(root, "apps", "demo")
+	sourceDir := filepath.Join(appDir, "internal", "ui")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sourcePath := filepath.Join(sourceDir, "layout.gox")
+	source := `package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <main><p>Broken</main>
+}
+`
+	if err := os.WriteFile(sourcePath, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := generateIntoDirectory(appDir, t.TempDir(), true)
+	if err == nil {
+		t.Fatal("generateIntoDirectory() returned nil error")
+	}
+	for _, want := range []string{
+		"generate failed for " + sourcePath,
+		sourcePath + ":6:",
+		"expected closing tag </p>, got </main>",
+		"<p>Broken</main>",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
 func TestWriteWorkspaceGoModUsesRootModulePath(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/example/root\n\ngo 1.22\n"), 0o644); err != nil {

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -91,6 +91,7 @@ exact shapes can still change before public preview.
 
 - GOX syntax surface.
 - GOX expression ergonomics.
+- GOX diagnostic wording beyond the filename/line/column/source-line contract.
 - Context topology behavior and selector limitations.
 - Virtualization details such as fixed-height range buffering and table spacer
   structure.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,7 +21,7 @@ It checks:
 - `go test -race ./pkg/... ./cmd/...`;
 - `go vet ./...`;
 - `go test -tags=goframe_debug ./...`;
-- GOX golden tests.
+- GOX golden tests, including source-oriented error diagnostics.
 
 ### WASM Size
 
@@ -61,6 +61,11 @@ failures. It currently covers Todo reconciliation, duplicate-key debug
 diagnostics, dashboard-sized filtering/sorting/selection behavior, context
 selector rerender isolation, virtualized collection scroll/selection/toggle
 behavior, and a multi-package GOX workspace smoke.
+
+GOX diagnostic golden tests intentionally assert filenames, line/column
+prefixes, specific unsupported-syntax messages, and source snippets. They are
+part of the compiler/toolchain contract even though the broader GOX syntax
+surface remains experimental.
 
 ### VS Code Extension
 

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -350,10 +350,31 @@ examples/app.gox:12:18: expected closing tag </div>, got </main>
 ```
 
 GOX also reports focused diagnostics for unclosed tags, invalid component
-names, spread props, and namespace tags.
+names, invalid component prop names, empty child/attribute expressions,
+duplicate or valueless `Key` pseudo-props, spread props, and namespace tags.
+Nested GOX markup inside callback return expressions is also reported against
+the original `.gox` file rather than only the generated `.goframe/work` output.
+
+Unsupported namespace tags remain unsupported. The diagnostic points users back
+to ordinary Go imports and function calls for cross-package composition:
+
+```text
+examples/app.gox:8:10: namespace tags are not supported; use ordinary Go imports and function calls for cross-package composition: <ui.Header>
+  <ui.Header />
+```
+
+Unsupported spread props remain unsupported. Pass explicit props instead:
+
+```text
+examples/app.gox:8:15: spread props are not supported; pass explicit props instead: {...props}
+  <Button {...props} />
+```
 
 Go type errors, such as a missing props struct or invalid field type, are
-reported by the selected Go or TinyGo compiler after generation.
+reported by the selected Go or TinyGo compiler after generation. Those errors
+may still mention the hidden `.goframe/work/<profile>` workspace because they
+come from the Go toolchain, but `goxc` generation failures prefer the original
+`.gox` source path.
 
 ## Current limitations
 

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -68,6 +68,18 @@ component id github.com/graybuton/goframe/examples/multipackage/internal/ui.Head
 If no module path can be determined, generation falls back to the package-name
 identity path used by `GenerateNamed`.
 
+## Diagnostics
+
+GOX generation errors in child packages keep the original source path. For
+example, a broken `internal/ui/layout.gox` should report
+`examples/multipackage/internal/ui/layout.gox:line:column` instead of only a
+generated `.goframe/work/.../layout.gox.go` file.
+
+Lower-level Go or TinyGo type-checking errors can still mention the hidden
+workspace because the compiler is checking materialized generated Go files.
+When that happens, inspect the matching `.gox` source and the generated file
+under `.goframe/work/<profile>` together.
+
 ## Cross-package Components
 
 GOX does not add namespace tags in MVP 20. This remains unsupported:

--- a/pkg/gox/codegen.go
+++ b/pkg/gox/codegen.go
@@ -23,6 +23,11 @@ type codegenContext struct {
 	declareComponentTypes bool
 	componentTypes        map[string]string
 	componentOrder        []string
+	diagnosticFilename    string
+	diagnosticSource      string
+	diagnosticLine        int
+	diagnosticColumn      int
+	positions             map[Node]int
 }
 
 func newCodegenContext(componentIdentity string, sourceName string, declareComponentTypes bool) *codegenContext {
@@ -39,6 +44,36 @@ func newCodegenContext(componentIdentity string, sourceName string, declareCompo
 		declareComponentTypes: declareComponentTypes,
 		componentTypes:        make(map[string]string),
 	}
+}
+
+func (ctx *codegenContext) withDiagnostics(filename, source string, line, column int, positions map[Node]int) {
+	ctx.diagnosticFilename = filename
+	ctx.diagnosticSource = source
+	ctx.diagnosticLine = line
+	ctx.diagnosticColumn = column
+	ctx.positions = positions
+}
+
+func (ctx *codegenContext) errorAtNode(node Node, err error) error {
+	if err == nil {
+		return nil
+	}
+	if diagnostic, ok := asDiagnosticError(err); ok && diagnostic.Diagnostic.Filename == ctx.diagnosticFilename {
+		return err
+	}
+	if ctx.diagnosticFilename == "" || ctx.diagnosticSource == "" || ctx.positions == nil {
+		return err
+	}
+	offset, ok := ctx.positions[node]
+	if !ok {
+		return err
+	}
+	line, column := lineColumn(ctx.diagnosticSource, offset)
+	if line == 1 {
+		column += ctx.diagnosticColumn - 1
+	}
+	line += ctx.diagnosticLine - 1
+	return diagnosticError(ctx.diagnosticFilename, line, column, diagnosticMessage(err), sourceLine(ctx.diagnosticSource, offset))
 }
 
 func (ctx *codegenContext) codegen(node Node) (string, error) {
@@ -82,11 +117,11 @@ func (ctx *codegenContext) writeNode(output *bytes.Buffer, node Node, depth int)
 	switch node := node.(type) {
 	case *Element:
 		if isComponent(node.Tag) {
-			return ctx.writeComponent(output, node, depth)
+			return ctx.errorAtNode(node, ctx.writeComponent(output, node, depth))
 		}
-		return ctx.writeElement(output, node, depth)
+		return ctx.errorAtNode(node, ctx.writeElement(output, node, depth))
 	case *Fragment:
-		return ctx.writeFragment(output, node.Children, depth)
+		return ctx.errorAtNode(node, ctx.writeFragment(output, node.Children, depth))
 	case *Text:
 		value := normalizeText(node.Value)
 		if value == "" {
@@ -99,7 +134,7 @@ func (ctx *codegenContext) writeNode(output *bytes.Buffer, node Node, depth int)
 		if code == "" {
 			return fmt.Errorf("gox: empty child expression")
 		}
-		return ctx.writeChildExpression(output, code, depth)
+		return ctx.errorAtNode(node, ctx.writeChildExpression(output, code, depth))
 	default:
 		return fmt.Errorf("gox: unsupported AST node %T", node)
 	}

--- a/pkg/gox/diagnostic.go
+++ b/pkg/gox/diagnostic.go
@@ -1,0 +1,55 @@
+package gox
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Diagnostic describes one source-oriented GOX compiler diagnostic.
+type Diagnostic struct {
+	Filename string
+	Line     int
+	Column   int
+	Message  string
+	Source   string
+}
+
+// DiagnosticError is returned when GOX can point an error back to source.
+type DiagnosticError struct {
+	Diagnostic Diagnostic
+}
+
+func (err DiagnosticError) Error() string {
+	diagnostic := err.Diagnostic
+	if diagnostic.Source == "" {
+		return fmt.Sprintf("%s:%d:%d: %s", diagnostic.Filename, diagnostic.Line, diagnostic.Column, diagnostic.Message)
+	}
+	return fmt.Sprintf("%s:%d:%d: %s\n  %s", diagnostic.Filename, diagnostic.Line, diagnostic.Column, diagnostic.Message, diagnostic.Source)
+}
+
+func diagnosticError(filename string, line, column int, message, snippet string) error {
+	return DiagnosticError{
+		Diagnostic: Diagnostic{
+			Filename: filename,
+			Line:     line,
+			Column:   column,
+			Message:  message,
+			Source:   snippet,
+		},
+	}
+}
+
+func asDiagnosticError(err error) (DiagnosticError, bool) {
+	var diagnostic DiagnosticError
+	if errors.As(err, &diagnostic) {
+		return diagnostic, true
+	}
+	return DiagnosticError{}, false
+}
+
+func diagnosticMessage(err error) string {
+	if diagnostic, ok := asDiagnosticError(err); ok {
+		return diagnostic.Diagnostic.Message
+	}
+	return err.Error()
+}

--- a/pkg/gox/generate.go
+++ b/pkg/gox/generate.go
@@ -55,12 +55,16 @@ func GenerateWithOptions(source []byte, options GenerateOptions) ([]byte, error)
 		}
 
 		line, column := lineColumn(input, start)
-		element, consumed, err := parseElementAt(input[start:], options.Filename, line, column)
+		element, consumed, positions, err := parseElementAtWithPositions(input[start:], options.Filename, line, column)
 		if err != nil {
 			return nil, err
 		}
+		ctx.withDiagnostics(options.Filename, input[start:], line, column, positions)
 		code, err := ctx.codegen(element)
 		if err != nil {
+			if _, ok := asDiagnosticError(err); ok {
+				return nil, err
+			}
 			return nil, diagnosticError(options.Filename, line, column, err.Error(), sourceLine(input, start))
 		}
 

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -1,6 +1,7 @@
 package gox
 
 import (
+	"errors"
 	"go/parser"
 	gotoken "go/token"
 	"strings"
@@ -239,5 +240,31 @@ func App() any {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not contain %q", err, want)
 		}
+	}
+}
+
+func TestGenerateNamedReturnsDiagnosticError(t *testing.T) {
+	source := []byte(`package main
+
+func App() any {
+	return <main>{}</main>
+}
+`)
+	_, err := GenerateNamed("examples/broken/app.gox", source)
+	if err == nil {
+		t.Fatal("GenerateNamed() returned nil error")
+	}
+	var diagnostic DiagnosticError
+	if !errors.As(err, &diagnostic) {
+		t.Fatalf("error %T is not DiagnosticError: %v", err, err)
+	}
+	if diagnostic.Diagnostic.Filename != "examples/broken/app.gox" {
+		t.Fatalf("diagnostic filename = %q", diagnostic.Diagnostic.Filename)
+	}
+	if diagnostic.Diagnostic.Line != 4 || diagnostic.Diagnostic.Column == 0 {
+		t.Fatalf("diagnostic location = %d:%d", diagnostic.Diagnostic.Line, diagnostic.Diagnostic.Column)
+	}
+	if !strings.Contains(diagnostic.Diagnostic.Message, "empty child expression") {
+		t.Fatalf("diagnostic message = %q", diagnostic.Diagnostic.Message)
 	}
 }

--- a/pkg/gox/lexer.go
+++ b/pkg/gox/lexer.go
@@ -255,10 +255,3 @@ func sourceLine(input string, offset int) string {
 	}
 	return strings.TrimSpace(input[start:end])
 }
-
-func diagnosticError(filename string, line, column int, message, snippet string) error {
-	if snippet == "" {
-		return fmt.Errorf("%s:%d:%d: %s", filename, line, column, message)
-	}
-	return fmt.Errorf("%s:%d:%d: %s\n  %s", filename, line, column, message, snippet)
-}

--- a/pkg/gox/parser.go
+++ b/pkg/gox/parser.go
@@ -7,7 +7,8 @@ import (
 
 // Parser builds a small GOX element tree from lexer tokens.
 type Parser struct {
-	lexer *Lexer
+	lexer     *Lexer
+	positions map[Node]int
 }
 
 // ParseElement parses one root GOX node and returns the number of consumed
@@ -17,20 +18,28 @@ func ParseElement(input string) (Node, int, error) {
 }
 
 func parseElementAt(input, filename string, line, column int) (Node, int, error) {
-	parser := &Parser{lexer: newLexerAt(input, filename, line, column)}
+	node, consumed, _, err := parseElementAtWithPositions(input, filename, line, column)
+	return node, consumed, err
+}
+
+func parseElementAtWithPositions(input, filename string, line, column int) (Node, int, map[Node]int, error) {
+	parser := &Parser{
+		lexer:     newLexerAt(input, filename, line, column),
+		positions: map[Node]int{},
+	}
 	start, err := parser.lexer.next()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 	if start.kind != tokenOpenTag {
-		return nil, 0, parser.unexpected(start, "opening tag")
+		return nil, 0, nil, parser.unexpected(start, "opening tag")
 	}
 
 	node, err := parser.parseOpenedNode()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
-	return node, parser.lexer.pos, nil
+	return node, parser.lexer.pos, parser.positions, nil
 }
 
 func (parser *Parser) parseOpenedNode() (Node, error) {
@@ -40,6 +49,7 @@ func (parser *Parser) parseOpenedNode() (Node, error) {
 	}
 	if name.kind == tokenTagEnd {
 		fragment := &Fragment{}
+		parser.positions[fragment] = name.offset
 		children, err := parser.parseChildren("")
 		if err != nil {
 			return nil, err
@@ -51,13 +61,16 @@ func (parser *Parser) parseOpenedNode() (Node, error) {
 		return nil, parser.unexpected(name, "tag name or > for fragment")
 	}
 	if strings.ContainsAny(name.value, ".:") {
-		return nil, parser.lexer.errorAt(name.offset, "namespace component tags are not supported yet: <%s>", name.value)
+		return nil, parser.lexer.errorAt(name.offset, "namespace tags are not supported; use ordinary Go imports and function calls for cross-package composition: <%s>", name.value)
 	}
-	if isComponent(name.value) && !validGoIdentifier(name.value) {
+	component := isComponent(name.value)
+	if component && !validGoIdentifier(name.value) {
 		return nil, parser.lexer.errorAt(name.offset, "invalid component tag <%s>; component names must be Go identifiers", name.value)
 	}
 
 	element := &Element{Tag: name.value}
+	parser.positions[element] = name.offset
+	seenKey := false
 	for {
 		next, err := parser.lexer.next()
 		if err != nil {
@@ -75,6 +88,15 @@ func (parser *Parser) parseOpenedNode() (Node, error) {
 		case tokenSelfClose:
 			return element, nil
 		case tokenIdentifier:
+			if component && next.value != "Key" && !validGoIdentifier(next.value) {
+				return nil, parser.lexer.errorAt(next.offset, "component prop %q must be a Go field name", next.value)
+			}
+			if next.value == "Key" {
+				if seenKey {
+					return nil, parser.lexer.errorAt(next.offset, "gox: duplicate Key prop")
+				}
+				seenKey = true
+			}
 			attribute, err := parser.parseAttribute(next)
 			if err != nil {
 				return nil, err
@@ -82,7 +104,7 @@ func (parser *Parser) parseOpenedNode() (Node, error) {
 			element.Attributes = append(element.Attributes, attribute)
 		case tokenExpression:
 			if strings.HasPrefix(strings.TrimSpace(next.value), "...") {
-				return nil, parser.lexer.errorAt(next.offset, "spread props are not supported yet: {%s}", strings.TrimSpace(next.value))
+				return nil, parser.lexer.errorAt(next.offset, "spread props are not supported; pass explicit props instead: {%s}", strings.TrimSpace(next.value))
 			}
 			return nil, parser.unexpected(next, "attribute, >, or />")
 		default:
@@ -97,6 +119,9 @@ func (parser *Parser) parseAttribute(name token) (Attribute, error) {
 		return Attribute{}, err
 	}
 	if next.kind != tokenEquals {
+		if name.value == "Key" {
+			return Attribute{}, parser.lexer.errorAt(name.offset, "gox: Key requires a value")
+		}
 		return Attribute{}, parser.unexpected(next, "= after attribute "+name.value)
 	}
 
@@ -108,6 +133,12 @@ func (parser *Parser) parseAttribute(name token) (Attribute, error) {
 	case tokenString:
 		return Attribute{Name: name.value, Value: StringValue{Value: value.value}}, nil
 	case tokenExpression:
+		if strings.TrimSpace(value.value) == "" {
+			if name.value == "Key" {
+				return Attribute{}, parser.lexer.errorAt(value.offset, "gox: Key requires a value")
+			}
+			return Attribute{}, parser.lexer.errorAt(value.offset, "gox: empty expression for attribute %q", name.value)
+		}
 		return Attribute{Name: name.value, Value: ExpressionValue{Code: value.value}}, nil
 	default:
 		return Attribute{}, parser.unexpected(value, "quoted string or Go expression")
@@ -124,9 +155,16 @@ func (parser *Parser) parseChildren(expectedTag string) ([]Node, error) {
 
 		switch next.kind {
 		case tokenText:
-			children = append(children, &Text{Value: next.value})
+			child := &Text{Value: next.value}
+			parser.positions[child] = next.offset
+			children = append(children, child)
 		case tokenExpression:
-			children = append(children, &Expression{Code: next.value})
+			if strings.TrimSpace(next.value) == "" {
+				return nil, parser.lexer.errorAt(next.offset, "gox: empty child expression")
+			}
+			child := &Expression{Code: next.value}
+			parser.positions[child] = next.offset
+			children = append(children, child)
 		case tokenOpenTag:
 			child, err := parser.parseOpenedNode()
 			if err != nil {

--- a/pkg/gox/testdata/errors/bool_key.golden.txt
+++ b/pkg/gox/testdata/errors/bool_key.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/bool_key.gox:4:12: gox: Key requires a value
+  <p Key>Broken</p>

--- a/pkg/gox/testdata/errors/bool_key.gox
+++ b/pkg/gox/testdata/errors/bool_key.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <p Key>Broken</p>
+}

--- a/pkg/gox/testdata/errors/duplicate_key.golden.txt
+++ b/pkg/gox/testdata/errors/duplicate_key.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/duplicate_key.gox:6:9: gox: duplicate Key prop
-  return <p Key={id} Key="again">Broken</p>
+testdata/errors/duplicate_key.gox:6:21: gox: duplicate Key prop
+  <p Key={id} Key="again">Broken</p>

--- a/pkg/gox/testdata/errors/empty_attr_expression.golden.txt
+++ b/pkg/gox/testdata/errors/empty_attr_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/empty_attr_expression.gox:4:23: gox: empty expression for attribute "Label"
+  <Button Label={} />

--- a/pkg/gox/testdata/errors/empty_attr_expression.gox
+++ b/pkg/gox/testdata/errors/empty_attr_expression.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <Button Label={} />
+}

--- a/pkg/gox/testdata/errors/empty_child_expression.golden.txt
+++ b/pkg/gox/testdata/errors/empty_child_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/empty_child_expression.gox:4:15: gox: empty child expression
+  <main>{}</main>

--- a/pkg/gox/testdata/errors/empty_child_expression.gox
+++ b/pkg/gox/testdata/errors/empty_child_expression.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <main>{}</main>
+}

--- a/pkg/gox/testdata/errors/empty_key.golden.txt
+++ b/pkg/gox/testdata/errors/empty_key.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/empty_key.gox:4:16: gox: Key requires a value
+  <p Key={}>Broken</p>

--- a/pkg/gox/testdata/errors/empty_key.gox
+++ b/pkg/gox/testdata/errors/empty_key.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <p Key={}>Broken</p>
+}

--- a/pkg/gox/testdata/errors/fragment_closing_mismatch.golden.txt
+++ b/pkg/gox/testdata/errors/fragment_closing_mismatch.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/fragment_closing_mismatch.gox:4:17: expected closing tag </main>, got </>
+  <main></>

--- a/pkg/gox/testdata/errors/fragment_closing_mismatch.gox
+++ b/pkg/gox/testdata/errors/fragment_closing_mismatch.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <main></>
+}

--- a/pkg/gox/testdata/errors/invalid_component_prop.golden.txt
+++ b/pkg/gox/testdata/errors/invalid_component_prop.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/invalid_component_prop.gox:4:17: component prop "bad-prop" must be a Go field name
+  <Button bad-prop="x" />

--- a/pkg/gox/testdata/errors/invalid_component_prop.gox
+++ b/pkg/gox/testdata/errors/invalid_component_prop.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <Button bad-prop="x" />
+}

--- a/pkg/gox/testdata/errors/missing_ternary_colon.golden.txt
+++ b/pkg/gox/testdata/errors/missing_ternary_colon.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/missing_ternary_colon.gox:6:9: gox: ternary render expression is missing ':'
-  return <main>{show ? <p>Yes</p>}</main>
+testdata/errors/missing_ternary_colon.gox:6:15: gox: ternary render expression is missing ':'
+  <main>{show ? <p>Yes</p>}</main>

--- a/pkg/gox/testdata/errors/namespace.golden.txt
+++ b/pkg/gox/testdata/errors/namespace.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/namespace.gox:4:10: namespace component tags are not supported yet: <ui.Button>
+testdata/errors/namespace.gox:4:10: namespace tags are not supported; use ordinary Go imports and function calls for cross-package composition: <ui.Button>
   <ui.Button />

--- a/pkg/gox/testdata/errors/nested_markup_callback_error.golden.txt
+++ b/pkg/gox/testdata/errors/nested_markup_callback_error.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/nested_markup_callback_error.gox:6:15: expected closing tag </Item>, got </Wrong>
+  <main>{gf.Map(items, func(item string) gf.Node {

--- a/pkg/gox/testdata/errors/nested_markup_callback_error.gox
+++ b/pkg/gox/testdata/errors/nested_markup_callback_error.gox
@@ -1,0 +1,9 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View(items []string) gf.Node {
+	return <main>{gf.Map(items, func(item string) gf.Node {
+		return <Item Label={item}></Wrong>
+	})}</main>
+}

--- a/pkg/gox/testdata/errors/non_node_ternary_branch.golden.txt
+++ b/pkg/gox/testdata/errors/non_node_ternary_branch.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/non_node_ternary_branch.gox:6:9: gox: ternary render branches must be GOX nodes
-  return <main>{show ? "yes" : <p>No</p>}</main>
+testdata/errors/non_node_ternary_branch.gox:6:15: gox: ternary render branches must be GOX nodes
+  <main>{show ? "yes" : <p>No</p>}</main>

--- a/pkg/gox/testdata/errors/spread.golden.txt
+++ b/pkg/gox/testdata/errors/spread.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/spread.gox:4:15: spread props are not supported yet: {...props}
+testdata/errors/spread.gox:4:15: spread props are not supported; pass explicit props instead: {...props}
   <main {...props}></main>

--- a/pkg/gox/testdata/errors/unclosed_fragment.golden.txt
+++ b/pkg/gox/testdata/errors/unclosed_fragment.golden.txt
@@ -1,0 +1,1 @@
+testdata/errors/unclosed_fragment.gox:6:1: unclosed fragment; expected </>

--- a/pkg/gox/testdata/errors/unclosed_fragment.gox
+++ b/pkg/gox/testdata/errors/unclosed_fragment.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <><p>Broken</p>
+}

--- a/pkg/gox/testdata/errors/unexpected_text_after_node_expression.golden.txt
+++ b/pkg/gox/testdata/errors/unexpected_text_after_node_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/unexpected_text_after_node_expression.gox:6:15: gox: unexpected text after GOX node expression
+  <main>{show ? <p>Yes</p> nope : <p>No</p>}</main>

--- a/pkg/gox/testdata/errors/unexpected_text_after_node_expression.gox
+++ b/pkg/gox/testdata/errors/unexpected_text_after_node_expression.gox
@@ -1,0 +1,7 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View(show bool) gf.Node {
+	return <main>{show ? <p>Yes</p> nope : <p>No</p>}</main>
+}


### PR DESCRIPTION
## Summary

Improves GOX diagnostics and parser error reporting without changing the GOX language surface.

## Changes

- Add `gox.Diagnostic`
- Add `gox.DiagnosticError`
- Return source-oriented diagnostics from `GenerateNamed` / `GenerateWithOptions`
- Attach codegen errors to original GOX nodes/expressions where possible
- Improve parser errors for:
  - namespace tags
  - spread props
  - duplicate / empty / bool `Key`
  - empty child expressions
  - empty attribute expressions
  - invalid component prop names
  - fragment closing mismatch
  - nested callback markup errors
- Preserve original `.gox` file context in `goxc generate` and workspace materialization errors
- Add GOX error golden coverage
- Update GOX diagnostics docs

## Non-goals

- No namespace tag support
- No spread props support
- No formatter
- No LSP
- No child entry package support
- No router
- No SSR/hydration
- No Player/Engine

## Checks

- `go fmt ./...`
- `git diff --check`
- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- `go test ./examples/dashboard`
- `go test ./examples/context`
- `go test ./examples/virtualized`
- `go test ./examples/multipackage`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `node --experimental-websocket scripts/dashboard-dom-pressure.mjs`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`