### PR TITLE
MVP 22: child entry package support

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -58,6 +58,8 @@ jobs:
           goxc package ./examples/virtualized --compiler=tinygo
           goxc generate ./examples/multipackage
           goxc package ./examples/multipackage --compiler=tinygo
+          goxc generate ./examples/cmdapp
+          goxc package ./examples/cmdapp --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
@@ -65,6 +67,7 @@ jobs:
           goxc package ./examples/context --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/virtualized --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/multipackage --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/cmdapp --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
 - GOX diagnostic hardening with structured source diagnostics, clearer
   unsupported namespace/spread errors, stricter parser-side validation for
   empty expressions and `Key`, and multi-package source-path error coverage.
+- Child entry package support for `goxc`, including `"entry": "./cmd/app"` and
+  other relative child package directories, app-root-wide GOX generation,
+  import-aware component identities, and a focused `cmdapp` example plus
+  browser smoke.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ goxc package ./examples/multipackage --compiler=tinygo
 goxc serve ./examples/multipackage --port=8080
 ```
 
+The child-entry example demonstrates a Go-first `cmd/app + internal/...`
+layout with `"entry": "./cmd/app"`:
+
+```bash
+goxc package ./examples/cmdapp --compiler=tinygo
+goxc serve ./examples/cmdapp --port=8080
+```
+
 ## GOX component model
 
 Lowercase tags create HTML elements:
@@ -542,8 +550,9 @@ early.
 CLI flags override manifest compiler and output choices. The `output` field is
 kept as a legacy/export convention; normal package output is written under the
 hidden `.goframe/package/standalone` workspace. The hidden workspace builder
-supports `"entry": "."` apps with child packages below the app root. Child
-entry packages such as `"./cmd/app"` remain future toolchain work.
+supports `"entry": "."` apps and child entry packages such as `"./cmd/app"`,
+`"cmd/app"`, `"./src/app"`, and `"app"` when they stay inside the app root.
+GOX discovery remains app-root-wide.
 
 ## Size experiment
 
@@ -658,6 +667,7 @@ required.
 - [Todo example](examples/todo/README.md)
 - [Dashboard pressure-test example](examples/dashboard/README.md)
 - [Multi-package GOX example](examples/multipackage/README.md)
+- [Child entry package example](examples/cmdapp/README.md)
 - [Virtualized collections example](examples/virtualized/README.md)
 
 ## Development

--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -97,7 +97,7 @@ func buildApp(options buildOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	workDir, err := prepareBuildWorkspace(layout, manifest)
+	entryPath, err := prepareBuildWorkspace(layout, manifest)
 	if err != nil {
 		return "", fmt.Errorf("prepare build workspace: %w", err)
 	}
@@ -106,7 +106,6 @@ func buildApp(options buildOptions) (string, error) {
 		return "", fmt.Errorf("create build directory: %w", err)
 	}
 
-	entryPath := filepath.Join(workDir, manifest.Entry)
 	fmt.Printf("building %s with %s compiler\n", options.appDir, options.compiler)
 	if err := compileWASM(options.compiler, entryPath, outputPath); err != nil {
 		return "", err

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -165,6 +165,44 @@ func TestManifestRejectsEscapingPaths(t *testing.T) {
 	}
 }
 
+func TestManifestRejectsUnsafeEntryPaths(t *testing.T) {
+	tests := []string{
+		`{"entry":""}`,
+		`{"entry":"/abs/path"}`,
+		`{"entry":"cmd/../outside"}`,
+		`{"entry":".goframe/work"}`,
+		`{"entry":"build"}`,
+		`{"entry":"dist"}`,
+		`{"entry":"node_modules"}`,
+		`{"entry":".git"}`,
+	}
+	for _, content := range tests {
+		t.Run(content, func(t *testing.T) {
+			appDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadManifest(appDir); err == nil {
+				t.Fatalf("loadManifest() accepted unsafe entry path from %s", content)
+			}
+		})
+	}
+}
+
+func TestLoadManifestNormalizesChildEntry(t *testing.T) {
+	appDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(`{"entry":"./cmd/app"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest(child entry) error: %v", err)
+	}
+	if manifest.Entry != "cmd/app" {
+		t.Fatalf("manifest entry = %q, want cmd/app", manifest.Entry)
+	}
+}
+
 func TestManifestRejectsUnknownFields(t *testing.T) {
 	appDir := t.TempDir()
 	content := []byte(`{"compielr":"tinygo"}`)

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -51,6 +51,9 @@ func loadManifest(appDir string) (projectManifest, error) {
 	if manifest.Name == "" {
 		manifest.Name = filepath.Base(filepath.Clean(appDir))
 	}
+	if err := rejectExplicitEmptyEntry(content); err != nil {
+		return projectManifest{}, err
+	}
 	if manifest.Entry == "" {
 		manifest.Entry = "."
 	}
@@ -67,9 +70,11 @@ func loadManifest(appDir string) (projectManifest, error) {
 		manifest.Assets = []string{"index.html"}
 	}
 
-	if !safeRelativePath(manifest.Entry) {
-		return projectManifest{}, fmt.Errorf("entry %q in %s must be a relative path inside the application", manifest.Entry, manifestName)
+	entry, err := cleanManifestEntry(manifest.Entry)
+	if err != nil {
+		return projectManifest{}, fmt.Errorf("entry %q in %s %s", manifest.Entry, manifestName, err)
 	}
+	manifest.Entry = entry
 	for name, value := range map[string]string{
 		"output": manifest.Output,
 		"wasm":   manifest.WASM,
@@ -87,6 +92,66 @@ func loadManifest(appDir string) (projectManifest, error) {
 		}
 	}
 	return manifest, nil
+}
+
+func rejectExplicitEmptyEntry(content []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return err
+	}
+	value, ok := raw["entry"]
+	if !ok {
+		return nil
+	}
+	var entry string
+	if err := json.Unmarshal(value, &entry); err != nil {
+		return nil
+	}
+	if entry == "" {
+		return fmt.Errorf("entry %q in %s must be a relative child package inside the application", entry, manifestName)
+	}
+	return nil
+}
+
+func cleanManifestEntry(entry string) (string, error) {
+	if entry == "." {
+		return ".", nil
+	}
+	if entry == "" || filepath.IsAbs(entry) {
+		return "", fmt.Errorf("must be a relative child package inside the application")
+	}
+	rawParts := strings.Split(filepath.ToSlash(entry), "/")
+	for _, part := range rawParts {
+		if part == ".." {
+			return "", fmt.Errorf("must be a relative child package inside the application")
+		}
+	}
+	entry = filepath.Clean(entry)
+	if entry == "." {
+		return ".", nil
+	}
+	parts := strings.Split(filepath.ToSlash(entry), "/")
+	for _, part := range parts {
+		if part == ".." {
+			return "", fmt.Errorf("must be a relative child package inside the application")
+		}
+	}
+	if strings.HasPrefix(entry, ".."+string(filepath.Separator)) || entry == ".." {
+		return "", fmt.Errorf("must be a relative child package inside the application")
+	}
+	if isToolOwnedEntryRoot(parts[0]) {
+		return "", fmt.Errorf("points to a GoFrame-owned or tool-owned directory")
+	}
+	return filepath.ToSlash(entry), nil
+}
+
+func isToolOwnedEntryRoot(root string) bool {
+	switch root {
+	case defaultWorkspaceName, "build", "dist", "node_modules", ".git", ".goxc-tmp":
+		return true
+	default:
+		return false
+	}
 }
 
 func safeChildPath(path string) bool {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -189,7 +189,7 @@ func packageApp(options packageOptions) error {
 			return err
 		}
 	}
-	workDir, err := prepareBuildWorkspace(layout, manifest)
+	entryPath, err := prepareBuildWorkspace(layout, manifest)
 	if err != nil {
 		return fmt.Errorf("prepare package workspace: %w", err)
 	}
@@ -202,7 +202,6 @@ func packageApp(options packageOptions) error {
 
 	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
 	tempWASM := filepath.Join(tempDir, wasmLogicalName)
-	entryPath := filepath.Join(workDir, manifest.Entry)
 	fmt.Printf("packaging %s with %s compiler\n", options.appDir, options.compiler)
 	if err := compileWASM(options.compiler, entryPath, tempWASM); err != nil {
 		return err

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -16,8 +16,9 @@ var (
 )
 
 func prepareBuildWorkspace(layout BuildLayout, manifest projectManifest) (string, error) {
-	if manifest.Entry != "." {
-		return "", fmt.Errorf("entry %q is not supported by the hidden workspace builder yet; MVP 20 supports multi-package apps under entry %q", manifest.Entry, ".")
+	entry, err := resolveEntryPackageDir(layout.AppDir, manifest.Entry)
+	if err != nil {
+		return "", err
 	}
 	if err := refreshDirectory(layout.WorkDir); err != nil {
 		return "", err
@@ -38,7 +39,43 @@ func prepareBuildWorkspace(layout BuildLayout, manifest projectManifest) (string
 	if err := writeWorkspaceGoMod(layout.WorkDir, layout.AppDir); err != nil {
 		return "", err
 	}
-	return filepath.Join(appWorkDir, manifest.Entry), nil
+	entryRelative, err := filepath.Rel(layout.AppDir, entry)
+	if err != nil {
+		return "", fmt.Errorf("resolve entry workspace path: %w", err)
+	}
+	return filepath.Join(appWorkDir, entryRelative), nil
+}
+
+func resolveEntryPackageDir(appDir, entry string) (string, error) {
+	originalEntry := entry
+	entry, err := cleanManifestEntry(entry)
+	if err != nil {
+		return "", fmt.Errorf("entry %q %s", originalEntry, err)
+	}
+	appDir, err = filepath.Abs(appDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve application directory: %w", err)
+	}
+	entryDir := appDir
+	if entry != "." {
+		entryDir = filepath.Join(appDir, filepath.FromSlash(entry))
+	}
+	relative, err := filepath.Rel(appDir, entryDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve entry %q: %w", entry, err)
+	}
+	relative = filepath.ToSlash(filepath.Clean(relative))
+	if relative == ".." || strings.HasPrefix(relative, "../") {
+		return "", fmt.Errorf("entry %q must be a relative child package inside the app root", entry)
+	}
+	info, err := os.Stat(entryDir)
+	if err != nil {
+		return "", fmt.Errorf("entry %q does not exist or is not readable: %w", entry, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("entry %q points to a file; entry must be a Go package directory", entry)
+	}
+	return entryDir, nil
 }
 
 func refreshDirectory(directory string) error {

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -7,18 +7,6 @@ import (
 	"testing"
 )
 
-func TestPrepareBuildWorkspaceRejectsUnsupportedEntry(t *testing.T) {
-	_, err := prepareBuildWorkspace(BuildLayout{}, projectManifest{Entry: "cmd/app"})
-	if err == nil {
-		t.Fatal("prepareBuildWorkspace() accepted unsupported entry")
-	}
-	for _, want := range []string{"entry", "not supported", `"."`, "multi-package"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q does not mention %q", err, want)
-		}
-	}
-}
-
 func TestWriteWorkspaceGoModFailsWithoutRepoRootOrVersion(t *testing.T) {
 	oldFind := findRepositoryRootForWorkspace
 	oldVersion := goframeModuleVersionForBuild
@@ -181,6 +169,143 @@ func View() gf.Node {
 	}
 }
 
+func TestCleanManifestEntryAcceptsChildEntries(t *testing.T) {
+	tests := map[string]string{
+		".":         ".",
+		"./cmd/app": "cmd/app",
+		"cmd/app":   "cmd/app",
+		"./src/app": "src/app",
+		"src/app":   "src/app",
+		"./app":     "app",
+		"app":       "app",
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			got, err := cleanManifestEntry(input)
+			if err != nil {
+				t.Fatalf("cleanManifestEntry(%q) error: %v", input, err)
+			}
+			if got != want {
+				t.Fatalf("cleanManifestEntry(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestCleanManifestEntryRejectsUnsafeEntries(t *testing.T) {
+	tests := []string{
+		"",
+		"/abs/path",
+		"../outside",
+		"./../outside",
+		"cmd/../outside",
+		".goframe/work",
+		"./.goframe/work",
+		"build",
+		"dist",
+		"node_modules",
+		".git",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			if _, err := cleanManifestEntry(input); err == nil {
+				t.Fatalf("cleanManifestEntry(%q) returned nil error", input)
+			}
+		})
+	}
+}
+
+func TestResolveEntryPackageDirRejectsFile(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "cmd/app/main.go", "package main\n")
+	if _, err := resolveEntryPackageDir(appDir, "cmd/app/main.go"); err == nil {
+		t.Fatal("resolveEntryPackageDir() accepted a file entry")
+	}
+}
+
+func TestPrepareBuildWorkspaceAcceptsChildEntry(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module github.com/example/root\n\ngo 1.22\n")
+	appDir := filepath.Join(root, "apps", "demo")
+	writeTestFile(t, appDir, "cmd/app/main.go", "package main\n")
+	writeTestFile(t, appDir, "cmd/app/app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func AppShell() gf.Node {
+	return <main>Demo</main>
+}
+`)
+	writeTestFile(t, appDir, "internal/ui/layout.gox", `package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Layout() gf.Node {
+	return <section>UI</section>
+}
+`)
+
+	layout := BuildLayout{
+		AppDir:  appDir,
+		WorkDir: filepath.Join(t.TempDir(), "work"),
+	}
+	entryDir, err := prepareBuildWorkspace(layout, projectManifest{Entry: "cmd/app"})
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspace(child entry) error: %v", err)
+	}
+	wantEntry := filepath.Join(layout.WorkDir, "apps", "demo", "cmd", "app")
+	if entryDir != wantEntry {
+		t.Fatalf("entry dir = %q, want %q", entryDir, wantEntry)
+	}
+	for _, path := range []string{
+		"apps/demo/cmd/app/app.gox.go",
+		"apps/demo/internal/ui/layout.gox.go",
+	} {
+		if _, err := os.Stat(filepath.Join(layout.WorkDir, path)); err != nil {
+			t.Fatalf("workspace generated file %s missing: %v", path, err)
+		}
+	}
+}
+
+func TestPrepareBuildWorkspaceAcceptsGenericSrcEntry(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, root, "go.mod", "module github.com/example/root\n\ngo 1.22\n")
+	appDir := filepath.Join(root, "apps", "demo")
+	writeTestFile(t, appDir, "src/app/main.go", "package main\n")
+	writeTestFile(t, appDir, "src/app/app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main>src app</main>
+}
+`)
+	writeTestFile(t, appDir, "src/components/button.gox", `package components
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Button() gf.Node {
+	return <button>Button</button>
+}
+`)
+
+	layout := BuildLayout{
+		AppDir:  appDir,
+		WorkDir: filepath.Join(t.TempDir(), "work"),
+	}
+	entryDir, err := prepareBuildWorkspace(layout, projectManifest{Entry: "./src/app"})
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspace(src entry) error: %v", err)
+	}
+	wantEntry := filepath.Join(layout.WorkDir, "apps", "demo", "src", "app")
+	if entryDir != wantEntry {
+		t.Fatalf("entry dir = %q, want %q", entryDir, wantEntry)
+	}
+	if _, err := os.Stat(filepath.Join(layout.WorkDir, "apps/demo/src/components/button.gox.go")); err != nil {
+		t.Fatalf("workspace did not generate non-entry package GOX file: %v", err)
+	}
+}
+
 func TestWriteWorkspaceGoModUsesRootModulePath(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/example/root\n\ngo 1.22\n"), 0o644); err != nil {
@@ -211,5 +336,16 @@ func TestWriteWorkspaceGoModUsesRootModulePath(t *testing.T) {
 		if !strings.Contains(string(content), want) {
 			t.Fatalf("workspace go.mod missing %q:\n%s", want, content)
 		}
+	}
+}
+
+func writeTestFile(t *testing.T, root, relative, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -142,7 +142,7 @@ Not stable:
 - router design;
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
-- child-entry and multi-module app support;
+- multi-module app support;
 - final public component package identity policy;
 - dynamic virtualization measurement;
 - infinite loading;
@@ -156,8 +156,8 @@ Not stable:
 
 Before public preview, GoFrame should have:
 
-- a component identity decision for child-entry apps, multi-module workspaces,
-  and reusable component packages;
+- a component identity decision for multi-module workspaces and reusable
+  component packages;
 - a symlink/file safety test matrix;
 - clearer package manifest compatibility policy;
 - stable migration notes for GOX syntax changes;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,11 +141,13 @@ CLI flags override manifest defaults. Paths in the manifest must remain inside
 the application directory. Unknown manifest fields are rejected so typos fail
 early instead of silently falling back to defaults.
 
-The hidden workspace builder supports `"entry": "."` apps with child packages
-under the app root. During build/package it materializes a module-root mirror
-under `.goframe/work/<profile>` so generated `.gox.go` files can sit beside
-the corresponding package sources without polluting the authored tree. Child
-entry packages such as `"./cmd/app"` remain future toolchain work.
+The hidden workspace builder supports `"entry": "."` apps and child entry
+packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when
+they stay inside the app root. During build/package it materializes a
+module-root mirror under `.goframe/work/<profile>` so generated `.gox.go`
+files can sit beside the corresponding package sources without polluting the
+authored tree. GOX discovery remains app-root-wide even when the executable
+entry is a child package.
 
 ## Build targets
 
@@ -177,6 +179,7 @@ dashboard bundle.wasm   162,773 bytes
 context bundle.wasm     111,440 bytes
 virtualized bundle.wasm 118,546 bytes
 multipackage bundle.wasm 89,727 bytes
+cmdapp bundle.wasm       89,786 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -188,7 +191,8 @@ than Counter because it also demonstrates compact localStorage persistence.
 The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
 dashboard-sized pressure-test example, the context selector example, and the
-virtualized collections and multi-package workspace examples.
+virtualized collections, multi-package workspace, and child-entry workspace
+examples.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,8 +29,8 @@ It checks:
 and manually through `workflow_dispatch`.
 
 It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
-counter, components, todo, dashboard, context, virtualized, and multipackage
-examples with TinyGo. It also runs a release-style package pass with
+counter, components, todo, dashboard, context, virtualized, multipackage, and
+cmdapp examples with TinyGo. It also runs a release-style package pass with
 `--asset-hash --preload --compress=gzip,br` before checking:
 
 ```bash
@@ -60,7 +60,7 @@ storage cleanup, checks WASM MIME type, and separates harness failures from app
 failures. It currently covers Todo reconciliation, duplicate-key debug
 diagnostics, dashboard-sized filtering/sorting/selection behavior, context
 selector rerender isolation, virtualized collection scroll/selection/toggle
-behavior, and a multi-package GOX workspace smoke.
+behavior, a multi-package GOX workspace smoke, and a child-entry package smoke.
 
 GOX diagnostic golden tests intentionally assert filenames, line/column
 prefixes, specific unsupported-syntax messages, and source snippets. They are

--- a/docs/component-identity-next.md
+++ b/docs/component-identity-next.md
@@ -52,8 +52,9 @@ multi-package applications:
 - memoization and effects depend on instance reuse being correct;
 - keyed lists rely on component identity plus key, not key alone.
 
-These are smaller after MVP 20, but child entry packages, multi-module
-workspaces, and final public identity policy remain open.
+These are smaller after MVP 20 and MVP 22, but multi-module workspaces,
+reusable component package policy, and the final public identity policy remain
+open.
 
 ## Required Properties
 
@@ -131,8 +132,7 @@ Remaining cons:
 - `goxc` generated ids use import paths when known, but lower-level generation
   helpers can still emit package-name fallback ids;
 - token variable names include source-file context and are not public API;
-- child-entry and multi-module support still need additional package-token
-  decisions;
+- multi-module support still needs additional package-token decisions;
 - token lifetime and initialization must stay simple for TinyGo.
 
 ## Option D: Explicit User Tokens
@@ -200,16 +200,17 @@ A conservative path:
 
 MVP 19 prototypes compiler-generated component tokens while preserving legacy
 `gf.Component` compatibility. MVP 20 makes the `goxc` path import-path-aware
-when a nearest module path is known. That is enough for the first
-multi-package app workspace, but not a final answer for child entries,
-multi-module monorepos, or public component package policy.
+when a nearest module path is known. MVP 22 uses the same package-directory
+identity for child entry packages such as `./cmd/app`. That is enough for the
+current single-module app workspace, but not a final answer for multi-module
+monorepos or public component package policy.
 
 The current recommendation is:
 
 ```text
-entry "." apps: use generated ComponentT tokens with import-aware ids when known
+entry "." and child-entry apps: use generated ComponentT tokens with import-aware ids when known
 handwritten/raw Go: gf.Component remains compatible; ComponentT is available
-future workspace forms: require child-entry and multi-module identity design
+future workspace forms: require multi-module identity design
 ```
 
 ## Open Questions

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -99,14 +99,14 @@ Remaining cons:
 - lower-level generation helpers can still fall back to package name plus
   component name;
 - token variable names are generated-code details;
-- child-entry and multi-module workspace support still need more identity
-  design;
+- multi-module workspace support still needs more identity design;
 - may increase bundle size if token metadata grows.
 
 Recommendation: keep the token path as the generated default while retaining
 `gf.Component` as compatibility API. MVP 20's import-aware `goxc` ids cover
-`entry: "."` apps with child packages, but they are not a complete
-multi-module or child-entry identity policy.
+`entry: "."` apps with child packages, and MVP 22 applies the same model to
+child entry packages such as `./cmd/app`. They are not a complete multi-module
+identity policy.
 
 ## Alternative C: Function Identity
 
@@ -129,8 +129,8 @@ Use generated typed identity for GOX, with these hardening rules:
 - use keys for reordered lists;
 - treat duplicate keys as a bug;
 - keep duplicate-key diagnostics in `goframe_debug` builds only;
-- revisit child-entry, multi-module, and reusable component package identity
-  before claiming a public package ecosystem.
+- revisit multi-module and reusable component package identity before claiming
+  a public package ecosystem.
 
 ## Migration Plan For Tokens
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -212,9 +212,10 @@ old workspaces by removing legacy `build/` and adjacent generated `.gox.go`
 files. Legacy `dist/` is removed only if it looks like a GoFrame export; user
 directories are skipped instead of silently deleted.
 
-The materialized hidden workspace supports `"entry": "."` apps with child
-packages under the app root. Child entry packages such as `"./cmd/app"` are not
-implemented yet; goxc fails with a clear error instead of guessing.
+The materialized hidden workspace supports `"entry": "."` apps and child entry
+packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when
+they point to package directories inside the app root. GOX discovery remains
+app-root-wide so imported internal packages get generated files too.
 
 ## Cache Policy
 

--- a/docs/foundation-audit-iv.md
+++ b/docs/foundation-audit-iv.md
@@ -250,8 +250,9 @@ Safety findings:
 
 - manifest paths are validated as relative child paths;
 - unknown manifest fields fail;
-- hidden workspace build supports `entry: "."` apps with child packages under
-  the app root and fails clearly for unsupported child entry packages;
+- hidden workspace build supported `entry: "."` apps with child packages under
+  the app root at the time of the audit; MVP 22 later added child entry package
+  support inside the app root;
 - package output uses staging before publishing;
 - explicit package destinations must be empty or GoFrame-owned;
 - export refuses non-empty non-GoFrame directories unless `--force` is used;

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -1,13 +1,13 @@
 # Multi-package GOX Workspace
 
-MVP 20 adds the first `goxc` path for applications with more than one Go
-package. This is toolchain support, not a router, namespace system, or app
-framework convention.
+MVP 20 added the first `goxc` path for applications with more than one Go
+package. MVP 22 extends that path so the executable entry package can live in
+a child directory such as `./cmd/app`. This is toolchain support, not a
+router, namespace system, or app framework convention.
 
 ## Supported Layout
 
-The supported MVP 20 layout is an application root with `entry: "."` and any
-number of child packages below that root:
+The app-root entry layout remains supported:
 
 ```text
 app/
@@ -22,8 +22,35 @@ app/
     └── model.go
 ```
 
-Child entry packages such as `entry: "./cmd/app"` are not implemented yet.
-`goxc` rejects them with a clear error.
+Child entry packages are also supported when they are relative package
+directories inside the app root:
+
+```json
+{
+  "entry": "./cmd/app"
+}
+```
+
+The recommended Go-first layout is:
+
+```text
+app/
+├── goframe.json
+├── index.html
+├── styles.css
+├── cmd/app/
+│   ├── main.go
+│   └── app.gox
+└── internal/
+    ├── ui/
+    │   └── layout.gox
+    └── features/
+        └── tasks/list.gox
+```
+
+Generic child entry paths such as `./app` or `./src/app` work as ordinary Go
+package directories. Frontend-flavored layouts such as `src/app` are allowed,
+but the Go-first recommendation is `cmd/app` plus `internal/...`.
 
 ## Workspace Strategy
 
@@ -43,6 +70,22 @@ examples/multipackage/.goframe/work/dev/
 The authored source tree remains clean. Generated files are written under
 `.goframe/gen` for `goxc generate` and under `.goframe/work/<profile>` for
 build/package materialization.
+
+For a child entry app, the workspace still mirrors the app root and then builds
+the selected child package:
+
+```text
+examples/cmdapp/.goframe/work/dev/
+├── go.mod
+├── pkg/goframe/
+└── examples/cmdapp/
+    ├── cmd/app/app.gox.go
+    └── internal/ui/layout.gox.go
+```
+
+The build package is `examples/cmdapp/.goframe/work/dev/examples/cmdapp/cmd/app`.
+GOX discovery remains app-root-wide so imported internal packages get their
+generated files too.
 
 This model is intentionally used instead of a Go overlay because TinyGo
 support for overlays is not part of the current baseline.
@@ -65,6 +108,16 @@ component:   Header
 component id github.com/graybuton/goframe/examples/multipackage/internal/ui.Header
 ```
 
+For a child entry package:
+
+```text
+package dir: examples/cmdapp/cmd/app
+component id github.com/graybuton/goframe/examples/cmdapp/cmd/app.Header
+
+package dir: examples/cmdapp/internal/ui
+component id github.com/graybuton/goframe/examples/cmdapp/internal/ui.Header
+```
+
 If no module path can be determined, generation falls back to the package-name
 identity path used by `GenerateNamed`.
 
@@ -82,7 +135,7 @@ under `.goframe/work/<profile>` together.
 
 ## Cross-package Components
 
-GOX does not add namespace tags in MVP 20. This remains unsupported:
+GOX does not add namespace tags in MVP 22. This remains unsupported:
 
 ```gox
 <ui.Header />
@@ -104,6 +157,28 @@ call itself is not a runtime component boundary unless that package exposes one
 through its own local GOX-generated component calls or handwritten
 `gf.ComponentT` wrapper.
 
+## Entry Path Rules
+
+Allowed examples:
+
+```text
+.
+./cmd/app
+cmd/app
+./src/app
+src/app
+./app
+app
+```
+
+Rejected examples include empty paths, absolute paths, paths containing `..`,
+and tool-owned directories such as `.goframe`, `build`, `dist`,
+`node_modules`, and `.git`.
+
+The entry must point to a directory, not a file. Symlink behavior is still
+covered by the broader file safety policy rather than a full symlink-hardening
+claim.
+
 ## Commands
 
 The multi-package example supports:
@@ -117,9 +192,19 @@ goxc size ./examples/multipackage
 goxc serve ./examples/multipackage --port=8080
 ```
 
+The child-entry example supports:
+
+```bash
+goxc generate ./examples/cmdapp
+goxc build ./examples/cmdapp --compiler=go
+goxc package ./examples/cmdapp --compiler=go
+goxc package ./examples/cmdapp --compiler=tinygo
+goxc size ./examples/cmdapp
+goxc serve ./examples/cmdapp --port=8080
+```
+
 ## Current Limitations
 
-- `entry: "."` only.
 - No namespace tags.
 - No full multi-module monorepo story.
 - No router/layout convention.
@@ -130,5 +215,6 @@ goxc serve ./examples/multipackage --port=8080
 
 ## Example
 
-See `examples/multipackage` for a compact app with a root package,
-`internal/ui`, `internal/issues`, and ordinary shared Go helpers.
+See `examples/multipackage` for a compact `entry: "."` app with a root
+package, `internal/ui`, `internal/issues`, and ordinary shared Go helpers.
+See `examples/cmdapp` for a compact `entry: "./cmd/app"` app.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -17,7 +17,8 @@ The baseline covers:
 - Go, race, vet, debug-tag, and GOX golden tests;
 - TinyGo raw, gzip, brotli, and zstd size budgets;
 - browser smoke behavior for Todo, duplicate keys, dashboard, context,
-  virtualized collections, and the multi-package example;
+  virtualized collections, the multi-package example, and the child-entry
+  example;
 - dashboard DOM pressure and listener stability;
 - pure runtime benchmark reports;
 - package, export, artifact, and module path safety gates.
@@ -145,6 +146,14 @@ MVP 20 measured size for the new example:
 |---|---:|---:|---:|---:|
 | multipackage | 89727 | 35422 | 29549 | 31831 |
 
+MVP 22 adds a child-entry package example. Existing example budgets remain
+authoritative in `scripts/size-budget.sh`; the new example is tracked with its
+own budget.
+
+| Example | Raw | gzip | br | zstd |
+|---|---:|---:|---:|---:|
+| cmdapp | 89786 | 35453 | 29569 | 31836 |
+
 ## Browser / DOM Baseline
 
 `scripts/browser-smoke.sh` currently covers:
@@ -159,6 +168,8 @@ MVP 20 measured size for the new example:
   selection/toggle after scroll, and listener net stability.
 - Multi-package GOX workspace loading, internal package component rendering,
   readable debug names, and a simple state interaction.
+- Child-entry package loading from `cmd/app`, internal package component
+  rendering, readable debug names, and a simple state interaction.
 
 Hard browser gates focus on correctness and structural invariants. Timing
 printed by smoke scripts is useful for trend spotting, but it is not a stable

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -38,10 +38,11 @@ Manifest fields such as `entry`, `output`, `wasm`, and `assets` are validated
 as relative child paths. Absolute paths, `..`, and paths escaping the
 application directory are rejected.
 
-`entry` currently supports `"."` for the hidden workspace builder. Packages
-below the app root can participate in that app workspace. Child entry packages
-such as `"./cmd/app"` are still unsupported and fail clearly; this is a
-toolchain limitation, not a security feature.
+`entry` supports `"."` and relative child package directories such as
+`"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"`. Entries that point to
+tool-owned directories such as `.goframe`, `build`, `dist`, `node_modules`, or
+`.git` are rejected. The entry must point to a directory inside the app root,
+not a file.
 
 ## Workspace Paths
 
@@ -140,7 +141,7 @@ tool-owned output directories.
 - No production static server hardening beyond local development needs.
 - No signed package/export metadata.
 - No permission model for future Player or `.gfapp` bundles.
-- No child-entry or full multi-module workspace model.
+- No full multi-module workspace model.
 
 ## Recommended Future Tests
 

--- a/examples/cmdapp/README.md
+++ b/examples/cmdapp/README.md
@@ -1,0 +1,51 @@
+# Child Entry Package Example
+
+This example exercises `goxc` support for an executable entry package below
+the application root:
+
+```json
+{
+  "entry": "./cmd/app"
+}
+```
+
+The layout follows Go package conventions:
+
+```text
+examples/cmdapp/
+├── cmd/app/                  # executable entry package
+├── internal/ui/              # app-private UI package with GOX files
+├── internal/features/tasks/  # app-private feature package with GOX files
+└── internal/shared/          # ordinary Go helpers
+```
+
+Generated `.gox.go` files stay under `.goframe`; the authored source tree
+should remain free of adjacent generated files, `build/`, and `dist/` output.
+
+## Run
+
+```bash
+goxc package ./examples/cmdapp --compiler=tinygo
+goxc serve ./examples/cmdapp --port=8080
+```
+
+For a cache-safe package:
+
+```bash
+goxc package ./examples/cmdapp --compiler=tinygo --asset-hash --preload --compress=gzip,br
+```
+
+## What It Proves
+
+`goxc` builds the child entry package under `cmd/app` while still discovering
+GOX files across the whole app root, including `internal/ui` and
+`internal/features/tasks`.
+
+GOX does not add namespace tags such as `<ui.Header />`. Cross-package
+composition uses ordinary Go imports and function calls. Local capitalized tags
+inside each package still get import-aware component identities, for example:
+
+```text
+github.com/graybuton/goframe/examples/cmdapp/cmd/app.Header
+github.com/graybuton/goframe/examples/cmdapp/internal/ui.Header
+```

--- a/examples/cmdapp/cmd/app/app.gox
+++ b/examples/cmdapp/cmd/app/app.gox
@@ -1,0 +1,42 @@
+package main
+
+import (
+	tasks "github.com/graybuton/goframe/examples/cmdapp/internal/features/tasks"
+	ui "github.com/graybuton/goframe/examples/cmdapp/internal/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+type HeaderProps struct {
+	Subtitle string
+}
+
+func Header(props HeaderProps) gf.Node {
+	return (
+		<section class="entry-header" data-testid="entry-header">
+			<strong>Entry Header</strong>
+			<span>{props.Subtitle}</span>
+		</section>
+	)
+}
+
+func App() gf.Node {
+	count, setCount := gf.UseState(0)
+
+	return (
+		<main class="cmdapp-page">
+			<Header Subtitle={appSubtitle} />
+			{ui.Layout(ui.LayoutProps{
+				Title: "Child entry GOX",
+				Count: count,
+				OnIncrement: func() {
+					setCount(count + 1)
+				},
+				Children: []gf.Node{
+					tasks.TaskList(tasks.TaskListProps{
+						Items: tasks.DemoTasks(),
+					}),
+				},
+			})}
+		</main>
+	)
+}

--- a/examples/cmdapp/cmd/app/main.go
+++ b/examples/cmdapp/cmd/app/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/cmdapp/cmd/app/model.go
+++ b/examples/cmdapp/cmd/app/model.go
@@ -1,0 +1,3 @@
+package main
+
+const appSubtitle = "Child entry package calling internal GOX packages"

--- a/examples/cmdapp/doc.go
+++ b/examples/cmdapp/doc.go
@@ -1,0 +1,2 @@
+// Package cmdapp documents the child-entry package example.
+package cmdapp

--- a/examples/cmdapp/goframe.json
+++ b/examples/cmdapp/goframe.json
@@ -1,0 +1,11 @@
+{
+  "name": "cmdapp",
+  "entry": "./cmd/app",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css"
+  ]
+}

--- a/examples/cmdapp/index.html
+++ b/examples/cmdapp/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>goframe cmdapp</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <script>
+        window.goframeComponentRenderCounts = {};
+        window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
+        window.goframeComponentRenderProbe = (name) => {
+            window.goframeComponentRenderCounts[name] =
+                (window.goframeComponentRenderCounts[name] || 0) + 1;
+        };
+        window.goframeComponentPatchProbe = (name) => {
+            window.goframeComponentPatchCounts[name] =
+                (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
+        };
+    </script>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance))
+            .catch((error) => {
+                console.error("[goframe] startup failed", error);
+                document.getElementById("root").textContent = "Failed to start goframe. See console.";
+            });
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/examples/cmdapp/internal/features/tasks/list.gox
+++ b/examples/cmdapp/internal/features/tasks/list.gox
@@ -1,0 +1,29 @@
+package tasks
+
+import (
+	shared "github.com/graybuton/goframe/examples/cmdapp/internal/shared"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func TaskList(props TaskListProps) gf.Node {
+	return (
+		<section class="task-list" data-testid="cmdapp-task-list">
+			<h2>{shared.FormatCount(len(props.Items))}</h2>
+			<ul>
+				{gf.Map(props.Items, func(task Task) gf.Node {
+					return <TaskRow Key={task.ID} Task={task} />
+				})}
+			</ul>
+		</section>
+	)
+}
+
+func TaskRow(props TaskRowProps) gf.Node {
+	return (
+		<li class="task-row" data-testid="cmdapp-task-row">
+			<strong>{props.Task.ID}</strong>
+			<span>{props.Task.Title}</span>
+			<small>{shared.FormatPriority(props.Task.Priority)}</small>
+		</li>
+	)
+}

--- a/examples/cmdapp/internal/features/tasks/model.go
+++ b/examples/cmdapp/internal/features/tasks/model.go
@@ -1,0 +1,23 @@
+package tasks
+
+type Task struct {
+	ID       string
+	Title    string
+	Priority string
+}
+
+type TaskListProps struct {
+	Items []Task
+}
+
+type TaskRowProps struct {
+	Task Task
+}
+
+func DemoTasks() []Task {
+	return []Task{
+		{ID: "CE-1", Title: "Build child entry package", Priority: "high"},
+		{ID: "CE-2", Title: "Generate internal GOX packages", Priority: "medium"},
+		{ID: "CE-3", Title: "Keep source tree clean", Priority: "low"},
+	}
+}

--- a/examples/cmdapp/internal/shared/format.go
+++ b/examples/cmdapp/internal/shared/format.go
@@ -1,0 +1,11 @@
+package shared
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func FormatCount(count int) string {
+	return gf.ToString(count) + " child-entry tasks"
+}
+
+func FormatPriority(priority string) string {
+	return "priority: " + priority
+}

--- a/examples/cmdapp/internal/ui/header.gox
+++ b/examples/cmdapp/internal/ui/header.gox
@@ -1,0 +1,12 @@
+package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Header(props HeaderProps) gf.Node {
+	return (
+		<header class="ui-header" data-testid="cmdapp-ui-header">
+			<strong>UI Header</strong>
+			<span>{props.Title}</span>
+		</header>
+	)
+}

--- a/examples/cmdapp/internal/ui/layout.gox
+++ b/examples/cmdapp/internal/ui/layout.gox
@@ -1,0 +1,19 @@
+package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Layout(props LayoutProps) gf.Node {
+	return (
+		<section class="layout-card" data-testid="cmdapp-ui-layout">
+			<Header Title={props.Title} />
+			<div class="layout-actions">
+				<button data-testid="cmdapp-increment" onClick={props.OnIncrement}>
+					Increment {props.Count}
+				</button>
+			</div>
+			<div class="layout-children" data-testid="cmdapp-layout-children">
+				{props.Children}
+			</div>
+		</section>
+	)
+}

--- a/examples/cmdapp/internal/ui/model.go
+++ b/examples/cmdapp/internal/ui/model.go
@@ -1,0 +1,14 @@
+package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type LayoutProps struct {
+	Title       string
+	Count       int
+	OnIncrement func()
+	Children    []gf.Node
+}
+
+type HeaderProps struct {
+	Title string
+}

--- a/examples/cmdapp/styles.css
+++ b/examples/cmdapp/styles.css
@@ -1,0 +1,88 @@
+:root {
+    color-scheme: light;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #f4f7fb;
+    color: #162033;
+}
+
+button {
+    font: inherit;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.65rem 1rem;
+    background: #265bdc;
+    color: white;
+    cursor: pointer;
+}
+
+.cmdapp-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 32px;
+}
+
+.entry-header,
+.ui-header,
+.layout-card,
+.task-list {
+    border: 1px solid #dbe3f2;
+    border-radius: 18px;
+    background: white;
+    box-shadow: 0 16px 40px rgba(27, 39, 71, 0.08);
+}
+
+.entry-header,
+.ui-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 16px;
+    padding: 16px 18px;
+}
+
+.layout-card {
+    padding: 20px;
+}
+
+.layout-actions {
+    margin-bottom: 18px;
+}
+
+.layout-children {
+    display: grid;
+    gap: 16px;
+}
+
+.task-list {
+    padding: 18px;
+}
+
+.task-list h2 {
+    margin: 0 0 12px;
+}
+
+.task-list ul {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.task-row {
+    display: grid;
+    grid-template-columns: 80px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 12px;
+    border-radius: 12px;
+    background: #f8faff;
+}
+
+.task-row small {
+    color: #52627a;
+}

--- a/examples/multipackage/README.md
+++ b/examples/multipackage/README.md
@@ -40,5 +40,5 @@ for example:
 github.com/graybuton/goframe/examples/multipackage/internal/ui.Header
 ```
 
-MVP 20 supports `entry: "."` with packages under the app root. Child entry
-packages such as `entry: "./cmd/app"` remain future work.
+`entry: "."` remains supported for apps with packages under the app root. For
+a child-entry layout such as `entry: "./cmd/app"`, see `examples/cmdapp`.

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -12,6 +12,7 @@ DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
 VIRTUALIZED_SMOKE_URL_BASE="${GOFRAME_VIRTUALIZED_SMOKE_URL:-http://127.0.0.1}"
 MULTIPACKAGE_SMOKE_URL_BASE="${GOFRAME_MULTIPACKAGE_SMOKE_URL:-http://127.0.0.1}"
+CMDAPP_SMOKE_URL_BASE="${GOFRAME_CMDAPP_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -106,6 +107,11 @@ build_virtualized_smoke_url() {
 build_multipackage_smoke_url() {
 	local port="$1"
 	echo "${MULTIPACKAGE_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_cmdapp_smoke_url() {
+	local port="$1"
+	echo "${CMDAPP_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -267,11 +273,27 @@ run_with_server ./examples/multipackage "$MULTIPACKAGE_PORT" "$MULTIPACKAGE_URL"
 	node --experimental-websocket scripts/multipackage-browser-smoke.mjs
 
 echo
+echo "== Cmdapp debug browser smoke =="
+"$GOXC" package ./examples/cmdapp --compiler=tinygo
+(
+	cd ./examples/cmdapp/.goframe/work/dev/examples/cmdapp/cmd/app
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/cmdapp/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+CMDAPP_PORT="$(resolve_port "${GOFRAME_CMDAPP_SMOKE_PORT:-}")"
+export GOFRAME_CMDAPP_CHROME_DEBUG_PORT="${GOFRAME_CMDAPP_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+CMDAPP_URL="$(build_cmdapp_smoke_url "$CMDAPP_PORT")"
+run_with_server ./examples/cmdapp "$CMDAPP_PORT" "$CMDAPP_URL" \
+	node --experimental-websocket scripts/cmdapp-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
 "$GOXC" package ./examples/context --compiler=tinygo
 "$GOXC" package ./examples/virtualized --compiler=tinygo
 "$GOXC" package ./examples/multipackage --compiler=tinygo
+"$GOXC" package ./examples/cmdapp --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -56,6 +56,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/virtualized --compiler=tinygo
 "$GOXC" generate ./examples/multipackage
 "$GOXC" package ./examples/multipackage --compiler=tinygo
+"$GOXC" generate ./examples/cmdapp
+"$GOXC" package ./examples/cmdapp --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/cmdapp-browser-smoke.mjs
+++ b/scripts/cmdapp-browser-smoke.mjs
@@ -1,0 +1,216 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_CMDAPP_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_CMDAPP_CHROME_DEBUG_PORT ?? "19239");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-cmdapp-smoke-"));
+const expectedApp = new URL(appURL);
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL));
+    await waitForAppPage(client, expectedApp);
+
+    assertDeepEqual(
+        await appState(client),
+        {
+            entryHeader: "Entry HeaderChild entry package calling internal GOX packages",
+            uiHeader: "UI HeaderChild entry GOX",
+            increment: "Increment0",
+            taskCount: 3,
+            taskSummary: "3 child-entry tasks",
+            headerRenders: 2,
+            layoutRenders: 0,
+            taskListRenders: 0,
+            taskRowRenders: 3,
+        },
+        "cmdapp initial render",
+    );
+
+    await client.evaluate(`document.querySelector("[data-testid='cmdapp-increment']").click()`);
+    await wait(140);
+    const afterClick = await appState(client);
+    if (afterClick.increment !== "Increment1") {
+        throw new Error(`APP FAILURE: cmdapp increment did not update: ${JSON.stringify(afterClick)}`);
+    }
+    if (afterClick.taskCount !== 3 || afterClick.taskSummary !== "3 child-entry tasks") {
+        throw new Error(`APP FAILURE: cmdapp task list changed unexpectedly: ${JSON.stringify(afterClick)}`);
+    }
+    if (afterClick.headerRenders < 4 || afterClick.taskRowRenders < 3) {
+        throw new Error(`APP FAILURE: cmdapp debug render counters are not readable: ${JSON.stringify(afterClick)}`);
+    }
+    console.log("cmdapp interaction: ok");
+
+    client.close();
+    console.log("Cmdapp browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function appState(client) {
+    return await client.evaluate(`(() => ({
+        entryHeader: document.querySelector("[data-testid='entry-header']")?.textContent.trim(),
+        uiHeader: document.querySelector("[data-testid='cmdapp-ui-header']")?.textContent.trim(),
+        increment: document.querySelector("[data-testid='cmdapp-increment']")?.textContent.trim(),
+        taskCount: document.querySelectorAll("[data-testid='cmdapp-task-row']").length,
+        taskSummary: document.querySelector("[data-testid='cmdapp-task-list'] h2")?.textContent.trim(),
+        headerRenders: window.goframeComponentRenderCounts?.Header ?? 0,
+        layoutRenders: window.goframeComponentRenderCounts?.Layout ?? 0,
+        taskListRenders: window.goframeComponentRenderCounts?.TaskList ?? 0,
+        taskRowRenders: window.goframeComponentRenderCounts?.TaskRow ?? 0,
+    }))()`);
+}
+
+function withSmokeParam(url) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", String(Date.now()));
+    return String(next);
+}
+
+async function waitForPage(port) {
+    const endpoint = `http://127.0.0.1:${port}/json/version`;
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        try {
+            const version = await fetch(endpoint).then((response) => response.json());
+            if (version.webSocketDebuggerUrl) {
+                const pages = await fetch(`http://127.0.0.1:${port}/json`).then((response) => response.json());
+                const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+                if (page) {
+                    return page;
+                }
+            }
+        } catch {
+            if (browser.exitCode !== null) {
+                throw new Error(`HARNESS FAILURE: Chrome exited early. stderr:\n${browserError}`);
+            }
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools endpoint did not start. stderr:\n${browserError}`);
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const { resolve, reject } = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            reject(new Error(`${message.error.message}: ${message.error.data ?? ""}`));
+        } else {
+            resolve(message.result ?? {});
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    return {
+        call(method, params = {}) {
+            const id = nextID++;
+            socket.send(JSON.stringify({ id, method, params }));
+            return new Promise((resolve, reject) => {
+                pending.set(id, { resolve, reject });
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                awaitPromise: true,
+                returnByValue: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`APP FAILURE: evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+    await waitForCondition(async () => {
+        const readyState = await client.evaluate("document.readyState");
+        return readyState === "complete" || readyState === "interactive";
+    }, "page navigation");
+}
+
+async function waitForAppPage(client, expectedApp) {
+    await waitForCondition(async () => {
+        const state = await client.evaluate(`(() => ({
+            href: location.href,
+            ready: Boolean(document.querySelector("[data-testid='entry-header']") && document.querySelector("[data-testid='cmdapp-task-list']")),
+        }))()`);
+        const actual = new URL(state.href);
+        if (actual.origin !== expectedApp.origin) {
+            throw new Error(`HARNESS FAILURE: expected app origin ${expectedApp.origin}, got ${actual.origin}`);
+        }
+        return state.ready;
+    }, "cmdapp app ready");
+}
+
+async function waitForCondition(check, label) {
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        if (await check()) {
+            return;
+        }
+        await wait(50);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label}`);
+}
+
+function assertDeepEqual(actual, expected, label) {
+    const actualJSON = JSON.stringify(actual);
+    const expectedJSON = JSON.stringify(expected);
+    if (actualJSON !== expectedJSON) {
+        throw new Error(`APP FAILURE: ${label}: got ${actualJSON}, want ${expectedJSON}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -135,5 +135,6 @@ check_app "dashboard" "$(bundle_path dashboard)" 168960 53248 71680 61440 || sta
 check_app "context" "$(bundle_path context)" 113664 36864 46080 40960 || status=1
 check_app "virtualized" "$(bundle_path virtualized)" 122880 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
+check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adds child entry package support to `goxc`, allowing apps to use layouts such as `entry: "./cmd/app"` while preserving the clean `.goframe` workspace model.

## Changes

- Support child entry package paths:
  - `.`
  - `./cmd/app`
  - `cmd/app`
  - `./src/app`
  - `src/app`
  - `./app`
  - `app`
- Reject unsafe entry paths:
  - empty entry
  - absolute paths
  - `..`
  - tool-owned directories like `.goframe`, `build`, `dist`, `node_modules`, `.git`
  - file entries
- Keep GOX discovery app-root-wide
- Build the selected child entry package inside `.goframe/work/<profile>`
- Preserve import-aware component identity for entry and internal packages
- Add `examples/cmdapp`
- Add `scripts/cmdapp-browser-smoke.mjs`
- Update docs, CI, size budget, README, and CHANGELOG

## Semantics

- `entry: "."` remains supported and unchanged
- `entry: "./cmd/app"` is now supported
- `cmd/app + internal/...` is the recommended Go-first layout
- `src/app` style layouts are allowed as ordinary child entry packages, but are not the primary Go-first recommendation
- Generated `.gox.go` files remain under `.goframe`
- Source tree stays clean

## Limits

- No router
- No layout convention
- No namespace tags
- No spread props
- No formatter/LSP
- No SSR/hydration
- No Player/Engine
- No full multi-module monorepo support
- No production deployment server

## Checks

- `go fmt ./...`
- `git diff --check`
- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- `go test ./examples/dashboard ./examples/context ./examples/virtualized ./examples/multipackage ./examples/cmdapp`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `node --experimental-websocket scripts/dashboard-dom-pressure.mjs`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`