### PR TITLE
MVP 24: client hash router

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -60,6 +60,8 @@ jobs:
           goxc package ./examples/multipackage --compiler=tinygo
           goxc generate ./examples/cmdapp
           goxc package ./examples/cmdapp --compiler=tinygo
+          goxc generate ./examples/router
+          goxc package ./examples/router --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
@@ -68,6 +70,7 @@ jobs:
           goxc package ./examples/virtualized --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/multipackage --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/cmdapp --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/router --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
   `gf.SetErrorHandler`, phase-specific error reports, event/effect/cleanup
   containment, memo comparator fallback, render fallback, and browser smoke
   coverage for recoverable runtime errors.
+- Hash-based client router primitives, including route params, not-found
+  handling, `RouterView`, `RouterLink`, programmatic navigation, a Go-first
+  router example, and browser smoke coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Current baseline includes:
 
 - GOX expression ergonomics and source-oriented diagnostics;
 - component boundaries, state, reducer dispatch, effects, context selectors,
-  memoization, keyed reconciliation, and fixed-height virtualization;
+  memoization, keyed reconciliation, fixed-height virtualization, and a small
+  hash-based client router;
 - cache-safe packaging, hidden `.goframe` workspace output, export safety, and
   clean workspace commands;
 - multi-package GOX workspaces, child entry packages such as `./cmd/app`, and
@@ -27,10 +28,11 @@ Current baseline includes:
 - CI gates for Go/GOX tests, TinyGo size budgets, browser smoke, artifact
   checks, module path checks, and docs consistency.
 
-Non-goals for the current project surface include router, SSR, hydration,
-Player/Engine implementation, dynamic virtualization, infinite loading, LSP,
-formatter, namespace tags, spread props, production deployment server, and
-full multi-module monorepo support.
+Non-goals for the current project surface include SSR, hydration,
+Player/Engine implementation, path/history-mode routing, file-based routing,
+route loaders, dynamic virtualization, infinite loading, LSP, formatter,
+namespace tags, spread props, production deployment server, and full
+multi-module monorepo support.
 
 ## What Is GoFrame?
 
@@ -124,6 +126,7 @@ goxc package ./examples/counter --compiler=go
 | `examples/virtualized` | `gf.VirtualList`, `gf.VirtualTable`, bounded DOM with 10,000 logical rows. | `goxc package ./examples/virtualized --compiler=tinygo` |
 | `examples/multipackage` | `entry: "."` app with root plus `internal/...` packages. | `goxc package ./examples/multipackage --compiler=tinygo` |
 | `examples/cmdapp` | Child entry package with `"entry": "./cmd/app"` and Go-first layout. | `goxc package ./examples/cmdapp --compiler=tinygo` |
+| `examples/router` | Hash router, route params, not-found route, and stable shell layout. | `goxc package ./examples/router --compiler=tinygo` |
 
 Serve any packaged example with:
 
@@ -306,6 +309,23 @@ protects against dirty descendants hidden under memoized ancestors.
 Large fixed-height collections should use `gf.VirtualList` or
 `gf.VirtualTable` instead of mounting hidden offscreen rows.
 
+Client-side page changes can use the small hash router:
+
+```go
+var router = gf.NewHashRouter([]gf.Route{
+	gf.RoutePath("/", homeRoute),
+	gf.RoutePath("/issues/:id", issueRoute),
+	gf.NotFoundRoute(notFoundRoute),
+})
+
+func App() gf.Node {
+	return gf.RouterView(router)
+}
+```
+
+The MVP router is hash-based. Path/history mode, file-based routing, loaders,
+route middleware, and route-level error boundaries remain future work.
+
 ## Toolchain Workflow
 
 Generated, build, and package outputs live under an app-local hidden workspace:
@@ -367,6 +387,7 @@ Runtime topics:
 - [Explicit memoization](docs/memoization.md)
 - [Context selectors](docs/context.md)
 - [Virtualized collections](docs/virtualization.md)
+- [Client router](docs/router.md)
 - [Component identity strategy](docs/component-identity.md)
 - [Component identity next steps](docs/component-identity-next.md)
 
@@ -395,13 +416,15 @@ Examples:
 - [Virtualized collections example](examples/virtualized/README.md)
 - [Multi-package GOX example](examples/multipackage/README.md)
 - [Child entry package example](examples/cmdapp/README.md)
+- [Router example](examples/router/README.md)
 - [VS Code GOX extension](extensions/vscode-gox/README.md)
 
 ## Current Limitations
 
 - Experimental browser/WASM target only.
-- No router, SSR, hydration, hot reload, CSS-in-Go, or production deployment
-  server.
+- Hash router only; no SSR, hydration, path/history-mode server fallback,
+  file-based routing, route loaders, hot reload, CSS-in-Go, or production
+  deployment server.
 - No Player/Engine implementation or `.gfapp` package format yet.
 - No namespace tags, spread props, template-block loops, formatter, or LSP.
 - No full multi-module monorepo story.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -69,6 +69,13 @@ Runtime:
 - `gf.UseContextSelector`
 - `gf.VirtualList`
 - `gf.VirtualTable`
+- `gf.RoutePath`
+- `gf.NotFoundRoute`
+- `gf.NewHashRouter`
+- `gf.RouterView`
+- `gf.RouterLink`
+- `gf.Navigate`
+- `gf.HashHref`
 - basic event facades such as `gf.Event`, `gf.InputEvent`, and
   `gf.ScrollEvent`
 
@@ -99,6 +106,8 @@ exact shapes can still change before public preview.
 - Runtime error reporting API and exact phase containment behavior:
   `gf.SetErrorHandler`, `gf.ErrorInfo`, `gf.ErrorHandler`, and
   `gf.ErrorPhase`.
+- Hash router details such as route remount policy, declaration-order matching
+  edge cases, link props, and browser listener internals.
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands and snippets.
@@ -142,7 +151,9 @@ For now, deprecations should:
 
 Not stable:
 
-- router design;
+- path/history-mode routing and server fallback behavior;
+- file-based routing, route loaders, route middleware, and route-level error
+  boundaries;
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
 - multi-module app support;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,7 @@ context bundle.wasm      113,108 bytes
 virtualized bundle.wasm  121,195 bytes
 multipackage bundle.wasm 89,727 bytes
 cmdapp bundle.wasm       89,786 bytes
+router bundle.wasm       106,671 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -192,7 +193,7 @@ The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
 dashboard-sized pressure-test example, the context selector example, and the
 virtualized collections, multi-package workspace, and child-entry workspace
-examples.
+examples, plus the hash-router example.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.
@@ -234,6 +235,8 @@ The MVP runtime currently has:
 - scoped context providers with selector-based consumer dirtying;
 - component-scoped lifecycle/effect slots;
 - fixed-height `VirtualList` and `VirtualTable` collection primitives;
+- hash-based client routing through `RouterView`, `RouterLink`, and Go-declared
+  routes;
 - dirty component updates coalesced into one animation-frame flush;
 - direct dirty-owner subtree updates without root traversal;
 - dirty queue ancestor pruning when parent and child are dirty in the same
@@ -275,7 +278,8 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 - GOX has expression-oriented conditional rendering, but no template-block
   loops/conditionals, spread props, or component namespaces.
 - No spread props or component namespaces.
-- No routing, SSR, hydration, or accessibility abstraction.
+- Hash routing only; no path/history-mode server fallback, file-based routing,
+  route loaders, SSR, hydration, or accessibility abstraction.
 - TinyGo compatibility is experimental and feature-dependent.
 - `goxc serve` is a development server without compression negotiation.
 - Debug-tag performance probes are observations, not rigorous benchmarks.
@@ -289,5 +293,5 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 3. Add deeper symlink/path-safety tests before public preview.
 4. Continue measuring size, DOM pressure, and browser smoke invariants before
    taking on larger features.
-5. Explore router, Player/Engine, SSR/hydration, and `.gfapp` only as separate
-   design efforts, not incidental cleanup.
+5. Explore path/history routing, Player/Engine, SSR/hydration, and `.gfapp`
+   only as separate design efforts, not incidental cleanup.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -30,9 +30,9 @@ It checks:
 and manually through `workflow_dispatch`.
 
 It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
-counter, components, todo, dashboard, context, virtualized, multipackage, and
-cmdapp examples with TinyGo. It also runs a release-style package pass with
-`--asset-hash --preload --compress=gzip,br` before checking:
+counter, components, todo, dashboard, context, virtualized, multipackage,
+cmdapp, and router examples with TinyGo. It also runs a release-style package
+pass with `--asset-hash --preload --compress=gzip,br` before checking:
 
 ```bash
 scripts/size-budget.sh
@@ -62,7 +62,8 @@ failures. It currently covers Todo reconciliation, duplicate-key debug
 diagnostics, runtime error containment for event/effect/cleanup panics,
 dashboard-sized filtering/sorting/selection behavior, context selector rerender
 isolation, virtualized collection scroll/selection/toggle behavior, a
-multi-package GOX workspace smoke, and a child-entry package smoke.
+multi-package GOX workspace smoke, a child-entry package smoke, and a
+hash-router navigation smoke.
 
 The runtime error containment fixture is compiled with the Go WASM compiler so
 `recover` semantics are available. The size-oriented TinyGo package path uses
@@ -219,6 +220,9 @@ missing Chrome, unavailable storage, or stale server state. App failures include
 DOM identity loss, render counter regressions, localStorage persistence issues,
 duplicate key diagnostics failures, dashboard filter/sort regressions,
 virtualized collection window regressions, or listener churn regressions.
+Router smoke failures include broken hash navigation, missing route params,
+not-found fallback regressions, browser back handling regressions, or unstable
+shell layout identity.
 
 The smoke script must not continue against an unknown server or `about:blank`.
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -142,4 +142,4 @@ goxc serve ./examples/context --port=8080
 - No server context, async context, or context devtools.
 - Context is not a global store; provider scope is the component tree.
 - Context selectors do not replace reducer dispatch, explicit memoization,
-  virtualization, or future router design.
+  virtualization, or the hash router's route state.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -230,8 +230,19 @@ When serving precompressed files, configure the web server or CDN to return the
 matching `Content-Encoding` for `.gz` and `.br` variants. `goxc serve` is
 development-only and does not implement production compression negotiation.
 
+## Hash Router Deployment
+
+The MVP 24 router is hash-based. Routes such as `#/issues/42` are handled by
+the browser after `index.html` loads, so static hosting can serve the same
+package without server-side route rewrites.
+
+Path/history-mode routing is not implemented. If a future app wants clean URLs
+such as `/issues/42`, the server or CDN would need a fallback that serves
+`index.html` for application routes. `goxc serve` remains development-only and
+does not configure a production fallback policy.
+
 ## Not In MVP 13
 
 Bundle splitting is intentionally not part of this stage. It needs an app graph,
-route/loading model, loader design, and probably router, SSR/hydration, or
-Player decisions first.
+route/loading model, loader design, and probably path/history routing,
+SSR/hydration, or Player decisions first.

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -156,6 +156,6 @@ The Todo example uses effects to persist tasks:
 - No lifecycle hooks for before-render or before-patch.
 - No automatic component memoization in the GOX compiler or runtime. Memoization is
   explicit via `MemoEqual` on component props and is intentionally opt-in.
-- No context, router integration, SSR, hydration, or async component model.
+- No route-aware effect lifecycle, SSR, hydration, or async component model.
 - Hook order changes are unsupported and may panic only when the slot type
   changes.

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -387,9 +387,10 @@ GOX does not currently support:
 - component namespaces or dotted tags;
 - style objects;
 - lifecycle/effect-specific GOX syntax; use Go calls such as `gf.UseEffect`;
+- routing-specific GOX syntax; use Go route declarations such as
+  `gf.NewHashRouter`;
 - advanced reconciliation controls;
 - async components;
-- routing;
 - SSR or hydration;
 - compile-time validation that a component function or props struct exists.
 

--- a/docs/memoization.md
+++ b/docs/memoization.md
@@ -63,7 +63,8 @@ other compared prop tracks that data.
   that can be represented as pure actions.
 - Virtualization is a separate tool. Use `gf.VirtualList` or `gf.VirtualTable`
   when offscreen collection items should not be mounted at all.
-- No router/Player integration in this stage.
+- Router route changes are ordinary component updates; memoization does not
+  provide route loaders, route-level error handling, or Player integration.
 
 If `MemoEqual` panics, GoFrame reports `gf.ErrorPhaseMemo` through the runtime
 error handler and falls back to rendering instead of skipping. A broken

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -207,7 +207,8 @@ goxc serve ./examples/cmdapp --port=8080
 
 - No namespace tags.
 - No full multi-module monorepo story.
-- No router/layout convention.
+- No file-based router or framework-level layout convention. The hash router
+  uses ordinary Go route declarations and stable shell composition.
 - External module dependencies in app packages are not deeply exercised yet.
   The current path is focused on packages below the app root plus the GoFrame
   runtime dependency.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document records the measurable baseline after MVP 23. It is a decision
+This document records the measurable baseline after MVP 24. It is a decision
 aid for future runtime and tooling work, not a claim that GoFrame is
 production-ready.
 
@@ -17,8 +17,8 @@ The baseline covers:
 - Go, race, vet, debug-tag, and GOX golden tests;
 - TinyGo raw, gzip, brotli, and zstd size budgets;
 - browser smoke behavior for Todo, duplicate keys, dashboard, context,
-  virtualized collections, the multi-package example, and the child-entry
-  example;
+  virtualized collections, the multi-package example, the child-entry example,
+  and the hash-router example;
 - dashboard DOM pressure and listener stability;
 - pure runtime benchmark reports;
 - package, export, artifact, and module path safety gates.
@@ -68,8 +68,8 @@ CDP node drift as an investigation signal, not a failure by itself.
 
 ## Current Baseline
 
-Recorded during the runtime error semantics pass from local `main` after the
-public surface polish baseline.
+Recorded during the hash router pass from local `main` after the runtime error
+semantics baseline.
 
 Tool versions:
 
@@ -96,6 +96,7 @@ Baseline checks passed before documentation changes:
 - `go test ./examples/virtualized`
 - `go test ./examples/multipackage`
 - `go test ./examples/cmdapp`
+- `go test ./examples/router`
 - `scripts/check.sh`
 - `scripts/size-budget.sh`
 - `scripts/perf-report.sh`
@@ -118,6 +119,7 @@ TinyGo packaged WASM sizes:
 | virtualized | 122478 | 47194 | 38732 | 41904 |
 | multipackage | 90515 | 35840 | 29836 | 32293 |
 | cmdapp | 90574 | 35864 | 29811 | 32307 |
+| router | 106671 | 41830 | 34422 | 37389 |
 
 The authoritative gate remains `scripts/size-budget.sh`. This table is a
 snapshot, not a second budget file.
@@ -138,6 +140,9 @@ snapshot, not a second budget file.
   readable debug names, and a simple state interaction.
 - Child-entry package loading from `cmd/app`, internal package component
   rendering, readable debug names, and a simple state interaction.
+- Hash-router initial route, hash links, route params, programmatic
+  navigation, browser back handling, not-found rendering, and stable shell
+  layout.
 
 Hard browser gates focus on correctness and structural invariants. Timing
 printed by smoke scripts is useful for trend spotting, but it is not a stable

--- a/docs/router.md
+++ b/docs/router.md
@@ -1,0 +1,206 @@
+# Client Router
+
+## Purpose
+
+MVP 24 adds a small client-side router for browser/WASM applications. It is a
+hash-based router designed for static hosting, Go-first route declarations, and
+stable layout composition.
+
+This is not a full application framework. There is no file-based routing,
+server routing, route loader system, async resource model, Suspense-like
+behavior, middleware, auth guard, or route-level error boundary API.
+
+## Scope
+
+The router supports:
+
+- hash-based navigation;
+- static and parameterized route patterns;
+- route params;
+- a not-found route;
+- `RouterView`;
+- `RouterLink`;
+- programmatic `Navigate`;
+- browser back/forward through hash changes;
+- a stable shell layout pattern.
+
+The router intentionally does not support:
+
+- path/history mode;
+- server fallback automation;
+- query-state management;
+- route loaders or data fetching;
+- nested route/layout DSL;
+- scroll restoration;
+- code splitting;
+- file-system route discovery.
+
+## Hash Routing
+
+Hash routing is the default and only router mode in MVP 24. It works on static
+hosting because the browser requests `index.html` once, and route changes happen
+inside the URL fragment:
+
+```text
+#/
+#/issues
+#/issues/42
+```
+
+The empty hash, `#`, and `#/` normalize to `/`.
+
+`gf.HashHref("/issues")` returns `#/issues`. `gf.Navigate("/issues")` updates
+`window.location.hash` in browser builds.
+
+Path/history mode remains future work. It would require server or CDN fallback
+to `index.html`, which GoFrame does not configure in this MVP.
+
+## Route Matching
+
+Routes are declared in Go:
+
+```go
+var router = gf.NewHashRouter([]gf.Route{
+    gf.RoutePath("/", homeRoute),
+    gf.RoutePath("/issues", issuesRoute),
+    gf.RoutePath("/issues/:id", issueDetailsRoute),
+    gf.NotFoundRoute(notFoundRoute),
+})
+```
+
+Supported patterns:
+
+```text
+/
+/issues
+/issues/:id
+/projects/:projectID/issues/:issueID
+```
+
+Matching is deterministic and declaration-order based. The first route that
+matches wins.
+
+Supported semantics:
+
+- static path segments match exactly;
+- `:param` matches one non-empty segment;
+- trailing slash is normalized away except for `/`;
+- query text after `?` is stored as raw query text;
+- wildcard, optional, regex, and splat params are not supported.
+
+## Params
+
+Route handlers receive a `RouteContext`:
+
+```go
+func issueDetailsRoute(ctx gf.RouteContext) gf.Node {
+    return pages.IssueDetails(pages.IssueDetailsProps{
+        ID: ctx.Param("id"),
+    })
+}
+```
+
+`RouteContext.Param(name)` returns the matching route param or an empty string.
+`RouteContext.RawQuery` contains the query text after `?` without parsing it
+into a map.
+
+## RouterView
+
+`gf.RouterView(router)` is a component boundary that:
+
+- reads the current hash path on first render;
+- subscribes to browser `hashchange`;
+- updates internal state when the hash changes;
+- matches the current route;
+- renders the matched route handler;
+- cleans up its browser listener when unmounted.
+
+If no route matches and no `NotFoundRoute` exists, `RouterView` renders
+`gf.Empty()`.
+
+Route content is keyed by matched route pattern. Moving between different
+patterns remounts the route subtree. Moving between the same pattern with
+different params updates `RouteContext` and may preserve route-local state.
+Applications that want a per-param reset can add their own keyed component
+inside the route handler.
+
+## RouterLink
+
+`gf.RouterLink` renders a normal hash link:
+
+```go
+gf.RouterLink(gf.RouterLinkProps{
+    To: "/issues",
+    Children: []gf.Node{gf.Text("Issues")},
+})
+```
+
+The output is an anchor with `href="#/issues"`. MVP 24 does not intercept
+clicks, compute active link classes, or manage focus/scroll restoration.
+
+## Layout Composition
+
+The MVP layout model is a Go-first composition pattern:
+
+```go
+func App() gf.Node {
+    return layout.Shell(layout.ShellProps{
+        Children: []gf.Node{
+            gf.RouterView(router),
+        },
+    })
+}
+```
+
+The shell is an ordinary component that stays mounted while `RouterView`
+changes the route content inside it. This gives applications a stable layout
+without a nested route DSL.
+
+## Browser Back/Forward
+
+Browser back and forward work through the native hash history stack. Since
+`RouterView` listens for `hashchange`, user navigation, `RouterLink`, and
+`gf.Navigate` all converge on the same update path.
+
+## Error Semantics
+
+Route handlers run as render work. If a route handler panics, MVP 23 runtime
+error containment reports it as a render error and uses the normal render
+fallback behavior.
+
+The router does not provide route-level error elements or error pages in MVP
+24. A full Error Boundary API remains future work.
+
+## Deployment Notes
+
+Hash routing works with static package output because the server always serves
+`index.html` for the initial request. The route lives after `#`, so it is not
+sent as a separate server path.
+
+Path/history mode would require server or CDN fallback rules. `goxc serve` is
+development-only and does not implement a production fallback policy.
+
+## Limitations
+
+- Hash routing only.
+- No file-based routes.
+- No namespace tags or GOX syntax changes.
+- No route loaders or async resources.
+- No route-level ErrorBoundary API.
+- No middleware or auth guards.
+- No scroll restoration.
+- No active link helper.
+- No query parsing beyond raw query text.
+- No route ranking beyond declaration order.
+
+## Future Work
+
+Potential future router work should be separate from this MVP:
+
+- path/history mode with documented deployment fallback;
+- route-level error UI after Error Boundaries exist;
+- loader/resource integration;
+- nested route layout DSL if Go-first composition proves insufficient;
+- active link helpers;
+- scroll restoration;
+- route-aware code splitting.

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -5,7 +5,7 @@
 GoFrame is still experimental, but applications are now large enough that user
 panics need clear runtime semantics. MVP 23 defines how the runtime reports and
 contains common user-code failures without adding a full Error Boundary,
-Suspense, router, or async resource model.
+Suspense, route-level error boundary, or async resource model.
 
 ## Current Problem
 

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -252,6 +252,30 @@ The current virtualized model assumes fixed item or row height. Dynamic
 measurement, infinite loading, keyboard navigation, and richer table
 accessibility are future work. See [virtualized collections](virtualization.md).
 
+## Client routing
+
+MVP 24 adds a small hash-based client router for browser/WASM apps. Routes are
+declared in Go and matched by normalized hash path:
+
+```go
+var router = gf.NewHashRouter([]gf.Route{
+	gf.RoutePath("/", homeRoute),
+	gf.RoutePath("/issues/:id", issueRoute),
+	gf.NotFoundRoute(notFoundRoute),
+})
+```
+
+`gf.RouterView(router)` is a component boundary. It reads the current hash,
+subscribes to `hashchange`, and renders the matched route handler. The route
+subtree is keyed by route pattern. Navigating between different patterns
+remounts the route subtree; navigating between the same pattern with different
+params updates the route context and may preserve route-local state.
+
+The recommended layout model is a stable shell component with `RouterView` as
+an outlet. There is no nested route DSL, file-based routing, path/history-mode
+server fallback, route loader system, or route-level Error Boundary API in this
+MVP. See [client router](router.md).
+
 ## DOM stability regression
 
 DOM node replacement, component render, patch traversal, DOM mutation, and
@@ -403,6 +427,8 @@ The dependency-free headless Chrome probe verifies:
   custom non-comparable selector equality;
 - virtualized collections are fixed-height only and do not include dynamic
   measurement, infinite loading, or keyboard navigation;
+- hash routing only; no path/history-mode server fallback, file-based routing,
+  route loaders, or nested route layout DSL;
 - no error boundaries;
 - GOX-generated component identity uses a typed token derived from package
   import path when `goxc` knows it, with package-name fallback for lower-level

--- a/examples/router/README.md
+++ b/examples/router/README.md
@@ -1,0 +1,41 @@
+# Router Example
+
+This example demonstrates the MVP 24 hash router with a Go-first child entry
+package layout.
+
+It shows:
+
+- `"entry": "./cmd/app"`;
+- a stable shell layout;
+- `gf.NewHashRouter`;
+- `gf.RouterView`;
+- `gf.RouterLink`;
+- route params;
+- a not-found route;
+- programmatic navigation with `gf.Navigate`.
+
+## Run
+
+```bash
+goxc package ./examples/router --compiler=tinygo
+goxc serve ./examples/router --port=8080
+```
+
+Open <http://127.0.0.1:8080>.
+
+Try:
+
+- `#/`
+- `#/issues`
+- `#/issues/1`
+- `#/missing`
+
+## Notes
+
+MVP 24 routing is hash-based. It works on static hosting because route changes
+stay after `#` and do not require a server rewrite rule.
+
+There is no file-based routing, route loader system, route-level error
+boundary, or history-mode server fallback in this MVP. Layout composition is
+the Go-first pattern used here: a stable shell plus `gf.RouterView(router)` as
+the outlet.

--- a/examples/router/cmd/app/app.gox
+++ b/examples/router/cmd/app/app.gox
@@ -1,0 +1,56 @@
+package main
+
+import (
+	layout "github.com/graybuton/goframe/examples/router/internal/layout"
+	pages "github.com/graybuton/goframe/examples/router/internal/pages"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var router = gf.NewHashRouter([]gf.Route{
+	gf.RoutePath("/", homeRoute),
+	gf.RoutePath("/issues", issuesRoute),
+	gf.RoutePath("/issues/:id", issueDetailsRoute),
+	gf.NotFoundRoute(notFoundRoute),
+})
+
+func App() gf.Node {
+	return (
+		<main class="router-app">
+			{layout.Shell(shellProps())}
+		</main>
+	)
+}
+
+func homeRoute(gf.RouteContext) gf.Node {
+	return pages.Home(pages.HomeProps{})
+}
+
+func issuesRoute(gf.RouteContext) gf.Node {
+	return pages.Issues(pages.IssuesProps{
+		Items: pages.DemoIssues(),
+	})
+}
+
+func issueDetailsRoute(ctx gf.RouteContext) gf.Node {
+	return pages.IssueDetails(pages.IssueDetailsProps{
+		ID:       ctx.Param("id"),
+		RawQuery: ctx.RawQuery,
+	})
+}
+
+func notFoundRoute(ctx gf.RouteContext) gf.Node {
+	return pages.NotFound(pages.NotFoundProps{
+		Path: ctx.Path,
+	})
+}
+
+func shellProps() layout.ShellProps {
+	return layout.ShellProps{
+		OnOpenFirstIssue: func() {
+			gf.Navigate("/issues/2")
+		},
+		Children: []gf.Node{
+			gf.RouterView(router),
+		},
+	}
+}

--- a/examples/router/cmd/app/main.go
+++ b/examples/router/cmd/app/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/router/doc.go
+++ b/examples/router/doc.go
@@ -1,0 +1,2 @@
+// Package router documents the hash-router example.
+package router

--- a/examples/router/goframe.json
+++ b/examples/router/goframe.json
@@ -1,0 +1,11 @@
+{
+  "name": "router",
+  "entry": "./cmd/app",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css"
+  ]
+}

--- a/examples/router/index.html
+++ b/examples/router/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>goframe router</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <script>
+        window.goframeComponentRenderCounts = {};
+        window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
+        window.goframeComponentRenderProbe = (name) => {
+            window.goframeComponentRenderCounts[name] =
+                (window.goframeComponentRenderCounts[name] || 0) + 1;
+        };
+        window.goframeComponentPatchProbe = (name) => {
+            window.goframeComponentPatchCounts[name] =
+                (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
+        };
+    </script>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance))
+            .catch((error) => {
+                console.error("[goframe] startup failed", error);
+                document.getElementById("root").textContent = "Failed to start goframe. See console.";
+            });
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/examples/router/internal/layout/model.go
+++ b/examples/router/internal/layout/model.go
@@ -1,0 +1,8 @@
+package layout
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type ShellProps struct {
+	OnOpenFirstIssue func()
+	Children         []gf.Node
+}

--- a/examples/router/internal/layout/shell.gox
+++ b/examples/router/internal/layout/shell.gox
@@ -1,0 +1,36 @@
+package layout
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Shell(props ShellProps) gf.Node {
+	return (
+		<section class="router-shell" data-testid="router-shell">
+			<header class="router-header">
+				<div>
+					<h1>GoFrame Router</h1>
+					<p class="muted">Hash routing with a stable Go-first shell layout.</p>
+				</div>
+				<nav class="router-nav" aria-label="Primary navigation">
+					{gf.RouterLink(gf.RouterLinkProps{
+						To: "/",
+						Class: "router-link",
+						TestID: "router-link-home",
+						Children: []gf.Node{gf.Text("Home")},
+					})}
+					{gf.RouterLink(gf.RouterLinkProps{
+						To: "/issues",
+						Class: "router-link",
+						TestID: "router-link-issues",
+						Children: []gf.Node{gf.Text("Issues")},
+					})}
+					<button data-testid="router-programmatic-nav" onClick={props.OnOpenFirstIssue}>
+						Open issue 2
+					</button>
+				</nav>
+			</header>
+			<div class="router-content" data-testid="router-outlet">
+				{props.Children}
+			</div>
+		</section>
+	)
+}

--- a/examples/router/internal/pages/home.gox
+++ b/examples/router/internal/pages/home.gox
@@ -1,0 +1,23 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Home(props HomeProps) gf.Node {
+	return (
+		<section class="router-card" data-testid="router-home">
+			<h2>Home</h2>
+			<p>
+				This page is rendered by the root <code>/</code> route.
+				The shell around it stays mounted while route content changes.
+			</p>
+			<p>
+				{gf.RouterLink(gf.RouterLinkProps{
+					To: "/issues",
+					Class: "router-link",
+					TestID: "router-home-issues-link",
+					Children: []gf.Node{gf.Text("Browse issues")},
+				})}
+			</p>
+		</section>
+	)
+}

--- a/examples/router/internal/pages/issue_details.gox
+++ b/examples/router/internal/pages/issue_details.gox
@@ -1,0 +1,18 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func IssueDetails(props IssueDetailsProps) gf.Node {
+	return (
+		<section class="router-card" data-testid="router-issue-details">
+			<h2>Issue details</h2>
+			<p>
+				Selected issue:
+				<strong data-testid="router-issue-id">{props.ID}</strong>
+			</p>
+			<p class="muted" data-testid="router-raw-query">
+				Raw query: {props.RawQuery}
+			</p>
+		</section>
+	)
+}

--- a/examples/router/internal/pages/issues.gox
+++ b/examples/router/internal/pages/issues.gox
@@ -1,0 +1,31 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Issues(props IssuesProps) gf.Node {
+	return (
+		<section class="router-card" data-testid="router-issues">
+			<h2>Issues</h2>
+			<p class="muted">Each issue link uses a route param.</p>
+			<ul class="issue-list">
+				{gf.Map(props.Items, func(issue Issue) gf.Node {
+					return <IssueLink Key={issue.ID} Item={issue} />
+				})}
+			</ul>
+		</section>
+	)
+}
+
+func IssueLink(props IssueLinkProps) gf.Node {
+	return (
+		<li data-testid="router-issue-item">
+			<span>{props.Item.Title}</span>
+			{gf.RouterLink(gf.RouterLinkProps{
+				To: props.Item.Path(),
+				Class: "router-link",
+				TestID: props.Item.TestID(),
+				Children: linkChildren("Open " + props.Item.ID),
+			})}
+		</li>
+	)
+}

--- a/examples/router/internal/pages/model.go
+++ b/examples/router/internal/pages/model.go
@@ -1,0 +1,51 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type HomeProps struct{}
+
+type IssuesProps struct {
+	Items []Issue
+}
+
+type IssueDetailsProps struct {
+	ID       string
+	RawQuery string
+}
+
+type NotFoundProps struct {
+	Path string
+}
+
+type IssueLinkProps struct {
+	Item Issue
+}
+
+type Issue struct {
+	ID    string
+	Title string
+	Owner string
+}
+
+func DemoIssues() []Issue {
+	return []Issue{
+		{ID: "1", Title: "Document hash router semantics", Owner: "Runtime"},
+		{ID: "2", Title: "Verify browser back and forward", Owner: "Smoke"},
+		{ID: "3", Title: "Keep layout mounted across routes", Owner: "DX"},
+	}
+}
+
+func (issue Issue) Path() string {
+	return "/issues/" + issue.ID
+}
+
+func (issue Issue) TestID() string {
+	if issue.ID == "1" {
+		return "router-link-first-issue"
+	}
+	return "router-link-issue-" + issue.ID
+}
+
+func linkChildren(text string) []gf.Node {
+	return []gf.Node{gf.Text(text)}
+}

--- a/examples/router/internal/pages/not_found.gox
+++ b/examples/router/internal/pages/not_found.gox
@@ -1,0 +1,21 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func NotFound(props NotFoundProps) gf.Node {
+	return (
+		<section class="router-card" data-testid="router-not-found">
+			<h2>Not found</h2>
+			<p>
+				No route matched
+				<code data-testid="router-not-found-path">{props.Path}</code>.
+			</p>
+			{gf.RouterLink(gf.RouterLinkProps{
+				To: "/",
+				Class: "router-link",
+				TestID: "router-not-found-home",
+				Children: []gf.Node{gf.Text("Back home")},
+			})}
+		</section>
+	)
+}

--- a/examples/router/styles.css
+++ b/examples/router/styles.css
@@ -1,0 +1,100 @@
+:root {
+    color-scheme: light;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #f5f7fb;
+    color: #182033;
+}
+
+a {
+    color: #2857d4;
+}
+
+button {
+    font: inherit;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.65rem 1rem;
+    background: #2857d4;
+    color: white;
+    cursor: pointer;
+}
+
+.router-shell {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 32px;
+}
+
+.router-header,
+.router-content,
+.router-card {
+    border: 1px solid #dfe6f3;
+    border-radius: 18px;
+    background: white;
+    box-shadow: 0 16px 40px rgba(27, 39, 71, 0.08);
+}
+
+.router-header {
+    display: grid;
+    gap: 16px;
+    margin-bottom: 18px;
+    padding: 20px;
+}
+
+.router-header h1 {
+    margin: 0;
+}
+
+.router-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.router-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 38px;
+    border-radius: 999px;
+    padding: 0 0.9rem;
+    background: #eef3ff;
+    text-decoration: none;
+}
+
+.router-content {
+    padding: 22px;
+}
+
+.router-card {
+    padding: 18px;
+}
+
+.router-card h2 {
+    margin-top: 0;
+}
+
+.issue-list {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.issue-list li {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px;
+    border-radius: 12px;
+    background: #f8faff;
+}
+
+.muted {
+    color: #5c6980;
+}

--- a/pkg/goframe/router.go
+++ b/pkg/goframe/router.go
@@ -1,0 +1,290 @@
+package goframe
+
+import "strings"
+
+// RouteContext describes the currently matched route.
+type RouteContext struct {
+	Path     string
+	Pattern  string
+	Params   map[string]string
+	RawQuery string
+}
+
+// Param returns a route parameter by name, or an empty string when absent.
+func (ctx RouteContext) Param(name string) string {
+	if ctx.Params == nil {
+		return ""
+	}
+	return ctx.Params[name]
+}
+
+// RouteHandler renders one matched route.
+type RouteHandler func(RouteContext) Node
+
+// Route describes one router entry.
+type Route struct {
+	pattern  string
+	segments []routeSegment
+	handler  RouteHandler
+	notFound bool
+}
+
+type routeSegment struct {
+	literal string
+	param   string
+}
+
+// RoutePath creates an exact or parameterized route.
+func RoutePath(pattern string, handler RouteHandler) Route {
+	if handler == nil {
+		panic("goframe: RoutePath requires a handler")
+	}
+	pattern = normalizeRoutePattern(pattern)
+	return Route{
+		pattern:  pattern,
+		segments: parseRoutePattern(pattern),
+		handler:  handler,
+	}
+}
+
+// NotFoundRoute creates a fallback route for unmatched paths.
+func NotFoundRoute(handler RouteHandler) Route {
+	if handler == nil {
+		panic("goframe: NotFoundRoute requires a handler")
+	}
+	return Route{
+		handler:  handler,
+		notFound: true,
+	}
+}
+
+// Router stores a route table.
+type Router struct {
+	routes []Route
+}
+
+// NewHashRouter creates a hash-based browser router.
+func NewHashRouter(routes []Route) *Router {
+	copied := make([]Route, len(routes))
+	copy(copied, routes)
+	return &Router{routes: copied}
+}
+
+// RouterLinkProps configures a hash router anchor.
+type RouterLinkProps struct {
+	To       string
+	Children []Node
+	Class    string
+	TestID   string
+}
+
+var (
+	routerViewComponentType  = NewComponentType("goframe.RouterView", "RouterView")
+	routerRouteComponentType = NewComponentType("goframe.RouterRoute", "RouterRoute")
+)
+
+// RouterLink renders an anchor using hash router href semantics.
+func RouterLink(props RouterLinkProps) Node {
+	linkProps := Props{
+		"href": HashHref(props.To),
+	}
+	if props.Class != "" {
+		linkProps["class"] = props.Class
+	}
+	if props.TestID != "" {
+		linkProps["data-testid"] = props.TestID
+	}
+	return El("a", linkProps, props.Children...)
+}
+
+// RouterView renders the current route for a hash router.
+func RouterView(router *Router) Node {
+	return ComponentT(routerViewComponentType, routerViewProps{router: router}, renderRouterView)
+}
+
+type routerViewProps struct {
+	router *Router
+}
+
+type routerRouteProps struct {
+	handler RouteHandler
+	context RouteContext
+}
+
+func renderRouterView(props routerViewProps) Node {
+	if props.router == nil {
+		panic("goframe: RouterView requires router")
+	}
+	current, setCurrent := UseState(routerCurrentTarget())
+	UseEffect(func() Cleanup {
+		return routerSubscribeHashChange(func(next string) {
+			setCurrent(next)
+		})
+	})
+
+	match, ok := matchRouterTarget(props.router.routes, current)
+	if !ok {
+		return Empty()
+	}
+	return Key(match.key, ComponentT(routerRouteComponentType, routerRouteProps{
+		handler: match.handler,
+		context: match.context,
+	}, renderRouterRoute))
+}
+
+func renderRouterRoute(props routerRouteProps) Node {
+	return props.handler(props.context)
+}
+
+type routeMatch struct {
+	key     string
+	handler RouteHandler
+	context RouteContext
+}
+
+func matchRouterTarget(routes []Route, target string) (routeMatch, bool) {
+	path, rawQuery := splitRouteTarget(normalizeRouteTarget(target))
+	var fallback *Route
+	for index := range routes {
+		route := &routes[index]
+		if route.notFound {
+			if fallback == nil {
+				fallback = route
+			}
+			continue
+		}
+		params, ok := matchRouteSegments(route.segments, path)
+		if !ok {
+			continue
+		}
+		return routeMatch{
+			key:     "route:" + route.pattern,
+			handler: route.handler,
+			context: RouteContext{
+				Path:     path,
+				Pattern:  route.pattern,
+				Params:   params,
+				RawQuery: rawQuery,
+			},
+		}, true
+	}
+	if fallback == nil {
+		return routeMatch{}, false
+	}
+	return routeMatch{
+		key:     "route:not-found",
+		handler: fallback.handler,
+		context: RouteContext{
+			Path:     path,
+			RawQuery: rawQuery,
+		},
+	}, true
+}
+
+// HashHref converts a route path to a hash href.
+func HashHref(to string) string {
+	return "#" + normalizeRouteTarget(to)
+}
+
+func normalizeRoutePattern(pattern string) string {
+	if pattern == "" {
+		panic("goframe: route pattern must not be empty")
+	}
+	pattern, _ = splitRouteTarget(normalizeRouteTarget(pattern))
+	return pattern
+}
+
+func parseRoutePattern(pattern string) []routeSegment {
+	parts := routeParts(pattern)
+	segments := make([]routeSegment, len(parts))
+	for index, part := range parts {
+		if strings.HasPrefix(part, ":") {
+			name := part[1:]
+			if name == "" {
+				panic("goframe: route parameter name must not be empty")
+			}
+			segments[index] = routeSegment{param: name}
+			continue
+		}
+		segments[index] = routeSegment{literal: part}
+	}
+	return segments
+}
+
+func matchRouteSegments(pattern []routeSegment, path string) (map[string]string, bool) {
+	parts := routeParts(path)
+	if len(pattern) != len(parts) {
+		return nil, false
+	}
+	var params map[string]string
+	for index, segment := range pattern {
+		part := parts[index]
+		if segment.param != "" {
+			if part == "" {
+				return nil, false
+			}
+			if params == nil {
+				params = make(map[string]string)
+			}
+			params[segment.param] = part
+			continue
+		}
+		if segment.literal != part {
+			return nil, false
+		}
+	}
+	if params == nil {
+		params = map[string]string{}
+	}
+	return params, true
+}
+
+func normalizeRouteTarget(target string) string {
+	if target == "" || target == "#" {
+		return "/"
+	}
+	if strings.HasPrefix(target, "#") {
+		target = target[1:]
+	}
+	if target == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(target, "/") {
+		target = "/" + target
+	}
+	path, rawQuery := splitRouteTarget(target)
+	path = trimTrailingRouteSlash(path)
+	if rawQuery != "" {
+		return path + "?" + rawQuery
+	}
+	return path
+}
+
+func splitRouteTarget(target string) (path string, rawQuery string) {
+	if target == "" {
+		return "/", ""
+	}
+	index := strings.IndexByte(target, '?')
+	if index < 0 {
+		return target, ""
+	}
+	return target[:index], target[index+1:]
+}
+
+func trimTrailingRouteSlash(path string) string {
+	for len(path) > 1 && strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func routeParts(path string) []string {
+	path = trimTrailingRouteSlash(path)
+	if path == "/" {
+		return nil
+	}
+	return strings.Split(strings.TrimPrefix(path, "/"), "/")
+}

--- a/pkg/goframe/router_js.go
+++ b/pkg/goframe/router_js.go
@@ -1,0 +1,43 @@
+//go:build js && wasm
+
+package goframe
+
+import "syscall/js"
+
+func routerCurrentTarget() string {
+	location := js.Global().Get("location")
+	if location.IsUndefined() || location.IsNull() {
+		return "/"
+	}
+	return normalizeRouteTarget(location.Get("hash").String())
+}
+
+func routerSubscribeHashChange(callback func(string)) Cleanup {
+	var listener js.Func
+	listener = js.FuncOf(func(this js.Value, args []js.Value) any {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				reportRecoveredRuntimeError(ErrorInfo{
+					Phase:     ErrorPhaseEvent,
+					Operation: "hashchange",
+				}, recovered)
+			}
+		}()
+		callback(routerCurrentTarget())
+		return nil
+	})
+	js.Global().Call("addEventListener", "hashchange", listener)
+	return func() {
+		js.Global().Call("removeEventListener", "hashchange", listener)
+		listener.Release()
+	}
+}
+
+// Navigate changes the browser hash route.
+func Navigate(to string) {
+	location := js.Global().Get("location")
+	if location.IsUndefined() || location.IsNull() {
+		return
+	}
+	location.Set("hash", HashHref(to))
+}

--- a/pkg/goframe/router_nonjs.go
+++ b/pkg/goframe/router_nonjs.go
@@ -1,0 +1,14 @@
+//go:build !js || !wasm
+
+package goframe
+
+func routerCurrentTarget() string {
+	return "/"
+}
+
+func routerSubscribeHashChange(func(string)) Cleanup {
+	return nil
+}
+
+// Navigate is a no-op outside browser/WASM builds.
+func Navigate(string) {}

--- a/pkg/goframe/router_test.go
+++ b/pkg/goframe/router_test.go
@@ -1,0 +1,199 @@
+package goframe
+
+import "testing"
+
+func TestNormalizeRouteTarget(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "", want: "/"},
+		{input: "#", want: "/"},
+		{input: "#/", want: "/"},
+		{input: "#/issues", want: "/issues"},
+		{input: "/issues/", want: "/issues"},
+		{input: "issues/42", want: "/issues/42"},
+		{input: "#/issues/42?tab=comments", want: "/issues/42?tab=comments"},
+	}
+	for _, test := range tests {
+		if got := normalizeRouteTarget(test.input); got != test.want {
+			t.Fatalf("normalizeRouteTarget(%q) = %q, want %q", test.input, got, test.want)
+		}
+	}
+}
+
+func TestRouteMatchingStaticPath(t *testing.T) {
+	match, ok := matchRouterTarget([]Route{
+		RoutePath("/", routeTestNode("home")),
+		RoutePath("/issues", routeTestNode("issues")),
+	}, "#/issues")
+
+	if !ok {
+		t.Fatal("expected route match")
+	}
+	if match.context.Path != "/issues" || match.context.Pattern != "/issues" {
+		t.Fatalf("context = %#v", match.context)
+	}
+	if got := match.handler(match.context).(TextNode).Value; got != "issues" {
+		t.Fatalf("handler text = %q, want issues", got)
+	}
+}
+
+func TestRouteMatchingParams(t *testing.T) {
+	match, ok := matchRouterTarget([]Route{
+		RoutePath("/projects/:projectID/issues/:issueID", routeTestNode("details")),
+	}, "#/projects/p1/issues/42?tab=comments")
+
+	if !ok {
+		t.Fatal("expected route match")
+	}
+	if got := match.context.Param("projectID"); got != "p1" {
+		t.Fatalf("projectID = %q, want p1", got)
+	}
+	if got := match.context.Param("issueID"); got != "42" {
+		t.Fatalf("issueID = %q, want 42", got)
+	}
+	if got := match.context.Param("missing"); got != "" {
+		t.Fatalf("missing param = %q, want empty", got)
+	}
+	if match.context.RawQuery != "tab=comments" {
+		t.Fatalf("raw query = %q, want tab=comments", match.context.RawQuery)
+	}
+}
+
+func TestRouteMatchingDeclarationOrderWins(t *testing.T) {
+	match, ok := matchRouterTarget([]Route{
+		RoutePath("/issues/new", routeTestNode("new")),
+		RoutePath("/issues/:id", routeTestNode("details")),
+	}, "/issues/new")
+
+	if !ok {
+		t.Fatal("expected route match")
+	}
+	if got := match.handler(match.context).(TextNode).Value; got != "new" {
+		t.Fatalf("matched handler = %q, want new", got)
+	}
+}
+
+func TestNotFoundRouteHandlesUnmatchedPath(t *testing.T) {
+	match, ok := matchRouterTarget([]Route{
+		RoutePath("/", routeTestNode("home")),
+		NotFoundRoute(routeTestNode("missing")),
+	}, "#/missing")
+
+	if !ok {
+		t.Fatal("expected not-found match")
+	}
+	if match.context.Path != "/missing" || match.context.Pattern != "" {
+		t.Fatalf("not-found context = %#v", match.context)
+	}
+	if got := match.handler(match.context).(TextNode).Value; got != "missing" {
+		t.Fatalf("not-found handler = %q, want missing", got)
+	}
+}
+
+func TestNoMatchWithoutNotFoundReturnsFalse(t *testing.T) {
+	if _, ok := matchRouterTarget([]Route{
+		RoutePath("/", routeTestNode("home")),
+	}, "/missing"); ok {
+		t.Fatal("unexpected route match")
+	}
+}
+
+func TestHashHref(t *testing.T) {
+	tests := []struct {
+		to   string
+		want string
+	}{
+		{to: "", want: "#/"},
+		{to: "/", want: "#/"},
+		{to: "/issues", want: "#/issues"},
+		{to: "issues/42", want: "#/issues/42"},
+		{to: "#/issues/42/", want: "#/issues/42"},
+		{to: "/issues/42?tab=comments", want: "#/issues/42?tab=comments"},
+	}
+	for _, test := range tests {
+		if got := HashHref(test.to); got != test.want {
+			t.Fatalf("HashHref(%q) = %q, want %q", test.to, got, test.want)
+		}
+	}
+}
+
+func TestRoutePathValidation(t *testing.T) {
+	assertPanic(t, "goframe: RoutePath requires a handler", func() {
+		RoutePath("/", nil)
+	})
+	assertPanic(t, "goframe: route pattern must not be empty", func() {
+		RoutePath("", routeTestNode("empty"))
+	})
+	assertPanic(t, "goframe: route parameter name must not be empty", func() {
+		RoutePath("/:id/:", routeTestNode("bad"))
+	})
+}
+
+func TestNotFoundRouteValidation(t *testing.T) {
+	assertPanic(t, "goframe: NotFoundRoute requires a handler", func() {
+		NotFoundRoute(nil)
+	})
+}
+
+func TestRouterLinkRendersHashAnchor(t *testing.T) {
+	node := RouterLink(RouterLinkProps{
+		To:       "/issues",
+		Class:    "nav-link",
+		TestID:   "issues-link",
+		Children: []Node{Text("Issues")},
+	}).(VNode)
+
+	if node.Tag != "a" {
+		t.Fatalf("tag = %q, want a", node.Tag)
+	}
+	if node.Props["href"] != "#/issues" || node.Props["class"] != "nav-link" || node.Props["data-testid"] != "issues-link" {
+		t.Fatalf("props = %#v", node.Props)
+	}
+	if got := node.Children[0].(TextNode).Value; got != "Issues" {
+		t.Fatalf("child = %q, want Issues", got)
+	}
+}
+
+func TestRouterViewCreatesRouteBoundaryKeyedByPattern(t *testing.T) {
+	router := NewHashRouter([]Route{
+		RoutePath("/", routeTestNode("home")),
+	})
+	node := RouterView(router).(ComponentNode)
+	if node.Name != "RouterView" {
+		t.Fatalf("RouterView component name = %q", node.Name)
+	}
+
+	instance := newComponentInstance(node, "", nil, nil)
+	rendered := renderComponentInstance(instance)
+	keyed := requireKeyedNode(t, rendered)
+	if keyed.Key != "route:/" {
+		t.Fatalf("route key = %q, want route:/", keyed.Key)
+	}
+	routeNode := requireComponentNode(t, keyed.Node)
+	if routeNode.Name != "RouterRoute" {
+		t.Fatalf("route component = %q, want RouterRoute", routeNode.Name)
+	}
+}
+
+func TestRouteContextParamHandlesNilParams(t *testing.T) {
+	if got := (RouteContext{}).Param("id"); got != "" {
+		t.Fatalf("nil params Param = %q, want empty", got)
+	}
+}
+
+func routeTestNode(label string) RouteHandler {
+	return func(RouteContext) Node {
+		return Text(label)
+	}
+}
+
+func requireComponentNode(t *testing.T, node Node) ComponentNode {
+	t.Helper()
+	component, ok := node.(ComponentNode)
+	if !ok {
+		t.Fatalf("node = %#v, want ComponentNode", node)
+	}
+	return component
+}

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -14,6 +14,7 @@ CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
 VIRTUALIZED_SMOKE_URL_BASE="${GOFRAME_VIRTUALIZED_SMOKE_URL:-http://127.0.0.1}"
 MULTIPACKAGE_SMOKE_URL_BASE="${GOFRAME_MULTIPACKAGE_SMOKE_URL:-http://127.0.0.1}"
 CMDAPP_SMOKE_URL_BASE="${GOFRAME_CMDAPP_SMOKE_URL:-http://127.0.0.1}"
+ROUTER_SMOKE_URL_BASE="${GOFRAME_ROUTER_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -118,6 +119,11 @@ build_multipackage_smoke_url() {
 build_cmdapp_smoke_url() {
 	local port="$1"
 	echo "${CMDAPP_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_router_smoke_url() {
+	local port="$1"
+	echo "${ROUTER_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -304,6 +310,21 @@ run_with_server ./examples/cmdapp "$CMDAPP_PORT" "$CMDAPP_URL" \
 	node --experimental-websocket scripts/cmdapp-browser-smoke.mjs
 
 echo
+echo "== Router debug browser smoke =="
+"$GOXC" package ./examples/router --compiler=tinygo
+(
+	cd ./examples/router/.goframe/work/dev/examples/router/cmd/app
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/router/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+ROUTER_PORT="$(resolve_port "${GOFRAME_ROUTER_SMOKE_PORT:-}")"
+export GOFRAME_ROUTER_CHROME_DEBUG_PORT="${GOFRAME_ROUTER_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+ROUTER_URL="$(build_router_smoke_url "$ROUTER_PORT")"
+run_with_server ./examples/router "$ROUTER_PORT" "$ROUTER_URL" \
+	node --experimental-websocket scripts/router-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
@@ -311,5 +332,6 @@ echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/virtualized --compiler=tinygo
 "$GOXC" package ./examples/multipackage --compiler=tinygo
 "$GOXC" package ./examples/cmdapp --compiler=tinygo
+"$GOXC" package ./examples/router --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -61,6 +61,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/multipackage --compiler=tinygo
 "$GOXC" generate ./examples/cmdapp
 "$GOXC" package ./examples/cmdapp --compiler=tinygo
+"$GOXC" generate ./examples/router
+"$GOXC" package ./examples/router --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/router-browser-smoke.mjs
+++ b/scripts/router-browser-smoke.mjs
@@ -1,0 +1,264 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_ROUTER_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_ROUTER_CHROME_DEBUG_PORT ?? "19249");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-router-smoke-"));
+const expectedApp = new URL(appURL);
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL));
+    await waitForAppPage(client, expectedApp);
+    await client.evaluate(`window.__routerSmokeShell = document.querySelector("[data-testid='router-shell']")`);
+
+    assertRoute(await appState(client), {
+        route: "home",
+        hash: "",
+        shellSame: true,
+    }, "router initial home route");
+
+    await client.evaluate(`document.querySelector("[data-testid='router-link-issues']").click()`);
+    await waitForRoute(client, "issues");
+    assertRoute(await appState(client), {
+        route: "issues",
+        hash: "#/issues",
+        issueCount: 3,
+        shellSame: true,
+    }, "router issues link route");
+
+    await client.evaluate(`document.querySelector("[data-testid='router-link-first-issue']").click()`);
+    await waitForRoute(client, "details");
+    assertRoute(await appState(client), {
+        route: "details",
+        hash: "#/issues/1",
+        issueID: "1",
+        shellSame: true,
+    }, "router param route");
+
+    await client.evaluate(`document.querySelector("[data-testid='router-programmatic-nav']").click()`);
+    await waitForIssueID(client, "2");
+    assertRoute(await appState(client), {
+        route: "details",
+        hash: "#/issues/2",
+        issueID: "2",
+        shellSame: true,
+    }, "router programmatic navigate");
+
+    await client.evaluate(`history.back()`);
+    await waitForIssueID(client, "1");
+    assertRoute(await appState(client), {
+        route: "details",
+        hash: "#/issues/1",
+        issueID: "1",
+        shellSame: true,
+    }, "router browser back");
+
+    await client.evaluate(`location.hash = "#/missing"`);
+    await waitForRoute(client, "notFound");
+    assertRoute(await appState(client), {
+        route: "notFound",
+        hash: "#/missing",
+        notFoundPath: "/missing",
+        shellSame: true,
+    }, "router not-found route");
+
+    const debug = await appState(client);
+    if (debug.routerViewRenders < 2 || debug.routerRouteRenders < 2) {
+        throw new Error(`APP FAILURE: router debug render counters are not readable: ${JSON.stringify(debug)}`);
+    }
+
+    client.close();
+    console.log("Router browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function appState(client) {
+    return await client.evaluate(`(() => {
+        const home = document.querySelector("[data-testid='router-home']");
+        const issues = document.querySelector("[data-testid='router-issues']");
+        const details = document.querySelector("[data-testid='router-issue-details']");
+        const notFound = document.querySelector("[data-testid='router-not-found']");
+        return {
+            route: home ? "home" : issues ? "issues" : details ? "details" : notFound ? "notFound" : "missing",
+            href: location.href,
+            hash: location.hash,
+            issueID: document.querySelector("[data-testid='router-issue-id']")?.textContent.trim() ?? "",
+            issueCount: document.querySelectorAll("[data-testid='router-issue-item']").length,
+            notFoundPath: document.querySelector("[data-testid='router-not-found-path']")?.textContent.trim() ?? "",
+            shellSame: window.__routerSmokeShell === document.querySelector("[data-testid='router-shell']"),
+            shellText: document.querySelector("[data-testid='router-shell']")?.textContent.trim() ?? "",
+            routerViewRenders: window.goframeComponentRenderCounts?.RouterView ?? 0,
+            routerRouteRenders: window.goframeComponentRenderCounts?.RouterRoute ?? 0,
+        };
+    })()`);
+}
+
+async function waitForRoute(client, route) {
+    await waitForCondition(async () => {
+        return (await appState(client)).route === route;
+    }, `route ${route}`);
+}
+
+async function waitForIssueID(client, id) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "details" && state.issueID === id;
+    }, `issue ${id}`);
+}
+
+function assertRoute(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (actual[key] !== value) {
+            throw new Error(`APP FAILURE: ${label}: ${key} got ${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; state=${JSON.stringify(actual)}`);
+        }
+    }
+    console.log(`${label}: ok`);
+}
+
+function withSmokeParam(url) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", String(Date.now()));
+    next.hash = "";
+    return String(next);
+}
+
+async function waitForPage(port) {
+    const endpoint = `http://127.0.0.1:${port}/json/version`;
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        try {
+            const version = await fetch(endpoint).then((response) => response.json());
+            if (version.webSocketDebuggerUrl) {
+                const pages = await fetch(`http://127.0.0.1:${port}/json`).then((response) => response.json());
+                const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+                if (page) {
+                    return page;
+                }
+            }
+        } catch {
+            if (browser.exitCode !== null) {
+                throw new Error(`HARNESS FAILURE: Chrome exited early. stderr:\n${browserError}`);
+            }
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools endpoint did not start. stderr:\n${browserError}`);
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const { resolve, reject } = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            reject(new Error(`${message.error.message}: ${message.error.data ?? ""}`));
+        } else {
+            resolve(message.result ?? {});
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    return {
+        call(method, params = {}) {
+            const id = nextID++;
+            socket.send(JSON.stringify({ id, method, params }));
+            return new Promise((resolve, reject) => {
+                pending.set(id, { resolve, reject });
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                awaitPromise: true,
+                returnByValue: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`APP FAILURE: evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+    await waitForCondition(async () => {
+        const readyState = await client.evaluate("document.readyState");
+        return readyState === "complete" || readyState === "interactive";
+    }, "page navigation");
+}
+
+async function waitForAppPage(client, expectedApp) {
+    await waitForCondition(async () => {
+        const state = await client.evaluate(`(() => ({
+            href: location.href,
+            ready: Boolean(document.querySelector("[data-testid='router-shell']") && document.querySelector("[data-testid='router-home']")),
+        }))()`);
+        const actual = new URL(state.href);
+        if (actual.origin !== expectedApp.origin) {
+            throw new Error(`HARNESS FAILURE: expected app origin ${expectedApp.origin}, got ${actual.origin}`);
+        }
+        return state.ready;
+    }, "router app ready");
+}
+
+async function waitForCondition(check, label) {
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        if (await check()) {
+            return;
+        }
+        await wait(50);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label}`);
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -136,5 +136,6 @@ check_app "context" "$(bundle_path context)" 115200 36864 46080 40960 || status=
 check_app "virtualized" "$(bundle_path virtualized)" 122880 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
+check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adds a small Go-first hash router for browser/WASM apps.

This MVP introduces route matching, route params, not-found handling, `RouterView`, `RouterLink`, programmatic `Navigate`, browser back/forward support, a stable shell/outlet layout pattern, a router example, browser smoke coverage, and router documentation.

## Changes

- Add runtime router primitives:
  - `RoutePath`
  - `NotFoundRoute`
  - `NewHashRouter`
  - `RouterView`
  - `RouterLink`
  - `Navigate`
  - `HashHref`
  - `RouteContext.Param`
- Add static and parameterized route matching
- Preserve `RouteContext.RawQuery`
- Use declaration-order route matching
- Key route subtree by matched route pattern
- Subscribe to `hashchange` in browser/WASM builds
- Clean up browser listener on unmount
- Add `examples/router`
- Add router browser smoke
- Update docs, README, CI docs, performance baseline, API stability, deployment docs, and changelog

## Non-goals

- No SSR
- No hydration
- No file-based routing
- No path/history mode fallback
- No route loaders
- No async resources
- No Suspense
- No route-level ErrorBoundary API
- No middleware/auth guards
- No scroll restoration
- No query-state manager
- No code splitting
- No production deployment server

## Checks

- `go fmt ./...`
- `git diff --check`
- `go test ./...`
- `go test -race ./pkg/... ./cmd/...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- example tests including `examples/router`
- `scripts/check.sh`
- `scripts/size-budget.sh`
- `scripts/perf-report.sh`
- `scripts/browser-smoke.sh`
- `node --experimental-websocket scripts/dashboard-dom-pressure.mjs`
- `scripts/artifact-check.sh`
- `scripts/module-path-check.sh`
- `node scripts/docs-check.mjs`