### PR TITLE
MVP 25: public preview hardening

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -62,6 +62,8 @@ jobs:
           goxc package ./examples/cmdapp --compiler=tinygo
           goxc generate ./examples/router
           goxc package ./examples/router --compiler=tinygo
+          goxc generate ./examples/router-dashboard
+          goxc package ./examples/router-dashboard --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
@@ -71,6 +73,7 @@ jobs:
           goxc package ./examples/multipackage --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/cmdapp --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/router --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/router-dashboard --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 - Hash-based client router primitives, including route params, not-found
   handling, `RouterView`, `RouterLink`, programmatic navigation, a Go-first
   router example, and browser smoke coverage.
+- MVP 25 public preview hardening, including router query helpers, documented
+  forms/validation patterns, a router-dashboard reference example, browser
+  smoke coverage, and public API surface clarification.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -20,19 +20,20 @@ Current baseline includes:
 - GOX expression ergonomics and source-oriented diagnostics;
 - component boundaries, state, reducer dispatch, effects, context selectors,
   memoization, keyed reconciliation, fixed-height virtualization, and a small
-  hash-based client router;
+  hash-based client router with tiny query helpers;
 - cache-safe packaging, hidden `.goframe` workspace output, export safety, and
   clean workspace commands;
 - multi-package GOX workspaces, child entry packages such as `./cmd/app`, and
   import-aware generated component identity;
+- documented forms/validation patterns and a router-dashboard reference app;
 - CI gates for Go/GOX tests, TinyGo size budgets, browser smoke, artifact
   checks, module path checks, and docs consistency.
 
 Non-goals for the current project surface include SSR, hydration,
 Player/Engine implementation, path/history-mode routing, file-based routing,
 route loaders, dynamic virtualization, infinite loading, LSP, formatter,
-namespace tags, spread props, production deployment server, and full
-multi-module monorepo support.
+namespace tags, spread props, schema validation framework, production
+deployment server, and full multi-module monorepo support.
 
 ## What Is GoFrame?
 
@@ -116,17 +117,35 @@ goxc package ./examples/counter --compiler=go
 
 ## Examples
 
+### Quickstart
+
 | Example | What it demonstrates | Command |
 |---|---|---|
 | `examples/counter` | Minimal state, events, TinyGo quickstart, package/serve workflow. | `goxc package ./examples/counter --compiler=tinygo` |
 | `examples/components` | Typed props, children, fragments, component composition. | `goxc package ./examples/components --compiler=tinygo` |
+
+### Application Primitives
+
+| Example | What it demonstrates | Command |
+|---|---|---|
 | `examples/todo` | Controlled inputs, events, effects, keys, list helpers, localStorage. | `goxc package ./examples/todo --compiler=tinygo` |
-| `examples/dashboard` | Reducer dispatch, explicit memoization, virtual table, dashboard pressure smoke. | `goxc package ./examples/dashboard --compiler=tinygo` |
 | `examples/context` | Scoped providers, selector consumers, broad `UseContext`, nested providers. | `goxc package ./examples/context --compiler=tinygo` |
 | `examples/virtualized` | `gf.VirtualList`, `gf.VirtualTable`, bounded DOM with 10,000 logical rows. | `goxc package ./examples/virtualized --compiler=tinygo` |
+| `examples/router` | Hash router, query helpers, route params, not-found route, and stable shell layout. | `goxc package ./examples/router --compiler=tinygo` |
+
+### Toolchain / Layout
+
+| Example | What it demonstrates | Command |
+|---|---|---|
 | `examples/multipackage` | `entry: "."` app with root plus `internal/...` packages. | `goxc package ./examples/multipackage --compiler=tinygo` |
 | `examples/cmdapp` | Child entry package with `"entry": "./cmd/app"` and Go-first layout. | `goxc package ./examples/cmdapp --compiler=tinygo` |
-| `examples/router` | Hash router, route params, not-found route, and stable shell layout. | `goxc package ./examples/router --compiler=tinygo` |
+
+### Reference / Pressure
+
+| Example | What it demonstrates | Command |
+|---|---|---|
+| `examples/dashboard` | Reducer dispatch, explicit memoization, virtual table, dashboard pressure smoke. | `goxc package ./examples/dashboard --compiler=tinygo` |
+| `examples/router-dashboard` | Router, query-state filters, controlled form validation, and Go-first layout. | `goxc package ./examples/router-dashboard --compiler=tinygo` |
 
 Serve any packaged example with:
 
@@ -326,6 +345,22 @@ func App() gf.Node {
 The MVP router is hash-based. Path/history mode, file-based routing, loaders,
 route middleware, and route-level error boundaries remain future work.
 
+For small URL-driven state, routes expose query helpers:
+
+```go
+query := ctx.Query()
+status := query.Get("status")
+
+gf.Navigate(gf.WithQuery("/issues", gf.QueryValues{
+	"status": {"open"},
+	"q":      {"auth"},
+}))
+```
+
+Forms use ordinary runtime primitives: controlled inputs, `gf.InputEvent`,
+`gf.Event.PreventDefault`, and application-owned validation state. GoFrame
+does not include a schema validation framework.
+
 ## Toolchain Workflow
 
 Generated, build, and package outputs live under an app-local hidden workspace:
@@ -384,6 +419,7 @@ Runtime topics:
 
 - [Lifecycle and effects](docs/effects.md)
 - [Runtime error semantics](docs/runtime-errors.md)
+- [Forms and validation patterns](docs/forms.md)
 - [Explicit memoization](docs/memoization.md)
 - [Context selectors](docs/context.md)
 - [Virtualized collections](docs/virtualization.md)
@@ -404,6 +440,7 @@ Project audits and future design:
 - [Foundation audit](docs/foundation-audit.md)
 - [Foundation Audit IV](docs/foundation-audit-iv.md)
 - [Public Surface Audit V](docs/public-surface-audit-v.md)
+- [Public Preview Hardening I](docs/public-preview-hardening-i.md)
 - [Future GoFrame Player vision](docs/player-vision.md)
 
 Examples:
@@ -417,6 +454,7 @@ Examples:
 - [Multi-package GOX example](examples/multipackage/README.md)
 - [Child entry package example](examples/cmdapp/README.md)
 - [Router example](examples/router/README.md)
+- [Router dashboard reference example](examples/router-dashboard/README.md)
 - [VS Code GOX extension](extensions/vscode-gox/README.md)
 
 ## Current Limitations

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -48,11 +48,13 @@ After public preview, this policy should be revisited and tightened.
 
 Runtime:
 
+- `gf.Node`
 - `gf.El`
 - `gf.Text`
 - `gf.Fragment`
 - `gf.Child`
 - `gf.Key`
+- `gf.Props`
 - `gf.Component`
 - `gf.C`
 - `gf.NewComponentType`
@@ -76,6 +78,9 @@ Runtime:
 - `gf.RouterLink`
 - `gf.Navigate`
 - `gf.HashHref`
+- `gf.QueryValues`
+- `gf.ParseQuery`
+- `gf.WithQuery`
 - basic event facades such as `gf.Event`, `gf.InputEvent`, and
   `gf.ScrollEvent`
 
@@ -94,6 +99,12 @@ Tooling:
 These are public-candidate because examples and docs rely on them, but their
 exact shapes can still change before public preview.
 
+Low-level node helpers such as `gf.El`, `gf.Text`, `gf.Fragment`, `gf.Child`,
+`gf.Key`, `gf.Props`, `gf.If`, `gf.IfElse`, `gf.Map`, and `gf.MapIndexed` are
+also compiler-facing exported primitives. GOX-generated code uses them
+directly, and handwritten low-level Go can use them when needed. Most app code
+should prefer GOX markup for structure.
+
 ### Experimental
 
 - GOX syntax surface.
@@ -107,7 +118,10 @@ exact shapes can still change before public preview.
   `gf.SetErrorHandler`, `gf.ErrorInfo`, `gf.ErrorHandler`, and
   `gf.ErrorPhase`.
 - Hash router details such as route remount policy, declaration-order matching
-  edge cases, link props, and browser listener internals.
+  edge cases, link props, query helper edge cases, and browser listener
+  internals.
+- Form and validation patterns. MVP 25 documents controlled-input patterns but
+  intentionally does not add a runtime form framework.
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands and snippets.
@@ -154,6 +168,8 @@ Not stable:
 - path/history-mode routing and server fallback behavior;
 - file-based routing, route loaders, route middleware, and route-level error
   boundaries;
+- schema validation or a form framework;
+- external data/resource story;
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
 - multi-module app support;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,15 +172,16 @@ TinyGo is the preferred lightweight experiment. It supports a smaller runtime
 surface but dramatically reduces the counter:
 
 ```text
-counter bundle.wasm       82,097 bytes
-components bundle.wasm    87,745 bytes
-todo bundle.wasm         115,337 bytes
-dashboard bundle.wasm    166,248 bytes
-context bundle.wasm      113,108 bytes
-virtualized bundle.wasm  121,195 bytes
-multipackage bundle.wasm 89,727 bytes
-cmdapp bundle.wasm       89,786 bytes
-router bundle.wasm       106,671 bytes
+counter bundle.wasm          83,540 bytes
+components bundle.wasm       89,188 bytes
+todo bundle.wasm            117,399 bytes
+dashboard bundle.wasm       168,618 bytes
+context bundle.wasm         115,344 bytes
+virtualized bundle.wasm     123,134 bytes
+multipackage bundle.wasm     91,170 bytes
+cmdapp bundle.wasm           91,229 bytes
+router bundle.wasm          107,303 bytes
+router-dashboard bundle.wasm 156,170 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -192,8 +193,8 @@ than Counter because it also demonstrates compact localStorage persistence.
 The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
 dashboard-sized pressure-test example, the context selector example, and the
-virtualized collections, multi-package workspace, and child-entry workspace
-examples, plus the hash-router example.
+virtualized collections, multi-package workspace, child-entry workspace,
+hash-router, and router-dashboard reference examples.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.
@@ -209,13 +210,18 @@ events, browser startup, compilation, packaging, and serving. It is not a good
 measure of platform value because it contains almost no application behavior.
 
 `examples/dashboard` is the first dashboard-sized pressure test. It keeps all
-components in one Go package because GOX does not yet support component
-namespaces, but splits layout, metrics, filters, table, and detail components
-across multiple GOX files. It models 300 deterministic rows and exercises
-search, filters, sorting, keyed row identity, selection, metric updates, and a
-small document-title effect. The table is physically virtualized with
-`gf.VirtualTable`, so the logical row count can stay dashboard-sized while the
-mounted DOM remains bounded.
+components in one Go package, but splits layout, metrics, filters, table, and
+detail components across multiple GOX files. It models 300 deterministic rows
+and exercises search, filters, sorting, keyed row identity, selection, metric
+updates, and a small document-title effect. The table is physically
+virtualized with `gf.VirtualTable`, so the logical row count can stay
+dashboard-sized while the mounted DOM remains bounded.
+
+`examples/router-dashboard` is the first reference-grade integrated app. It
+uses a child entry package, internal packages, the hash router, query-driven
+filters, controlled form state, synchronous validation, and stable shell
+composition without adding a data-loading framework or schema validation
+library.
 
 Future editor-sized experiments should measure startup, update time, memory,
 compressed transfer size, and development ergonomics before broader conclusions

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -62,8 +62,9 @@ failures. It currently covers Todo reconciliation, duplicate-key debug
 diagnostics, runtime error containment for event/effect/cleanup panics,
 dashboard-sized filtering/sorting/selection behavior, context selector rerender
 isolation, virtualized collection scroll/selection/toggle behavior, a
-multi-package GOX workspace smoke, a child-entry package smoke, and a
-hash-router navigation smoke.
+multi-package GOX workspace smoke, a child-entry package smoke, hash-router
+navigation smoke, and the router-dashboard reference app smoke for query
+filters plus form validation.
 
 The runtime error containment fixture is compiled with the Go WASM compiler so
 `recover` semantics are available. The size-oriented TinyGo package path uses
@@ -221,7 +222,8 @@ DOM identity loss, render counter regressions, localStorage persistence issues,
 duplicate key diagnostics failures, dashboard filter/sort regressions,
 virtualized collection window regressions, or listener churn regressions.
 Router smoke failures include broken hash navigation, missing route params,
-not-found fallback regressions, browser back handling regressions, or unstable
+not-found fallback regressions, browser back handling regressions, query helper
+regressions, form validation regressions in the reference app, or unstable
 shell layout identity.
 
 The smoke script must not continue against an unknown server or `about:blank`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -236,6 +236,10 @@ The MVP 24 router is hash-based. Routes such as `#/issues/42` are handled by
 the browser after `index.html` loads, so static hosting can serve the same
 package without server-side route rewrites.
 
+Route query state also lives in the hash, for example
+`#/issues?status=open&q=auth`. The server still receives only the original
+`index.html` request.
+
 Path/history-mode routing is not implemented. If a future app wants clean URLs
 such as `/issues/42`, the server or CDN would need a fallback that serves
 `index.html` for application routes. `goxc serve` remains development-only and

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,0 +1,194 @@
+# Forms and Validation
+
+## Purpose
+
+GoFrame does not include a form framework in MVP 25. This document describes
+the recommended patterns for controlled inputs, submit handling, validation,
+touched/dirty state, and reset behavior using the existing runtime primitives.
+
+The goal is to give applications a clear starting point without adding schema
+validation, async submit, server actions, or a form registry to the runtime.
+
+## Current Primitive Model
+
+Forms are ordinary components:
+
+- keep form state in `gf.UseState` or `gf.UseReducer`;
+- use `gf.InputEvent.Value()` from `OnInput` or `OnChange`;
+- call `gf.Event.PreventDefault()` from `OnSubmit`;
+- render validation messages as normal conditional UI;
+- run validation in ordinary Go functions.
+
+## Controlled Inputs
+
+A controlled input receives its value from component state and writes changes
+back through an event handler:
+
+```gox
+<input
+    Value={state.Title}
+    OnInput={func(event gf.InputEvent) {
+        dispatch(FormAction{
+            Kind: FormActionTitleChanged,
+            Value: event.Value(),
+        })
+    }}
+/>
+```
+
+The runtime keeps one browser listener per event name and updates the current
+Go callback during patching. Reducer dispatch is the preferred pattern when
+callbacks may be retained by memoized children, because dispatch reads the
+latest state slot at event time.
+
+## Submit Handling
+
+Use `OnSubmit` on the `<form>` and prevent the browser's default navigation:
+
+```gox
+<form OnSubmit={func(event gf.Event) {
+    event.PreventDefault()
+    dispatch(FormAction{Kind: FormActionSubmit})
+}}>
+    ...
+</form>
+```
+
+Submit remains synchronous in MVP 25. There is no server action, async
+resource, or route loader integration.
+
+## Field State
+
+A practical field model is application-owned:
+
+```go
+type FieldState struct {
+    Value   string
+    Error   string
+    Touched bool
+    Dirty   bool
+}
+```
+
+GoFrame does not define this type in the runtime. Keeping it in the app avoids
+turning the runtime into a validation library and lets each app choose the
+shape it needs.
+
+## Validation State
+
+Validation is plain Go:
+
+```go
+func validateTitle(value string) string {
+    value = strings.TrimSpace(value)
+    switch {
+    case value == "":
+        return "Title is required."
+    case len(value) < 4:
+        return "Title must be at least 4 characters."
+    default:
+        return ""
+    }
+}
+```
+
+Run validation on input, blur, submit, or any combination your UX needs. The
+reference example validates on input after a field has been touched and always
+validates on submit.
+
+## Touched / Dirty Patterns
+
+Common flags:
+
+- `Touched`: the user interacted with the field;
+- `Dirty`: the current value differs from the initial value;
+- `Submitted`: the form has attempted submit at least once.
+
+A typical reducer updates these flags alongside the value:
+
+```go
+case FormActionTitleChanged:
+    state.Title.Value = action.Value
+    state.Title.Touched = true
+    state.Title.Dirty = state.Title.Value != state.InitialTitle
+```
+
+## Error Display
+
+Render errors only when they should be visible:
+
+```gox
+{(field.Error != "" && (field.Touched || state.Submitted)) && (
+    <p class="field-error">{field.Error}</p>
+)}
+```
+
+Use ordinary attributes such as `aria-invalid` and `aria-describedby` where
+appropriate. GoFrame does not add an accessibility abstraction for forms yet.
+
+## Form Reset
+
+Reset can be a normal reducer action:
+
+```gox
+<button Type="button" OnClick={func() {
+    dispatch(FormAction{Kind: FormActionReset})
+}}>
+    Reset
+</button>
+```
+
+The reset action should restore initial values, clear errors, and clear
+touched/dirty/submitted flags according to the app's desired UX.
+
+## Browser Event Semantics
+
+Useful event facades:
+
+- `gf.Event.PreventDefault()`
+- `gf.Event.StopPropagation()`
+- `gf.InputEvent.Value()`
+
+`InputEvent.Value()` returns an empty string when no target value is available.
+It keeps `syscall/js` out of app-facing form code.
+
+## Recommended Patterns
+
+For small forms:
+
+- use `UseState` for one or two fields;
+- validate in small local functions;
+- keep submit state local to the form component.
+
+For larger forms:
+
+- use `UseReducer`;
+- define explicit action kinds;
+- keep field value/error/touched/dirty together;
+- make validation deterministic and synchronous;
+- keep navigation after successful submit explicit with `gf.Navigate`.
+
+When a stateful form lives in another Go package, expose a small local GOX
+wrapper in that package that renders the capitalized form tag. Calling a
+stateful GOX render function directly from another package is just an ordinary
+Go function call and does not create its own component boundary.
+
+## What GoFrame Does Not Provide Yet
+
+GoFrame does not provide:
+
+- schema validation;
+- async validation;
+- server submit actions;
+- automatic field registration;
+- form context;
+- route loaders/resources;
+- query-state binding;
+- browser-native constraint validation wrappers;
+- file upload helpers.
+
+## Future Work
+
+Future work may add small helpers if repeated app patterns prove stable, but
+that should be separate from MVP 25 and measured against bundle size and API
+surface growth.

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -203,6 +203,14 @@ goxc size ./examples/cmdapp
 goxc serve ./examples/cmdapp --port=8080
 ```
 
+The router-dashboard reference example uses the same child-entry model while
+also demonstrating router query filters and local form validation:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=tinygo
+goxc serve ./examples/router-dashboard --port=8080
+```
+
 ## Current Limitations
 
 - No namespace tags.
@@ -219,3 +227,5 @@ goxc serve ./examples/cmdapp --port=8080
 See `examples/multipackage` for a compact `entry: "."` app with a root
 package, `internal/ui`, `internal/issues`, and ordinary shared Go helpers.
 See `examples/cmdapp` for a compact `entry: "./cmd/app"` app.
+See `examples/router-dashboard` for a larger child-entry reference app that
+combines routing, query-state filters, and controlled forms.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-This document records the measurable baseline after MVP 24. It is a decision
-aid for future runtime and tooling work, not a claim that GoFrame is
+This document records the measurable baseline through MVP 25. It is a
+decision aid for future runtime and tooling work, not a claim that GoFrame is
 production-ready.
 
 The goal is to separate hard regression gates from noisy informational metrics
@@ -18,7 +18,7 @@ The baseline covers:
 - TinyGo raw, gzip, brotli, and zstd size budgets;
 - browser smoke behavior for Todo, duplicate keys, dashboard, context,
   virtualized collections, the multi-package example, the child-entry example,
-  and the hash-router example;
+  the hash-router example, and the router-dashboard reference example;
 - dashboard DOM pressure and listener stability;
 - pure runtime benchmark reports;
 - package, export, artifact, and module path safety gates.
@@ -68,8 +68,8 @@ CDP node drift as an investigation signal, not a failure by itself.
 
 ## Current Baseline
 
-Recorded during the hash router pass from local `main` after the runtime error
-semantics baseline.
+Updated during the public preview hardening pass from local `main` after the
+hash router baseline.
 
 Tool versions:
 
@@ -82,7 +82,7 @@ Tool versions:
 `main` and `origin/main` pointed at the same commit when this baseline was
 taken.
 
-Baseline checks passed before documentation changes:
+Current verification includes:
 
 - `go fmt ./...`
 - `git diff --check`
@@ -97,6 +97,7 @@ Baseline checks passed before documentation changes:
 - `go test ./examples/multipackage`
 - `go test ./examples/cmdapp`
 - `go test ./examples/router`
+- `go test ./examples/router-dashboard`
 - `scripts/check.sh`
 - `scripts/size-budget.sh`
 - `scripts/perf-report.sh`
@@ -111,15 +112,16 @@ TinyGo packaged WASM sizes:
 
 | Example | Raw | gzip | br | zstd |
 |---|---:|---:|---:|---:|
-| counter | 82885 | 33356 | 27739 | 29977 |
-| components | 88533 | 35020 | 29241 | 31375 |
-| todo | 116727 | 44793 | 37407 | 40340 |
-| dashboard | 167962 | 62645 | 50713 | 54906 |
-| context | 114656 | 43058 | 35370 | 38255 |
-| virtualized | 122478 | 47194 | 38732 | 41904 |
-| multipackage | 90515 | 35840 | 29836 | 32293 |
-| cmdapp | 90574 | 35864 | 29811 | 32307 |
-| router | 106671 | 41830 | 34422 | 37389 |
+| counter | 83540 | 33574 | 27965 | 30155 |
+| components | 89188 | 35206 | 29301 | 31556 |
+| todo | 117399 | 44995 | 37552 | 40479 |
+| dashboard | 168618 | 62895 | 50775 | 55100 |
+| context | 115344 | 43248 | 35584 | 38452 |
+| virtualized | 123134 | 47419 | 38837 | 42090 |
+| multipackage | 91170 | 36059 | 30015 | 32442 |
+| cmdapp | 91229 | 36087 | 30070 | 32445 |
+| router | 107303 | 42038 | 34721 | 37544 |
+| router-dashboard | 156170 | 59279 | 48264 | 52492 |
 
 The authoritative gate remains `scripts/size-budget.sh`. This table is a
 snapshot, not a second budget file.
@@ -143,6 +145,9 @@ snapshot, not a second budget file.
 - Hash-router initial route, hash links, route params, programmatic
   navigation, browser back handling, not-found rendering, and stable shell
   layout.
+- Router-dashboard query filters, browser back query restoration, route params,
+  controlled form validation, reset behavior, not-found rendering, and stable
+  shell layout.
 
 Hard browser gates focus on correctness and structural invariants. Timing
 printed by smoke scripts is useful for trend spotting, but it is not a stable

--- a/docs/public-preview-hardening-i.md
+++ b/docs/public-preview-hardening-i.md
@@ -1,0 +1,153 @@
+# Public Preview Hardening I
+
+## Purpose
+
+MVP 25 narrows and strengthens GoFrame's public surface before the next wave of
+features. It is a product-hardening pass, not a framework expansion.
+
+The goal is to make the current experimental platform easier to evaluate:
+
+- clarify which APIs are meant for users, generated code, or internals;
+- add a small router query helper layer for URL-driven state;
+- document form and validation patterns without adding a form framework;
+- add one reference-grade app that combines router, query filters, forms,
+  validation, and the Go-first child-entry layout;
+- keep CI, size, smoke, and docs aligned with that surface.
+
+## Strategic Context
+
+The current project direction is:
+
+> GoFrame is an experimental Go-first browser/WASM framework and toolchain for
+> SPA-style and dashboard/admin-class applications.
+
+That direction makes router/query/forms polish more useful than jumping
+directly to data loading, LSP, history routing, Player/Engine work, or a broad
+application convention layer. Small real apps need URL-driven filters and
+forms before they need a large app framework.
+
+## Scope
+
+In scope:
+
+- public API surface review;
+- router query parsing and URL building helpers;
+- form patterns based on existing event, state, and reducer primitives;
+- reference example using local deterministic data only;
+- browser smoke and size budget coverage for the reference example;
+- README and docs alignment.
+
+Out of scope:
+
+- server resources, server functions, or external data fetching;
+- async resource framework or Suspense-like behavior;
+- history-mode router or server fallback automation;
+- route loaders, middleware, auth guards, or route-level Error Boundary API;
+- schema validation library or large form registry;
+- new GOX syntax, namespace tags, or spread props;
+- LSP, formatter, Player/Engine, `.gfapp`, or production deployment server.
+
+## Public API Surface Review
+
+MVP 25 keeps the API small and classifies it more clearly.
+
+Public-candidate core APIs are the primary surface for application authors:
+components, hooks, context selectors, fixed-height virtualization, hash router
+primitives, runtime error reporting, and browser event facades.
+
+Low-level node builders such as `El`, `Text`, `Fragment`, `Child`, `Key`,
+`Props`, `If`, `IfElse`, `Map`, and `MapIndexed` remain exported because GOX
+and handwritten low-level code need them. They are documented as
+compiler-facing or low-level helpers; most app code should prefer GOX markup.
+
+Internal runtime details, generated workspace layout, smoke harness objects,
+and debug probe globals remain intentionally unstable.
+
+## Router Query / Route State
+
+MVP 24 exposed `RouteContext.RawQuery` but left parsing and writing to user
+code. MVP 25 adds a tiny query helper layer for common URL-driven state:
+
+- parse `RawQuery` into `QueryValues`;
+- read the first value with `Get`;
+- check presence with `Has`;
+- preserve repeated values through `map[string][]string`;
+- build route targets with `WithQuery`.
+
+This is not a query-state manager. There are no typed codecs, no automatic
+binding to component state, no route store, and no loader integration.
+
+## Forms and Validation Patterns
+
+MVP 25 does not add a form framework. The recommended model is:
+
+- controlled inputs with `gf.UseReducer` or `gf.UseState`;
+- `gf.InputEvent.Value()` for input changes;
+- `gf.Event.PreventDefault()` for submit handling;
+- example-level field state for value, error, touched, dirty, and submitted
+  state;
+- validation as ordinary Go functions close to the form.
+
+This keeps the runtime small while documenting a canonical pattern that users
+can copy.
+
+## Reference Example
+
+`examples/router-dashboard` is the integrated reference example for this pass.
+It demonstrates:
+
+- `entry: "./cmd/app"` and `cmd/app + internal/...`;
+- `gf.NewHashRouter`, `gf.RouterView`, `gf.RouterLink`, and params;
+- query-driven filters for an issues list;
+- controlled edit form with local validation;
+- touched/dirty/submit state;
+- local deterministic data only;
+- not-found route and stable shell layout.
+
+It is intentionally smaller than `examples/dashboard`. The existing dashboard
+remains the pressure test; the new example is the user-facing reference app.
+
+## CI / Smoke / Size Gates
+
+The reference example is added to:
+
+- TinyGo package checks;
+- size budgets;
+- browser smoke;
+- docs/example consistency checks;
+- CI WASM size workflow.
+
+Smoke gates should verify behavior, not exact timing. The dashboard DOM
+pressure audit remains the structural performance gate for large tables.
+
+## Non-goals
+
+MVP 25 does not introduce:
+
+- a global store;
+- a schema validation package;
+- external data loading;
+- async submit/data resource model;
+- route loaders or route middleware;
+- history-mode routing;
+- production server behavior.
+
+## Remaining Risks
+
+- Query helpers intentionally cover a small URL-encoding subset. They are
+  suitable for simple route-state strings, not arbitrary web form encoding.
+- Forms remain patterns rather than a library. This is deliberate, but users
+  who want schema validation still need app-level code.
+- Router state remains hash-based only.
+- The reference app is local and deterministic; it does not answer the future
+  external data/resource story.
+
+## Next Steps
+
+After this pass, likely next work should focus on one of:
+
+- a careful external data/resource model;
+- browser support and deployment documentation hardening;
+- public-preview compatibility policy;
+- route-level error UI after Error Boundaries are designed;
+- deeper accessibility review for forms and virtualized tables.

--- a/docs/router.md
+++ b/docs/router.md
@@ -17,6 +17,7 @@ The router supports:
 - hash-based navigation;
 - static and parameterized route patterns;
 - route params;
+- small query helpers for URL-driven route state;
 - a not-found route;
 - `RouterView`;
 - `RouterLink`;
@@ -28,7 +29,7 @@ The router intentionally does not support:
 
 - path/history mode;
 - server fallback automation;
-- query-state management;
+- full query-state management;
 - route loaders or data fetching;
 - nested route/layout DSL;
 - scroll restoration;
@@ -51,6 +52,12 @@ The empty hash, `#`, and `#/` normalize to `/`.
 
 `gf.HashHref("/issues")` returns `#/issues`. `gf.Navigate("/issues")` updates
 `window.location.hash` in browser builds.
+
+Query strings stay inside the hash target:
+
+```text
+#/issues?status=open&q=auth
+```
 
 Path/history mode remains future work. It would require server or CDN fallback
 to `index.html`, which GoFrame does not configure in this MVP.
@@ -85,7 +92,8 @@ Supported semantics:
 - static path segments match exactly;
 - `:param` matches one non-empty segment;
 - trailing slash is normalized away except for `/`;
-- query text after `?` is stored as raw query text;
+- query text after `?` is stored as raw query text and can be parsed with
+  `RouteContext.Query()`;
 - wildcard, optional, regex, and splat params are not supported.
 
 ## Params
@@ -101,8 +109,47 @@ func issueDetailsRoute(ctx gf.RouteContext) gf.Node {
 ```
 
 `RouteContext.Param(name)` returns the matching route param or an empty string.
-`RouteContext.RawQuery` contains the query text after `?` without parsing it
-into a map.
+`RouteContext.RawQuery` contains the query text after `?`.
+
+## Query Helpers
+
+MVP 25 adds a tiny query helper layer:
+
+```go
+query := ctx.Query()
+status := query.Get("status")
+
+target := gf.WithQuery("/issues", gf.QueryValues{
+	"status": {"open"},
+	"q":      {"auth"},
+})
+gf.Navigate(target)
+```
+
+API:
+
+```go
+type QueryValues map[string][]string
+
+func (ctx RouteContext) Query() QueryValues
+func ParseQuery(raw string) QueryValues
+func (values QueryValues) Get(name string) string
+func (values QueryValues) Has(name string) bool
+func (values QueryValues) Encode() string
+func WithQuery(path string, values QueryValues) string
+```
+
+Semantics:
+
+- `Get` returns the first value or an empty string;
+- repeated keys are preserved in `QueryValues`;
+- keys without `=` parse as present with an empty first value;
+- `WithQuery` replaces any existing query on the path;
+- `Encode` orders keys deterministically and preserves per-key value order;
+- malformed percent escapes are preserved literally instead of panicking.
+
+This is not a full query-state manager. There are no typed codecs, no automatic
+state binding, no route loaders, and no external data fetching story in MVP 25.
 
 ## RouterView
 
@@ -190,7 +237,7 @@ development-only and does not implement a production fallback policy.
 - No middleware or auth guards.
 - No scroll restoration.
 - No active link helper.
-- No query parsing beyond raw query text.
+- No typed query-state manager.
 - No route ranking beyond declaration order.
 
 ## Future Work

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -271,6 +271,11 @@ subtree is keyed by route pattern. Navigating between different patterns
 remounts the route subtree; navigating between the same pattern with different
 params updates the route context and may preserve route-local state.
 
+`RouteContext.RawQuery` stores query text after `?`, and
+`RouteContext.Query()` parses it into `QueryValues` for small URL-driven state
+such as filters. `gf.WithQuery` builds normalized route targets for
+`gf.Navigate` and `gf.RouterLink`.
+
 The recommended layout model is a stable shell component with `RouterView` as
 an outlet. There is no nested route DSL, file-based routing, path/history-mode
 server fallback, route loader system, or route-level Error Boundary API in this

--- a/examples/router-dashboard/README.md
+++ b/examples/router-dashboard/README.md
@@ -1,0 +1,45 @@
+# Router Dashboard Example
+
+This reference example demonstrates how to combine GoFrame's current
+public-candidate app primitives without adding a larger framework layer.
+
+It shows:
+
+- Go-first child entry layout with `"entry": "./cmd/app"`;
+- `gf.NewHashRouter`, `gf.RouterView`, `gf.RouterLink`, route params, and a
+  not-found route;
+- URL-driven filters with `gf.RouteContext.Query()` and `gf.WithQuery`;
+- controlled form inputs with `gf.InputEvent`;
+- synchronous validation with touched/dirty/submitted state;
+- a stable shell layout around route content;
+- local deterministic data only.
+
+## Run
+
+```bash
+goxc package ./examples/router-dashboard --compiler=tinygo
+goxc serve ./examples/router-dashboard --port=8080
+```
+
+Open <http://127.0.0.1:8080>.
+
+Try:
+
+- `#/issues`
+- `#/issues?status=open&q=auth`
+- `#/issues/RD-2`
+- `#/issues/RD-2/edit`
+- `#/missing`
+
+## Notes
+
+This is not a data-loading example. It does not use server calls, async
+resources, schema validation, route loaders, middleware, or a global store.
+The form validation logic is ordinary application Go code.
+
+The larger `examples/dashboard` remains the DOM pressure test. This example is
+the smaller reference app for router + query state + form patterns.
+
+Stateful cross-package GOX components are exposed through small GOX wrapper
+functions in their own package. The wrapper renders the local capitalized tag,
+so generated code creates a component boundary before other packages call it.

--- a/examples/router-dashboard/cmd/app/app.gox
+++ b/examples/router-dashboard/cmd/app/app.gox
@@ -1,0 +1,74 @@
+package main
+
+import (
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+	layout "github.com/graybuton/goframe/examples/router-dashboard/internal/layout"
+	pages "github.com/graybuton/goframe/examples/router-dashboard/internal/pages"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var router = gf.NewHashRouter([]gf.Route{
+	gf.RoutePath("/", homeRoute),
+	gf.RoutePath("/issues", issuesRoute),
+	gf.RoutePath("/issues/:id/edit", issueEditRoute),
+	gf.RoutePath("/issues/:id", issueDetailsRoute),
+	gf.NotFoundRoute(notFoundRoute),
+})
+
+func App() gf.Node {
+	return (
+		<main class="rd-app">
+			{layout.Shell(layout.ShellProps{
+				Children: []gf.Node{
+					gf.RouterView(router),
+				},
+			})}
+		</main>
+	)
+}
+
+func homeRoute(gf.RouteContext) gf.Node {
+	return pages.Home(pages.HomeProps{
+		Title: appTitle,
+	})
+}
+
+func issuesRoute(ctx gf.RouteContext) gf.Node {
+	query := ctx.Query()
+	allIssues := data.DemoIssues()
+	filter := data.IssueFilter{
+		Query:  query.Get("q"),
+		Status: query.Get("status"),
+	}
+	return pages.IssueList(pages.IssueListProps{
+		Items:       data.FilterIssues(allIssues, filter),
+		TotalCount:  len(allIssues),
+		Query:       filter.Query,
+		Status:      filter.Status,
+		CurrentPath: ctx.Path,
+	})
+}
+
+func issueDetailsRoute(ctx gf.RouteContext) gf.Node {
+	issue, ok := data.FindIssue(ctx.Param("id"))
+	return pages.IssueDetails(pages.IssueDetailsProps{
+		Issue: issue,
+		Found: ok,
+		ID:    ctx.Param("id"),
+	})
+}
+
+func issueEditRoute(ctx gf.RouteContext) gf.Node {
+	issue, ok := data.FindIssue(ctx.Param("id"))
+	return pages.IssueEdit(pages.IssueEditProps{
+		Issue: issue,
+		Found: ok,
+		ID:    ctx.Param("id"),
+	})
+}
+
+func notFoundRoute(ctx gf.RouteContext) gf.Node {
+	return pages.NotFound(pages.NotFoundProps{
+		Path: ctx.Path,
+	})
+}

--- a/examples/router-dashboard/cmd/app/main.go
+++ b/examples/router-dashboard/cmd/app/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/router-dashboard/cmd/app/model.go
+++ b/examples/router-dashboard/cmd/app/model.go
@@ -1,0 +1,3 @@
+package main
+
+const appTitle = "Router Dashboard"

--- a/examples/router-dashboard/doc.go
+++ b/examples/router-dashboard/doc.go
@@ -1,0 +1,2 @@
+// Package routerdashboard documents the router-dashboard reference example.
+package routerdashboard

--- a/examples/router-dashboard/goframe.json
+++ b/examples/router-dashboard/goframe.json
@@ -1,0 +1,11 @@
+{
+  "name": "router-dashboard",
+  "entry": "./cmd/app",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css"
+  ]
+}

--- a/examples/router-dashboard/index.html
+++ b/examples/router-dashboard/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>goframe router dashboard</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <script>
+        window.goframeComponentRenderCounts = {};
+        window.goframeComponentPatchCounts = {};
+        window.goframeComponentMemoSkips = {};
+        window.goframeComponentRenderProbe = (name) => {
+            window.goframeComponentRenderCounts[name] =
+                (window.goframeComponentRenderCounts[name] || 0) + 1;
+        };
+        window.goframeComponentPatchProbe = (name) => {
+            window.goframeComponentPatchCounts[name] =
+                (window.goframeComponentPatchCounts[name] || 0) + 1;
+        };
+        window.goframeComponentMemoSkipProbe = (name) => {
+            window.goframeComponentMemoSkips[name] =
+                (window.goframeComponentMemoSkips[name] || 0) + 1;
+        };
+    </script>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance))
+            .catch((error) => {
+                console.error("[goframe] startup failed", error);
+                document.getElementById("root").textContent = "Failed to start goframe. See console.";
+            });
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/examples/router-dashboard/internal/data/issues.go
+++ b/examples/router-dashboard/internal/data/issues.go
@@ -1,0 +1,93 @@
+package data
+
+import "strings"
+
+type Issue struct {
+	ID          string
+	Title       string
+	Status      string
+	Owner       string
+	Priority    string
+	Description string
+}
+
+type IssueFilter struct {
+	Query  string
+	Status string
+}
+
+func DemoIssues() []Issue {
+	return []Issue{
+		{ID: "RD-1", Title: "Auth token refresh fails on slow networks", Status: "open", Owner: "Identity", Priority: "high", Description: "Refresh retry state is not visible in the admin screen."},
+		{ID: "RD-2", Title: "Billing dashboard needs clearer empty state", Status: "review", Owner: "Billing", Priority: "medium", Description: "Empty invoices should explain the current filter."},
+		{ID: "RD-3", Title: "Export CSV action should preserve filters", Status: "open", Owner: "Reports", Priority: "medium", Description: "CSV export currently ignores the active query string."},
+		{ID: "RD-4", Title: "Audit log row spacing is inconsistent", Status: "closed", Owner: "Platform", Priority: "low", Description: "Visual polish issue in dense table mode."},
+		{ID: "RD-5", Title: "Support queue route needs not-found copy", Status: "review", Owner: "Support", Priority: "low", Description: "Unknown support ticket routes should be clearer."},
+		{ID: "RD-6", Title: "Search input should keep URL state", Status: "open", Owner: "Experience", Priority: "high", Description: "Filter state should survive reload and browser back."},
+		{ID: "RD-7", Title: "Admin form validation needs touched state", Status: "open", Owner: "Experience", Priority: "medium", Description: "Field errors should not appear before user interaction."},
+		{ID: "RD-8", Title: "Router smoke should cover query filters", Status: "closed", Owner: "Runtime", Priority: "medium", Description: "The preview app should lock down URL-driven filters."},
+	}
+}
+
+func FindIssue(id string) (Issue, bool) {
+	for _, issue := range DemoIssues() {
+		if issue.ID == id {
+			return issue, true
+		}
+	}
+	return Issue{}, false
+}
+
+func FilterIssues(items []Issue, filter IssueFilter) []Issue {
+	query := strings.ToLower(strings.TrimSpace(filter.Query))
+	status := NormalizeStatus(filter.Status)
+	filtered := make([]Issue, 0, len(items))
+	for _, issue := range items {
+		if status != "" && issue.Status != status {
+			continue
+		}
+		if query != "" && !matchesIssue(issue, query) {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+func NormalizeStatus(status string) string {
+	status = strings.ToLower(strings.TrimSpace(status))
+	switch status {
+	case "open", "review", "closed":
+		return status
+	default:
+		return ""
+	}
+}
+
+func StatusLabel(status string) string {
+	switch NormalizeStatus(status) {
+	case "open":
+		return "Open"
+	case "review":
+		return "In review"
+	case "closed":
+		return "Closed"
+	default:
+		return "All statuses"
+	}
+}
+
+func IssuePath(id string) string {
+	return "/issues/" + id
+}
+
+func IssueEditPath(id string) string {
+	return "/issues/" + id + "/edit"
+}
+
+func matchesIssue(issue Issue, query string) bool {
+	return strings.Contains(strings.ToLower(issue.ID), query) ||
+		strings.Contains(strings.ToLower(issue.Title), query) ||
+		strings.Contains(strings.ToLower(issue.Owner), query) ||
+		strings.Contains(strings.ToLower(issue.Description), query)
+}

--- a/examples/router-dashboard/internal/filters/filters.gox
+++ b/examples/router-dashboard/internal/filters/filters.gox
@@ -1,0 +1,66 @@
+package filters
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func FilterControlsView(props FilterControlsProps) gf.Node {
+	return <FilterControls
+		Key={FilterKey(props.Query, props.Status)}
+		Query={props.Query}
+		Status={props.Status}
+		ResultCount={props.ResultCount}
+		TotalCount={props.TotalCount}
+	/>
+}
+
+func FilterControls(props FilterControlsProps) gf.Node {
+	query, setQuery := gf.UseState(props.Query)
+	status, setStatus := gf.UseState(normalizeStatusForControl(props.Status))
+
+	applyFilters := func() {
+		gf.Navigate(filterTarget(query, status))
+	}
+
+	resetFilters := func() {
+		setQuery("")
+		setStatus("all")
+		gf.Navigate("/issues")
+	}
+
+	return (
+		<form class="rd-filters" data-testid="rd-filters" OnSubmit={func(event gf.Event) {
+			event.PreventDefault()
+			applyFilters()
+		}}>
+			<label>
+				<span>Search</span>
+				<input
+					data-testid="rd-filter-query"
+					Type="search"
+					Value={query}
+					Placeholder="Search issues"
+					OnInput={func(event gf.InputEvent) {
+						setQuery(event.Value())
+					}}
+				/>
+			</label>
+			<label>
+				<span>Status</span>
+				<select data-testid="rd-filter-status" Value={status} OnChange={func(event gf.InputEvent) {
+					setStatus(event.Value())
+				}}>
+					<option Value="all">All statuses</option>
+					<option Value="open">Open</option>
+					<option Value="review">In review</option>
+					<option Value="closed">Closed</option>
+				</select>
+			</label>
+			<div class="rd-filter-actions">
+				<button data-testid="rd-filter-apply" Type="submit">Apply filters</button>
+				<button data-testid="rd-filter-reset" Type="button" OnClick={resetFilters}>Reset</button>
+			</div>
+			<p class="rd-summary" data-testid="rd-filter-summary">
+				Showing {props.ResultCount} of {props.TotalCount} issues
+			</p>
+		</form>
+	)
+}

--- a/examples/router-dashboard/internal/filters/model.go
+++ b/examples/router-dashboard/internal/filters/model.go
@@ -1,0 +1,41 @@
+package filters
+
+import (
+	"strings"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+type FilterControlsProps struct {
+	Query       string
+	Status      string
+	ResultCount int
+	TotalCount  int
+}
+
+func FilterKey(query string, status string) string {
+	return strings.TrimSpace(query) + "|" + normalizeStatusForControl(status)
+}
+
+func filterTarget(query string, status string) string {
+	values := gf.QueryValues{}
+	query = strings.TrimSpace(query)
+	status = normalizeStatusForControl(status)
+	if query != "" {
+		values["q"] = []string{query}
+	}
+	if status != "all" {
+		values["status"] = []string{status}
+	}
+	return gf.WithQuery("/issues", values)
+}
+
+func normalizeStatusForControl(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch normalized {
+	case "open", "review", "closed":
+		return normalized
+	default:
+		return "all"
+	}
+}

--- a/examples/router-dashboard/internal/forms/issue_form.gox
+++ b/examples/router-dashboard/internal/forms/issue_form.gox
@@ -1,0 +1,65 @@
+package forms
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func IssueFormView(props IssueFormProps) gf.Node {
+	return <IssueForm Key={props.Issue.ID} Issue={props.Issue} />
+}
+
+func IssueForm(props IssueFormProps) gf.Node {
+	state, dispatch := gf.UseReducer(newIssueFormState(props.Issue), reduceIssueForm)
+
+	return (
+		<form class="rd-form" data-testid="rd-issue-form" OnSubmit={func(event gf.Event) {
+			event.PreventDefault()
+			dispatch(IssueFormAction{Kind: issueFormSubmit})
+		}}>
+			<label>
+				<span>Title</span>
+				<input
+					data-testid="rd-field-title"
+					Type="text"
+					Value={state.Title.Value}
+					aria-invalid={state.TitleInvalid()}
+					aria-describedby="rd-field-error-title"
+					OnInput={func(event gf.InputEvent) {
+						dispatch(IssueFormAction{Kind: issueFormTitleChanged, Value: event.Value()})
+					}}
+				/>
+			</label>
+			{state.ShowTitleError() && (
+				<p class="rd-field-error" id="rd-field-error-title" data-testid="rd-field-error-title">
+					{state.Title.Error}
+				</p>
+			)}
+			<label>
+				<span>Status</span>
+				<select data-testid="rd-field-status" Value={state.Status.Value} OnChange={func(event gf.InputEvent) {
+					dispatch(IssueFormAction{Kind: issueFormStatusChanged, Value: event.Value()})
+				}}>
+					<option Value="open">Open</option>
+					<option Value="review">In review</option>
+					<option Value="closed">Closed</option>
+				</select>
+			</label>
+			<label>
+				<span>Description</span>
+				<textarea data-testid="rd-field-description" Value={state.Description.Value} OnInput={func(event gf.InputEvent) {
+					dispatch(IssueFormAction{Kind: issueFormDescriptionChanged, Value: event.Value()})
+				}} />
+			</label>
+			<p class="rd-dirty" data-testid="rd-form-dirty">{state.DirtyText()}</p>
+			<div class="rd-form-actions">
+				<button data-testid="rd-form-submit" Type="submit">Save issue</button>
+				<button data-testid="rd-form-reset" Type="button" OnClick={func() {
+					dispatch(IssueFormAction{Kind: issueFormReset})
+				}}>Reset form</button>
+			</div>
+			{state.Saved && (
+				<p class="rd-saved" data-testid="rd-form-saved">
+					Saved locally. This example does not persist to a server.
+				</p>
+			)}
+		</form>
+	)
+}

--- a/examples/router-dashboard/internal/forms/model.go
+++ b/examples/router-dashboard/internal/forms/model.go
@@ -1,0 +1,125 @@
+package forms
+
+import (
+	"strings"
+
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+)
+
+type IssueFormProps struct {
+	Issue data.Issue
+}
+
+type FieldState struct {
+	Value   string
+	Error   string
+	Touched bool
+	Dirty   bool
+}
+
+type IssueFormState struct {
+	Initial     data.Issue
+	Title       FieldState
+	Status      FieldState
+	Description FieldState
+	Submitted   bool
+	Saved       bool
+}
+
+type IssueFormAction struct {
+	Kind  issueFormActionKind
+	Value string
+}
+
+type issueFormActionKind int
+
+const (
+	issueFormTitleChanged issueFormActionKind = iota + 1
+	issueFormStatusChanged
+	issueFormDescriptionChanged
+	issueFormSubmit
+	issueFormReset
+)
+
+func newIssueFormState(issue data.Issue) IssueFormState {
+	state := IssueFormState{
+		Initial: issue,
+		Title: FieldState{
+			Value: issue.Title,
+		},
+		Status: FieldState{
+			Value: data.NormalizeStatus(issue.Status),
+		},
+		Description: FieldState{
+			Value: issue.Description,
+		},
+	}
+	state.validate()
+	return state
+}
+
+func reduceIssueForm(state IssueFormState, action IssueFormAction) IssueFormState {
+	switch action.Kind {
+	case issueFormTitleChanged:
+		state.Title.Value = action.Value
+		state.Title.Touched = true
+		state.Saved = false
+	case issueFormStatusChanged:
+		state.Status.Value = data.NormalizeStatus(action.Value)
+		state.Status.Touched = true
+		state.Saved = false
+	case issueFormDescriptionChanged:
+		state.Description.Value = action.Value
+		state.Description.Touched = true
+		state.Saved = false
+	case issueFormSubmit:
+		state.Submitted = true
+		state.Title.Touched = true
+		state.Status.Touched = true
+		state.Description.Touched = true
+	case issueFormReset:
+		return newIssueFormState(state.Initial)
+	}
+	state.validate()
+	if action.Kind == issueFormSubmit && state.Title.Error == "" {
+		state.Saved = true
+	}
+	return state
+}
+
+func (state IssueFormState) ShowTitleError() bool {
+	return state.Title.Error != "" && (state.Title.Touched || state.Submitted)
+}
+
+func (state IssueFormState) TitleInvalid() string {
+	if state.ShowTitleError() {
+		return "true"
+	}
+	return "false"
+}
+
+func (state IssueFormState) DirtyText() string {
+	if state.Title.Dirty || state.Status.Dirty || state.Description.Dirty {
+		return "Unsaved local changes"
+	}
+	return "No local changes"
+}
+
+func (state *IssueFormState) validate() {
+	state.Title.Error = validateTitle(state.Title.Value)
+	state.Title.Dirty = state.Title.Value != state.Initial.Title
+	state.Status.Dirty = state.Status.Value != data.NormalizeStatus(state.Initial.Status)
+	state.Description.Dirty = state.Description.Value != state.Initial.Description
+}
+
+func validateTitle(value string) string {
+	value = strings.TrimSpace(value)
+	switch {
+	case value == "":
+		return "Title is required."
+	case len(value) < 4:
+		return "Title must be at least 4 characters."
+	default:
+		return ""
+	}
+}

--- a/examples/router-dashboard/internal/layout/model.go
+++ b/examples/router-dashboard/internal/layout/model.go
@@ -1,0 +1,7 @@
+package layout
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type ShellProps struct {
+	Children []gf.Node
+}

--- a/examples/router-dashboard/internal/layout/shell.gox
+++ b/examples/router-dashboard/internal/layout/shell.gox
@@ -1,0 +1,34 @@
+package layout
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Shell(props ShellProps) gf.Node {
+	return (
+		<section class="rd-shell" data-testid="rd-shell">
+			<header class="rd-header">
+				<div>
+					<p class="rd-eyebrow">GoFrame reference app</p>
+					<h1>Router Dashboard</h1>
+					<p class="rd-muted">Hash routes, query filters, controlled forms, and Go-first layout.</p>
+				</div>
+				<nav class="rd-nav" aria-label="Primary navigation">
+					{gf.RouterLink(gf.RouterLinkProps{
+						To: "/",
+						Class: "rd-link",
+						TestID: "rd-nav-home",
+						Children: []gf.Node{gf.Text("Home")},
+					})}
+					{gf.RouterLink(gf.RouterLinkProps{
+						To: "/issues",
+						Class: "rd-link",
+						TestID: "rd-nav-issues",
+						Children: []gf.Node{gf.Text("Issues")},
+					})}
+				</nav>
+			</header>
+			<div class="rd-outlet" data-testid="rd-outlet">
+				{props.Children}
+			</div>
+		</section>
+	)
+}

--- a/examples/router-dashboard/internal/pages/home.gox
+++ b/examples/router-dashboard/internal/pages/home.gox
@@ -1,0 +1,23 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Home(props HomeProps) gf.Node {
+	return (
+		<section class="rd-card" data-testid="rd-home">
+			<h2>{props.Title}</h2>
+			<p>
+				This reference app combines the small hash router, route query helpers,
+				and controlled form validation without a larger app framework.
+			</p>
+			<p>
+				{gf.RouterLink(gf.RouterLinkProps{
+					To: "/issues?status=open",
+					Class: "rd-link",
+					TestID: "rd-home-open-issues",
+					Children: []gf.Node{gf.Text("Open issues")},
+				})}
+			</p>
+		</section>
+	)
+}

--- a/examples/router-dashboard/internal/pages/issue_details.gox
+++ b/examples/router-dashboard/internal/pages/issue_details.gox
@@ -1,0 +1,44 @@
+package pages
+
+import (
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func IssueDetails(props IssueDetailsProps) gf.Node {
+	if !props.Found {
+		return <MissingIssue ID={props.ID} />
+	}
+	return (
+		<section class="rd-card" data-testid="rd-issue-detail">
+			<p class="rd-eyebrow">{props.Issue.ID}</p>
+			<h2>{props.Issue.Title}</h2>
+			<div class="rd-meta">
+				<span>{data.StatusLabel(props.Issue.Status)}</span>
+				<span>{props.Issue.Priority}</span>
+				<span>{props.Issue.Owner}</span>
+			</div>
+			<p>{props.Issue.Description}</p>
+			{gf.RouterLink(gf.RouterLinkProps{
+				To: data.IssueEditPath(props.Issue.ID),
+				Class: "rd-link",
+				TestID: "rd-edit-link",
+				Children: []gf.Node{gf.Text("Edit issue")},
+			})}
+		</section>
+	)
+}
+
+func MissingIssue(props MissingIssueProps) gf.Node {
+	return (
+		<section class="rd-card" data-testid="rd-issue-missing">
+			<h2>Issue not found</h2>
+			<p>No local issue matched {props.ID}.</p>
+			{gf.RouterLink(gf.RouterLinkProps{
+				To: "/issues",
+				Class: "rd-link",
+				Children: []gf.Node{gf.Text("Back to issues")},
+			})}
+		</section>
+	)
+}

--- a/examples/router-dashboard/internal/pages/issue_edit.gox
+++ b/examples/router-dashboard/internal/pages/issue_edit.gox
@@ -1,0 +1,24 @@
+package pages
+
+import (
+	forms "github.com/graybuton/goframe/examples/router-dashboard/internal/forms"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func IssueEdit(props IssueEditProps) gf.Node {
+	if !props.Found {
+		return <MissingIssue ID={props.ID} />
+	}
+	return (
+		<section class="rd-card" data-testid="rd-issue-edit">
+			<p class="rd-eyebrow">Edit {props.Issue.ID}</p>
+			<h2>Update issue</h2>
+			<p class="rd-muted">
+				This form validates local state only. It does not call a server.
+			</p>
+			{forms.IssueFormView(forms.IssueFormProps{
+				Issue: props.Issue,
+			})}
+		</section>
+	)
+}

--- a/examples/router-dashboard/internal/pages/issue_list.gox
+++ b/examples/router-dashboard/internal/pages/issue_list.gox
@@ -1,0 +1,66 @@
+package pages
+
+import (
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+	filters "github.com/graybuton/goframe/examples/router-dashboard/internal/filters"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func IssueList(props IssueListProps) gf.Node {
+	return (
+		<section class="rd-card" data-testid="rd-issue-list">
+			<div class="rd-section-heading">
+				<div>
+					<p class="rd-eyebrow">Issues</p>
+					<h2>URL-driven filters</h2>
+				</div>
+				{gf.RouterLink(gf.RouterLinkProps{
+					To: "/issues/RD-1/edit",
+					Class: "rd-link",
+					Children: []gf.Node{gf.Text("Edit RD-1")},
+				})}
+			</div>
+			{filters.FilterControlsView(filters.FilterControlsProps{
+				Query:       props.Query,
+				Status:      props.Status,
+				ResultCount: len(props.Items),
+				TotalCount:  props.TotalCount,
+			})}
+			{(len(props.Items) == 0) ? (
+				<p class="rd-empty" data-testid="rd-issue-empty">No issues matched this route query.</p>
+			) : (
+				<ul class="rd-issue-rows">
+					{gf.Map(props.Items, func(issue data.Issue) gf.Node {
+						return <IssueRow Key={issue.ID} Issue={issue} />
+					})}
+				</ul>
+			)}
+		</section>
+	)
+}
+
+func IssueRow(props IssueRowProps) gf.Node {
+	return (
+		<li class="rd-issue-row" data-testid="rd-issue-row">
+			<div>
+				<strong>{props.Issue.ID}</strong>
+				<span>{props.Issue.Title}</span>
+			</div>
+			<div class="rd-row-actions">
+				<span>{data.StatusLabel(props.Issue.Status)}</span>
+				{gf.RouterLink(gf.RouterLinkProps{
+					To: data.IssuePath(props.Issue.ID),
+					Class: "rd-link",
+					TestID: "rd-issue-link-"+props.Issue.ID,
+					Children: []gf.Node{gf.Text("Details")},
+				})}
+				{gf.RouterLink(gf.RouterLinkProps{
+					To: data.IssueEditPath(props.Issue.ID),
+					Class: "rd-link",
+					TestID: "rd-issue-edit-"+props.Issue.ID,
+					Children: []gf.Node{gf.Text("Edit")},
+				})}
+			</div>
+		</li>
+	)
+}

--- a/examples/router-dashboard/internal/pages/model.go
+++ b/examples/router-dashboard/internal/pages/model.go
@@ -1,0 +1,39 @@
+package pages
+
+import data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+
+type HomeProps struct {
+	Title string
+}
+
+type IssueListProps struct {
+	Items       []data.Issue
+	TotalCount  int
+	Query       string
+	Status      string
+	CurrentPath string
+}
+
+type IssueRowProps struct {
+	Issue data.Issue
+}
+
+type IssueDetailsProps struct {
+	Issue data.Issue
+	Found bool
+	ID    string
+}
+
+type IssueEditProps struct {
+	Issue data.Issue
+	Found bool
+	ID    string
+}
+
+type MissingIssueProps struct {
+	ID string
+}
+
+type NotFoundProps struct {
+	Path string
+}

--- a/examples/router-dashboard/internal/pages/not_found.gox
+++ b/examples/router-dashboard/internal/pages/not_found.gox
@@ -1,0 +1,20 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func NotFound(props NotFoundProps) gf.Node {
+	return (
+		<section class="rd-card" data-testid="rd-not-found">
+			<h2>Route not found</h2>
+			<p>
+				No route matched
+				<code data-testid="rd-not-found-path">{props.Path}</code>.
+			</p>
+			{gf.RouterLink(gf.RouterLinkProps{
+				To: "/issues",
+				Class: "rd-link",
+				Children: []gf.Node{gf.Text("Back to issues")},
+			})}
+		</section>
+	)
+}

--- a/examples/router-dashboard/styles.css
+++ b/examples/router-dashboard/styles.css
@@ -1,0 +1,211 @@
+:root {
+    color-scheme: light;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #f4f7fb;
+    color: #172033;
+}
+
+button,
+input,
+select,
+textarea {
+    font: inherit;
+}
+
+button {
+    border: 0;
+    border-radius: 999px;
+    padding: 0.7rem 1rem;
+    background: #2857d4;
+    color: #fff;
+    cursor: pointer;
+}
+
+button[type="button"] {
+    background: #e8eefb;
+    color: #25406f;
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid #ccd8eb;
+    border-radius: 12px;
+    padding: 0.72rem 0.82rem;
+    background: #fff;
+    color: #172033;
+}
+
+textarea {
+    min-height: 96px;
+    resize: vertical;
+}
+
+.rd-app {
+    min-height: 100vh;
+}
+
+.rd-shell {
+    max-width: 1040px;
+    margin: 0 auto;
+    padding: 32px;
+}
+
+.rd-header,
+.rd-card {
+    border: 1px solid #dce5f4;
+    border-radius: 20px;
+    background: #fff;
+    box-shadow: 0 18px 44px rgba(27, 39, 71, 0.08);
+}
+
+.rd-header {
+    display: grid;
+    gap: 18px;
+    margin-bottom: 20px;
+    padding: 22px;
+}
+
+.rd-header h1,
+.rd-card h2 {
+    margin: 0;
+}
+
+.rd-nav,
+.rd-filter-actions,
+.rd-form-actions,
+.rd-row-actions,
+.rd-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+}
+
+.rd-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 38px;
+    border-radius: 999px;
+    padding: 0 0.9rem;
+    background: #eef3ff;
+    color: #2857d4;
+    text-decoration: none;
+}
+
+.rd-card {
+    padding: 22px;
+}
+
+.rd-card + .rd-card {
+    margin-top: 18px;
+}
+
+.rd-eyebrow {
+    margin: 0 0 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.78rem;
+    color: #64738c;
+}
+
+.rd-muted {
+    color: #5e6d82;
+}
+
+.rd-section-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+    margin-bottom: 18px;
+}
+
+.rd-filters,
+.rd-form {
+    display: grid;
+    gap: 14px;
+    margin: 18px 0;
+}
+
+.rd-filters {
+    grid-template-columns: minmax(0, 1fr) minmax(160px, 220px);
+    align-items: end;
+}
+
+.rd-filters label,
+.rd-form label {
+    display: grid;
+    gap: 6px;
+}
+
+.rd-summary,
+.rd-dirty,
+.rd-field-error,
+.rd-saved,
+.rd-empty {
+    margin: 0;
+}
+
+.rd-summary {
+    grid-column: 1 / -1;
+    color: #5e6d82;
+}
+
+.rd-issue-rows {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.rd-issue-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px;
+    border-radius: 14px;
+    background: #f8faff;
+}
+
+.rd-issue-row > div:first-child {
+    display: grid;
+    gap: 4px;
+}
+
+.rd-meta span,
+.rd-row-actions span {
+    border-radius: 999px;
+    padding: 0.25rem 0.6rem;
+    background: #f0f4fb;
+    color: #42516a;
+}
+
+.rd-field-error {
+    color: #b42318;
+}
+
+.rd-saved {
+    color: #087443;
+}
+
+@media (max-width: 720px) {
+    .rd-shell {
+        padding: 18px;
+    }
+
+    .rd-filters {
+        grid-template-columns: 1fr;
+    }
+
+    .rd-issue-row {
+        display: grid;
+    }
+}

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -42,6 +42,7 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		mounted.pending = element
 		patchProps(element, mounted, nil, node.Props, owner)
 		mounted.children = mountChildren(document, element, node.Children, js.Null(), owner)
+		applyPostMountProps(element, node)
 	case TextNode:
 		text := document.Call("createTextNode", node.Value)
 		mounted.first = text
@@ -68,6 +69,16 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		panic("goframe: unsupported node type")
 	}
 	return mounted
+}
+
+func applyPostMountProps(element js.Value, node VNode) {
+	if node.Tag != "select" || len(node.Props) == 0 {
+		return
+	}
+	props, _ := splitProps(node.Props)
+	if prop, ok := props["value"]; ok {
+		setDOMProp(element, "value", prop)
+	}
 }
 
 func mountChildren(document, parent js.Value, nodes []Node, boundary js.Value, owner *componentInstance) []*mountedNode {

--- a/pkg/goframe/router.go
+++ b/pkg/goframe/router.go
@@ -2,6 +2,10 @@ package goframe
 
 import "strings"
 
+// QueryValues stores parsed route query values. Repeated query keys are kept
+// in insertion order for that key.
+type QueryValues map[string][]string
+
 // RouteContext describes the currently matched route.
 type RouteContext struct {
 	Path     string
@@ -16,6 +20,32 @@ func (ctx RouteContext) Param(name string) string {
 		return ""
 	}
 	return ctx.Params[name]
+}
+
+// Query parses RawQuery into route query values.
+func (ctx RouteContext) Query() QueryValues {
+	return ParseQuery(ctx.RawQuery)
+}
+
+// Get returns the first query value for name, or an empty string when absent.
+func (values QueryValues) Get(name string) string {
+	if values == nil {
+		return ""
+	}
+	items := values[name]
+	if len(items) == 0 {
+		return ""
+	}
+	return items[0]
+}
+
+// Has reports whether name is present in the query.
+func (values QueryValues) Has(name string) bool {
+	if values == nil {
+		return false
+	}
+	_, ok := values[name]
+	return ok
 }
 
 // RouteHandler renders one matched route.
@@ -186,6 +216,81 @@ func HashHref(to string) string {
 	return "#" + normalizeRouteTarget(to)
 }
 
+// WithQuery returns path with query values applied. Existing query text on path
+// is replaced.
+func WithQuery(path string, values QueryValues) string {
+	path, _ = splitRouteTarget(normalizeRouteTarget(path))
+	encoded := values.Encode()
+	if encoded == "" {
+		return path
+	}
+	return path + "?" + encoded
+}
+
+// ParseQuery parses raw route query text into QueryValues. Malformed percent
+// escapes are preserved literally rather than panicking.
+func ParseQuery(raw string) QueryValues {
+	values := QueryValues{}
+	if raw == "" {
+		return values
+	}
+	parts := strings.Split(raw, "&")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		name := part
+		value := ""
+		hasValue := false
+		if index := strings.IndexByte(part, '='); index >= 0 {
+			name = part[:index]
+			value = part[index+1:]
+			hasValue = true
+		}
+		name = decodeQueryComponent(name)
+		if name == "" {
+			continue
+		}
+		if hasValue {
+			value = decodeQueryComponent(value)
+			values[name] = append(values[name], value)
+		} else {
+			values[name] = append(values[name], "")
+		}
+	}
+	return values
+}
+
+// Encode serializes query values with deterministic key ordering.
+func (values QueryValues) Encode() string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	sortRouteQueryKeys(keys)
+	var builder strings.Builder
+	for _, key := range keys {
+		items := values[key]
+		if len(items) == 0 {
+			appendQuerySeparator(&builder)
+			builder.WriteString(encodeQueryComponent(key))
+			continue
+		}
+		for _, value := range items {
+			appendQuerySeparator(&builder)
+			builder.WriteString(encodeQueryComponent(key))
+			builder.WriteByte('=')
+			builder.WriteString(encodeQueryComponent(value))
+		}
+	}
+	return builder.String()
+}
+
 func normalizeRoutePattern(pattern string) string {
 	if pattern == "" {
 		panic("goframe: route pattern must not be empty")
@@ -287,4 +392,94 @@ func routeParts(path string) []string {
 		return nil
 	}
 	return strings.Split(strings.TrimPrefix(path, "/"), "/")
+}
+
+func appendQuerySeparator(builder *strings.Builder) {
+	if builder.Len() > 0 {
+		builder.WriteByte('&')
+	}
+}
+
+func sortRouteQueryKeys(keys []string) {
+	for index := 1; index < len(keys); index++ {
+		key := keys[index]
+		position := index - 1
+		for position >= 0 && keys[position] > key {
+			keys[position+1] = keys[position]
+			position--
+		}
+		keys[position+1] = key
+	}
+}
+
+func encodeQueryComponent(value string) string {
+	var builder strings.Builder
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if isQueryUnreserved(char) {
+			builder.WriteByte(char)
+			continue
+		}
+		if char == ' ' {
+			builder.WriteByte('+')
+			continue
+		}
+		builder.WriteByte('%')
+		builder.WriteByte(hexDigit(char >> 4))
+		builder.WriteByte(hexDigit(char))
+	}
+	return builder.String()
+}
+
+func decodeQueryComponent(value string) string {
+	var builder strings.Builder
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if char == '+' {
+			builder.WriteByte(' ')
+			continue
+		}
+		if char == '%' && index+2 < len(value) {
+			high, highOK := fromHex(value[index+1])
+			low, lowOK := fromHex(value[index+2])
+			if highOK && lowOK {
+				builder.WriteByte(high<<4 | low)
+				index += 2
+				continue
+			}
+		}
+		builder.WriteByte(char)
+	}
+	return builder.String()
+}
+
+func isQueryUnreserved(char byte) bool {
+	return (char >= 'a' && char <= 'z') ||
+		(char >= 'A' && char <= 'Z') ||
+		(char >= '0' && char <= '9') ||
+		char == '-' ||
+		char == '_' ||
+		char == '.' ||
+		char == '~'
+}
+
+func hexDigit(value byte) byte {
+	value = value & 0x0f
+	if value < 10 {
+		return '0' + value
+	}
+	return 'A' + value - 10
+}
+
+func fromHex(char byte) (byte, bool) {
+	switch {
+	case char >= '0' && char <= '9':
+		return char - '0', true
+	case char >= 'a' && char <= 'f':
+		return char - 'a' + 10, true
+	case char >= 'A' && char <= 'F':
+		return char - 'A' + 10, true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/goframe/router_query_test.go
+++ b/pkg/goframe/router_query_test.go
@@ -1,0 +1,87 @@
+package goframe
+
+import "testing"
+
+func TestRouteContextQueryParsesRawQuery(t *testing.T) {
+	query := RouteContext{
+		RawQuery: "status=open&status=review&q=auth+flow&flag&empty=",
+	}.Query()
+
+	if got := query.Get("q"); got != "auth flow" {
+		t.Fatalf("q = %q, want auth flow", got)
+	}
+	if !query.Has("flag") {
+		t.Fatal("flag should be present")
+	}
+	if got := query.Get("flag"); got != "" {
+		t.Fatalf("flag = %q, want empty", got)
+	}
+	if got := query.Get("empty"); got != "" {
+		t.Fatalf("empty = %q, want empty", got)
+	}
+	status := query["status"]
+	if len(status) != 2 || status[0] != "open" || status[1] != "review" {
+		t.Fatalf("status = %#v, want open/review", status)
+	}
+}
+
+func TestQueryValuesHandlesEmptyAndMissingKeys(t *testing.T) {
+	query := ParseQuery("")
+	if query.Has("missing") {
+		t.Fatal("empty query should not have missing")
+	}
+	if got := query.Get("missing"); got != "" {
+		t.Fatalf("missing = %q, want empty", got)
+	}
+	if got := (QueryValues(nil)).Get("missing"); got != "" {
+		t.Fatalf("nil query Get = %q, want empty", got)
+	}
+	if (QueryValues(nil)).Has("missing") {
+		t.Fatal("nil query Has should be false")
+	}
+}
+
+func TestParseQueryDecodesCommonEscapes(t *testing.T) {
+	query := ParseQuery("q=auth%2Flogin&space=hello+world&bad=%zz")
+
+	if got := query.Get("q"); got != "auth/login" {
+		t.Fatalf("q = %q, want auth/login", got)
+	}
+	if got := query.Get("space"); got != "hello world" {
+		t.Fatalf("space = %q, want hello world", got)
+	}
+	if got := query.Get("bad"); got != "%zz" {
+		t.Fatalf("bad = %q, want literal malformed percent", got)
+	}
+}
+
+func TestQueryValuesEncodeIsDeterministic(t *testing.T) {
+	values := QueryValues{
+		"status": {"open", "review"},
+		"q":      {"auth flow"},
+		"flag":   nil,
+	}
+
+	if got := values.Encode(); got != "flag&q=auth+flow&status=open&status=review" {
+		t.Fatalf("Encode = %q", got)
+	}
+}
+
+func TestWithQueryReplacesExistingQuery(t *testing.T) {
+	got := WithQuery("/issues?old=true", QueryValues{
+		"q":      {"auth/login"},
+		"status": {"open"},
+	})
+	if got != "/issues?q=auth%2Flogin&status=open" {
+		t.Fatalf("WithQuery = %q", got)
+	}
+	if href := HashHref(got); href != "#/issues?q=auth%2Flogin&status=open" {
+		t.Fatalf("HashHref(WithQuery) = %q", href)
+	}
+}
+
+func TestWithQueryClearsQueryForEmptyValues(t *testing.T) {
+	if got := WithQuery("#/issues?status=open", nil); got != "/issues" {
+		t.Fatalf("WithQuery empty = %q, want /issues", got)
+	}
+}

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -15,6 +15,7 @@ VIRTUALIZED_SMOKE_URL_BASE="${GOFRAME_VIRTUALIZED_SMOKE_URL:-http://127.0.0.1}"
 MULTIPACKAGE_SMOKE_URL_BASE="${GOFRAME_MULTIPACKAGE_SMOKE_URL:-http://127.0.0.1}"
 CMDAPP_SMOKE_URL_BASE="${GOFRAME_CMDAPP_SMOKE_URL:-http://127.0.0.1}"
 ROUTER_SMOKE_URL_BASE="${GOFRAME_ROUTER_SMOKE_URL:-http://127.0.0.1}"
+ROUTER_DASHBOARD_SMOKE_URL_BASE="${GOFRAME_ROUTER_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -124,6 +125,11 @@ build_cmdapp_smoke_url() {
 build_router_smoke_url() {
 	local port="$1"
 	echo "${ROUTER_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_router_dashboard_smoke_url() {
+	local port="$1"
+	echo "${ROUTER_DASHBOARD_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -325,6 +331,21 @@ run_with_server ./examples/router "$ROUTER_PORT" "$ROUTER_URL" \
 	node --experimental-websocket scripts/router-browser-smoke.mjs
 
 echo
+echo "== Router dashboard debug browser smoke =="
+"$GOXC" package ./examples/router-dashboard --compiler=tinygo
+(
+	cd ./examples/router-dashboard/.goframe/work/dev/examples/router-dashboard/cmd/app
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/router-dashboard/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+ROUTER_DASHBOARD_PORT="$(resolve_port "${GOFRAME_ROUTER_DASHBOARD_SMOKE_PORT:-}")"
+export GOFRAME_ROUTER_DASHBOARD_CHROME_DEBUG_PORT="${GOFRAME_ROUTER_DASHBOARD_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+ROUTER_DASHBOARD_URL="$(build_router_dashboard_smoke_url "$ROUTER_DASHBOARD_PORT")"
+run_with_server ./examples/router-dashboard "$ROUTER_DASHBOARD_PORT" "$ROUTER_DASHBOARD_URL" \
+	node --experimental-websocket scripts/router-dashboard-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
@@ -333,5 +354,6 @@ echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/multipackage --compiler=tinygo
 "$GOXC" package ./examples/cmdapp --compiler=tinygo
 "$GOXC" package ./examples/router --compiler=tinygo
+"$GOXC" package ./examples/router-dashboard --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -63,6 +63,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/cmdapp --compiler=tinygo
 "$GOXC" generate ./examples/router
 "$GOXC" package ./examples/router --compiler=tinygo
+"$GOXC" generate ./examples/router-dashboard
+"$GOXC" package ./examples/router-dashboard --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/router-dashboard-browser-smoke.mjs
+++ b/scripts/router-dashboard-browser-smoke.mjs
@@ -1,0 +1,357 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_ROUTER_DASHBOARD_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_ROUTER_DASHBOARD_CHROME_DEBUG_PORT ?? "19250");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-router-dashboard-smoke-"));
+const expectedApp = new URL(appURL);
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL));
+    await waitForAppPage(client, expectedApp);
+    await client.evaluate(`window.__routerDashboardSmokeShell = document.querySelector("[data-testid='rd-shell']")`);
+
+    assertState(await appState(client), {
+        route: "home",
+        hash: "",
+        shellSame: true,
+    }, "router-dashboard initial home");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-nav-issues']").click()`);
+    await waitForRoute(client, "issues");
+    assertState(await appState(client), {
+        route: "issues",
+        hash: "#/issues",
+        rowCount: 8,
+        queryValue: "",
+        statusValue: "all",
+        shellSame: true,
+    }, "router-dashboard issues route");
+
+    await setInput(client, "[data-testid='rd-filter-query']", "auth");
+    await setSelect(client, "[data-testid='rd-filter-status']", "open");
+    await settleAnimationFrame(client);
+    await client.evaluate(`document.querySelector("[data-testid='rd-filter-apply']").click()`);
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "issues" && state.rowCount === 1 && state.hash === "#/issues?q=auth&status=open";
+    }, "filtered issues route");
+    assertState(await appState(client), {
+        route: "issues",
+        hash: "#/issues?q=auth&status=open",
+        rowCount: 1,
+        queryValue: "auth",
+        statusValue: "open",
+        shellSame: true,
+    }, "router-dashboard query filter");
+
+    await client.evaluate(`history.back()`);
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "issues" && state.hash === "#/issues" && state.rowCount === 8;
+    }, "browser back restores query");
+    assertState(await appState(client), {
+        route: "issues",
+        hash: "#/issues",
+        rowCount: 8,
+        queryValue: "",
+        statusValue: "all",
+        shellSame: true,
+    }, "router-dashboard browser back");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-issue-link-RD-2']").click()`);
+    await waitForRoute(client, "details");
+    assertState(await appState(client), {
+        route: "details",
+        hash: "#/issues/RD-2",
+        detailTitle: "Billing dashboard needs clearer empty state",
+        shellSame: true,
+    }, "router-dashboard detail route");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-edit-link']").click()`);
+    await waitForRoute(client, "edit");
+    assertState(await appState(client), {
+        route: "edit",
+        hash: "#/issues/RD-2/edit",
+        formTitle: "Billing dashboard needs clearer empty state",
+        formDirty: "No local changes",
+        shellSame: true,
+    }, "router-dashboard edit route");
+
+    await setInput(client, "[data-testid='rd-field-title']", "");
+    await client.evaluate(`document.querySelector("[data-testid='rd-form-submit']").click()`);
+    await waitForCondition(async () => {
+        return (await appState(client)).titleError === "Title is required.";
+    }, "title validation error");
+    assertState(await appState(client), {
+        route: "edit",
+        titleError: "Title is required.",
+        formDirty: "Unsaved local changes",
+        saved: false,
+        shellSame: true,
+    }, "router-dashboard validation error");
+
+    await setInput(client, "[data-testid='rd-field-title']", "Updated billing title");
+    await client.evaluate(`document.querySelector("[data-testid='rd-form-submit']").click()`);
+    await waitForCondition(async () => {
+        return (await appState(client)).saved;
+    }, "valid form submit");
+    assertState(await appState(client), {
+        route: "edit",
+        titleError: "",
+        saved: true,
+        shellSame: true,
+    }, "router-dashboard valid submit");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-form-reset']").click()`);
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.formTitle === "Billing dashboard needs clearer empty state" &&
+            state.formDirty === "No local changes" &&
+            !state.saved &&
+            state.titleError === "";
+    }, "form reset");
+    assertState(await appState(client), {
+        route: "edit",
+        formTitle: "Billing dashboard needs clearer empty state",
+        formDirty: "No local changes",
+        saved: false,
+        titleError: "",
+        shellSame: true,
+    }, "router-dashboard form reset");
+
+    await client.evaluate(`location.hash = "#/missing"`);
+    await waitForRoute(client, "notFound");
+    assertState(await appState(client), {
+        route: "notFound",
+        hash: "#/missing",
+        notFoundPath: "/missing",
+        shellSame: true,
+    }, "router-dashboard not-found");
+
+    const debug = await appState(client);
+    if (debug.routerViewRenders < 2 || debug.routerRouteRenders < 2) {
+        throw new Error(`APP FAILURE: router-dashboard debug render counters are not readable: ${JSON.stringify(debug)}`);
+    }
+
+    client.close();
+    console.log("Router dashboard browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function appState(client) {
+    return await client.evaluate(`(() => {
+        const home = document.querySelector("[data-testid='rd-home']");
+        const issues = document.querySelector("[data-testid='rd-issue-list']");
+        const details = document.querySelector("[data-testid='rd-issue-detail']");
+        const edit = document.querySelector("[data-testid='rd-issue-edit']");
+        const notFound = document.querySelector("[data-testid='rd-not-found']");
+        return {
+            route: home ? "home" : issues ? "issues" : details ? "details" : edit ? "edit" : notFound ? "notFound" : "missing",
+            hash: location.hash,
+            rowCount: document.querySelectorAll("[data-testid='rd-issue-row']").length,
+            queryValue: document.querySelector("[data-testid='rd-filter-query']")?.value ?? "",
+            statusValue: document.querySelector("[data-testid='rd-filter-status']")?.value ?? "",
+            summary: document.querySelector("[data-testid='rd-filter-summary']")?.textContent.trim() ?? "",
+            detailTitle: document.querySelector("[data-testid='rd-issue-detail'] h2")?.textContent.trim() ?? "",
+            formTitle: document.querySelector("[data-testid='rd-field-title']")?.value ?? "",
+            formDirty: document.querySelector("[data-testid='rd-form-dirty']")?.textContent.trim() ?? "",
+            titleError: document.querySelector("[data-testid='rd-field-error-title']")?.textContent.trim() ?? "",
+            saved: Boolean(document.querySelector("[data-testid='rd-form-saved']")),
+            notFoundPath: document.querySelector("[data-testid='rd-not-found-path']")?.textContent.trim() ?? "",
+            shellSame: window.__routerDashboardSmokeShell === document.querySelector("[data-testid='rd-shell']"),
+            routerViewRenders: window.goframeComponentRenderCounts?.RouterView ?? 0,
+            routerRouteRenders: window.goframeComponentRenderCounts?.RouterRoute ?? 0,
+        };
+    })()`);
+}
+
+async function setInput(client, selector, value) {
+    await client.evaluate(`(() => {
+        const element = document.querySelector(${JSON.stringify(selector)});
+        if (!element) throw new Error("missing input " + ${JSON.stringify(selector)});
+        element.value = ${JSON.stringify(value)};
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+    })()`);
+}
+
+async function setSelect(client, selector, value) {
+    await client.evaluate(`(() => {
+        const element = document.querySelector(${JSON.stringify(selector)});
+        if (!element) throw new Error("missing select " + ${JSON.stringify(selector)});
+        element.value = ${JSON.stringify(value)};
+        element.dispatchEvent(new Event("change", { bubbles: true }));
+    })()`);
+}
+
+async function settleAnimationFrame(client) {
+    await client.evaluate(`new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(resolve));
+    })`);
+}
+
+async function waitForRoute(client, route) {
+    await waitForCondition(async () => {
+        return (await appState(client)).route === route;
+    }, `route ${route}`);
+}
+
+function assertState(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (actual[key] !== value) {
+            throw new Error(`APP FAILURE: ${label}: ${key} got ${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; state=${JSON.stringify(actual)}`);
+        }
+    }
+    console.log(`${label}: ok`);
+}
+
+function withSmokeParam(url) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", String(Date.now()));
+    next.hash = "";
+    return String(next);
+}
+
+async function waitForPage(port) {
+    const endpoint = `http://127.0.0.1:${port}/json/version`;
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        try {
+            const version = await fetch(endpoint).then((response) => response.json());
+            if (version.webSocketDebuggerUrl) {
+                const pages = await fetch(`http://127.0.0.1:${port}/json`).then((response) => response.json());
+                const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+                if (page) {
+                    return page;
+                }
+            }
+        } catch {
+            if (browser.exitCode !== null) {
+                throw new Error(`HARNESS FAILURE: Chrome exited early. stderr:\n${browserError}`);
+            }
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools endpoint did not start. stderr:\n${browserError}`);
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const { resolve, reject } = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            reject(new Error(`${message.error.message}: ${message.error.data ?? ""}`));
+        } else {
+            resolve(message.result ?? {});
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    return {
+        call(method, params = {}) {
+            const id = nextID++;
+            socket.send(JSON.stringify({ id, method, params }));
+            return new Promise((resolve, reject) => {
+                pending.set(id, { resolve, reject });
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                awaitPromise: true,
+                returnByValue: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`APP FAILURE: evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+    await waitForCondition(async () => {
+        const readyState = await client.evaluate("document.readyState");
+        return readyState === "complete" || readyState === "interactive";
+    }, "page navigation");
+}
+
+async function waitForAppPage(client, expectedApp) {
+    await waitForCondition(async () => {
+        const state = await client.evaluate(`(() => ({
+            href: location.href,
+            origin: location.origin,
+            rootReady: Boolean(document.querySelector("#root")),
+            appReady: Boolean(document.querySelector("[data-testid='rd-shell']")),
+        }))()`);
+        return state.origin === expectedApp.origin && state.rootReady && state.appReady;
+    }, "router-dashboard app page");
+}
+
+async function waitForCondition(predicate, label) {
+    const started = Date.now();
+    let lastError;
+    while (Date.now() - started < 10_000) {
+        try {
+            if (await predicate()) {
+                return;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ""}`);
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -132,10 +132,11 @@ check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
 check_app "dashboard" "$(bundle_path dashboard)" 168960 53248 71680 61440 || status=1
-check_app "context" "$(bundle_path context)" 115200 36864 46080 40960 || status=1
-check_app "virtualized" "$(bundle_path virtualized)" 122880 40960 49152 44032 || status=1
+check_app "context" "$(bundle_path context)" 116736 36864 46080 40960 || status=1
+check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 159744 51200 61440 56320 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Hardens GoFrame’s public surface around a practical browser/WASM application flow.

This PR adds a small router query API, documents canonical form and validation patterns, and introduces `examples/router-dashboard` as a reference application combining routing, URL-driven filters, controlled forms, validation, and the Go-first `cmd/app + internal/...` layout.

## What changed

- Added router query helpers:
  - `gf.QueryValues`
  - `gf.ParseQuery`
  - `RouteContext.Query`
  - `QueryValues.Get`, `Has`, and `Encode`
  - `gf.WithQuery`
- Added deterministic query encoding, repeated-value support, and safe handling of malformed percent escapes.
- Documented forms as application-level patterns based on `UseReducer`, controlled inputs, local validation, and touched/dirty/submitted state.
- Added `examples/router-dashboard` with:
  - hash routing and route params;
  - query-driven list filters;
  - list, detail, edit, and not-found routes;
  - controlled form fields;
  - validation, reset, dirty state, and local save feedback.
- Added end-to-end browser smoke coverage for filtering, browser history, route transitions, form validation, submit, reset, and stable shell identity.
- Fixed controlled `<select>` mounting so its value is applied after options are mounted.
- Clarified public-candidate, experimental, compiler-facing, and internal API tiers.
- Updated README, CI documentation, performance baselines, size budgets, and changelog.

## Design decisions

- No form framework or schema-validation package was added.
- Form state and validation remain ordinary Go code owned by the application.
- Query helpers are intentionally small and do not introduce automatic route-state binding, typed codecs, loaders, or a global route store.
- Low-level node helpers remain exported for GOX-generated and handwritten low-level code, while normal application structure should prefer GOX.

## Non-goals

- Async resources or external data loading
- Server actions or route loaders
- History-mode routing
- Route middleware or auth guards
- Full Error Boundary API
- Formatter or LSP
- Player/Engine or production deployment server

## Validation

Passed:

- `go test ./...`
- race and debug-tag tests
- `go vet ./...`
- GOX golden and error-golden tests
- all example tests
- full browser smoke suite
- dashboard DOM-pressure audit
- size budgets and performance report
- artifact, module-path, and documentation checks
- TinyGo packaging for all examples
- Go/WASM packaging for multi-package and child-entry examples

All existing size budgets pass. Dashboard mounted-row, live-DOM, listener, and spacer-stability invariants remain unchanged.