### PR TITLE
MVP 28: component-scoped resources

### DIFF
--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -64,6 +64,8 @@ jobs:
           goxc package ./examples/router --compiler=tinygo
           goxc generate ./examples/router-dashboard
           goxc package ./examples/router-dashboard --compiler=tinygo
+          goxc generate ./examples/resource
+          goxc package ./examples/resource --compiler=tinygo
           goxc package ./examples/counter --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/components --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/todo --compiler=tinygo --asset-hash --preload --compress=gzip,br
@@ -74,6 +76,7 @@ jobs:
           goxc package ./examples/cmdapp --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/router --compiler=tinygo --asset-hash --preload --compress=gzip,br
           goxc package ./examples/router-dashboard --compiler=tinygo --asset-hash --preload --compress=gzip,br
+          goxc package ./examples/resource --compiler=tinygo --asset-hash --preload --compress=gzip,br
 
       - name: Size budgets
         run: scripts/size-budget.sh | tee size-report.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 - Error Boundary fallback correctness: a boundary no longer self-captures
   failures from the fallback subtree it is currently displaying; those failures
   bubble to an outer boundary or the default render fallback.
+- Component-scoped resource prototype with `gf.UseResource`, explicit
+  loading/ready/failed state, stale completion guards, cleanup/cancellation
+  semantics, and a focused resource example plus browser smoke coverage.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,16 @@
 - Artifact and module path regression gates.
 - CI and release hygiene documentation.
 
+### Fixed
+
+- Resource loader panics no longer leave the internal effect slot pending, so a
+  same-key rerender after failed state does not automatically restart the same
+  panicking loader. Explicit retry remains available through `reload` or key
+  change, and first completion still wins if a loader resolves or rejects before
+  panicking.
+- The resource example browser loader now releases cancelled promise/timer
+  callbacks on inactive response paths.
+
 ### Planned
 
 - CI pipeline tuning after the first public pull requests.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Current baseline includes:
 
 - GOX expression ergonomics and source-oriented diagnostics;
 - component boundaries, state, reducer dispatch, effects, context selectors,
-  memoization, keyed reconciliation, fixed-height virtualization, and a small
-  hash-based client router with tiny query helpers;
+  memoization, keyed reconciliation, fixed-height virtualization,
+  component-scoped resources, and a small hash-based client router with tiny
+  query helpers;
 - runtime error reporting plus scoped render-only Error Boundaries for
   recover-capable builds;
 - cache-safe packaging, hidden `.goframe` workspace output, export safety, and
@@ -33,9 +34,10 @@ Current baseline includes:
 
 Non-goals for the current project surface include SSR, hydration,
 Player/Engine implementation, path/history-mode routing, file-based routing,
-route loaders, dynamic virtualization, infinite loading, LSP, formatter,
-XML-style namespace tags, spread props, schema validation framework,
-production deployment server, and full multi-module monorepo support.
+route loaders, Suspense-style resources, global resource caching, dynamic
+virtualization, infinite loading, LSP, formatter, XML-style namespace tags,
+spread props, schema validation framework, production deployment server, and
+full multi-module monorepo support.
 
 ## What Is GoFrame?
 
@@ -134,6 +136,7 @@ goxc package ./examples/counter --compiler=go
 | `examples/context` | Scoped providers, selector consumers, broad `UseContext`, nested providers. | `goxc package ./examples/context --compiler=tinygo` |
 | `examples/virtualized` | `gf.VirtualList`, `gf.VirtualTable`, bounded DOM with 10,000 logical rows. | `goxc package ./examples/virtualized --compiler=tinygo` |
 | `examples/router` | Hash router, query helpers, route params, not-found route, and stable shell layout. | `goxc package ./examples/router --compiler=tinygo` |
+| `examples/resource` | Experimental `gf.UseResource`, explicit loading/ready/failed state, stale completion guards, and example-local browser fetch. | `goxc package ./examples/resource --compiler=tinygo` |
 
 ### Toolchain / Layout
 
@@ -459,6 +462,7 @@ Runtime topics:
 - [Context selectors](docs/context.md)
 - [Virtualized collections](docs/virtualization.md)
 - [Client router](docs/router.md)
+- [Component-scoped resources](docs/resources.md)
 - [Component identity strategy](docs/component-identity.md)
 - [Component identity next steps](docs/component-identity-next.md)
 
@@ -490,6 +494,7 @@ Examples:
 - [Child entry package example](examples/cmdapp/README.md)
 - [Router example](examples/router/README.md)
 - [Router dashboard reference example](examples/router-dashboard/README.md)
+- [Resource loading example](examples/resource/README.md)
 - [VS Code GOX extension](extensions/vscode-gox/README.md)
 
 ## Current Limitations
@@ -511,6 +516,9 @@ Examples:
 - Error Boundaries are render-only and recover-based. Default TinyGo
   `panic=trap` builds compile the API but are not the proof path for boundary
   containment.
+- Resources are component-scoped and explicit-state only. There is no global
+  resource cache, Suspense-style render blocking, route loader framework, or
+  runtime fetch/JSON API.
 - Duplicate key diagnostics are debug-only.
 - TinyGo compatibility remains version- and feature-dependent.
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -122,6 +122,9 @@ should prefer GOX markup for structure.
   `gf.ErrorBoundaryProps`, and `gf.ErrorBoundaryContext`.
   Internal boundary phases such as protected, captured, and fallback are not
   public API.
+- Component-scoped resource API and exact lifecycle semantics:
+  `gf.ResourceStatus`, `gf.Resource`, `gf.ResourceLoader`, and
+  `gf.UseResource`.
 - Hash router details such as route remount policy, declaration-order matching
   edge cases, link props, query helper edge cases, and browser listener
   internals.
@@ -174,7 +177,8 @@ Not stable:
 - file-based routing, route loaders, route middleware, and route-level error
   boundary policy;
 - schema validation or a form framework;
-- external data/resource story;
+- global resource cache, transport helpers, route loaders, and Suspense-style
+  resource story;
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
 - multi-module app support;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,6 +185,7 @@ multipackage bundle.wasm     94,344 bytes
 cmdapp bundle.wasm           94,370 bytes
 router bundle.wasm          114,706 bytes
 router-dashboard bundle.wasm 164,091 bytes
+resource bundle.wasm        147,562 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -197,7 +198,7 @@ The repository includes `scripts/size-budget.sh` as a regression gate for raw,
 gzip, brotli, and optional zstd packaged TinyGo examples, including the
 dashboard-sized pressure-test example, the context selector example, and the
 virtualized collections, multi-package workspace, child-entry workspace,
-hash-router, and router-dashboard reference examples.
+hash-router, router-dashboard reference, and resource loading examples.
 `scripts/perf-report.sh` runs pure runtime benchmarks plus the same size
 budgets, and `scripts/browser-smoke.sh` runs the optional headless Chrome
 regression probes.
@@ -226,6 +227,12 @@ filters, controlled form state, synchronous validation, and stable shell
 composition without adding a data-loading framework or schema validation
 library.
 
+`examples/resource` is the first resource-loading probe. It uses
+component-scoped `gf.UseResource` with example-local browser fetch, text
+parsing, delayed responses, and abort cleanup. It intentionally does not add a
+runtime fetch API, JSON helper, global resource cache, Suspense model, or route
+loader framework.
+
 Future editor-sized experiments should measure startup, update time, memory,
 compressed transfer size, and development ergonomics before broader conclusions
 are drawn.
@@ -243,6 +250,7 @@ The MVP runtime currently has:
 - reducer dispatch that applies actions to the latest component state slot;
 - scoped context providers with selector-based consumer dirtying;
 - component-scoped lifecycle/effect slots;
+- component-scoped explicit-state resources;
 - fixed-height `VirtualList` and `VirtualTable` collection primitives;
 - hash-based client routing through `RouterView`, `RouterLink`, and Go-declared
   routes;

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -31,8 +31,9 @@ and manually through `workflow_dispatch`.
 
 It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
 counter, components, todo, dashboard, context, virtualized, multipackage,
-cmdapp, and router examples with TinyGo. It also runs a release-style package
-pass with `--asset-hash --preload --compress=gzip,br` before checking:
+cmdapp, router, router-dashboard, and resource examples with TinyGo. It also
+runs a release-style package pass with `--asset-hash --preload
+--compress=gzip,br` before checking:
 
 ```bash
 scripts/size-budget.sh
@@ -65,7 +66,9 @@ filtering/sorting/selection behavior, context selector rerender isolation,
 virtualized collection scroll/selection/toggle behavior, a multi-package GOX
 workspace smoke, a child-entry package smoke, hash-router navigation smoke, and
 the router-dashboard reference app smoke for query filters plus form
-validation.
+validation. It also covers the resource example for explicit loading/ready/
+failed state, reload, stale completion guards, and cleanup-after-unmount
+behavior.
 
 The runtime error containment and Error Boundary fixtures are compiled with the
 Go WASM compiler so `recover` semantics are available. The size-oriented TinyGo
@@ -226,6 +229,9 @@ Router smoke failures include broken hash navigation, missing route params,
 not-found fallback regressions, browser back handling regressions, query helper
 regressions, form validation regressions in the reference app, or unstable
 shell layout identity.
+Resource smoke failures include broken loading/ready/failed transitions, stale
+completion updates, cleanup-after-unmount regressions, or resource failures
+escaping into Error Boundary fallback UI.
 Error Boundary smoke failures include missing render-failure reports, fallback
 or reset regressions, fallback component self-capture/report-loop regressions,
 nested-boundary bubbling regressions, protected-subtree cleanup regressions, or

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -150,6 +150,17 @@ The Todo example uses effects to persist tasks:
 - encoding lives in the example, not in `pkg/goframe`, so the runtime does not
   import `encoding/json`.
 
+## Resource Loaders
+
+`gf.UseResource` builds on the same after-patch timing and cleanup model as
+effects. A resource loader starts only after the component's render has been
+patched, and its cleanup runs when the resource key changes, `reload` starts a
+new generation, or the component unmounts.
+
+Resource loaders are expected to release browser timers, abort controllers,
+subscriptions, or other retained handles from their cleanup. Late `resolve` or
+`reject` calls after cleanup are ignored by the resource generation guard.
+
 ## Limitations
 
 - No `UseEffect` dependency inference.
@@ -158,6 +169,7 @@ The Todo example uses effects to persist tasks:
 - No lifecycle hooks for before-render or before-patch.
 - No automatic component memoization in the GOX compiler or runtime. Memoization is
   explicit via `MemoEqual` on component props and is intentionally opt-in.
-- No route-aware effect lifecycle, SSR, hydration, or async component model.
+- No route-aware effect lifecycle, SSR, hydration, Suspense, or async component
+  model.
 - Hook order changes are unsupported and may panic only when the slot type
   changes.

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -161,6 +161,13 @@ Resource loaders are expected to release browser timers, abort controllers,
 subscriptions, or other retained handles from their cleanup. Late `resolve` or
 `reject` calls after cleanup are ignored by the resource generation guard.
 
+Resource loader setup panics are resource-specific. In recover-capable builds,
+the resource wrapper reports `gf.ErrorPhaseEffect`, completes the current
+generation as failed if panic was the first completion, and lets the internal
+effect slot finish. A same-key rerender therefore does not retry a panicking
+loader automatically. Use `reload` or a key change to start a new generation.
+This does not change ordinary `UseEffect` body panic behavior.
+
 ## Limitations
 
 - No `UseEffect` dependency inference.

--- a/docs/error-boundaries.md
+++ b/docs/error-boundaries.md
@@ -4,7 +4,7 @@
 
 Error Boundaries add a small scoped fallback UI for render failures. They build
 on the runtime error reporting model from MVP 23 without turning GoFrame into a
-React-style boundary, Suspense, or async resource framework.
+React-style boundary, Suspense, or route-level resource framework.
 
 The boundary scope is intentionally narrow: it catches render-path failures in
 descendant component subtrees, reports them through the existing global runtime
@@ -79,6 +79,8 @@ They do not catch:
 
 Those phases keep the MVP 23 semantics and continue to report through
 `SetErrorHandler` without switching the boundary to fallback UI.
+Ordinary `gf.UseResource` rejection is explicit `ResourceFailed` state, not a
+render failure, so it also does not switch a boundary to fallback UI.
 
 Initial context selector panics happen during component render. They still
 report `ErrorPhaseContext`, then flow through render containment and can be
@@ -205,8 +207,8 @@ component style used elsewhere:
 
 Apps that want a stable shell can still keep the shell outside `RouterView` and
 put the boundary inside selected route handlers. This keeps routing and error
-UI policy separate. Automatic route-level error pages, loaders, async
-resources, and Suspense remain future work.
+UI policy separate. Automatic route-level error pages, route loaders, and
+Suspense-style resource fallback remain future work.
 
 The lower-level Go props/`Children` form remains valid for hand-written runtime
 code and tests, but the package-qualified GOX style is the recommended
@@ -231,7 +233,7 @@ They should not be treated as proof that runtime recover handlers execute.
 - No full Error Boundary component API beyond fallback and reset.
 - No route-level automatic boundary.
 - No event/effect/cleanup containment through boundaries.
-- No async resources or Suspense-like model.
+- No Suspense-like resource throwing or route loader model.
 - No stack trace parsing or source-map integration.
 - No production crash-reporting integration.
 - No special TinyGo recover-capable packaging profile yet.
@@ -244,4 +246,4 @@ Future stages may consider:
 - recover-capable TinyGo package mode if the size tradeoff is acceptable;
 - richer app diagnostics or debug probes;
 - optional crash reporting integration points;
-- async resource/error semantics, if GoFrame later adds a resource model.
+- route-level resource/error semantics if repeated app patterns justify them.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -189,7 +189,7 @@ GoFrame does not provide:
 - server submit actions;
 - automatic field registration;
 - form context;
-- route loaders/resources;
+- route loaders or automatic resource binding;
 - query-state binding;
 - browser-native constraint validation wrappers;
 - file upload helpers.

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document records the measurable baseline through MVP 27. It is a
+This document records the measurable baseline through MVP 28. It is a
 decision aid for future runtime and tooling work, not a claim that GoFrame is
 production-ready.
 
@@ -19,7 +19,7 @@ The baseline covers:
 - browser smoke behavior for Todo, duplicate keys, runtime errors, Error
   Boundaries, dashboard, context, virtualized collections, the multi-package
   example, the child-entry example, the hash-router example, and the
-  router-dashboard reference example;
+  router-dashboard reference example, and the resource example;
 - dashboard DOM pressure and listener stability;
 - pure runtime benchmark reports;
 - package, export, artifact, and module path safety gates.
@@ -40,6 +40,9 @@ These failures should block CI or a PR:
 - Error Boundary smoke fails to report a render failure once, switch to
   fallback UI, reset cleanly, preserve shell identity, or keep nested-boundary
   bubbling semantics.
+- Resource smoke fails explicit loading/ready/failed transitions, reload,
+  stale-completion guards, cleanup-after-unmount behavior, or non-boundary
+  failed-state semantics.
 - A smoke app loads from the wrong origin or cannot validate WASM MIME type.
 - Dashboard mounted `.issue-row` count becomes unbounded.
 - Dashboard DOM pressure shows live DOM growth across Open -> All cycles.
@@ -102,6 +105,7 @@ Current verification includes:
 - `go test ./examples/cmdapp`
 - `go test ./examples/router`
 - `go test ./examples/router-dashboard`
+- `go test ./examples/resource`
 - `scripts/check.sh`
 - `scripts/size-budget.sh`
 - `scripts/perf-report.sh`
@@ -127,6 +131,7 @@ TinyGo packaged WASM sizes:
 | cmdapp | 94380 | 36839 | 30720 | 33124 |
 | router | 114716 | 43602 | 36062 | 39026 |
 | router-dashboard | 164098 | 61873 | 49731 | 53810 |
+| resource | 147562 | 64576 | 54640 | 58090 |
 
 The authoritative gate remains `scripts/size-budget.sh`. This table is a
 snapshot, not a second budget file.
@@ -156,6 +161,9 @@ snapshot, not a second budget file.
 - Router-dashboard query filters, browser back query restoration, route params,
   controlled form validation, reset behavior, not-found rendering, and stable
   shell layout.
+- Resource example explicit loading/ready/failed state, reload behavior,
+  stale completion guards, cleanup after unmount, and failed-state behavior
+  that does not activate Error Boundary fallback.
 
 Hard browser gates focus on correctness and structural invariants. Timing
 printed by smoke scripts is useful for trend spotting, but it is not a stable
@@ -172,13 +180,13 @@ CI budget yet.
 | All logical rows | 300 |
 | All mounted row max | 28 |
 | Open mounted row max | 28 |
-| Average All duration | 53.71 ms |
-| Max All duration | 67 ms |
+| Average All duration | 51.08 ms |
+| Max All duration | 68.9 ms |
 | Average All created nodes | 621 |
 | Average All removed nodes | 69 |
-| Average All runtime render | 14.17 ms |
-| Average All script | 17.75 ms |
-| Average All layout | 3.73 ms |
+| Average All runtime render | 14.43 ms |
+| Average All script | 17.48 ms |
+| Average All layout | 4.39 ms |
 | Live DOM All start/end | 486 -> 486 |
 | Net listeners All start/end | 0 -> 0 |
 | Post-idle live DOM nodes | 486 |

--- a/docs/public-preview-hardening-i.md
+++ b/docs/public-preview-hardening-i.md
@@ -21,10 +21,11 @@ The current project direction is:
 > GoFrame is an experimental Go-first browser/WASM framework and toolchain for
 > SPA-style and dashboard/admin-class applications.
 
-That direction makes router/query/forms polish more useful than jumping
+That direction made router/query/forms polish more useful than jumping
 directly to data loading, LSP, history routing, Player/Engine work, or a broad
-application convention layer. Small real apps need URL-driven filters and
-forms before they need a large app framework.
+application convention layer. MVP 28 later adds a deliberately small
+component-scoped resource primitive; it does not change the MVP 25 conclusion
+that GoFrame should avoid a large app framework surface.
 
 ## Scope
 
@@ -39,8 +40,8 @@ In scope:
 
 Out of scope:
 
-- server resources, server functions, or external data fetching;
-- async resource framework or Suspense-like behavior;
+- server resources, server functions, or built-in external data fetching;
+- global resource cache, route loaders, or Suspense-like behavior;
 - history-mode router or server fallback automation;
 - route loaders, middleware, auth guards, or automatic route-level Error
   Boundary policy;
@@ -131,8 +132,8 @@ MVP 25 does not introduce:
 
 - a global store;
 - a schema validation package;
-- external data loading;
-- async submit/data resource model;
+- built-in external data loading;
+- async submit, route loader, or Suspense-style resource model;
 - route loaders or route middleware;
 - history-mode routing;
 - production server behavior.
@@ -144,14 +145,15 @@ MVP 25 does not introduce:
 - Forms remain patterns rather than a library. This is deliberate, but users
   who want schema validation still need app-level code.
 - Router state remains hash-based only.
-- The reference app is local and deterministic; it does not answer the future
-  external data/resource story.
+- The reference app is local and deterministic; it does not answer the broader
+  external data, global cache, or route-loader story. MVP 28's component
+  resource primitive is a smaller explicit-state step.
 
 ## Next Steps
 
 After this pass, likely next work should focus on one of:
 
-- a careful external data/resource model;
+- careful app patterns around the component-scoped resource model;
 - browser support and deployment documentation hardening;
 - public-preview compatibility policy;
 - route-level error UI helpers after scoped Error Boundaries have more usage;

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -154,9 +154,23 @@ Ordinary loader rejection is application data state. It becomes
 
 Loader panic happens while the loader starts inside an effect. In
 recover-capable builds, GoFrame records a failed resource state with an
-internal error and then lets the existing effect containment report
-`gf.ErrorPhaseEffect`. No cleanup is registered if the loader did not return
-one.
+internal error when the generation has not already completed, reports one
+`gf.ErrorPhaseEffect`, and treats that resource effect as finished for the
+current key. Same-key rerenders do not automatically retry a panicking loader.
+Retry is explicit: call the returned `reload` function or change the resource
+key.
+
+For one generation, the first completion still wins even when the loader later
+panics. If the loader calls `resolve(value)` and then panics, the resource
+remains `ResourceReady` with that value and the panic is still reported once.
+If the loader calls `reject(err)` and then panics, the resource remains
+`ResourceFailed` with the original error and the panic is still reported once.
+The internal loader-panic error is used only when panic is the first
+completion.
+
+No cleanup is registered when the loader panics before returning one. The
+resource wrapper handles this panic itself so the generic `UseEffect` panic
+semantics are unchanged.
 
 MVP 28 does not add `ErrorPhaseResource`.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,225 @@
+# Resources
+
+## Purpose
+
+Resources are a minimal component-scoped loading primitive for asynchronous
+work. They model a single explicit state machine:
+
+- loading;
+- ready;
+- failed.
+
+They do not add Suspense, async rendering, route loaders, server resources, a
+global cache, request deduplication, retries, polling, or a browser fetch API.
+The runtime stays transport-agnostic: a loader may use browser `fetch`, a
+timer, local storage, a host bridge, or any other callback source.
+
+## API
+
+```go
+type ResourceStatus uint8
+
+const (
+    ResourceLoading ResourceStatus = iota
+    ResourceReady
+    ResourceFailed
+)
+
+type Resource[T any] struct {
+    Status ResourceStatus
+    Value  T
+    Err    error
+}
+
+func (resource Resource[T]) Loading() bool
+func (resource Resource[T]) Ready() bool
+func (resource Resource[T]) Failed() bool
+
+type ResourceLoader[T any] func(
+    key string,
+    resolve func(T),
+    reject func(error),
+) Cleanup
+
+func UseResource[T any](
+    key string,
+    loader ResourceLoader[T],
+) (Resource[T], func())
+```
+
+The returned function requests a manual reload for the current component
+instance. Calling an old reload closure after later renders uses the latest
+component resource state. Calling it after unmount is a no-op.
+
+`key` is a string and may be empty. A nil loader is a runtime invariant panic.
+
+## Status Model
+
+The first render returns:
+
+- `Status: ResourceLoading`;
+- zero `Value`;
+- nil `Err`.
+
+The loader has not run yet during that render. It starts after the DOM patch
+through the existing effect lifecycle.
+
+A valid `resolve(value)` transitions the current generation to:
+
+- `Status: ResourceReady`;
+- `Value: value`;
+- nil `Err`.
+
+A valid `reject(err)` transitions the current generation to:
+
+- `Status: ResourceFailed`;
+- zero `Value`;
+- non-nil `Err`.
+
+If `reject(nil)` is called, the runtime stores a small internal non-nil error
+instead of panicking.
+
+For one generation, the first completion wins. Later `resolve` or `reject`
+calls are ignored.
+
+## Loader Contract
+
+The loader receives the current key and two completion callbacks. It may return
+a cleanup. Nil cleanup is allowed.
+
+Callbacks are intended to be called from the browser/WASM event loop or another
+single-threaded host callback path. GoFrame does not add synchronization or a
+cross-thread callback model in MVP 28.
+
+If the loader function identity changes while the key and reload generation are
+unchanged, the current load is not restarted. The latest loader is used on the
+next key change or manual reload.
+
+## Key Changes
+
+Changing the key invalidates the current generation immediately during render,
+before the next loader starts. This means late completions from the old key are
+ignored before they can update resource state or dirty the component.
+
+The next loader starts after the new render is patched. The previous generation
+cleanup runs before that next loader body.
+
+## Manual Reload
+
+Manual reload creates a new generation using the current key. It immediately
+invalidates old completion callbacks, switches public state back to loading,
+marks the component dirty, and lets the next effect pass start the new loader
+after patch.
+
+Reload does not use a global cache or dedupe shared keys. Two components using
+the same key have independent resources.
+
+## Cancellation And Cleanup
+
+The cleanup returned by the loader runs:
+
+- before starting a new generation after key change;
+- before starting a new generation after manual reload;
+- during component unmount.
+
+Each started generation cleanup runs at most once. Before cleanup calls user
+code, the generation is marked inactive so callbacks fired by cleanup cannot
+complete that generation.
+
+If cleanup panics, the existing effect cleanup containment reports
+`gf.ErrorPhaseEffectCleanup`. The resource does not switch status because of
+cleanup panic.
+
+## Stale Completion Protection
+
+Every generation has an internal token. Resolve and reject callbacks check that
+their token is still the current active generation before touching public
+resource state.
+
+Stale callbacks do not:
+
+- change `Resource[T]`;
+- dirty the component;
+- replace the current value or error;
+- start another load;
+- report a runtime error.
+
+This guard is immediate. It does not rely on hiding stale state on a later
+render.
+
+## Error Semantics
+
+Ordinary loader rejection is application data state. It becomes
+`ResourceFailed` and does not activate an Error Boundary.
+
+Loader panic happens while the loader starts inside an effect. In
+recover-capable builds, GoFrame records a failed resource state with an
+internal error and then lets the existing effect containment report
+`gf.ErrorPhaseEffect`. No cleanup is registered if the loader did not return
+one.
+
+MVP 28 does not add `ErrorPhaseResource`.
+
+## Error Boundaries
+
+`gf.ErrorBoundary` remains render-only. It can catch render failures in UI that
+displays a resource, but it does not catch normal `ResourceFailed` state.
+
+Applications should render loading, ready, and failed UI explicitly.
+
+## Synchronous Completion
+
+A loader may call `resolve` or `reject` synchronously during effect setup. The
+resource update is still scheduled through normal state/dirty mechanics after
+the current DOM patch and effect flush. The first render remains loading.
+
+## Component Lifetime
+
+Resources are owned by the component instance that calls `UseResource`.
+
+Unmount invalidates the active generation, runs its cleanup once, and makes
+future completion or reload callbacks no-ops. The runtime does not keep a
+global registry of resources.
+
+The implementation is intentionally composed from existing component-scoped
+hook machinery: one internal state slot stores a small mutable control object,
+and one effect slot starts/cleans generations. No new `componentInstance`
+fields are required.
+
+## TinyGo And Browser Notes
+
+Ordinary loading, resolving, rejecting, cleanup, key changes, manual reload,
+and stale completion protection work in Go/WASM and TinyGo/WASM.
+
+Recover-based loader panic containment depends on the build mode. The normal
+size-oriented TinyGo path may use trap-style panics, so it should not be
+treated as proof that loader panic recovery executes. This matches the existing
+runtime error and Error Boundary panic-mode note.
+
+## Non-goals
+
+MVP 28 intentionally does not provide:
+
+- Suspense or thrown promises;
+- async components;
+- global resource cache;
+- request deduplication;
+- retry/backoff;
+- polling;
+- stale-while-revalidate;
+- optimistic mutations;
+- route loaders;
+- server resources or server functions;
+- `context.Context` cancellation;
+- browser `fetch` or JSON helpers in `pkg/goframe`.
+
+## Future Work
+
+Future stages may consider:
+
+- route-level loader composition;
+- optional cache/deduplication layers outside the core primitive;
+- recover-capable TinyGo package mode;
+- richer debug probes for resource generations;
+- typed resource helpers for common app patterns;
+- integration guidance for external data sources.

--- a/docs/router.md
+++ b/docs/router.md
@@ -7,8 +7,8 @@ hash-based router designed for static hosting, Go-first route declarations, and
 stable layout composition.
 
 This is not a full application framework. There is no file-based routing,
-server routing, route loader system, async resource model, Suspense-like
-behavior, middleware, auth guard, or automatic route-level boundary policy.
+server routing, route loader system, Suspense-like resource behavior,
+middleware, auth guard, or automatic route-level boundary policy.
 
 ## Scope
 
@@ -31,6 +31,7 @@ The router intentionally does not support:
 - server fallback automation;
 - full query-state management;
 - route loaders or data fetching;
+- automatic integration with `UseResource`;
 - nested route/layout DSL;
 - scroll restoration;
 - code splitting;
@@ -149,7 +150,7 @@ Semantics:
 - malformed percent escapes are preserved literally instead of panicking.
 
 This is not a full query-state manager. There are no typed codecs, no automatic
-state binding, no route loaders, and no external data fetching story in MVP 25.
+state binding, no route loaders, and no automatic resource integration.
 
 ## RouterView
 
@@ -226,8 +227,8 @@ func issuesRoute(ctx gf.RouteContext) gf.Node {
 ```
 
 This keeps route matching separate from application error UI policy. Automatic
-route-level error elements, route loaders, async resources, and Suspense-like
-behavior remain future work.
+route-level error elements, route loaders, resource preloading, and
+Suspense-like behavior remain future work.
 
 ## Deployment Notes
 
@@ -244,7 +245,8 @@ development-only and does not implement a production fallback policy.
 - No file-based routes.
 - No XML-style namespace tags with `:` and no arbitrary selector-chain GOX
   tags beyond `packageAlias.Component`.
-- No route loaders or async resources.
+- No route loaders, resource preloading, or automatic `UseResource`
+  integration.
 - No automatic route-level Error Boundary installation.
 - No middleware or auth guards.
 - No scroll restoration.

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -7,8 +7,9 @@ panics need clear runtime semantics. MVP 23 defined how the runtime reports and
 contains common user-code failures. MVP 27 adds a narrow scoped Error Boundary
 for descendant render failures.
 
-This is still not Suspense, an async resource model, route loaders, or a
-route-level error framework.
+This is still not Suspense, a route loader framework, or a route-level error
+framework. MVP 28 resources use explicit component state rather than
+panic/throw-style render blocking.
 
 ## Current Problem
 
@@ -101,6 +102,11 @@ An effect body panic is reported as `ErrorPhaseEffect` and contained. The failed
 effect does not register a cleanup. The component remains mounted. A later
 render may queue and retry the effect according to the normal dependency rules.
 
+`UseResource` starts loaders through this same after-patch effect path. A
+loader setup panic reports `ErrorPhaseEffect` and leaves the resource in failed
+state where recover is available. Ordinary `reject(err)` is not a runtime
+panic; it is represented as `ResourceFailed`.
+
 ### Effect Cleanup
 
 A cleanup returned by `UseEffect` can run before a rerun or during unmount. If
@@ -112,6 +118,10 @@ cleanup slot, and continues with remaining cleanup work.
 `UseUnmount` cleanup panics are reported as `ErrorPhaseUnmountCleanup`. The
 runtime continues releasing effect slots, context subscriptions, event
 listeners, and other component resources where possible.
+
+Resource loader cleanup panics are reported as `ErrorPhaseEffectCleanup`.
+Cleanup still invalidates that resource generation first, so later callbacks
+from the same run are ignored.
 
 ### Memo Comparators
 
@@ -179,6 +189,9 @@ Boundary rules:
 Boundaries do not catch event, effect, cleanup, memo comparator, or context
 selector update failures. Those phases keep the phase-specific containment
 listed above and continue to report through `SetErrorHandler`.
+Ordinary resource failed state is also not a boundary incident; applications
+render loading, ready, and failed UI explicitly from the returned
+`gf.Resource[T]`.
 
 See [Error Boundaries](error-boundaries.md) for lifecycle details and the
 TinyGo panic-mode matrix.
@@ -227,7 +240,7 @@ the size and behavior tradeoff is acceptable.
 - Error Boundaries catch render-path failures only.
 - No automatic route-level Error Boundary installation.
 - No route-level error handling.
-- No async resource or Suspense-style model.
+- No Suspense-style resource throwing, render blocking, or route loader model.
 - No production crash reporting integration.
 - Context selector containment during initial render is report + re-panic.
 - TinyGo trap-style panic builds cannot provide recover-based containment.

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -103,9 +103,12 @@ effect does not register a cleanup. The component remains mounted. A later
 render may queue and retry the effect according to the normal dependency rules.
 
 `UseResource` starts loaders through this same after-patch effect path. A
-loader setup panic reports `ErrorPhaseEffect` and leaves the resource in failed
-state where recover is available. Ordinary `reject(err)` is not a runtime
-panic; it is represented as `ResourceFailed`.
+loader setup panic is handled by the resource wrapper: it reports
+`ErrorPhaseEffect`, leaves the current generation in failed state when panic is
+the first completion, and marks that resource effect run complete so an
+ordinary same-key rerender does not restart the loader. Explicit retry still
+uses `reload()` or a key change. Ordinary `reject(err)` is not a runtime panic;
+it is represented as `ResourceFailed`.
 
 ### Effect Cleanup
 

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -281,6 +281,36 @@ an outlet. There is no nested route DSL, file-based routing, path/history-mode
 server fallback, route loader system, or automatic route-level Error Boundary
 API in this MVP. See [client router](router.md).
 
+## Component-scoped resources
+
+MVP 28 adds an experimental component-scoped resource primitive:
+
+```go
+resource, reload := gf.UseResource(key, loader)
+```
+
+`UseResource` returns explicit `Loading`, `Ready`, or `Failed` state. It starts
+the loader after the current render has been patched, using the same lifecycle
+timing as effects. The first render for a key is always loading; the loader can
+later call `resolve(value)` or `reject(err)` to schedule a normal component
+update.
+
+The resource is owned by the component instance that called the hook. There is
+no global cache or shared registry: two components that use the same key own
+independent resources. Changing the key or calling `reload` invalidates the
+current generation, returns to loading state, runs the previous cleanup exactly
+once, and ignores stale completions before they can dirty the component.
+
+Loaders are transport-agnostic. Browser `fetch`, parsing, timers, abort
+controllers, local storage, or test fakes live in application/example code.
+The runtime does not import `net/http`, `encoding/json`, or browser APIs for
+resources.
+
+Ordinary loader rejection is modeled as `ResourceFailed`, not as a render
+panic, and it does not activate an Error Boundary. Loader setup panics are
+effect-phase runtime errors and also leave the resource in failed state where
+recover is available. See [component-scoped resources](resources.md).
+
 ## DOM stability regression
 
 DOM node replacement, component render, patch traversal, DOM mutation, and
@@ -389,10 +419,11 @@ programmer errors. Examples include invalid hook order, calling hooks outside
 render, unsupported effect dependency types, invalid component types, and
 invalid virtualization dimensions.
 
-Error Boundaries are render-only. Event, effect, cleanup, memo, and context
-update failures keep their phase-specific MVP 23 behavior and do not switch a
-boundary to fallback UI. There is no route-level error page, async resource
-model, or production crash reporting integration yet. The current TinyGo
+Error Boundaries are render-only. Event, effect, cleanup, memo, context update,
+and ordinary resource failed states keep their phase-specific behavior and do
+not switch a boundary to fallback UI. There is no route-level error page,
+Suspense-style resource model, or production crash reporting integration yet.
+The current TinyGo
 package path uses trap-style panic lowering, so recover-based containment is
 only available in recover-capable builds such as Go/WASM and Go tests. See
 [runtime error semantics](runtime-errors.md) and [Error Boundaries](error-boundaries.md).
@@ -447,8 +478,11 @@ The dependency-free headless Chrome probe verifies:
   measurement, infinite loading, or keyboard navigation;
 - hash routing only; no path/history-mode server fallback, file-based routing,
   route loaders, or nested route layout DSL;
+- resources are component-scoped explicit state only; no global cache,
+  Suspense-style blocking, route loader integration, or built-in fetch/JSON
+  transport;
 - Error Boundaries are render-only and recover-based; no automatic route-level
-  boundary or async resource error model;
+  boundary or resource fallback model;
 - GOX-generated component identity uses a typed token derived from package
   import path when `goxc` knows it, with package-name fallback for lower-level
   generation helpers. Legacy `gf.Component` still uses string identity.

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -309,7 +309,11 @@ resources.
 Ordinary loader rejection is modeled as `ResourceFailed`, not as a render
 panic, and it does not activate an Error Boundary. Loader setup panics are
 effect-phase runtime errors and also leave the resource in failed state where
-recover is available. See [component-scoped resources](resources.md).
+recover is available. A loader panic completes the current resource effect run,
+so a same-key rerender does not retry it automatically; retry is explicit via
+`reload` or key change. If the loader already resolved or rejected before
+panicking, that first completion remains authoritative while the panic is still
+reported once. See [component-scoped resources](resources.md).
 
 ## DOM stability regression
 

--- a/examples/resource/README.md
+++ b/examples/resource/README.md
@@ -1,0 +1,24 @@
+# Resource
+
+This example demonstrates the experimental `gf.UseResource` primitive.
+
+It loads small packaged text assets through browser `fetch`, but the runtime
+resource API itself is transport-agnostic. The fetch, parsing, delay, and abort
+logic live in the example under `internal/data`.
+
+## Run
+
+```bash
+goxc package ./examples/resource --compiler=tinygo
+goxc serve ./examples/resource --port=8080
+```
+
+## Notes
+
+- The first render shows loading before the loader starts.
+- `Load Missing` produces explicit failed state, not an Error Boundary.
+- `Load Slow Open` followed by `Load Fast All` demonstrates stale completion
+  protection.
+- `Toggle panel` unmounts the resource panel and runs loader cleanup.
+- There is no cache, Suspense, route loader, retry policy, JSON helper, or
+  runtime fetch API in this MVP.

--- a/examples/resource/cmd/app/app.gox
+++ b/examples/resource/cmd/app/app.gox
@@ -1,0 +1,63 @@
+package main
+
+import (
+	ui "github.com/graybuton/goframe/examples/resource/internal/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func App() gf.Node {
+	state, dispatch := gf.UseReducer(initialResourceAppState(), reduceResourceApp)
+
+	return (
+		<main class="resource-app" data-testid="resource-app">
+			<section class="resource-hero">
+				<p class="resource-muted">MVP 28 resource prototype</p>
+				<h1>Component-scoped resources</h1>
+				<p>
+					This example loads packaged static text assets through browser fetch.
+					The runtime resource API remains transport-agnostic.
+				</p>
+				<div class="resource-controls">
+					<button data-testid="resource-load-open" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppSetKey, Key: resourceOpenKey})
+					}}>Load Open</button>
+					<button data-testid="resource-load-all" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppSetKey, Key: resourceAllKey})
+					}}>Load All</button>
+					<button data-testid="resource-load-missing" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppSetKey, Key: resourceMissingKey})
+					}}>Load Missing</button>
+					<button data-testid="resource-load-slow" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppSetKey, Key: resourceSlowOpenKey})
+					}}>Load Slow Open</button>
+					<button data-testid="resource-load-fast" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppSetKey, Key: resourceAllKey})
+					}}>Load Fast All</button>
+					<button class="secondary" data-testid="resource-toggle-panel" OnClick={func() {
+						dispatch(resourceAppAction{Kind: resourceAppTogglePanel})
+					}}>Toggle panel</button>
+				</div>
+			</section>
+			<gf.ErrorBoundary ResetKey={state.Key} Fallback={resourceBoundaryFallback}>
+				{state.ShowPanel ? (
+					<ui.ResourcePanel ResourceKey={state.Key} />
+				) : (
+					<section class="resource-panel" data-testid="resource-panel-unmounted">
+						<h2>Panel unmounted</h2>
+						<p class="resource-muted">Resource cleanup has run for the active generation.</p>
+					</section>
+				)}
+			</gf.ErrorBoundary>
+		</main>
+	)
+}
+
+func resourceBoundaryFallback(ctx gf.ErrorBoundaryContext) gf.Node {
+	return (
+		<section class="resource-panel" data-testid="resource-boundary-fallback">
+			<h2>Unexpected render failure</h2>
+			<p>{ctx.Info.Component}</p>
+			<button OnClick={ctx.Reset}>Retry</button>
+		</section>
+	)
+}

--- a/examples/resource/cmd/app/main.go
+++ b/examples/resource/cmd/app/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/examples/resource/cmd/app/model.go
+++ b/examples/resource/cmd/app/model.go
@@ -1,0 +1,45 @@
+package main
+
+const (
+	resourceOpenKey     = "assets/data/issues-open.txt"
+	resourceAllKey      = "assets/data/issues-all.txt"
+	resourceMissingKey  = "assets/data/missing.txt"
+	resourceSlowOpenKey = "slow:assets/data/issues-open.txt"
+)
+
+type resourceAppState struct {
+	Key       string
+	ShowPanel bool
+}
+
+type resourceAppAction struct {
+	Kind resourceAppActionKind
+	Key  string
+}
+
+type resourceAppActionKind int
+
+const (
+	resourceAppSetKey resourceAppActionKind = iota + 1
+	resourceAppTogglePanel
+)
+
+func initialResourceAppState() resourceAppState {
+	return resourceAppState{
+		Key:       resourceSlowOpenKey,
+		ShowPanel: true,
+	}
+}
+
+func reduceResourceApp(state resourceAppState, action resourceAppAction) resourceAppState {
+	switch action.Kind {
+	case resourceAppSetKey:
+		state.Key = action.Key
+		if !state.ShowPanel {
+			state.ShowPanel = true
+		}
+	case resourceAppTogglePanel:
+		state.ShowPanel = !state.ShowPanel
+	}
+	return state
+}

--- a/examples/resource/data/issues-all.txt
+++ b/examples/resource/data/issues-all.txt
@@ -1,0 +1,4 @@
+GF-101|Audit render error fallback bubbling|open
+GF-102|Verify resource cleanup after unmount|open
+GF-201|Document router query limitations|review
+GF-301|Ship public preview polish notes|closed

--- a/examples/resource/data/issues-open.txt
+++ b/examples/resource/data/issues-open.txt
@@ -1,0 +1,2 @@
+GF-101|Audit render error fallback bubbling|open
+GF-102|Verify resource cleanup after unmount|open

--- a/examples/resource/doc.go
+++ b/examples/resource/doc.go
@@ -1,0 +1,1 @@
+package resource

--- a/examples/resource/goframe.json
+++ b/examples/resource/goframe.json
@@ -1,0 +1,13 @@
+{
+  "name": "resource",
+  "entry": "./cmd/app",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html",
+    "styles.css",
+    "data/issues-open.txt",
+    "data/issues-all.txt"
+  ]
+}

--- a/examples/resource/index.html
+++ b/examples/resource/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>GoFrame Resource Example</title>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <div id="root">Loading...</div>
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+      const go = new Go();
+      WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+        .then((result) => go.run(result.instance))
+        .catch((error) => {
+          console.error("[goframe] startup failed", error);
+          document.getElementById("root").textContent = "Failed to start goframe. See console.";
+        });
+    </script>
+    <!-- /goframe:bootstrap -->
+  </body>
+</html>

--- a/examples/resource/internal/data/loader_js.go
+++ b/examples/resource/internal/data/loader_js.go
@@ -1,0 +1,138 @@
+//go:build js && wasm
+
+package data
+
+import (
+	"strings"
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+const slowPrefix = "slow:"
+
+type LoadError string
+
+func (err LoadError) Error() string {
+	return string(err)
+}
+
+func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanup {
+	url := key
+	delay := 0
+	if strings.HasPrefix(key, slowPrefix) {
+		url = strings.TrimPrefix(key, slowPrefix)
+		delay = 320
+	}
+
+	active := true
+	releasedPromiseFuncs := false
+	releasedTimer := false
+	var timer js.Value
+	var timerCallback js.Func
+	var responseThen js.Func
+	var textThen js.Func
+	var catchFunc js.Func
+
+	releasePromiseFuncs := func() {
+		if releasedPromiseFuncs {
+			return
+		}
+		releasedPromiseFuncs = true
+		responseThen.Release()
+		textThen.Release()
+		catchFunc.Release()
+	}
+	releaseTimer := func() {
+		if releasedTimer {
+			return
+		}
+		releasedTimer = true
+		if timer.Type() == js.TypeNumber {
+			js.Global().Call("clearTimeout", timer)
+		}
+		timerCallback.Release()
+	}
+	complete := func(text string) {
+		if !active {
+			return
+		}
+		issues, err := ParseIssues(text)
+		active = false
+		if err != nil {
+			reject(err)
+			return
+		}
+		resolve(issues)
+	}
+
+	timerCallback = js.FuncOf(func(this js.Value, args []js.Value) any {
+		releaseTimer()
+		complete(args[0].String())
+		return nil
+	})
+	textThen = js.FuncOf(func(this js.Value, args []js.Value) any {
+		text := ""
+		if len(args) > 0 && args[0].Type() == js.TypeString {
+			text = args[0].String()
+		}
+		releasePromiseFuncs()
+		if !active {
+			return nil
+		}
+		if delay > 0 {
+			timer = js.Global().Call("setTimeout", timerCallback, delay, text)
+			return nil
+		}
+		releaseTimer()
+		complete(text)
+		return nil
+	})
+	catchFunc = js.FuncOf(func(this js.Value, args []js.Value) any {
+		releasePromiseFuncs()
+		releaseTimer()
+		if active {
+			active = false
+			reject(LoadError("fetch failed"))
+		}
+		return nil
+	})
+	responseThen = js.FuncOf(func(this js.Value, args []js.Value) any {
+		if !active {
+			return nil
+		}
+		if len(args) == 0 {
+			active = false
+			releasePromiseFuncs()
+			releaseTimer()
+			reject(LoadError("fetch returned no response"))
+			return nil
+		}
+		response := args[0]
+		if !response.Get("ok").Bool() {
+			active = false
+			releasePromiseFuncs()
+			releaseTimer()
+			reject(LoadError("fetch returned a non-ok response"))
+			return nil
+		}
+		response.Call("text").Call("then", textThen).Call("catch", catchFunc)
+		return nil
+	})
+
+	controller := js.Global().Get("AbortController").New()
+	options := js.Global().Get("Object").New()
+	options.Set("signal", controller.Get("signal"))
+	js.Global().Call("fetch", url, options).Call("then", responseThen).Call("catch", catchFunc)
+
+	return func() {
+		if !active {
+			return
+		}
+		active = false
+		if timer.Type() == js.TypeNumber {
+			releaseTimer()
+		}
+		controller.Call("abort")
+	}
+}

--- a/examples/resource/internal/data/loader_js.go
+++ b/examples/resource/internal/data/loader_js.go
@@ -99,6 +99,8 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 	})
 	responseThen = js.FuncOf(func(this js.Value, args []js.Value) any {
 		if !active {
+			releasePromiseFuncs()
+			releaseTimer()
 			return nil
 		}
 		if len(args) == 0 {
@@ -130,9 +132,7 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 			return
 		}
 		active = false
-		if timer.Type() == js.TypeNumber {
-			releaseTimer()
-		}
+		releaseTimer()
 		controller.Call("abort")
 	}
 }

--- a/examples/resource/internal/data/loader_stub.go
+++ b/examples/resource/internal/data/loader_stub.go
@@ -1,0 +1,16 @@
+//go:build !js || !wasm
+
+package data
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type LoadError string
+
+func (err LoadError) Error() string {
+	return string(err)
+}
+
+func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanup {
+	reject(LoadError("resource fetch is available only in browser/WASM builds"))
+	return nil
+}

--- a/examples/resource/internal/data/model.go
+++ b/examples/resource/internal/data/model.go
@@ -1,0 +1,7 @@
+package data
+
+type Issue struct {
+	ID     string
+	Title  string
+	Status string
+}

--- a/examples/resource/internal/data/parser.go
+++ b/examples/resource/internal/data/parser.go
@@ -1,0 +1,33 @@
+package data
+
+import "strings"
+
+type ParseError string
+
+func (err ParseError) Error() string {
+	return string(err)
+}
+
+func ParseIssues(text string) ([]Issue, error) {
+	lines := strings.Split(text, "\n")
+	issues := make([]Issue, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) != 3 {
+			return nil, ParseError("invalid issue data line")
+		}
+		issues = append(issues, Issue{
+			ID:     strings.TrimSpace(parts[0]),
+			Title:  strings.TrimSpace(parts[1]),
+			Status: strings.TrimSpace(parts[2]),
+		})
+	}
+	if len(issues) == 0 {
+		return nil, ParseError("issue data is empty")
+	}
+	return issues, nil
+}

--- a/examples/resource/internal/ui/model.go
+++ b/examples/resource/internal/ui/model.go
@@ -1,0 +1,5 @@
+package ui
+
+type ResourcePanelProps struct {
+	ResourceKey string
+}

--- a/examples/resource/internal/ui/resource_model.go
+++ b/examples/resource/internal/ui/resource_model.go
@@ -1,0 +1,7 @@
+package ui
+
+import data "github.com/graybuton/goframe/examples/resource/internal/data"
+
+type IssueItemProps struct {
+	Issue data.Issue
+}

--- a/examples/resource/internal/ui/resource_panel.gox
+++ b/examples/resource/internal/ui/resource_panel.gox
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	data "github.com/graybuton/goframe/examples/resource/internal/data"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func ResourcePanel(props ResourcePanelProps) gf.Node {
+	resource, reload := gf.UseResource(props.ResourceKey, data.LoadIssues)
+	attempt, setAttempt := gf.UseState(1)
+
+	return (
+		<section class="resource-panel" data-testid="resource-panel">
+			<div>
+				<p class="resource-muted">Component-scoped loader</p>
+				<h2>Issue resource</h2>
+			</div>
+			<div class="resource-meta">
+				<span data-testid="resource-key">{props.ResourceKey}</span>
+				<span data-testid="resource-attempt">{gf.ToString(attempt)}</span>
+				<span data-testid="resource-status">{resourceStatusText(resource)}</span>
+			</div>
+			<button data-testid="resource-reload" OnClick={func() {
+				setAttempt(attempt + 1)
+				reload()
+			}}>Reload</button>
+			{resource.Loading() && (
+				<p class="resource-status loading" data-testid="resource-loading">
+					Loading packaged issue data...
+				</p>
+			)}
+			{resource.Failed() && (
+				<div class="resource-status failed" data-testid="resource-failed">
+					<strong>Load failed</strong>
+					<p data-testid="resource-error">{resourceErrorText(resource)}</p>
+				</div>
+			)}
+			{resource.Ready() && (
+				<div data-testid="resource-ready">
+					<ul class="resource-items" data-testid="resource-items">
+						{gf.Map(resource.Value, func(issue data.Issue) gf.Node {
+							return <IssueItem Key={issue.ID} Issue={issue} />
+						})}
+					</ul>
+				</div>
+			)}
+		</section>
+	)
+}
+
+func IssueItem(props IssueItemProps) gf.Node {
+	return (
+		<li class="resource-item" data-testid="resource-item">
+			<span><strong>{props.Issue.ID}</strong> {props.Issue.Title}</span>
+			<span class="resource-status-pill">{props.Issue.Status}</span>
+		</li>
+	)
+}
+
+func resourceStatusText(resource gf.Resource[[]data.Issue]) string {
+	if resource.Ready() {
+		return "ready"
+	}
+	if resource.Failed() {
+		return "failed"
+	}
+	return "loading"
+}
+
+func resourceErrorText(resource gf.Resource[[]data.Issue]) string {
+	if resource.Err == nil {
+		return ""
+	}
+	return resource.Err.Error()
+}

--- a/examples/resource/styles.css
+++ b/examples/resource/styles.css
@@ -1,0 +1,108 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f4f7fb;
+  color: #162033;
+}
+
+body {
+  margin: 0;
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  background: #1c64f2;
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.55rem 0.9rem;
+}
+
+button.secondary {
+  background: #e5ecf7;
+  color: #25324a;
+}
+
+.resource-app {
+  margin: 0 auto;
+  max-width: 920px;
+  padding: 2rem;
+}
+
+.resource-hero,
+.resource-panel {
+  background: #fff;
+  border: 1px solid #d9e2ef;
+  border-radius: 24px;
+  box-shadow: 0 18px 45px rgba(34, 54, 84, 0.08);
+  margin-bottom: 1rem;
+  padding: 1.4rem;
+}
+
+.resource-hero h1,
+.resource-panel h2 {
+  margin: 0 0 0.45rem;
+}
+
+.resource-muted {
+  color: #61708a;
+}
+
+.resource-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.resource-meta {
+  background: #f7faff;
+  border-radius: 16px;
+  display: grid;
+  gap: 0.35rem;
+  margin: 1rem 0;
+  padding: 0.85rem;
+}
+
+.resource-status {
+  border-radius: 16px;
+  margin: 1rem 0;
+  padding: 0.9rem;
+}
+
+.resource-status.loading {
+  background: #eef5ff;
+  color: #2457a6;
+}
+
+.resource-status.failed {
+  background: #fff1f2;
+  color: #a22836;
+}
+
+.resource-items {
+  display: grid;
+  gap: 0.55rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.resource-item {
+  align-items: center;
+  background: #f8fbff;
+  border: 1px solid #e2e8f3;
+  border-radius: 14px;
+  display: flex;
+  justify-content: space-between;
+  padding: 0.75rem;
+}
+
+.resource-status-pill {
+  background: #dff7ea;
+  border-radius: 999px;
+  color: #166534;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.55rem;
+}

--- a/pkg/goframe/resource.go
+++ b/pkg/goframe/resource.go
@@ -1,0 +1,218 @@
+package goframe
+
+// ResourceStatus is the current state of a component-scoped resource.
+type ResourceStatus uint8
+
+const (
+	ResourceLoading ResourceStatus = iota
+	ResourceReady
+	ResourceFailed
+)
+
+// Resource is the public snapshot returned by UseResource.
+type Resource[T any] struct {
+	Status ResourceStatus
+	Value  T
+	Err    error
+}
+
+// Loading reports whether the resource is currently loading.
+func (resource Resource[T]) Loading() bool {
+	return resource.Status == ResourceLoading
+}
+
+// Ready reports whether the resource has a ready value.
+func (resource Resource[T]) Ready() bool {
+	return resource.Status == ResourceReady
+}
+
+// Failed reports whether the resource failed with an error.
+func (resource Resource[T]) Failed() bool {
+	return resource.Status == ResourceFailed
+}
+
+// ResourceLoader starts one resource generation for key.
+//
+// The first resolve or reject call wins for the generation. The optional
+// cleanup runs when the generation is invalidated or the component unmounts.
+type ResourceLoader[T any] func(key string, resolve func(T), reject func(error)) Cleanup
+
+// UseResource owns one component-scoped asynchronous resource.
+//
+// The loader starts after patch through the normal effect lifecycle. The
+// returned reload function starts a new generation for the current key.
+func UseResource[T any](key string, loader ResourceLoader[T]) (Resource[T], func()) {
+	if loader == nil {
+		panic("goframe: UseResource requires a loader")
+	}
+	slot := useStateSlot[*resourceControl[T]](nil, "UseResource")
+	control := slot.get()
+	if control == nil {
+		control = newResourceControl[T](currentComponent, key, loader)
+		slot.slot.value = control
+	}
+	control.owner = currentComponent
+	control.loader = loader
+	control.prepareKey(key)
+
+	generation := control.generation
+	UseEffect(func() Cleanup {
+		return control.start(key, generation)
+	}, Deps(key, generation))
+
+	return control.snapshot, control.reload
+}
+
+type resourceControl[T any] struct {
+	owner      *componentInstance
+	key        string
+	generation int
+	loader     ResourceLoader[T]
+	snapshot   Resource[T]
+	current    *resourceRun[T]
+}
+
+type resourceRun[T any] struct {
+	control       *resourceControl[T]
+	generation    int
+	active        bool
+	completed     bool
+	cleanup       Cleanup
+	cleanupCalled bool
+}
+
+type resourceInternalError string
+
+func (err resourceInternalError) Error() string {
+	return string(err)
+}
+
+const (
+	resourceNilRejectError   resourceInternalError = "goframe: resource rejected without error"
+	resourceLoaderPanicError resourceInternalError = "goframe: resource loader panicked"
+)
+
+func newResourceControl[T any](owner *componentInstance, key string, loader ResourceLoader[T]) *resourceControl[T] {
+	return &resourceControl[T]{
+		owner:    owner,
+		key:      key,
+		loader:   loader,
+		snapshot: resourceLoading[T](),
+	}
+}
+
+func (control *resourceControl[T]) prepareKey(key string) {
+	if control.key == key {
+		return
+	}
+	control.invalidateCurrent()
+	control.key = key
+	control.generation++
+	control.snapshot = resourceLoading[T]()
+}
+
+func (control *resourceControl[T]) reload() {
+	if control == nil || control.owner == nil || !control.owner.active {
+		return
+	}
+	control.invalidateCurrent()
+	control.generation++
+	control.snapshot = resourceLoading[T]()
+	markComponentDirty(control.owner)
+}
+
+func (control *resourceControl[T]) start(key string, generation int) Cleanup {
+	if control == nil || control.owner == nil || !control.owner.active {
+		return nil
+	}
+	if control.key != key || control.generation != generation {
+		return nil
+	}
+	run := &resourceRun[T]{
+		control:    control,
+		generation: generation,
+		active:     true,
+	}
+	control.current = run
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			control.fail(run, resourceLoaderPanicError)
+			panic(recovered)
+		}
+	}()
+	run.cleanup = control.loader(key, func(value T) {
+		control.resolve(run, value)
+	}, func(err error) {
+		control.reject(run, err)
+	})
+	return func() {
+		control.cleanupRun(run)
+	}
+}
+
+func (control *resourceControl[T]) resolve(run *resourceRun[T], value T) {
+	control.complete(run, Resource[T]{
+		Status: ResourceReady,
+		Value:  value,
+	})
+}
+
+func (control *resourceControl[T]) reject(run *resourceRun[T], err error) {
+	if err == nil {
+		err = resourceNilRejectError
+	}
+	control.fail(run, err)
+}
+
+func (control *resourceControl[T]) fail(run *resourceRun[T], err error) {
+	control.complete(run, Resource[T]{
+		Status: ResourceFailed,
+		Err:    err,
+	})
+}
+
+func (control *resourceControl[T]) complete(run *resourceRun[T], snapshot Resource[T]) {
+	if !control.accepts(run) {
+		return
+	}
+	run.completed = true
+	run.active = false
+	control.snapshot = snapshot
+	markComponentDirty(control.owner)
+}
+
+func (control *resourceControl[T]) accepts(run *resourceRun[T]) bool {
+	return control != nil &&
+		run != nil &&
+		control.current == run &&
+		control.owner != nil &&
+		control.owner.active &&
+		control.generation == run.generation &&
+		run.active &&
+		!run.completed
+}
+
+func (control *resourceControl[T]) invalidateCurrent() {
+	if control == nil || control.current == nil {
+		return
+	}
+	control.current.active = false
+}
+
+func (control *resourceControl[T]) cleanupRun(run *resourceRun[T]) {
+	if run == nil || run.cleanupCalled {
+		return
+	}
+	run.active = false
+	run.cleanupCalled = true
+	if control != nil && control.current == run {
+		control.current = nil
+	}
+	if run.cleanup != nil {
+		run.cleanup()
+	}
+}
+
+func resourceLoading[T any]() Resource[T] {
+	return Resource[T]{Status: ResourceLoading}
+}

--- a/pkg/goframe/resource.go
+++ b/pkg/goframe/resource.go
@@ -121,7 +121,7 @@ func (control *resourceControl[T]) reload() {
 	markComponentDirty(control.owner)
 }
 
-func (control *resourceControl[T]) start(key string, generation int) Cleanup {
+func (control *resourceControl[T]) start(key string, generation int) (cleanup Cleanup) {
 	if control == nil || control.owner == nil || !control.owner.active {
 		return nil
 	}
@@ -137,7 +137,12 @@ func (control *resourceControl[T]) start(key string, generation int) Cleanup {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			control.fail(run, resourceLoaderPanicError)
-			panic(recovered)
+			reportRecoveredRuntimeError(ErrorInfo{
+				Phase:     ErrorPhaseEffect,
+				Component: runtimeComponentName(control.owner),
+				Operation: "UseEffect",
+			}, recovered)
+			cleanup = nil
 		}
 	}()
 	run.cleanup = control.loader(key, func(value T) {
@@ -145,9 +150,10 @@ func (control *resourceControl[T]) start(key string, generation int) Cleanup {
 	}, func(err error) {
 		control.reject(run, err)
 	})
-	return func() {
+	cleanup = func() {
 		control.cleanupRun(run)
 	}
+	return cleanup
 }
 
 func (control *resourceControl[T]) resolve(run *resourceRun[T], value T) {

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -1,0 +1,539 @@
+package goframe
+
+import (
+	"errors"
+	"testing"
+)
+
+type resourceTestLoader struct {
+	starts   []string
+	resolves []func(string)
+	rejects  []func(error)
+	cleanups int
+	cleanup  func()
+}
+
+func (loader *resourceTestLoader) load(key string, resolve func(string), reject func(error)) Cleanup {
+	loader.starts = append(loader.starts, key)
+	loader.resolves = append(loader.resolves, resolve)
+	loader.rejects = append(loader.rejects, reject)
+	return func() {
+		loader.cleanups++
+		if loader.cleanup != nil {
+			loader.cleanup()
+		}
+	}
+}
+
+func TestUseResourceInitialRenderStartsAfterEffect(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("open", loader.load)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	if !resource.Loading() || resource.Value != "" || resource.Err != nil {
+		t.Fatalf("initial resource = %#v, want loading zero value", resource)
+	}
+	if len(loader.starts) != 0 {
+		t.Fatalf("loader starts during render = %d, want 0", len(loader.starts))
+	}
+
+	flushPendingEffects()
+	if got := loader.starts; len(got) != 1 || got[0] != "open" {
+		t.Fatalf("loader starts = %#v, want [open]", got)
+	}
+}
+
+func TestUseResourceResolveProducesReady(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	schedules := 0
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("open", loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.resolves[0]("ready")
+	if schedules != 1 || !instance.dirty {
+		t.Fatalf("schedules=%d dirty=%v, want one dirty update", schedules, instance.dirty)
+	}
+	renderComponentInstance(instance)
+
+	if !resource.Ready() || resource.Value != "ready" || resource.Err != nil {
+		t.Fatalf("resource after resolve = %#v, want ready value", resource)
+	}
+}
+
+func TestUseResourceRejectProducesFailed(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("missing", loader.load)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.rejects[0](errors.New("not found"))
+	renderComponentInstance(instance)
+
+	if !resource.Failed() || resource.Value != "" || resource.Err == nil || resource.Err.Error() != "not found" {
+		t.Fatalf("resource after reject = %#v, want failed not found", resource)
+	}
+}
+
+func TestUseResourceNilRejectProducesNonNilError(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("missing", loader.load)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.rejects[0](nil)
+	renderComponentInstance(instance)
+
+	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "goframe: resource rejected without error" {
+		t.Fatalf("resource after nil reject = %#v, want failed internal error", resource)
+	}
+}
+
+func TestUseResourceFirstCompletionWins(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	schedules := 0
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("key", loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.resolves[0]("first")
+	loader.rejects[0](errors.New("late"))
+	loader.resolves[0]("later")
+	renderComponentInstance(instance)
+
+	if schedules != 1 {
+		t.Fatalf("schedules = %d, want one first-completion update", schedules)
+	}
+	if !resource.Ready() || resource.Value != "first" || resource.Err != nil {
+		t.Fatalf("resource after multiple completions = %#v, want first ready", resource)
+	}
+}
+
+func TestUseResourceRejectThenResolveKeepsFailed(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource("key", loader.load)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.rejects[0](errors.New("first failure"))
+	loader.resolves[0]("late")
+	renderComponentInstance(instance)
+
+	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "first failure" {
+		t.Fatalf("resource after reject then resolve = %#v, want first failure", resource)
+	}
+}
+
+func TestUseResourceSameKeyRerenderAndLoaderChangeDoNotReload(t *testing.T) {
+	resetEffectsForTest()
+	first := &resourceTestLoader{}
+	second := &resourceTestLoader{}
+	useSecond := false
+	instance := testComponentInstance("Resource", func() Node {
+		loader := first.load
+		if useSecond {
+			loader = second.load
+		}
+		_, _ = UseResource("same", loader)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	useSecond = true
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if got := len(first.starts); got != 1 {
+		t.Fatalf("first loader starts = %d, want 1", got)
+	}
+	if got := len(second.starts); got != 0 {
+		t.Fatalf("second loader starts = %d, want 0 before reload/key change", got)
+	}
+}
+
+func TestUseResourceKeyChangeInvalidatesLateCallbacks(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	schedules := 0
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource(key, loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldResolve := loader.resolves[0]
+	key = "b"
+	renderComponentInstance(instance)
+
+	oldResolve("late-a")
+	if schedules != 0 || instance.dirty {
+		t.Fatalf("late old resolve schedules=%d dirty=%v, want no stale dirty update", schedules, instance.dirty)
+	}
+	if !resource.Loading() {
+		t.Fatalf("resource after key change before new effect = %#v, want loading", resource)
+	}
+
+	flushPendingEffects()
+	if loader.cleanups != 1 {
+		t.Fatalf("cleanups after key change = %d, want 1", loader.cleanups)
+	}
+	loader.resolves[1]("ready-b")
+	renderComponentInstance(instance)
+	if !resource.Ready() || resource.Value != "ready-b" {
+		t.Fatalf("resource after new key resolve = %#v, want ready-b", resource)
+	}
+}
+
+func TestUseResourceLateOldRejectDoesNotDirtyComponent(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	schedules := 0
+	instance := testComponentInstance("Resource", func() Node {
+		_, _ = UseResource(key, loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldReject := loader.rejects[0]
+	key = "b"
+	renderComponentInstance(instance)
+	oldReject(errors.New("late"))
+
+	if schedules != 0 || instance.dirty {
+		t.Fatalf("late old reject schedules=%d dirty=%v, want no stale dirty update", schedules, instance.dirty)
+	}
+}
+
+func TestUseResourceManualReloadInvalidatesLateCallbacks(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	schedules := 0
+	var reload func()
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, reload = UseResource("same", loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldResolve := loader.resolves[0]
+	reload()
+	if schedules != 1 || !instance.dirty {
+		t.Fatalf("reload schedules=%d dirty=%v, want one dirty update", schedules, instance.dirty)
+	}
+	renderComponentInstance(instance)
+	oldResolve("late")
+	if schedules != 1 || instance.dirty {
+		t.Fatalf("late pre-reload resolve schedules=%d dirty=%v, want no extra dirty update", schedules, instance.dirty)
+	}
+	if !resource.Loading() {
+		t.Fatalf("resource after reload render = %#v, want loading", resource)
+	}
+	flushPendingEffects()
+	if loader.cleanups != 1 || len(loader.starts) != 2 {
+		t.Fatalf("cleanups=%d starts=%d, want cleanup old and start new", loader.cleanups, len(loader.starts))
+	}
+}
+
+func TestUseResourceOldReloadClosureUsesLatestKey(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	var firstReload func()
+	instance := testComponentInstance("Resource", func() Node {
+		_, reload := UseResource(key, loader.load)
+		if firstReload == nil {
+			firstReload = reload
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	key = "b"
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	firstReload()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if got := loader.starts; len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "b" {
+		t.Fatalf("starts after old reload = %#v, want [a b b]", got)
+	}
+}
+
+func TestUseResourceCleanupOnReloadKeyChangeAndUnmount(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	var reload func()
+	instance := testComponentInstance("Resource", func() Node {
+		_, reload = UseResource(key, loader.load)
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	reload()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	key = "b"
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	deactivateComponent(instance)
+
+	if loader.cleanups != 3 {
+		t.Fatalf("cleanups = %d, want one per started generation", loader.cleanups)
+	}
+}
+
+func TestUseResourceCompletionAfterUnmountIsNoop(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	schedules := 0
+	var reload func()
+	instance := testComponentInstance("Resource", func() Node {
+		_, reload = UseResource("key", loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	resolve := loader.resolves[0]
+	deactivateComponent(instance)
+	resolve("late")
+	reload()
+
+	if schedules != 0 || instance.dirty {
+		t.Fatalf("after unmount schedules=%d dirty=%v, want no-op", schedules, instance.dirty)
+	}
+	if loader.cleanups != 1 {
+		t.Fatalf("cleanups after unmount = %d, want 1", loader.cleanups)
+	}
+}
+
+func TestUseResourceCleanupTriggeredCompletionIsIgnored(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	schedules := 0
+	var oldResolve func(string)
+	loader.cleanup = func() {
+		oldResolve("from-cleanup")
+	}
+	var resource Resource[string]
+	instance := testComponentInstance("Resource", func() Node {
+		resource, _ = UseResource(key, loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldResolve = loader.resolves[0]
+	key = "b"
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if schedules != 0 || instance.dirty {
+		t.Fatalf("cleanup-triggered resolve schedules=%d dirty=%v, want no stale update", schedules, instance.dirty)
+	}
+	if !resource.Loading() {
+		t.Fatalf("resource after key change cleanup = %#v, want loading", resource)
+	}
+}
+
+func TestUseResourceLoaderPanicReportsEffectAndFails(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceExploder", func() Node {
+		resource, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
+			panic("loader boom")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffect, "ResourceExploder", "UseEffect", "loader boom")
+	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "goframe: resource loader panicked" {
+		t.Fatalf("resource after loader panic = %#v, want failed loader panic", resource)
+	}
+}
+
+func TestUseResourceCleanupPanicReportsEffectCleanup(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	key := "a"
+	instance := testComponentInstance("ResourceCleanupExploder", func() Node {
+		_, _ = UseResource("a", func(string, func(string), func(error)) Cleanup {
+			return func() {
+				panic("cleanup boom")
+			}
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	key = "b"
+	instance.node = Component("ResourceCleanupExploder", struct{}{}, func(struct{}) Node {
+		_, _ = UseResource(key, func(string, func(string), func(error)) Cleanup {
+			return nil
+		})
+		return Empty()
+	}).(ComponentNode)
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffectCleanup, "ResourceCleanupExploder", "UseEffect cleanup", "cleanup boom")
+}
+
+func TestUseResourceRejectDoesNotActivateErrorBoundary(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	boundary := testErrorBoundaryInstance("", func(ErrorBoundaryContext) Node {
+		return Text("fallback")
+	}, nil)
+	child := testComponentInstanceWithParent("ResourceChild", boundary, func() Node {
+		_, _ = UseResource("missing", loader.load)
+		return Empty()
+	})
+
+	renderComponentInstance(boundary)
+	renderComponentInstance(child)
+	flushPendingEffects()
+	loader.rejects[0](errors.New("ordinary load failure"))
+	renderComponentInstance(child)
+
+	if boundary.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("boundary phase after resource reject = %d, want protected", boundary.errorBoundary.phase)
+	}
+}
+
+func TestUseResourceLoaderPanicDoesNotActivateErrorBoundary(t *testing.T) {
+	resetEffectsForTest()
+	_ = captureRuntimeErrors(t)
+	boundary := testErrorBoundaryInstance("", func(ErrorBoundaryContext) Node {
+		return Text("fallback")
+	}, nil)
+	child := testComponentInstanceWithParent("ResourceChild", boundary, func() Node {
+		_, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
+			panic("loader boom")
+		})
+		return Empty()
+	})
+
+	renderComponentInstance(boundary)
+	renderComponentInstance(child)
+	flushPendingEffects()
+
+	if boundary.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("boundary phase after resource loader panic = %d, want protected", boundary.errorBoundary.phase)
+	}
+}
+
+func TestUseResourceDirtyUpdatePiercesMemoizedAncestor(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	parent := dirtyCleanInstance("MemoParent", nil)
+	child := testComponentInstanceWithParent("ResourceChild", parent, func() Node {
+		_, _ = UseResource("key", loader.load)
+		return Empty()
+	})
+	renderComponentInstance(child)
+	flushPendingEffects()
+
+	loader.resolves[0]("ready")
+	if parent.dirtyDescendants != 1 || !child.dirty {
+		t.Fatalf("parent dirty descendants=%d child dirty=%v, want resource update visible through memo ancestor",
+			parent.dirtyDescendants, child.dirty)
+	}
+}
+
+func TestUseResourceHookKindDiagnostics(t *testing.T) {
+	resetEffectsForTest()
+	useResource := false
+	loader := &resourceTestLoader{}
+	instance := testComponentInstance("ResourceKind", func() Node {
+		if useResource {
+			_, _ = UseResource("key", loader.load)
+		} else {
+			_, _ = UseState(0)
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	useResource = true
+	assertPanic(t, "goframe: hook at state slot 0 changed from UseState to UseResource", func() {
+		renderComponentInstance(instance)
+	})
+}
+
+func TestUseResourceNilLoaderPanics(t *testing.T) {
+	resetEffectsForTest()
+	instance := testComponentInstance("ResourceNilLoader", func() Node {
+		_, _ = UseResource[string]("key", nil)
+		return Empty()
+	}, nil)
+
+	assertPanic(t, "goframe: UseResource requires a loader", func() {
+		renderComponentInstance(instance)
+	})
+}

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -398,9 +398,11 @@ func TestUseResourceCleanupTriggeredCompletionIsIgnored(t *testing.T) {
 func TestUseResourceLoaderPanicReportsEffectAndFails(t *testing.T) {
 	resetEffectsForTest()
 	errorsSeen := captureRuntimeErrors(t)
+	starts := 0
 	var resource Resource[string]
 	instance := testComponentInstance("ResourceExploder", func() Node {
 		resource, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
+			starts++
 			panic("loader boom")
 		})
 		return Empty()
@@ -413,6 +415,227 @@ func TestUseResourceLoaderPanicReportsEffectAndFails(t *testing.T) {
 	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffect, "ResourceExploder", "UseEffect", "loader boom")
 	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "goframe: resource loader panicked" {
 		t.Fatalf("resource after loader panic = %#v, want failed loader panic", resource)
+	}
+	if starts != 1 || len(errorsSeen()) != 1 {
+		t.Fatalf("starts=%d errors=%d, want one loader start and one report", starts, len(errorsSeen()))
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if starts != 1 || len(errorsSeen()) != 1 {
+		t.Fatalf("after same-key rerenders starts=%d errors=%d, want no automatic retry", starts, len(errorsSeen()))
+	}
+	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "goframe: resource loader panicked" {
+		t.Fatalf("resource after same-key rerenders = %#v, want stable failed state", resource)
+	}
+}
+
+func TestUseResourceLoaderPanicParentRerenderDoesNotRetry(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	starts := 0
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceParentRerender", func() Node {
+		resource, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
+			starts++
+			panic("loader boom")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if starts != 1 || len(errorsSeen()) != 1 {
+		t.Fatalf("parent rerenders starts=%d errors=%d, want no automatic retry", starts, len(errorsSeen()))
+	}
+	if !resource.Failed() {
+		t.Fatalf("resource after parent rerenders = %#v, want failed", resource)
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+}
+
+func TestUseResourceResolveThenPanicKeepsReadyAndDoesNotRetry(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	starts := 0
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceResolveThenPanic", func() Node {
+		resource, _ = UseResource("key", func(_ string, resolve func(string), _ func(error)) Cleanup {
+			starts++
+			resolve("ready")
+			panic("late panic")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffect, "ResourceResolveThenPanic", "UseEffect", "late panic")
+	if starts != 1 || len(errorsSeen()) != 1 {
+		t.Fatalf("starts=%d errors=%d, want one start/report", starts, len(errorsSeen()))
+	}
+	if !resource.Ready() || resource.Value != "ready" || resource.Err != nil {
+		t.Fatalf("resource after resolve then panic = %#v, want ready first completion", resource)
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+}
+
+func TestUseResourceRejectThenPanicKeepsOriginalErrorAndDoesNotRetry(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	original := errors.New("original failure")
+	starts := 0
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceRejectThenPanic", func() Node {
+		resource, _ = UseResource("key", func(_ string, _ func(string), reject func(error)) Cleanup {
+			starts++
+			reject(original)
+			panic("late panic")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffect, "ResourceRejectThenPanic", "UseEffect", "late panic")
+	if starts != 1 || len(errorsSeen()) != 1 {
+		t.Fatalf("starts=%d errors=%d, want one start/report", starts, len(errorsSeen()))
+	}
+	if !resource.Failed() || resource.Err != original {
+		t.Fatalf("resource after reject then panic = %#v, want original failure", resource)
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+}
+
+func TestUseResourceManualReloadAfterLoaderPanicRetriesExplicitly(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	starts := 0
+	var reload func()
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceReloadPanic", func() Node {
+		resource, reload = UseResource("key", func(string, func(string), func(error)) Cleanup {
+			starts++
+			panic("loader boom")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if starts != 1 || len(errorsSeen()) != 1 || !resource.Failed() {
+		t.Fatalf("before reload starts=%d errors=%d resource=%#v, want first failed generation", starts, len(errorsSeen()), resource)
+	}
+
+	reload()
+	renderComponentInstance(instance)
+	if !resource.Loading() {
+		t.Fatalf("resource after reload render = %#v, want loading", resource)
+	}
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if starts != 2 || len(errorsSeen()) != 2 {
+		t.Fatalf("after reload starts=%d errors=%d, want explicit second generation only", starts, len(errorsSeen()))
+	}
+	if !resource.Failed() || resource.Err == nil || resource.Err.Error() != "goframe: resource loader panicked" {
+		t.Fatalf("resource after reload panic = %#v, want failed", resource)
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+}
+
+func TestUseResourceKeyChangeAfterLoaderPanicRetriesExplicitly(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	key := "a"
+	starts := []string{}
+	resolves := map[string]func(string){}
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceKeyPanic", func() Node {
+		resource, _ = UseResource(key, func(key string, resolve func(string), _ func(error)) Cleanup {
+			starts = append(starts, key)
+			resolves[key] = resolve
+			panic("loader boom " + key)
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	key = "b"
+	renderComponentInstance(instance)
+	if !resource.Loading() {
+		t.Fatalf("resource after key change render = %#v, want loading", resource)
+	}
+	flushPendingEffects()
+	resolves["a"]("late-a")
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if len(starts) != 2 || starts[0] != "a" || starts[1] != "b" {
+		t.Fatalf("starts = %#v, want [a b]", starts)
+	}
+	if len(errorsSeen()) != 2 {
+		t.Fatalf("errors = %d, want two key-change reports", len(errorsSeen()))
+	}
+	if !resource.Failed() || resource.Value != "" {
+		t.Fatalf("resource after key change panic and old resolve = %#v, want failed B and no late A value", resource)
+	}
+	requireResourceEffectSlotCompleted(t, instance)
+}
+
+func TestUseResourceLoaderPanicDoesNotRegisterCleanup(t *testing.T) {
+	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
+	starts := 0
+	cleanups := 0
+	key := "a"
+	var reload func()
+	instance := testComponentInstance("ResourcePanicCleanup", func() Node {
+		_, reload = UseResource(key, func(string, func(string), func(error)) Cleanup {
+			starts++
+			panic("loader boom")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	renderComponentInstance(instance)
+	reload()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	key = "b"
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	deactivateComponent(instance)
+
+	if starts != 3 || len(errorsSeen()) != 3 {
+		t.Fatalf("starts=%d errors=%d, want explicit initial/reload/key generations", starts, len(errorsSeen()))
+	}
+	if cleanups != 0 {
+		t.Fatalf("cleanups = %d, want no synthetic cleanup after panic before return", cleanups)
 	}
 }
 
@@ -446,12 +669,14 @@ func TestUseResourceCleanupPanicReportsEffectCleanup(t *testing.T) {
 
 func TestUseResourceRejectDoesNotActivateErrorBoundary(t *testing.T) {
 	resetEffectsForTest()
+	errorsSeen := captureRuntimeErrors(t)
 	loader := &resourceTestLoader{}
+	var resource Resource[string]
 	boundary := testErrorBoundaryInstance("", func(ErrorBoundaryContext) Node {
 		return Text("fallback")
 	}, nil)
 	child := testComponentInstanceWithParent("ResourceChild", boundary, func() Node {
-		_, _ = UseResource("missing", loader.load)
+		resource, _ = UseResource("missing", loader.load)
 		return Empty()
 	})
 
@@ -464,16 +689,23 @@ func TestUseResourceRejectDoesNotActivateErrorBoundary(t *testing.T) {
 	if boundary.errorBoundary.phase != errorBoundaryProtected {
 		t.Fatalf("boundary phase after resource reject = %d, want protected", boundary.errorBoundary.phase)
 	}
+	if len(errorsSeen()) != 0 {
+		t.Fatalf("runtime errors after ordinary resource reject = %d, want 0", len(errorsSeen()))
+	}
+	if !resource.Failed() {
+		t.Fatalf("resource after ordinary reject = %#v, want failed UI state", resource)
+	}
 }
 
 func TestUseResourceLoaderPanicDoesNotActivateErrorBoundary(t *testing.T) {
 	resetEffectsForTest()
-	_ = captureRuntimeErrors(t)
+	errorsSeen := captureRuntimeErrors(t)
+	var resource Resource[string]
 	boundary := testErrorBoundaryInstance("", func(ErrorBoundaryContext) Node {
 		return Text("fallback")
 	}, nil)
 	child := testComponentInstanceWithParent("ResourceChild", boundary, func() Node {
-		_, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
+		resource, _ = UseResource("panic", func(string, func(string), func(error)) Cleanup {
 			panic("loader boom")
 		})
 		return Empty()
@@ -482,9 +714,17 @@ func TestUseResourceLoaderPanicDoesNotActivateErrorBoundary(t *testing.T) {
 	renderComponentInstance(boundary)
 	renderComponentInstance(child)
 	flushPendingEffects()
+	renderComponentInstance(child)
 
 	if boundary.errorBoundary.phase != errorBoundaryProtected {
 		t.Fatalf("boundary phase after resource loader panic = %d, want protected", boundary.errorBoundary.phase)
+	}
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseEffect, "ResourceChild", "UseEffect", "loader boom")
+	if len(errorsSeen()) != 1 {
+		t.Fatalf("runtime errors after loader panic = %d, want 1", len(errorsSeen()))
+	}
+	if !resource.Failed() {
+		t.Fatalf("resource after loader panic = %#v, want failed UI state", resource)
 	}
 }
 
@@ -536,4 +776,15 @@ func TestUseResourceNilLoaderPanics(t *testing.T) {
 	assertPanic(t, "goframe: UseResource requires a loader", func() {
 		renderComponentInstance(instance)
 	})
+}
+
+func requireResourceEffectSlotCompleted(t *testing.T, instance *componentInstance) {
+	t.Helper()
+	if len(instance.effectSlots) != 1 {
+		t.Fatalf("effect slots = %d, want 1", len(instance.effectSlots))
+	}
+	slot := instance.effectSlots[0]
+	if !slot.hasRun || slot.pending || slot.queued || slot.running || slot.cleanup != nil {
+		t.Fatalf("resource effect slot = %#v, want hasRun=true pending=false queued=false running=false cleanup=nil", slot)
+	}
 }

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -17,6 +17,7 @@ MULTIPACKAGE_SMOKE_URL_BASE="${GOFRAME_MULTIPACKAGE_SMOKE_URL:-http://127.0.0.1}
 CMDAPP_SMOKE_URL_BASE="${GOFRAME_CMDAPP_SMOKE_URL:-http://127.0.0.1}"
 ROUTER_SMOKE_URL_BASE="${GOFRAME_ROUTER_SMOKE_URL:-http://127.0.0.1}"
 ROUTER_DASHBOARD_SMOKE_URL_BASE="${GOFRAME_ROUTER_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
+RESOURCE_SMOKE_URL_BASE="${GOFRAME_RESOURCE_SMOKE_URL:-http://127.0.0.1}"
 
 cd "$ROOT_DIR"
 export GOCACHE="${GOCACHE:-/tmp/goframe-go-cache}"
@@ -136,6 +137,11 @@ build_router_smoke_url() {
 build_router_dashboard_smoke_url() {
 	local port="$1"
 	echo "${ROUTER_DASHBOARD_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_resource_smoke_url() {
+	local port="$1"
+	echo "${RESOURCE_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 stop_server() {
@@ -362,6 +368,21 @@ run_with_server ./examples/router-dashboard "$ROUTER_DASHBOARD_PORT" "$ROUTER_DA
 	node --experimental-websocket scripts/router-dashboard-browser-smoke.mjs
 
 echo
+echo "== Resource debug browser smoke =="
+"$GOXC" package ./examples/resource --compiler=tinygo
+(
+	cd ./examples/resource/.goframe/work/dev/examples/resource/cmd/app
+	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+		-o "$ROOT_DIR/examples/resource/.goframe/package/standalone/assets/bundle.wasm" .
+)
+
+RESOURCE_PORT="$(resolve_port "${GOFRAME_RESOURCE_SMOKE_PORT:-}")"
+export GOFRAME_RESOURCE_CHROME_DEBUG_PORT="${GOFRAME_RESOURCE_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+RESOURCE_URL="$(build_resource_smoke_url "$RESOURCE_PORT")"
+run_with_server ./examples/resource "$RESOURCE_PORT" "$RESOURCE_URL" \
+	node --experimental-websocket scripts/resource-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo
@@ -371,5 +392,6 @@ echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/cmdapp --compiler=tinygo
 "$GOXC" package ./examples/router --compiler=tinygo
 "$GOXC" package ./examples/router-dashboard --compiler=tinygo
+"$GOXC" package ./examples/resource --compiler=tinygo
 
 echo "browser smoke: ok"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -65,6 +65,8 @@ echo "== Package examples with TinyGo =="
 "$GOXC" package ./examples/router --compiler=tinygo
 "$GOXC" generate ./examples/router-dashboard
 "$GOXC" package ./examples/router-dashboard --compiler=tinygo
+"$GOXC" generate ./examples/resource
+"$GOXC" package ./examples/resource --compiler=tinygo
 
 echo "== Size budgets =="
 scripts/size-budget.sh

--- a/scripts/resource-browser-smoke.mjs
+++ b/scripts/resource-browser-smoke.mjs
@@ -1,0 +1,299 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_RESOURCE_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_RESOURCE_CHROME_DEBUG_PORT ?? "19260");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-resource-smoke-"));
+const expectedApp = new URL(appURL);
+
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await navigateToApp(client, withSmokeParam(appURL));
+    await waitForAppPage(client, expectedApp);
+    assertState(await resourceState(client), {
+        panel: true,
+        status: "loading",
+        key: "slow:assets/data/issues-open.txt",
+        boundaryFallback: false,
+    }, "resource initial loading");
+
+    await waitForStatus(client, "ready");
+    assertState(await resourceState(client), {
+        status: "ready",
+        itemCount: 2,
+        firstItem: "GF-101Audit render error fallback bubblingopen",
+        boundaryFallback: false,
+    }, "resource initial ready");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-reload']").click()`);
+    await waitForStatus(client, "loading");
+    assertState(await resourceState(client), {
+        status: "loading",
+        attempt: "2",
+        boundaryFallback: false,
+    }, "resource reload loading");
+    await waitForStatus(client, "ready");
+    assertState(await resourceState(client), {
+        status: "ready",
+        itemCount: 2,
+        attempt: "2",
+        boundaryFallback: false,
+    }, "resource reload ready");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-load-missing']").click()`);
+    await waitForStatus(client, "failed");
+    const failed = await resourceState(client);
+    if (!failed.errorText.includes("fetch")) {
+        throw new Error(`APP FAILURE: missing asset error did not mention fetch: ${JSON.stringify(failed)}`);
+    }
+    assertState(failed, {
+        status: "failed",
+        boundaryFallback: false,
+    }, "resource missing failed state");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-load-open']").click()`);
+    await waitForStatus(client, "ready");
+    assertState(await resourceState(client), {
+        status: "ready",
+        itemCount: 2,
+        key: "assets/data/issues-open.txt",
+        boundaryFallback: false,
+    }, "resource recovers after failed state");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-load-slow']").click()`);
+    await waitForStatus(client, "loading");
+    await client.evaluate(`document.querySelector("[data-testid='resource-load-fast']").click()`);
+    await waitForCondition(async () => {
+        const state = await resourceState(client);
+        return state.status === "ready" && state.key === "assets/data/issues-all.txt" && state.itemCount === 4;
+    }, "fast all wins over slow open");
+    await wait(500);
+    assertState(await resourceState(client), {
+        status: "ready",
+        key: "assets/data/issues-all.txt",
+        itemCount: 4,
+        lastItem: "GF-301Ship public preview polish notesclosed",
+        boundaryFallback: false,
+    }, "resource stale slow result ignored");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-load-slow']").click()`);
+    await waitForStatus(client, "loading");
+    await client.evaluate(`document.querySelector("[data-testid='resource-toggle-panel']").click()`);
+    await waitForCondition(async () => {
+        return (await resourceState(client)).unmounted === true;
+    }, "resource panel unmounted");
+    await wait(500);
+    assertState(await resourceState(client), {
+        panel: false,
+        unmounted: true,
+        boundaryFallback: false,
+    }, "resource late completion after unmount ignored");
+
+    await client.evaluate(`document.querySelector("[data-testid='resource-toggle-panel']").click()`);
+    await waitForStatus(client, "loading");
+    await waitForStatus(client, "ready");
+    assertState(await resourceState(client), {
+        panel: true,
+        status: "ready",
+        itemCount: 2,
+        boundaryFallback: false,
+    }, "resource app remains interactive");
+
+    client.close();
+    console.log("Resource browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function resourceState(client) {
+    return await client.evaluate(`(() => {
+        const itemTexts = [...document.querySelectorAll("[data-testid='resource-item']")]
+            .map((item) => item.textContent.trim().replace(/\\s+/g, " "));
+        return {
+            app: Boolean(document.querySelector("[data-testid='resource-app']")),
+            panel: Boolean(document.querySelector("[data-testid='resource-panel']")),
+            unmounted: Boolean(document.querySelector("[data-testid='resource-panel-unmounted']")),
+            boundaryFallback: Boolean(document.querySelector("[data-testid='resource-boundary-fallback']")),
+            key: document.querySelector("[data-testid='resource-key']")?.textContent.trim() ?? "",
+            attempt: document.querySelector("[data-testid='resource-attempt']")?.textContent.trim() ?? "",
+            status: document.querySelector("[data-testid='resource-status']")?.textContent.trim() ?? "",
+            loading: Boolean(document.querySelector("[data-testid='resource-loading']")),
+            ready: Boolean(document.querySelector("[data-testid='resource-ready']")),
+            failed: Boolean(document.querySelector("[data-testid='resource-failed']")),
+            errorText: document.querySelector("[data-testid='resource-error']")?.textContent.trim() ?? "",
+            itemCount: itemTexts.length,
+            firstItem: itemTexts[0] ?? "",
+            lastItem: itemTexts[itemTexts.length - 1] ?? "",
+            errors: window.goframeResourceErrors ?? [],
+        };
+    })()`);
+}
+
+async function waitForStatus(client, status) {
+    await waitForCondition(async () => {
+        return (await resourceState(client)).status === status;
+    }, `resource status ${status}`);
+}
+
+function assertState(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (actual[key] !== value) {
+            throw new Error(`APP FAILURE: ${label}: ${key} got ${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; state=${JSON.stringify(actual)}`);
+        }
+    }
+    console.log(`${label}: ok`);
+}
+
+function withSmokeParam(url) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", String(Date.now()));
+    next.hash = "";
+    return String(next);
+}
+
+async function waitForPage(port) {
+    const endpoint = `http://127.0.0.1:${port}/json/version`;
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        try {
+            const version = await fetch(endpoint).then((response) => response.json());
+            if (version.webSocketDebuggerUrl) {
+                const pages = await fetch(`http://127.0.0.1:${port}/json`).then((response) => response.json());
+                const page = pages.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+                if (page) {
+                    return page;
+                }
+            }
+        } catch {
+            if (browser.exitCode !== null) {
+                throw new Error(`HARNESS FAILURE: Chrome exited early. stderr:\n${browserError}`);
+            }
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools endpoint did not start. stderr:\n${browserError}`);
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const { resolve, reject } = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            reject(new Error(`${message.error.message}: ${message.error.data ?? ""}`));
+        } else {
+            resolve(message.result ?? {});
+        }
+    });
+
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    return {
+        call(method, params = {}) {
+            const id = nextID++;
+            socket.send(JSON.stringify({ id, method, params }));
+            return new Promise((resolve, reject) => {
+                pending.set(id, { resolve, reject });
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                awaitPromise: true,
+                returnByValue: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`APP FAILURE: evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function navigateToApp(client, url) {
+    await client.call("Page.navigate", { url });
+    await waitForCondition(async () => {
+        const readyState = await client.evaluate("document.readyState");
+        return readyState === "complete" || readyState === "interactive";
+    }, "page navigation");
+}
+
+async function waitForAppPage(client, expectedApp) {
+    let lastState = null;
+    try {
+        await waitForCondition(async () => {
+            const state = await client.evaluate(`(() => ({
+            href: location.href,
+            rootText: document.querySelector("#root")?.textContent.trim() ?? "",
+            ready: Boolean(document.querySelector("[data-testid='resource-app']")),
+            errors: window.goframeResourceErrors ?? [],
+        }))()`);
+            lastState = state;
+            const actual = new URL(state.href);
+            if (actual.origin !== expectedApp.origin) {
+                throw new Error(`HARNESS FAILURE: expected app origin ${expectedApp.origin}, got ${actual.origin}`);
+            }
+            return state.ready;
+        }, "resource app ready");
+    } catch (error) {
+        throw new Error(`${error.message}; state=${JSON.stringify(lastState)}`);
+    }
+}
+
+async function waitForCondition(check, label) {
+    const started = Date.now();
+    while (Date.now() - started < 10_000) {
+        if (await check()) {
+            return;
+        }
+        await wait(50);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label}`);
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -138,5 +138,6 @@ check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
 check_app "routerdash" "$(bundle_path router-dashboard)" 166912 51200 63488 56320 || status=1
+check_app "resource" "$(bundle_path resource)" 153600 57344 67584 61440 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adds a minimal component-scoped resource primitive for asynchronous data loading without introducing a cache, Suspense, or route loaders.

## Changes

- Add Resource, ResourceStatus, ResourceLoader, and UseResource
- Support loading, ready, and failed states
- Add key-based generations and explicit reload
- Ignore stale completions before they can update or dirty a component
- Run cleanup once on reload, key change, or unmount
- Prevent automatic retries after loader panics
- Preserve explicit ErrorBoundary and runtime error semantics
- Add a local browser-fetch resource example and smoke coverage
- Update documentation, CI, and size budgets

## Non-goals

No global cache, request deduplication, retries, polling, Suspense, route loaders, server resources, or runtime HTTP API.

## Validation

The full Go, race, vet, debug, GOX, browser smoke, size, documentation, and dashboard DOM-pressure suites pass.