### PR TITLE
MVP 29: reference app and tutorial path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@
 
 ### Fixed
 
+- The router-dashboard route Error Boundary fallback now distinguishes retrying
+  the current crashing route from safely navigating back to the issues list, and
+  browser smoke covers recovery from `?panic=render` without reloading the
+  resource owner.
 - Resource loader panics no longer leave the internal effect slot pending, so a
   same-key rerender after failed state does not automatically restart the same
   panicking loader. Explicit retry remains available through `reload` or key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@
 - Component-scoped resource prototype with `gf.UseResource`, explicit
   loading/ready/failed state, stale completion guards, cleanup/cancellation
   semantics, and a focused resource example plus browser smoke coverage.
+- MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
+  the flagship integrated tutorial app with packaged data, one app-local
+  resource owner, explicit loading/failed UI, manual reload, query filters,
+  controlled form validation, scoped render Error Boundary composition, and
+  strengthened browser smoke coverage.
+- `docs/tutorial.md` with a recommended learning path through focused,
+  reference, pressure, and toolchain examples.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Current baseline includes:
   clean workspace commands;
 - multi-package GOX workspaces, child entry packages such as `./cmd/app`, and
   import-aware generated component identity;
-- documented forms/validation patterns and a router-dashboard reference app;
+- documented forms/validation patterns and a resource-backed router-dashboard
+  reference app;
 - CI gates for Go/GOX tests, TinyGo size budgets, browser smoke, artifact
   checks, module path checks, and docs consistency.
 
@@ -119,6 +120,36 @@ size is not the main concern:
 goxc package ./examples/counter --compiler=go
 ```
 
+## Start Here
+
+Recommended first path:
+
+```text
+examples/counter
+  -> examples/components
+  -> examples/router-dashboard
+```
+
+`examples/router-dashboard` is the flagship reference app. It shows how the
+current primitives fit together in a small Go-first SPA/dashboard/admin-style
+application: stable shell, hash router, query filters, component-scoped
+resource data, explicit loading/failed UI, controlled form validation, and a
+render Error Boundary.
+
+Focused deep dives:
+
+- `examples/router`: routing only;
+- `examples/resource`: resource lifecycle, stale completion, failure, and
+  cleanup;
+- `examples/context`: scoped providers and selector consumers;
+- `examples/virtualized`: fixed-height bounded DOM;
+- `examples/todo`: controlled inputs, effects, events, and list helpers.
+
+Toolchain/layout examples: `examples/multipackage` and `examples/cmdapp`.
+Pressure/performance example: `examples/dashboard`.
+
+For the guided path, read [GoFrame Tutorial](docs/tutorial.md).
+
 ## Examples
 
 ### Quickstart
@@ -136,7 +167,7 @@ goxc package ./examples/counter --compiler=go
 | `examples/context` | Scoped providers, selector consumers, broad `UseContext`, nested providers. | `goxc package ./examples/context --compiler=tinygo` |
 | `examples/virtualized` | `gf.VirtualList`, `gf.VirtualTable`, bounded DOM with 10,000 logical rows. | `goxc package ./examples/virtualized --compiler=tinygo` |
 | `examples/router` | Hash router, query helpers, route params, not-found route, and stable shell layout. | `goxc package ./examples/router --compiler=tinygo` |
-| `examples/resource` | Experimental `gf.UseResource`, explicit loading/ready/failed state, stale completion guards, and example-local browser fetch. | `goxc package ./examples/resource --compiler=tinygo` |
+| `examples/resource` | Focused `gf.UseResource` lifecycle: loading/ready/failed state, stale completion guards, reload, and cleanup. | `goxc package ./examples/resource --compiler=tinygo` |
 
 ### Toolchain / Layout
 
@@ -150,7 +181,7 @@ goxc package ./examples/counter --compiler=go
 | Example | What it demonstrates | Command |
 |---|---|---|
 | `examples/dashboard` | Reducer dispatch, explicit memoization, virtual table, dashboard pressure smoke. | `goxc package ./examples/dashboard --compiler=tinygo` |
-| `examples/router-dashboard` | Router, query-state filters, controlled form validation, and Go-first layout. | `goxc package ./examples/router-dashboard --compiler=tinygo` |
+| `examples/router-dashboard` | Flagship reference app: router, query-state filters, component-scoped resource data, forms, validation, Error Boundary, and Go-first layout. | `goxc package ./examples/router-dashboard --compiler=tinygo` |
 
 Serve any packaged example with:
 
@@ -446,6 +477,7 @@ infrastructure.
 
 Start here:
 
+- [GoFrame Tutorial](docs/tutorial.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,17 +175,17 @@ TinyGo is the preferred lightweight experiment. It supports a smaller runtime
 surface but dramatically reduces the counter:
 
 ```text
-counter bundle.wasm          83,540 bytes
-components bundle.wasm       89,188 bytes
-todo bundle.wasm            117,399 bytes
-dashboard bundle.wasm       168,618 bytes
-context bundle.wasm         115,344 bytes
-virtualized bundle.wasm     123,134 bytes
-multipackage bundle.wasm     94,344 bytes
-cmdapp bundle.wasm           94,370 bytes
-router bundle.wasm          114,706 bytes
-router-dashboard bundle.wasm 164,091 bytes
-resource bundle.wasm        147,562 bytes
+counter bundle.wasm          83,550 bytes
+components bundle.wasm       89,198 bytes
+todo bundle.wasm            117,409 bytes
+dashboard bundle.wasm       168,628 bytes
+context bundle.wasm         115,354 bytes
+virtualized bundle.wasm     123,144 bytes
+multipackage bundle.wasm     94,354 bytes
+cmdapp bundle.wasm           94,380 bytes
+router bundle.wasm          114,716 bytes
+router-dashboard bundle.wasm 225,649 bytes
+resource bundle.wasm        147,673 bytes
 ```
 
 MVP 8.1 removed reflective props comparison and compiles browser
@@ -221,11 +221,12 @@ updates, and a small document-title effect. The table is physically
 virtualized with `gf.VirtualTable`, so the logical row count can stay
 dashboard-sized while the mounted DOM remains bounded.
 
-`examples/router-dashboard` is the first reference-grade integrated app. It
+`examples/router-dashboard` is the flagship reference-grade integrated app. It
 uses a child entry package, internal packages, the hash router, query-driven
-filters, controlled form state, synchronous validation, and stable shell
-composition without adding a data-loading framework or schema validation
-library.
+filters, one component-scoped resource owner for packaged issue data,
+controlled form state, synchronous validation, scoped render Error Boundary
+composition, and stable shell composition without adding route loaders, a
+global cache, server resources, or a schema validation library.
 
 `examples/resource` is the first resource-loading probe. It uses
 component-scoped `gf.UseResource` with example-local browser fetch, text

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -65,10 +65,11 @@ render Error Boundary fallback/reset behavior, dashboard-sized
 filtering/sorting/selection behavior, context selector rerender isolation,
 virtualized collection scroll/selection/toggle behavior, a multi-package GOX
 workspace smoke, a child-entry package smoke, hash-router navigation smoke, and
-the router-dashboard reference app smoke for query filters plus form
-validation. It also covers the resource example for explicit loading/ready/
-failed state, reload, stale completion guards, and cleanup-after-unmount
-behavior.
+the router-dashboard reference app smoke for query filters, form validation,
+single-owner resource loading, no duplicate reloads across navigation/query
+changes, manual reload, explicit resource failure UI, and stable shell
+identity. It also covers the resource example for explicit loading/ready/failed
+state, reload, stale completion guards, and cleanup-after-unmount behavior.
 
 The runtime error containment and Error Boundary fixtures are compiled with the
 Go WASM compiler so `recover` semantics are available. The size-oriented TinyGo
@@ -227,8 +228,9 @@ duplicate key diagnostics failures, dashboard filter/sort regressions,
 virtualized collection window regressions, or listener churn regressions.
 Router smoke failures include broken hash navigation, missing route params,
 not-found fallback regressions, browser back handling regressions, query helper
-regressions, form validation regressions in the reference app, or unstable
-shell layout identity.
+regressions, form validation regressions in the reference app, duplicate
+reference-app data loads on navigation/query changes, resource failure escaping
+to Error Boundary fallback UI, or unstable shell layout identity.
 Resource smoke failures include broken loading/ready/failed transitions, stale
 completion updates, cleanup-after-unmount regressions, or resource failures
 escaping into Error Boundary fallback UI.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -68,13 +68,16 @@ workspace smoke, a child-entry package smoke, hash-router navigation smoke, and
 the router-dashboard reference app smoke for query filters, form validation,
 single-owner resource loading, no duplicate reloads across navigation/query
 changes, manual reload, explicit resource failure UI, and stable shell
-identity. It also covers the resource example for explicit loading/ready/failed
-state, reload, stale completion guards, and cleanup-after-unmount behavior.
+identity. It also covers route Error Boundary fallback and safe navigation
+recovery in the reference app. It also covers the resource example for explicit
+loading/ready/failed state, reload, stale completion guards, and
+cleanup-after-unmount behavior.
 
-The runtime error containment and Error Boundary fixtures are compiled with the
-Go WASM compiler so `recover` semantics are available. The size-oriented TinyGo
-package path uses trap-style panic behavior, which is documented as a runtime
-error containment limitation.
+The runtime error containment fixture, Error Boundary fixture, and
+router-dashboard reference-app smoke are compiled with the Go WASM compiler
+where recover-based render containment is being asserted. The size-oriented
+TinyGo package path uses trap-style panic behavior, which is documented as a
+runtime error containment limitation.
 
 GOX diagnostic golden tests intentionally assert filenames, line/column
 prefixes, specific unsupported-syntax messages, and source snippets. They are

--- a/docs/error-boundaries.md
+++ b/docs/error-boundaries.md
@@ -210,6 +210,11 @@ put the boundary inside selected route handlers. This keeps routing and error
 UI policy separate. Automatic route-level error pages, route loaders, and
 Suspense-style resource fallback remain future work.
 
+`examples/router-dashboard` follows this model: the stable shell and
+component-scoped data owner remain mounted, route content is wrapped in an
+explicit render boundary, and ordinary `ResourceFailed` state renders a failed
+resource panel instead of switching to boundary fallback.
+
 The lower-level Go props/`Children` form remains valid for hand-written runtime
 code and tests, but the package-qualified GOX style is the recommended
 application-facing shape.

--- a/docs/error-boundaries.md
+++ b/docs/error-boundaries.md
@@ -148,6 +148,13 @@ actual failing render is still reported through the global handler.
 If the retried subtree panics again, that is a new incident and is reported as
 a new render failure.
 
+Reset retries the same protected subtree. It does not change route params,
+query strings, component props, or app data by itself. If those inputs still
+trigger the same render panic, the boundary can immediately capture another
+incident and show fallback UI again. Apps should provide an explicit escape
+path when the current route state may be the cause, such as a `RouterLink` back
+to a known-safe route.
+
 ## ResetKey
 
 `ResetKey` is an optional string. When it changes while the boundary is failed,
@@ -214,6 +221,10 @@ Suspense-style resource fallback remain future work.
 component-scoped data owner remain mounted, route content is wrapped in an
 explicit render boundary, and ordinary `ResourceFailed` state renders a failed
 resource panel instead of switching to boundary fallback.
+
+Its route fallback includes both "Retry current route" and "Back to issues".
+The retry button rerenders the same route, while the safe link removes the
+intentional crashing query parameter used by the smoke test.
 
 The lower-level Go props/`Children` form remains valid for hand-written runtime
 code and tests, but the package-qualified GOX style is the recommended

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -168,6 +168,10 @@ For larger forms:
 - make validation deterministic and synchronous;
 - keep navigation after successful submit explicit with `gf.Navigate`.
 
+`examples/router-dashboard` is the integrated reference for this pattern. Its
+edit route keeps save/reset behavior local to the form and does not pretend to
+be a server mutation or persistence layer.
+
 When a stateful form lives in another Go package, prefer a package-qualified
 component tag:
 

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document records the measurable baseline through MVP 28. It is a
+This document records the measurable baseline through MVP 29. It is a
 decision aid for future runtime and tooling work, not a claim that GoFrame is
 production-ready.
 
@@ -75,8 +75,7 @@ CDP node drift as an investigation signal, not a failure by itself.
 
 ## Current Baseline
 
-Updated during the Error Boundary hardening pass from local `main` after the
-public preview hardening baseline.
+Updated during MVP 29 from local `main` after the MVP 28 resource baseline.
 
 Tool versions:
 
@@ -130,7 +129,7 @@ TinyGo packaged WASM sizes:
 | multipackage | 94354 | 36850 | 30728 | 33175 |
 | cmdapp | 94380 | 36839 | 30720 | 33124 |
 | router | 114716 | 43602 | 36062 | 39026 |
-| router-dashboard | 164098 | 61873 | 49731 | 53810 |
+| router-dashboard | 225649 | 90888 | 74402 | 79524 |
 | resource | 147562 | 64576 | 54640 | 58090 |
 
 The authoritative gate remains `scripts/size-budget.sh`. This table is a

--- a/docs/public-preview-hardening-i.md
+++ b/docs/public-preview-hardening-i.md
@@ -34,7 +34,7 @@ In scope:
 - public API surface review;
 - router query parsing and URL building helpers;
 - form patterns based on existing event, state, and reducer primitives;
-- reference example using local deterministic data only;
+- reference example using local deterministic packaged data only;
 - browser smoke and size budget coverage for the reference example;
 - README and docs alignment.
 
@@ -103,12 +103,18 @@ It demonstrates:
 - query-driven filters for an issues list;
 - controlled edit form with local validation;
 - touched/dirty/submit state;
-- local deterministic data only;
+- local deterministic packaged data only;
 - not-found route and stable shell layout.
 
 MVP 26 refines the same example to use package-qualified component tags such
 as `<layout.Shell>` and `<filters.FilterControls>`, replacing the earlier
 cross-package props-struct function-call workaround.
+
+MVP 29 keeps this same example as the flagship reference app and integrates the
+later component-scoped resource and scoped render Error Boundary primitives:
+packaged data flows through one stable app-local resource owner, route pages
+render explicit loading/failed state, and render failures remain separate from
+ordinary resource failures.
 
 It is intentionally smaller than `examples/dashboard`. The existing dashboard
 remains the pressure test; the new example is the user-facing reference app.
@@ -145,9 +151,10 @@ MVP 25 does not introduce:
 - Forms remain patterns rather than a library. This is deliberate, but users
   who want schema validation still need app-level code.
 - Router state remains hash-based only.
-- The reference app is local and deterministic; it does not answer the broader
+- The reference app is local and deterministic; it demonstrates packaged data
+  plus one component-scoped resource owner, but it does not answer the broader
   external data, global cache, or route-loader story. MVP 28's component
-  resource primitive is a smaller explicit-state step.
+  resource primitive remains a smaller explicit-state step.
 
 ## Next Steps
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -200,6 +200,26 @@ hook machinery: one internal state slot stores a small mutable control object,
 and one effect slot starts/cleans generations. No new `componentInstance`
 fields are required.
 
+## Reference App Pattern
+
+`examples/resource` is the focused lifecycle example. It covers reload,
+failure, stale completion, and cleanup-after-unmount scenarios.
+
+`examples/router-dashboard` shows the integration pattern for a small app:
+
+```text
+App
+  -> data.IssueProvider
+    -> stable shell
+      -> RouterView
+```
+
+The resource owner sits outside the route subtree, so navigating between list,
+detail, edit, not-found routes, query filter changes, and browser back/forward
+do not start another loader. Manual reload is explicit and starts a new
+generation. Failed resource state renders application UI and does not activate
+an Error Boundary.
+
 ## TinyGo And Browser Notes
 
 Ordinary loading, resolving, rejecting, cleanup, key changes, manual reload,

--- a/docs/router.md
+++ b/docs/router.md
@@ -199,6 +199,17 @@ The shell is an ordinary component that stays mounted while `RouterView`
 changes the route content inside it. This gives applications a stable layout
 without a nested route DSL.
 
+When route pages share component-scoped data, keep the resource owner above the
+shell/router if data should survive route transitions:
+
+```text
+App -> IssueProvider -> Shell -> RouterView
+```
+
+`examples/router-dashboard` uses this pattern. It is still ordinary component
+composition, not a route loader system, global cache, or automatic preload
+policy.
+
 ## Browser Back/Forward
 
 Browser back and forward work through the native hash history stack. Since

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,291 @@
+# GoFrame Tutorial
+
+## What You Will Build
+
+This tutorial follows the reference app in `examples/router-dashboard`: a small
+Go-first browser/WASM dashboard with a stable shell, hash routes, URL query
+filters, a component-scoped resource owner, explicit loading and failed states,
+controlled form validation, and a scoped render Error Boundary.
+
+The goal is not to introduce a new app framework layer. The app uses the
+existing runtime primitives directly:
+
+- GOX package-qualified components;
+- `gf.NewHashRouter`, `gf.RouterView`, and `gf.RouterLink`;
+- `gf.RouteContext.Query()` and `gf.WithQuery`;
+- `gf.UseResource` for one component-scoped data load;
+- `gf.UseReducer` for form state;
+- `gf.ErrorBoundary` for render failures only.
+
+## Prerequisites
+
+Install Go, TinyGo, Node.js, Chrome or Chromium, gzip, brotli, and optionally
+zstd. The repository CI currently uses Go `1.24.x`, TinyGo `0.41.1`, and
+Node.js 20.
+
+## Install goxc
+
+For a published install:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@latest
+```
+
+Inside this repository, install the local checkout:
+
+```bash
+go install ./cmd/goxc
+goxc doctor
+```
+
+## Run The Reference App
+
+Package and serve the reference dashboard:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=tinygo
+goxc serve ./examples/router-dashboard --port=8080
+```
+
+Open <http://127.0.0.1:8080>.
+
+Try these routes:
+
+- `#/`
+- `#/issues`
+- `#/issues?status=open&q=auth`
+- `#/issues/RD-2`
+- `#/issues/RD-2/edit`
+- `#/missing`
+
+## Project Layout
+
+The reference app uses the recommended Go-first child-entry layout:
+
+```text
+examples/router-dashboard/
+├── goframe.json
+├── index.html
+├── styles.css
+├── data/
+│   └── issues.txt
+├── cmd/app/
+│   ├── main.go
+│   └── app.gox
+└── internal/
+    ├── data/
+    ├── filters/
+    ├── forms/
+    ├── layout/
+    └── pages/
+```
+
+`cmd/app` is the executable entry package. `internal/...` packages keep UI,
+data parsing/loading, forms, filters, and pages private to the app.
+
+`goxc` generates `.gox.go` files under `.goframe`, not next to source files.
+
+## GOX Components
+
+GOX lowercase tags create DOM elements:
+
+```gox
+<section class="rd-card">
+    <h2>Issues</h2>
+</section>
+```
+
+Capitalized tags create component boundaries. Cross-package components use
+ordinary Go imports and package-qualified GOX tags:
+
+```gox
+import layout "github.com/graybuton/goframe/examples/router-dashboard/internal/layout"
+
+func App() gf.Node {
+    return (
+        <layout.Shell>
+            {gf.RouterView(router)}
+        </layout.Shell>
+    )
+}
+```
+
+The supported package-qualified form is `packageAlias.Component`. There are no
+namespace tags, spread props, or file-based route components.
+
+## Stable App Shell
+
+The app keeps layout outside route content:
+
+```text
+App
+  -> data.IssueProvider
+    -> layout.Shell
+      -> gf.RouterView(router)
+```
+
+The shell stays mounted while routes, query filters, forms, and data reloads
+change the outlet. This is the recommended layout model for the current hash
+router.
+
+## Router And Route Params
+
+Routes are declared in Go:
+
+```go
+var router = gf.NewHashRouter([]gf.Route{
+    gf.RoutePath("/", homeRoute),
+    gf.RoutePath("/issues", issuesRoute),
+    gf.RoutePath("/issues/:id/edit", issueEditRoute),
+    gf.RoutePath("/issues/:id", issueDetailsRoute),
+    gf.NotFoundRoute(notFoundRoute),
+})
+```
+
+Route params come from `gf.RouteContext`:
+
+```go
+id := ctx.Param("id")
+```
+
+The router is hash-based. `#/issues/RD-2` works on static hosting because the
+server still serves `index.html`.
+
+## URL Query State
+
+The issues page reads query state from the route:
+
+```go
+query := ctx.Query()
+filter := data.IssueFilter{
+    Query:  query.Get("q"),
+    Status: query.Get("status"),
+}
+```
+
+Filter controls update the URL explicitly:
+
+```go
+gf.Navigate(gf.WithQuery("/issues", gf.QueryValues{
+    "q":      {query},
+    "status": {status},
+}))
+```
+
+There is no automatic query-state manager. The URL is just ordinary app state
+that components read and write deliberately.
+
+## Component-Scoped Resource
+
+The reference app has one stable resource owner. It loads the packaged
+`data/issues.txt` asset once and distributes the explicit resource state
+through app-local context.
+
+Important properties:
+
+- initial app load starts one generation;
+- route navigation does not reload data;
+- query changes do not reload data;
+- browser back/forward does not reload data;
+- manual reload starts a new generation;
+- failed state is rendered explicitly;
+- there is no global cache or route loader.
+
+The data loader is example-local browser code. GoFrame does not provide a
+runtime fetch API.
+
+## Loading And Failure UI
+
+Resource state is normal UI state:
+
+- loading shows a small loading panel while the shell remains mounted;
+- ready pages render list, detail, and edit views from the loaded data;
+- failed shows an error panel plus retry control.
+
+Ordinary resource failure is not a render failure and does not activate an
+Error Boundary.
+
+## Forms And Validation
+
+The edit page uses controlled inputs and a reducer:
+
+- `Value={state.Title.Value}`;
+- `OnInput={func(event gf.InputEvent) { ... }}`;
+- `OnSubmit={func(event gf.Event) { event.PreventDefault(); ... }}`;
+- local touched/dirty/submitted flags;
+- synchronous validation functions in the app package.
+
+There is no schema validation framework, server mutation API, optimistic
+mutation layer, or persistence story in this tutorial.
+
+## Error Boundaries
+
+Route content is wrapped in a scoped render Error Boundary. It protects route
+rendering from render panics and keeps the outer shell alive.
+
+Error Boundaries do not catch:
+
+- ordinary `ResourceFailed` state;
+- event handler panics;
+- effect panics;
+- async resource failures;
+- route loader failures, because route loaders do not exist yet.
+
+## Package And Serve
+
+For local development:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=tinygo
+goxc serve ./examples/router-dashboard --port=8080
+```
+
+For cache-safe deploy-style artifacts:
+
+```bash
+goxc package ./examples/router-dashboard \
+  --compiler=tinygo \
+  --asset-hash \
+  --preload \
+  --compress=gzip,br
+```
+
+Use `goxc export` only when you want a visible deploy directory.
+
+## Where To Go Next
+
+Recommended learning path:
+
+1. `examples/counter`: minimal state and packaging.
+2. `examples/components`: GOX components, props, children, and fragments.
+3. `examples/router`: focused routing.
+4. `examples/resource`: focused resource lifecycle, stale completion, failure,
+   and cleanup behavior.
+5. `examples/router-dashboard`: integrated reference app.
+6. `examples/dashboard`: pressure/performance example.
+
+Focused deep dives:
+
+- `examples/todo`: controlled inputs, effects, keys, and list helpers.
+- `examples/context`: scoped providers and selector consumers.
+- `examples/virtualized`: bounded DOM for fixed-height lists and tables.
+- `examples/multipackage` and `examples/cmdapp`: workspace and layout shapes.
+
+## Current Limitations
+
+GoFrame is experimental and not production-ready. The tutorial intentionally
+does not cover or provide:
+
+- SSR or hydration;
+- history-mode routing;
+- route loaders;
+- server resources or server functions;
+- global resource cache;
+- request deduplication;
+- Suspense-style async rendering;
+- schema validation;
+- mutation framework;
+- auth guards or route middleware;
+- production deployment server;
+- LSP or formatter;
+- Player/Engine runtime.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -223,6 +223,28 @@ mutation layer, or persistence story in this tutorial.
 Route content is wrapped in a scoped render Error Boundary. It protects route
 rendering from render panics and keeps the outer shell alive.
 
+The reference app includes an intentional route-render failure for integration
+testing:
+
+```text
+#/issues/RD-2?panic=render
+```
+
+That query parameter makes the detail route panic during render. The boundary
+shows fallback UI, while the outer shell and component-scoped resource owner
+stay mounted. The resource remains `ready`; this is not an ordinary
+`ResourceFailed` state and it does not reload the data.
+
+The fallback exposes two different actions:
+
+- retry the current route, which rerenders the same protected subtree with the
+  same route/query input;
+- navigate safely back to `/issues`, which removes the crashing query input and
+  returns the app to a normal route.
+
+Reset does not fix the cause of an error automatically. If the same route props
+or query still trigger a panic, fallback UI can appear again.
+
 Error Boundaries do not catch:
 
 - ordinary `ResourceFailed` state;

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -49,6 +49,15 @@ goxc serve ./examples/router-dashboard --port=8080
 
 Open <http://127.0.0.1:8080>.
 
+TinyGo is the normal path for the router, resource, query, and form scenarios.
+The intentional panic recovery demo in the Error Boundaries section requires a
+recover-capable Go/WASM build:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=go
+goxc serve ./examples/router-dashboard --port=8080
+```
+
 Try these routes:
 
 - `#/`
@@ -234,6 +243,17 @@ That query parameter makes the detail route panic during render. The boundary
 shows fallback UI, while the outer shell and component-scoped resource owner
 stay mounted. The resource remains `ready`; this is not an ordinary
 `ResourceFailed` state and it does not reload the data.
+
+Run this demo with the Go/WASM package path:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=go
+goxc serve ./examples/router-dashboard --port=8080
+```
+
+The size-oriented TinyGo build path does not guarantee recover-based
+containment and may trap instead of rendering the fallback. The rest of the
+router/resource/forms tutorial flow works through TinyGo.
 
 The fallback exposes two different actions:
 

--- a/examples/resource/README.md
+++ b/examples/resource/README.md
@@ -1,10 +1,13 @@
 # Resource
 
-This example demonstrates the experimental `gf.UseResource` primitive.
+This focused example demonstrates the experimental `gf.UseResource` primitive.
 
 It loads small packaged text assets through browser `fetch`, but the runtime
 resource API itself is transport-agnostic. The fetch, parsing, delay, and abort
 logic live in the example under `internal/data`.
+
+For an integrated app that combines resources with router/query/forms/Error
+Boundary patterns, start with `examples/router-dashboard`.
 
 ## Run
 
@@ -20,5 +23,7 @@ goxc serve ./examples/resource --port=8080
 - `Load Slow Open` followed by `Load Fast All` demonstrates stale completion
   protection.
 - `Toggle panel` unmounts the resource panel and runs loader cleanup.
+- Loader panic semantics are covered by runtime tests; this TinyGo browser
+  smoke focuses on ordinary resource lifecycle behavior.
 - There is no cache, Suspense, route loader, retry policy, JSON helper, or
   runtime fetch API in this MVP.

--- a/examples/router-dashboard/README.md
+++ b/examples/router-dashboard/README.md
@@ -38,6 +38,7 @@ Try:
 - `#/issues`
 - `#/issues?status=open&q=auth`
 - `#/issues/RD-2`
+- `#/issues/RD-2?panic=render`
 - `#/issues/RD-2/edit`
 - `#/missing`
 
@@ -158,6 +159,15 @@ mutation framework.
 Route render failures are handled by `gf.ErrorBoundary`. Ordinary resource
 failure renders `rd-resource-failed` instead.
 
+The detail route has an intentional render-failure trigger for smoke coverage:
+`#/issues/RD-2?panic=render`. The boundary fallback exposes two actions:
+
+- Retry current route: calls the boundary reset callback and rerenders the same
+  protected subtree with the same URL state. If `panic=render` is still present,
+  the route can fail again.
+- Back to issues: navigates to `/issues`, removing the crashing query input and
+  proving the shell and resource owner stay alive.
+
 This app does not install route loaders, route-level automatic boundaries, or
 server error pages.
 
@@ -178,6 +188,8 @@ The browser smoke verifies:
 - navigation and query changes do not reload data;
 - manual reload starts exactly one new generation;
 - resource failure stays outside Error Boundary fallback;
+- route render failure shows boundary fallback and safe navigation restores the
+  issues list without reloading data;
 - detail/edit/form/not-found routes still work after reload.
 
 ## Non-goals

--- a/examples/router-dashboard/README.md
+++ b/examples/router-dashboard/README.md
@@ -1,18 +1,27 @@
-# Router Dashboard Example
+# Router Dashboard
 
-This reference example demonstrates how to combine GoFrame's current
-public-candidate app primitives without adding a larger framework layer.
+## Purpose
 
-It shows:
+This is the flagship GoFrame reference app for a small Go-first
+SPA/dashboard/admin-style application.
 
-- Go-first child entry layout with `"entry": "./cmd/app"`;
-- `gf.NewHashRouter`, `gf.RouterView`, `gf.RouterLink`, route params, and a
-  not-found route;
-- URL-driven filters with `gf.RouteContext.Query()` and `gf.WithQuery`;
-- controlled form inputs with `gf.InputEvent`;
-- synchronous validation with touched/dirty/submitted state;
-- a stable shell layout around route content;
-- local deterministic data only.
+It demonstrates how the current primitives fit together without adding a
+larger framework layer:
+
+- child entry package with `cmd/app + internal/...`;
+- package-qualified GOX components;
+- stable shell plus `gf.RouterView`;
+- route params and not-found route;
+- URL query filters;
+- one component-scoped resource owner;
+- explicit loading and failed state;
+- manual resource reload;
+- controlled form inputs;
+- local validation with touched/dirty/submitted state;
+- scoped render Error Boundary.
+
+The larger `examples/dashboard` remains the DOM pressure test. The focused
+`examples/resource` app remains the lifecycle/stale-completion resource probe.
 
 ## Run
 
@@ -25,22 +34,163 @@ Open <http://127.0.0.1:8080>.
 
 Try:
 
+- `#/`
 - `#/issues`
 - `#/issues?status=open&q=auth`
 - `#/issues/RD-2`
 - `#/issues/RD-2/edit`
 - `#/missing`
 
-## Notes
+## What It Demonstrates
 
-This is not a data-loading example. It does not use server calls, async
-resources, schema validation, route loaders, middleware, or a global store.
-The form validation logic is ordinary application Go code.
+- `gf.NewHashRouter`, `gf.RouterView`, `gf.RouterLink`, params, and not-found
+  routing.
+- `gf.RouteContext.Query()` plus `gf.WithQuery` for small URL-driven filters.
+- `gf.UseResource` as an app-local data owner, not a route loader or global
+  cache.
+- Browser fetch of a packaged local text asset.
+- Form state with `gf.UseReducer`, `gf.InputEvent`, and `gf.Event`.
+- Synchronous validation in ordinary Go.
+- Render-only Error Boundary behavior separate from resource failure UI.
 
-The larger `examples/dashboard` remains the DOM pressure test. This example is
-the smaller reference app for router + query state + form patterns.
+## Project Structure
 
-Cross-package GOX components use package-qualified tags such as
-`<layout.Shell />`, `<filters.FilterControls />`, `<forms.IssueForm />`, and
-`<gf.RouterLink />`. This keeps component boundaries explicit without wrapper
-functions that only forward props across packages.
+```text
+examples/router-dashboard/
+├── goframe.json
+├── index.html
+├── styles.css
+├── data/
+│   └── issues.txt
+├── cmd/app/
+│   ├── app.gox
+│   ├── main.go
+│   └── model.go
+└── internal/
+    ├── data/
+    ├── filters/
+    ├── forms/
+    ├── layout/
+    └── pages/
+```
+
+`data/issues.txt` is copied into the packaged app and fetched from the same
+origin as `assets/data/issues.txt`.
+
+## Data Flow
+
+```text
+packaged data/issues.txt
+  -> example-local browser fetch loader
+  -> data.ParseIssues
+  -> data.IssueProvider
+  -> app-local context
+  -> route pages
+  -> query filters / detail / edit form
+```
+
+There is one stable resource owner:
+
+```text
+App
+  -> data.IssueProvider
+    -> layout.Shell
+      -> gf.RouterView(router)
+```
+
+The provider stays mounted across route changes, query changes, browser
+back/forward, and form edits. Navigation does not start another loader.
+Manual reload starts a new resource generation.
+
+## Routing
+
+Routes are declared in `cmd/app/app.gox`:
+
+- `/`
+- `/issues`
+- `/issues/:id`
+- `/issues/:id/edit`
+- not found
+
+Route content is wrapped in a render Error Boundary. The shell remains outside
+the route subtree.
+
+## Query State
+
+The issues list reads `q` and `status` from the hash query:
+
+```text
+#/issues?status=open&q=auth
+```
+
+Filter controls update the URL explicitly with `gf.Navigate(gf.WithQuery(...))`.
+This example does not add automatic query binding.
+
+## Resource Ownership
+
+The resource owner uses `gf.UseResource` with one stable data key. The UI
+shows:
+
+- `rd-resource-status`;
+- `rd-resource-attempt`;
+- `rd-resource-reload`;
+- explicit loading panel;
+- explicit failed panel with retry.
+
+Resource failure is normal app state. It does not activate the Error Boundary.
+
+## Forms And Validation
+
+`internal/forms` keeps field state local to the form:
+
+- value;
+- error;
+- touched;
+- dirty;
+- submitted;
+- saved.
+
+Save is local-only. It does not persist to a server and does not introduce a
+mutation framework.
+
+## Error Handling
+
+Route render failures are handled by `gf.ErrorBoundary`. Ordinary resource
+failure renders `rd-resource-failed` instead.
+
+This app does not install route loaders, route-level automatic boundaries, or
+server error pages.
+
+## Tests
+
+Focused checks:
+
+```bash
+go test ./examples/router-dashboard/...
+node --check scripts/router-dashboard-browser-smoke.mjs
+goxc package ./examples/router-dashboard --compiler=tinygo
+```
+
+The browser smoke verifies:
+
+- shell identity remains stable;
+- initial resource load starts once;
+- navigation and query changes do not reload data;
+- manual reload starts exactly one new generation;
+- resource failure stays outside Error Boundary fallback;
+- detail/edit/form/not-found routes still work after reload.
+
+## Non-goals
+
+This example intentionally does not provide:
+
+- external network calls;
+- route loaders;
+- global resource cache;
+- request deduplication;
+- Suspense;
+- server resources or server functions;
+- schema validation framework;
+- persistence or mutation framework;
+- auth, middleware, or route guards;
+- production deployment server.

--- a/examples/router-dashboard/README.md
+++ b/examples/router-dashboard/README.md
@@ -32,15 +32,26 @@ goxc serve ./examples/router-dashboard --port=8080
 
 Open <http://127.0.0.1:8080>.
 
-Try:
+TinyGo is the normal path for the router, resource, query, and form scenarios.
+The intentional panic recovery demo requires a recover-capable Go/WASM build:
+
+```bash
+goxc package ./examples/router-dashboard --compiler=go
+goxc serve ./examples/router-dashboard --port=8080
+```
+
+Try with either build:
 
 - `#/`
 - `#/issues`
 - `#/issues?status=open&q=auth`
 - `#/issues/RD-2`
-- `#/issues/RD-2?panic=render`
 - `#/issues/RD-2/edit`
 - `#/missing`
+
+Try only with the Go/WASM build:
+
+- `#/issues/RD-2?panic=render`
 
 ## What It Demonstrates
 
@@ -167,6 +178,11 @@ The detail route has an intentional render-failure trigger for smoke coverage:
   the route can fail again.
 - Back to issues: navigates to `/issues`, removing the crashing query input and
   proving the shell and resource owner stay alive.
+
+This demo depends on recover-based render containment. Use
+`goxc package ./examples/router-dashboard --compiler=go` for it. The
+size-oriented TinyGo build path does not guarantee recover-based containment
+and may trap instead of rendering the fallback.
 
 This app does not install route loaders, route-level automatic boundaries, or
 server error pages.

--- a/examples/router-dashboard/cmd/app/app.gox
+++ b/examples/router-dashboard/cmd/app/app.gox
@@ -18,9 +18,11 @@ var router = gf.NewHashRouter([]gf.Route{
 func App() gf.Node {
 	return (
 		<main class="rd-app">
-			<layout.Shell>
-				{gf.RouterView(router)}
-			</layout.Shell>
+			<data.IssueProvider>
+				<layout.Shell>
+					{gf.RouterView(router)}
+				</layout.Shell>
+			</data.IssueProvider>
 		</main>
 	)
 }
@@ -31,30 +33,42 @@ func homeRoute(gf.RouteContext) gf.Node {
 
 func issuesRoute(ctx gf.RouteContext) gf.Node {
 	query := ctx.Query()
-	allIssues := data.DemoIssues()
 	filter := data.IssueFilter{
 		Query:  query.Get("q"),
 		Status: query.Get("status"),
 	}
-	return <pages.IssueList
-		Items={data.FilterIssues(allIssues, filter)}
-		TotalCount={len(allIssues)}
+	return routeBoundary(ctx, <pages.IssueList
 		Query={filter.Query}
 		Status={filter.Status}
-		CurrentPath={ctx.Path}
-	/>
+	/>)
 }
 
 func issueDetailsRoute(ctx gf.RouteContext) gf.Node {
-	issue, ok := data.FindIssue(ctx.Param("id"))
-	return <pages.IssueDetails Issue={issue} Found={ok} ID={ctx.Param("id")} />
+	return routeBoundary(ctx, <pages.IssueDetails
+		ID={ctx.Param("id")}
+		Crash={ctx.Query().Get("panic") == "render"}
+	/>)
 }
 
 func issueEditRoute(ctx gf.RouteContext) gf.Node {
-	issue, ok := data.FindIssue(ctx.Param("id"))
-	return <pages.IssueEdit Issue={issue} Found={ok} ID={ctx.Param("id")} />
+	return routeBoundary(ctx, <pages.IssueEdit ID={ctx.Param("id")} />)
 }
 
 func notFoundRoute(ctx gf.RouteContext) gf.Node {
 	return <pages.NotFound Path={ctx.Path} />
+}
+
+func routeBoundary(ctx gf.RouteContext, child gf.Node) gf.Node {
+	return (
+		<gf.ErrorBoundary ResetKey={routeResetKey(ctx)} Fallback={pages.RouteErrorFallback}>
+			{child}
+		</gf.ErrorBoundary>
+	)
+}
+
+func routeResetKey(ctx gf.RouteContext) string {
+	if ctx.RawQuery == "" {
+		return ctx.Path
+	}
+	return ctx.Path + "?" + ctx.RawQuery
 }

--- a/examples/router-dashboard/data/issues.txt
+++ b/examples/router-dashboard/data/issues.txt
@@ -1,0 +1,12 @@
+RD-1|Auth token refresh fails on slow networks|open|high|Identity|Refresh retry state is not visible in the admin screen.
+RD-2|Billing dashboard needs clearer empty state|review|medium|Billing|Empty invoices should explain the current filter.
+RD-3|Export CSV action should preserve filters|open|medium|Reports|CSV export currently ignores the active query string.
+RD-4|Audit log row spacing is inconsistent|closed|low|Platform|Visual polish issue in dense table mode.
+RD-5|Support queue route needs not-found copy|review|low|Support|Unknown support ticket routes should be clearer.
+RD-6|Search input should keep URL state|open|high|Experience|Filter state should survive reload and browser back.
+RD-7|Admin form validation needs touched state|open|medium|Experience|Field errors should not appear before user interaction.
+RD-8|Router smoke should cover query filters|closed|medium|Runtime|The preview app should lock down URL-driven filters.
+RD-9|Resource reload should preserve route state|open|high|Runtime|Manual data reload should not reset the active hash route or query filters.
+RD-10|Render fallback copy needs a retry hint|review|medium|Experience|Error Boundary fallback should explain that resource failures are rendered separately.
+RD-11|Package manifest should list data assets|closed|low|Tooling|The reference app should prove packaged static data is available to browser fetch.
+RD-12|Edit form reset should clear touched state|open|medium|Experience|Reset should restore initial values and clear local validation state.

--- a/examples/router-dashboard/goframe.json
+++ b/examples/router-dashboard/goframe.json
@@ -6,6 +6,7 @@
   "wasm": "bundle.wasm",
   "assets": [
     "index.html",
-    "styles.css"
+    "styles.css",
+    "data/issues.txt"
   ]
 }

--- a/examples/router-dashboard/internal/data/issues.go
+++ b/examples/router-dashboard/internal/data/issues.go
@@ -16,21 +16,8 @@ type IssueFilter struct {
 	Status string
 }
 
-func DemoIssues() []Issue {
-	return []Issue{
-		{ID: "RD-1", Title: "Auth token refresh fails on slow networks", Status: "open", Owner: "Identity", Priority: "high", Description: "Refresh retry state is not visible in the admin screen."},
-		{ID: "RD-2", Title: "Billing dashboard needs clearer empty state", Status: "review", Owner: "Billing", Priority: "medium", Description: "Empty invoices should explain the current filter."},
-		{ID: "RD-3", Title: "Export CSV action should preserve filters", Status: "open", Owner: "Reports", Priority: "medium", Description: "CSV export currently ignores the active query string."},
-		{ID: "RD-4", Title: "Audit log row spacing is inconsistent", Status: "closed", Owner: "Platform", Priority: "low", Description: "Visual polish issue in dense table mode."},
-		{ID: "RD-5", Title: "Support queue route needs not-found copy", Status: "review", Owner: "Support", Priority: "low", Description: "Unknown support ticket routes should be clearer."},
-		{ID: "RD-6", Title: "Search input should keep URL state", Status: "open", Owner: "Experience", Priority: "high", Description: "Filter state should survive reload and browser back."},
-		{ID: "RD-7", Title: "Admin form validation needs touched state", Status: "open", Owner: "Experience", Priority: "medium", Description: "Field errors should not appear before user interaction."},
-		{ID: "RD-8", Title: "Router smoke should cover query filters", Status: "closed", Owner: "Runtime", Priority: "medium", Description: "The preview app should lock down URL-driven filters."},
-	}
-}
-
-func FindIssue(id string) (Issue, bool) {
-	for _, issue := range DemoIssues() {
+func FindIssue(items []Issue, id string) (Issue, bool) {
+	for _, issue := range items {
 		if issue.ID == id {
 			return issue, true
 		}
@@ -59,6 +46,16 @@ func NormalizeStatus(status string) string {
 	switch status {
 	case "open", "review", "closed":
 		return status
+	default:
+		return ""
+	}
+}
+
+func NormalizePriority(priority string) string {
+	priority = strings.ToLower(strings.TrimSpace(priority))
+	switch priority {
+	case "high", "medium", "low":
+		return priority
 	default:
 		return ""
 	}

--- a/examples/router-dashboard/internal/data/loader_js.go
+++ b/examples/router-dashboard/internal/data/loader_js.go
@@ -1,0 +1,97 @@
+//go:build js && wasm
+
+package data
+
+import (
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+type LoadError string
+
+func (err LoadError) Error() string {
+	return string(err)
+}
+
+func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanup {
+	active := true
+	releasedPromiseFuncs := false
+	var responseThen js.Func
+	var textThen js.Func
+	var catchFunc js.Func
+
+	releasePromiseFuncs := func() {
+		if releasedPromiseFuncs {
+			return
+		}
+		releasedPromiseFuncs = true
+		responseThen.Release()
+		textThen.Release()
+		catchFunc.Release()
+	}
+	complete := func(text string) {
+		if !active {
+			return
+		}
+		issues, err := ParseIssues(text)
+		active = false
+		if err != nil {
+			reject(err)
+			return
+		}
+		resolve(issues)
+	}
+
+	textThen = js.FuncOf(func(this js.Value, args []js.Value) any {
+		text := ""
+		if len(args) > 0 && args[0].Type() == js.TypeString {
+			text = args[0].String()
+		}
+		releasePromiseFuncs()
+		complete(text)
+		return nil
+	})
+	catchFunc = js.FuncOf(func(this js.Value, args []js.Value) any {
+		releasePromiseFuncs()
+		if active {
+			active = false
+			reject(LoadError("fetch failed"))
+		}
+		return nil
+	})
+	responseThen = js.FuncOf(func(this js.Value, args []js.Value) any {
+		if !active {
+			releasePromiseFuncs()
+			return nil
+		}
+		if len(args) == 0 {
+			active = false
+			releasePromiseFuncs()
+			reject(LoadError("fetch returned no response"))
+			return nil
+		}
+		response := args[0]
+		if !response.Get("ok").Bool() {
+			active = false
+			releasePromiseFuncs()
+			reject(LoadError("fetch returned a non-ok response"))
+			return nil
+		}
+		response.Call("text").Call("then", textThen).Call("catch", catchFunc)
+		return nil
+	})
+
+	controller := js.Global().Get("AbortController").New()
+	options := js.Global().Get("Object").New()
+	options.Set("signal", controller.Get("signal"))
+	js.Global().Call("fetch", key, options).Call("then", responseThen).Call("catch", catchFunc)
+
+	return func() {
+		if !active {
+			return
+		}
+		active = false
+		controller.Call("abort")
+	}
+}

--- a/examples/router-dashboard/internal/data/loader_stub.go
+++ b/examples/router-dashboard/internal/data/loader_stub.go
@@ -1,0 +1,16 @@
+//go:build !js || !wasm
+
+package data
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type LoadError string
+
+func (err LoadError) Error() string {
+	return string(err)
+}
+
+func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanup {
+	reject(LoadError("router dashboard data fetch is available only in browser/WASM builds"))
+	return nil
+}

--- a/examples/router-dashboard/internal/data/parser.go
+++ b/examples/router-dashboard/internal/data/parser.go
@@ -1,0 +1,46 @@
+package data
+
+import "strings"
+
+type ParseError string
+
+func (err ParseError) Error() string {
+	return string(err)
+}
+
+func ParseIssues(text string) ([]Issue, error) {
+	lines := strings.Split(text, "\n")
+	issues := make([]Issue, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) != 6 {
+			return nil, ParseError("invalid issue data line")
+		}
+		issue := Issue{
+			ID:          strings.TrimSpace(parts[0]),
+			Title:       strings.TrimSpace(parts[1]),
+			Status:      NormalizeStatus(parts[2]),
+			Priority:    NormalizePriority(parts[3]),
+			Owner:       strings.TrimSpace(parts[4]),
+			Description: strings.TrimSpace(parts[5]),
+		}
+		if issue.ID == "" || issue.Title == "" || issue.Owner == "" || issue.Description == "" {
+			return nil, ParseError("issue data contains an empty required field")
+		}
+		if issue.Status == "" {
+			return nil, ParseError("issue data contains an invalid status")
+		}
+		if issue.Priority == "" {
+			return nil, ParseError("issue data contains an invalid priority")
+		}
+		issues = append(issues, issue)
+	}
+	if len(issues) == 0 {
+		return nil, ParseError("issue data is empty")
+	}
+	return issues, nil
+}

--- a/examples/router-dashboard/internal/data/parser_test.go
+++ b/examples/router-dashboard/internal/data/parser_test.go
@@ -1,0 +1,76 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseIssuesValidInput(t *testing.T) {
+	text := strings.Join([]string{
+		"RD-1|Auth token refresh fails on slow networks|open|high|Identity|Refresh state is not visible.",
+		"",
+		"RD-2|Billing dashboard needs clearer empty state|review|medium|Billing|Empty invoices should explain filters.",
+	}, "\n")
+
+	issues, err := ParseIssues(text)
+	if err != nil {
+		t.Fatalf("ParseIssues returned error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("len(ParseIssues) = %d, want 2", len(issues))
+	}
+	if issues[0].ID != "RD-1" || issues[1].ID != "RD-2" {
+		t.Fatalf("issues parsed out of order: %#v", issues)
+	}
+	if issues[0].Status != "open" || issues[0].Priority != "high" {
+		t.Fatalf("first issue normalized fields = %q/%q", issues[0].Status, issues[0].Priority)
+	}
+}
+
+func TestParseIssuesPackagedDataset(t *testing.T) {
+	path := filepath.Join("..", "..", "data", "issues.txt")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	issues, err := ParseIssues(string(raw))
+	if err != nil {
+		t.Fatalf("ParseIssues(packaged dataset): %v", err)
+	}
+	if len(issues) < 10 || len(issues) > 30 {
+		t.Fatalf("packaged dataset len = %d, want compact reference range", len(issues))
+	}
+	if issues[1].ID != "RD-2" {
+		t.Fatalf("second packaged issue = %q, want RD-2", issues[1].ID)
+	}
+}
+
+func TestParseIssuesRejectsMalformedRow(t *testing.T) {
+	_, err := ParseIssues("RD-1|Missing fields")
+	if err == nil || err.Error() != "invalid issue data line" {
+		t.Fatalf("ParseIssues malformed row error = %v", err)
+	}
+}
+
+func TestParseIssuesRejectsInvalidStatus(t *testing.T) {
+	_, err := ParseIssues("RD-1|Title|blocked|high|Owner|Description")
+	if err == nil || err.Error() != "issue data contains an invalid status" {
+		t.Fatalf("ParseIssues invalid status error = %v", err)
+	}
+}
+
+func TestParseIssuesRejectsInvalidPriority(t *testing.T) {
+	_, err := ParseIssues("RD-1|Title|open|urgent|Owner|Description")
+	if err == nil || err.Error() != "issue data contains an invalid priority" {
+		t.Fatalf("ParseIssues invalid priority error = %v", err)
+	}
+}
+
+func TestParseIssuesRejectsEmptyDataset(t *testing.T) {
+	_, err := ParseIssues("\n\n")
+	if err == nil || err.Error() != "issue data is empty" {
+		t.Fatalf("ParseIssues empty dataset error = %v", err)
+	}
+}

--- a/examples/router-dashboard/internal/data/provider.gox
+++ b/examples/router-dashboard/internal/data/provider.gox
@@ -1,0 +1,35 @@
+package data
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func IssueProvider(props IssueProviderProps) gf.Node {
+	key, setKey := gf.UseState(issueDataKey)
+	attempts, setAttempts := gf.UseState(0)
+	resource, reload := gf.UseResource(key, func(currentKey string, resolve func([]Issue), reject func(error)) gf.Cleanup {
+		setAttempts(attempts + 1)
+		return LoadIssues(currentKey, resolve, reject)
+	})
+
+	repository := IssueRepository{
+		Resource: resource,
+		Attempts: attempts,
+		Reload: reload,
+		Retry: func() {
+			if key != issueDataKey {
+				setKey(issueDataKey)
+				return
+			}
+			reload()
+		},
+		SimulateFailure: func() {
+			if key == issueMissingKey {
+				reload()
+				return
+			}
+			setKey(issueMissingKey)
+		},
+	}
+	gf.ProvideContext(IssueRepositoryContext, repository)
+
+	return <>{props.Children}</>
+}

--- a/examples/router-dashboard/internal/data/repository.go
+++ b/examples/router-dashboard/internal/data/repository.go
@@ -1,0 +1,103 @@
+package data
+
+import (
+	"strings"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+const (
+	issueDataKey    = "assets/data/issues.txt"
+	issueMissingKey = "assets/data/missing-issues.txt"
+)
+
+var IssueRepositoryContext = gf.CreateContext(IssueRepository{})
+
+type IssueProviderProps struct {
+	Children []gf.Node
+}
+
+type ResourceStatusPanelProps struct{}
+
+type IssueRepository struct {
+	Resource        gf.Resource[[]Issue]
+	Attempts        int
+	Reload          func()
+	Retry           func()
+	SimulateFailure func()
+}
+
+func UseIssueRepository() IssueRepository {
+	return gf.UseContext(IssueRepositoryContext)
+}
+
+func (repository IssueRepository) Issues() []Issue {
+	if repository.Resource.Ready() {
+		return repository.Resource.Value
+	}
+	return nil
+}
+
+func (repository IssueRepository) StatusText() string {
+	switch {
+	case repository.Resource.Ready():
+		return "ready"
+	case repository.Resource.Failed():
+		return "failed"
+	default:
+		return "loading"
+	}
+}
+
+func (repository IssueRepository) AttemptText() string {
+	return gf.ToString(repository.Attempts)
+}
+
+func (repository IssueRepository) ErrorText() string {
+	if repository.Resource.Err == nil {
+		return "unknown resource error"
+	}
+	return repository.Resource.Err.Error()
+}
+
+func (repository IssueRepository) Ready() bool {
+	return repository.Resource.Ready()
+}
+
+func (repository IssueRepository) Loading() bool {
+	return repository.Resource.Loading()
+}
+
+func (repository IssueRepository) Failed() bool {
+	return repository.Resource.Failed()
+}
+
+func (repository IssueRepository) HasData() bool {
+	return repository.Resource.Ready() && len(repository.Resource.Value) > 0
+}
+
+func (repository IssueRepository) ReloadData() {
+	if repository.Reload != nil {
+		repository.Reload()
+	}
+}
+
+func (repository IssueRepository) RetryData() {
+	if repository.Retry != nil {
+		repository.Retry()
+	}
+}
+
+func (repository IssueRepository) SimulateDataFailure() {
+	if repository.SimulateFailure != nil {
+		repository.SimulateFailure()
+	}
+}
+
+func StatusClass(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "rd-resource-status rd-resource-status-loading"
+	}
+	return "rd-resource-status rd-resource-status-" + status
+}

--- a/examples/router-dashboard/internal/data/status_panel.gox
+++ b/examples/router-dashboard/internal/data/status_panel.gox
@@ -1,0 +1,27 @@
+package data
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func ResourceStatusPanel(props ResourceStatusPanelProps) gf.Node {
+	repository := UseIssueRepository()
+	if repository.Resource.Loading() {
+		return (
+			<section class="rd-card rd-resource-panel" data-testid="rd-resource-loading">
+				<p class="rd-eyebrow">Loading</p>
+				<h2>Loading packaged issue data</h2>
+				<p class="rd-muted">The shell and current route stay mounted while the resource resolves.</p>
+			</section>
+		)
+	}
+	if repository.Resource.Failed() {
+		return (
+			<section class="rd-card rd-resource-panel" data-testid="rd-resource-failed">
+				<p class="rd-eyebrow">Resource failed</p>
+				<h2>Issue data did not load</h2>
+				<p class="rd-muted" data-testid="rd-resource-error">{repository.ErrorText()}</p>
+				<button data-testid="rd-resource-retry" OnClick={repository.Retry}>Retry packaged data</button>
+			</section>
+		)
+	}
+	return gf.Empty()
+}

--- a/examples/router-dashboard/internal/layout/shell.gox
+++ b/examples/router-dashboard/internal/layout/shell.gox
@@ -1,15 +1,20 @@
 package layout
 
-import gf "github.com/graybuton/goframe/pkg/goframe"
+import (
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
 
 func Shell(props ShellProps) gf.Node {
+	repository := data.UseIssueRepository()
+
 	return (
 		<section class="rd-shell" data-testid="rd-shell">
 			<header class="rd-header">
 				<div>
 					<p class="rd-eyebrow">GoFrame reference app</p>
 					<h1>Router Dashboard</h1>
-					<p class="rd-muted">Hash routes, query filters, controlled forms, and Go-first layout.</p>
+					<p class="rd-muted">Hash routes, query filters, resource data, controlled forms, and Go-first layout.</p>
 				</div>
 				<nav class="rd-nav" aria-label="Primary navigation">
 					<gf.RouterLink To="/" Class="rd-link" TestID="rd-nav-home">
@@ -19,6 +24,20 @@ func Shell(props ShellProps) gf.Node {
 						Issues
 					</gf.RouterLink>
 				</nav>
+				<div class="rd-resource-strip" aria-label="Issue data resource">
+					<span class={data.StatusClass(repository.StatusText())} data-testid="rd-resource-status">
+						{repository.StatusText()}
+					</span>
+					<span class="rd-resource-attempt" data-testid="rd-resource-attempt">
+						load attempts: {repository.AttemptText()}
+					</span>
+					<button data-testid="rd-resource-reload" Type="button" OnClick={repository.ReloadData}>
+						Reload data
+					</button>
+					<button class="secondary" data-testid="rd-resource-fail" Type="button" OnClick={repository.SimulateDataFailure}>
+						Simulate failed load
+					</button>
+				</div>
 			</header>
 			<div class="rd-outlet" data-testid="rd-outlet">
 				{props.Children}

--- a/examples/router-dashboard/internal/pages/home.gox
+++ b/examples/router-dashboard/internal/pages/home.gox
@@ -7,8 +7,9 @@ func Home(props HomeProps) gf.Node {
 		<section class="rd-card" data-testid="rd-home">
 			<h2>{props.Title}</h2>
 			<p>
-				This reference app combines the small hash router, route query helpers,
-				and controlled form validation without a larger app framework.
+				This flagship reference app combines the small hash router, URL query
+				state, a component-scoped resource, controlled form validation, and a
+				scoped render Error Boundary without a larger app framework.
 			</p>
 			<p>
 				<gf.RouterLink To="/issues?status=open" Class="rd-link" TestID="rd-home-open-issues">

--- a/examples/router-dashboard/internal/pages/issue_details.gox
+++ b/examples/router-dashboard/internal/pages/issue_details.gox
@@ -6,20 +6,28 @@ import (
 )
 
 func IssueDetails(props IssueDetailsProps) gf.Node {
-	if !props.Found {
+	if props.Crash {
+		panic("router dashboard requested render failure")
+	}
+	repository := data.UseIssueRepository()
+	if !repository.Ready() {
+		return <data.ResourceStatusPanel />
+	}
+	issue, ok := data.FindIssue(repository.Issues(), props.ID)
+	if !ok {
 		return <MissingIssue ID={props.ID} />
 	}
 	return (
 		<section class="rd-card" data-testid="rd-issue-detail">
-			<p class="rd-eyebrow">{props.Issue.ID}</p>
-			<h2>{props.Issue.Title}</h2>
+			<p class="rd-eyebrow">{issue.ID}</p>
+			<h2>{issue.Title}</h2>
 			<div class="rd-meta">
-				<span>{data.StatusLabel(props.Issue.Status)}</span>
-				<span>{props.Issue.Priority}</span>
-				<span>{props.Issue.Owner}</span>
+				<span>{data.StatusLabel(issue.Status)}</span>
+				<span>{issue.Priority}</span>
+				<span>{issue.Owner}</span>
 			</div>
-			<p>{props.Issue.Description}</p>
-			<gf.RouterLink To={data.IssueEditPath(props.Issue.ID)} Class="rd-link" TestID="rd-edit-link">
+			<p>{issue.Description}</p>
+			<gf.RouterLink To={data.IssueEditPath(issue.ID)} Class="rd-link" TestID="rd-edit-link">
 				Edit issue
 			</gf.RouterLink>
 		</section>

--- a/examples/router-dashboard/internal/pages/issue_edit.gox
+++ b/examples/router-dashboard/internal/pages/issue_edit.gox
@@ -1,22 +1,28 @@
 package pages
 
 import (
+	data "github.com/graybuton/goframe/examples/router-dashboard/internal/data"
 	forms "github.com/graybuton/goframe/examples/router-dashboard/internal/forms"
 	gf "github.com/graybuton/goframe/pkg/goframe"
 )
 
 func IssueEdit(props IssueEditProps) gf.Node {
-	if !props.Found {
+	repository := data.UseIssueRepository()
+	if !repository.Ready() {
+		return <data.ResourceStatusPanel />
+	}
+	issue, ok := data.FindIssue(repository.Issues(), props.ID)
+	if !ok {
 		return <MissingIssue ID={props.ID} />
 	}
 	return (
 		<section class="rd-card" data-testid="rd-issue-edit">
-			<p class="rd-eyebrow">Edit {props.Issue.ID}</p>
+			<p class="rd-eyebrow">Edit {issue.ID}</p>
 			<h2>Update issue</h2>
 			<p class="rd-muted">
 				This form validates local state only. It does not call a server.
 			</p>
-			<forms.IssueForm Key={props.Issue.ID} Issue={props.Issue} />
+			<forms.IssueForm Key={issue.ID} Issue={issue} />
 		</section>
 	)
 }

--- a/examples/router-dashboard/internal/pages/issue_list.gox
+++ b/examples/router-dashboard/internal/pages/issue_list.gox
@@ -7,6 +7,15 @@ import (
 )
 
 func IssueList(props IssueListProps) gf.Node {
+	repository := data.UseIssueRepository()
+	if !repository.Ready() {
+		return <data.ResourceStatusPanel />
+	}
+	items := data.FilterIssues(repository.Issues(), data.IssueFilter{
+		Query:  props.Query,
+		Status: props.Status,
+	})
+
 	return (
 		<section class="rd-card" data-testid="rd-issue-list">
 			<div class="rd-section-heading">
@@ -22,14 +31,14 @@ func IssueList(props IssueListProps) gf.Node {
 				Key={filters.FilterKey(props.Query, props.Status)}
 				Query={props.Query}
 				Status={props.Status}
-				ResultCount={len(props.Items)}
-				TotalCount={props.TotalCount}
+				ResultCount={len(items)}
+				TotalCount={len(repository.Issues())}
 			/>
-			{(len(props.Items) == 0) ? (
+			{(len(items) == 0) ? (
 				<p class="rd-empty" data-testid="rd-issue-empty">No issues matched this route query.</p>
 			) : (
 				<ul class="rd-issue-rows">
-					{gf.Map(props.Items, func(issue data.Issue) gf.Node {
+					{gf.Map(items, func(issue data.Issue) gf.Node {
 						return <IssueRow Key={issue.ID} Issue={issue} />
 					})}
 				</ul>

--- a/examples/router-dashboard/internal/pages/model.go
+++ b/examples/router-dashboard/internal/pages/model.go
@@ -7,11 +7,8 @@ type HomeProps struct {
 }
 
 type IssueListProps struct {
-	Items       []data.Issue
-	TotalCount  int
-	Query       string
-	Status      string
-	CurrentPath string
+	Query  string
+	Status string
 }
 
 type IssueRowProps struct {
@@ -19,15 +16,12 @@ type IssueRowProps struct {
 }
 
 type IssueDetailsProps struct {
-	Issue data.Issue
-	Found bool
 	ID    string
+	Crash bool
 }
 
 type IssueEditProps struct {
-	Issue data.Issue
-	Found bool
-	ID    string
+	ID string
 }
 
 type MissingIssueProps struct {

--- a/examples/router-dashboard/internal/pages/route_error.gox
+++ b/examples/router-dashboard/internal/pages/route_error.gox
@@ -10,7 +10,16 @@ func RouteErrorFallback(ctx gf.ErrorBoundaryContext) gf.Node {
 			<p class="rd-muted">
 				The stable shell stayed mounted. Component: {ctx.Info.Component}.
 			</p>
-			<button data-testid="rd-boundary-reset" OnClick={ctx.Reset}>Reset route content</button>
+			<p class="rd-muted">
+				Retry repeats the current route with the same URL state. If the route input is still invalid,
+				the fallback can appear again.
+			</p>
+			<div class="rd-actions">
+				<button data-testid="rd-boundary-reset" OnClick={ctx.Reset}>Retry current route</button>
+				<gf.RouterLink To="/issues" Class="rd-link" TestID="rd-boundary-back-to-issues">
+					Back to issues
+				</gf.RouterLink>
+			</div>
 		</section>
 	)
 }

--- a/examples/router-dashboard/internal/pages/route_error.gox
+++ b/examples/router-dashboard/internal/pages/route_error.gox
@@ -1,0 +1,16 @@
+package pages
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func RouteErrorFallback(ctx gf.ErrorBoundaryContext) gf.Node {
+	return (
+		<section class="rd-card rd-boundary-fallback" data-testid="rd-boundary-fallback">
+			<p class="rd-eyebrow">Render failure</p>
+			<h2>Route content failed to render</h2>
+			<p class="rd-muted">
+				The stable shell stayed mounted. Component: {ctx.Info.Component}.
+			</p>
+			<button data-testid="rd-boundary-reset" OnClick={ctx.Reset}>Reset route content</button>
+		</section>
+	)
+}

--- a/examples/router-dashboard/styles.css
+++ b/examples/router-dashboard/styles.css
@@ -81,7 +81,8 @@ textarea {
 .rd-filter-actions,
 .rd-form-actions,
 .rd-row-actions,
-.rd-meta {
+.rd-meta,
+.rd-resource-strip {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
@@ -194,6 +195,39 @@ textarea {
 
 .rd-saved {
     color: #087443;
+}
+
+.rd-resource-strip {
+    border-top: 1px solid #e7edf8;
+    padding-top: 14px;
+}
+
+.rd-resource-status,
+.rd-resource-attempt {
+    border-radius: 999px;
+    padding: 0.35rem 0.7rem;
+    background: #f0f4fb;
+    color: #42516a;
+}
+
+.rd-resource-status-ready {
+    background: #e8f7ef;
+    color: #087443;
+}
+
+.rd-resource-status-loading {
+    background: #fff4d6;
+    color: #7a4d00;
+}
+
+.rd-resource-status-failed {
+    background: #fee4e2;
+    color: #b42318;
+}
+
+.rd-resource-panel,
+.rd-boundary-fallback {
+    border-style: dashed;
 }
 
 @media (max-width: 720px) {

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -354,10 +354,10 @@ run_with_server ./examples/router "$ROUTER_PORT" "$ROUTER_URL" \
 
 echo
 echo "== Router dashboard debug browser smoke =="
-"$GOXC" package ./examples/router-dashboard --compiler=tinygo
+"$GOXC" package ./examples/router-dashboard --compiler=go
 (
 	cd ./examples/router-dashboard/.goframe/work/dev/examples/router-dashboard/cmd/app
-	tinygo build -target=wasm -no-debug -panic=trap -tags=goframe_debug \
+	GOOS=js GOARCH=wasm go build -tags=goframe_debug \
 		-o "$ROOT_DIR/examples/router-dashboard/.goframe/package/standalone/assets/bundle.wasm" .
 )
 

--- a/scripts/router-dashboard-browser-smoke.mjs
+++ b/scripts/router-dashboard-browser-smoke.mjs
@@ -155,6 +155,47 @@ try {
         shellSame: true,
     }, "router-dashboard detail route after edit back");
 
+    await client.evaluate(`location.hash = "#/issues/RD-2?panic=render"`);
+    await waitForRoute(client, "boundary");
+    assertState(await appState(client), {
+        route: "boundary",
+        hash: "#/issues/RD-2?panic=render",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        resourceLoading: false,
+        resourceFailed: false,
+        boundaryFallback: true,
+        boundaryResetPresent: true,
+        boundaryBackPresent: true,
+        shellSame: true,
+    }, "router-dashboard route error fallback");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-boundary-back-to-issues']").click()`);
+    await waitForRoute(client, "issues");
+    assertState(await appState(client), {
+        route: "issues",
+        hash: "#/issues",
+        rowCount: 12,
+        queryValue: "",
+        statusValue: "all",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard route error safe recovery");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-issue-link-RD-2']").click()`);
+    await waitForRoute(client, "details");
+    assertState(await appState(client), {
+        route: "details",
+        hash: "#/issues/RD-2",
+        detailTitle: "Billing dashboard needs clearer empty state",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard route error post-recovery interaction");
+
     await client.evaluate(`document.querySelector("[data-testid='rd-resource-fail']").click()`);
     await waitForResourceStatus(client, "failed");
     const failed = await appState(client);
@@ -285,8 +326,9 @@ async function appState(client) {
         const edit = document.querySelector("[data-testid='rd-issue-edit']");
         const notFound = document.querySelector("[data-testid='rd-not-found']");
         const resourcePanel = document.querySelector("[data-testid='rd-resource-loading'], [data-testid='rd-resource-failed']");
+        const boundary = document.querySelector("[data-testid='rd-boundary-fallback']");
         return {
-            route: home ? "home" : issues ? "issues" : details ? "details" : edit ? "edit" : notFound ? "notFound" : resourcePanel ? "resource" : "missing",
+            route: home ? "home" : issues ? "issues" : details ? "details" : edit ? "edit" : notFound ? "notFound" : resourcePanel ? "resource" : boundary ? "boundary" : "missing",
             hash: location.hash,
             rowCount: document.querySelectorAll("[data-testid='rd-issue-row']").length,
             queryValue: document.querySelector("[data-testid='rd-filter-query']")?.value ?? "",
@@ -303,7 +345,9 @@ async function appState(client) {
             resourceLoading: Boolean(document.querySelector("[data-testid='rd-resource-loading']")),
             resourceFailed: Boolean(document.querySelector("[data-testid='rd-resource-failed']")),
             resourceError: document.querySelector("[data-testid='rd-resource-error']")?.textContent.trim() ?? "",
-            boundaryFallback: Boolean(document.querySelector("[data-testid='rd-boundary-fallback']")),
+            boundaryFallback: Boolean(boundary),
+            boundaryResetPresent: Boolean(document.querySelector("[data-testid='rd-boundary-reset']")),
+            boundaryBackPresent: Boolean(document.querySelector("[data-testid='rd-boundary-back-to-issues']")),
             shellSame: window.__routerDashboardSmokeShell === document.querySelector("[data-testid='rd-shell']"),
             routerViewRenders: window.goframeComponentRenderCounts?.RouterView ?? 0,
             routerRouteRenders: window.goframeComponentRenderCounts?.RouterRoute ?? 0,

--- a/scripts/router-dashboard-browser-smoke.mjs
+++ b/scripts/router-dashboard-browser-smoke.mjs
@@ -38,10 +38,14 @@ try {
     await navigateToApp(client, withSmokeParam(appURL));
     await waitForAppPage(client, expectedApp);
     await client.evaluate(`window.__routerDashboardSmokeShell = document.querySelector("[data-testid='rd-shell']")`);
+    await waitForResourceStatus(client, "ready");
 
     assertState(await appState(client), {
         route: "home",
         hash: "",
+        resourceStatus: "ready",
+        resourceAttempt: "1",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard initial home");
 
@@ -50,9 +54,12 @@ try {
     assertState(await appState(client), {
         route: "issues",
         hash: "#/issues",
-        rowCount: 8,
+        rowCount: 12,
         queryValue: "",
         statusValue: "all",
+        resourceStatus: "ready",
+        resourceAttempt: "1",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard issues route");
 
@@ -70,20 +77,45 @@ try {
         rowCount: 1,
         queryValue: "auth",
         statusValue: "open",
+        resourceStatus: "ready",
+        resourceAttempt: "1",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard query filter");
+
+    const filteredHash = (await appState(client)).hash;
+    await client.evaluate(`document.querySelector("[data-testid='rd-resource-reload']").click()`);
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.resourceStatus === "loading" || state.resourceAttempt === "2";
+    }, "resource reload starts");
+    await waitForResourceStatus(client, "ready");
+    assertState(await appState(client), {
+        route: "issues",
+        hash: filteredHash,
+        rowCount: 1,
+        queryValue: "auth",
+        statusValue: "open",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard resource reload preserves query");
 
     await client.evaluate(`history.back()`);
     await waitForCondition(async () => {
         const state = await appState(client);
-        return state.route === "issues" && state.hash === "#/issues" && state.rowCount === 8;
+        return state.route === "issues" && state.hash === "#/issues" && state.rowCount === 12;
     }, "browser back restores query");
     assertState(await appState(client), {
         route: "issues",
         hash: "#/issues",
-        rowCount: 8,
+        rowCount: 12,
         queryValue: "",
         statusValue: "all",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard browser back");
 
@@ -93,6 +125,9 @@ try {
         route: "details",
         hash: "#/issues/RD-2",
         detailTitle: "Billing dashboard needs clearer empty state",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard detail route");
 
@@ -103,8 +138,67 @@ try {
         hash: "#/issues/RD-2/edit",
         formTitle: "Billing dashboard needs clearer empty state",
         formDirty: "No local changes",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard edit route");
+
+    await client.evaluate(`history.back()`);
+    await waitForRoute(client, "details");
+    assertState(await appState(client), {
+        route: "details",
+        hash: "#/issues/RD-2",
+        resourceStatus: "ready",
+        resourceAttempt: "2",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard detail route after edit back");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-resource-fail']").click()`);
+    await waitForResourceStatus(client, "failed");
+    const failed = await appState(client);
+    if (!failed.resourceError.includes("fetch")) {
+        throw new Error(`APP FAILURE: router-dashboard resource failure did not mention fetch: ${JSON.stringify(failed)}`);
+    }
+    assertState(failed, {
+        route: "resource",
+        hash: "#/issues/RD-2",
+        resourceStatus: "failed",
+        resourceAttempt: "3",
+        resourceFailed: true,
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard resource failed state");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-resource-retry']").click()`);
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.resourceStatus === "loading" || state.resourceAttempt === "4";
+    }, "resource retry starts");
+    await waitForResourceStatus(client, "ready");
+    assertState(await appState(client), {
+        route: "details",
+        hash: "#/issues/RD-2",
+        detailTitle: "Billing dashboard needs clearer empty state",
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard resource retry restores data");
+
+    await client.evaluate(`document.querySelector("[data-testid='rd-edit-link']").click()`);
+    await waitForRoute(client, "edit");
+    assertState(await appState(client), {
+        route: "edit",
+        hash: "#/issues/RD-2/edit",
+        formTitle: "Billing dashboard needs clearer empty state",
+        formDirty: "No local changes",
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
+        shellSame: true,
+    }, "router-dashboard edit route after resource retry");
 
     await setInput(client, "[data-testid='rd-field-title']", "");
     await client.evaluate(`document.querySelector("[data-testid='rd-form-submit']").click()`);
@@ -116,6 +210,9 @@ try {
         titleError: "Title is required.",
         formDirty: "Unsaved local changes",
         saved: false,
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard validation error");
 
@@ -128,6 +225,9 @@ try {
         route: "edit",
         titleError: "",
         saved: true,
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard valid submit");
 
@@ -145,6 +245,9 @@ try {
         formDirty: "No local changes",
         saved: false,
         titleError: "",
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard form reset");
 
@@ -154,6 +257,9 @@ try {
         route: "notFound",
         hash: "#/missing",
         notFoundPath: "/missing",
+        resourceStatus: "ready",
+        resourceAttempt: "4",
+        boundaryFallback: false,
         shellSame: true,
     }, "router-dashboard not-found");
 
@@ -178,8 +284,9 @@ async function appState(client) {
         const details = document.querySelector("[data-testid='rd-issue-detail']");
         const edit = document.querySelector("[data-testid='rd-issue-edit']");
         const notFound = document.querySelector("[data-testid='rd-not-found']");
+        const resourcePanel = document.querySelector("[data-testid='rd-resource-loading'], [data-testid='rd-resource-failed']");
         return {
-            route: home ? "home" : issues ? "issues" : details ? "details" : edit ? "edit" : notFound ? "notFound" : "missing",
+            route: home ? "home" : issues ? "issues" : details ? "details" : edit ? "edit" : notFound ? "notFound" : resourcePanel ? "resource" : "missing",
             hash: location.hash,
             rowCount: document.querySelectorAll("[data-testid='rd-issue-row']").length,
             queryValue: document.querySelector("[data-testid='rd-filter-query']")?.value ?? "",
@@ -191,6 +298,12 @@ async function appState(client) {
             titleError: document.querySelector("[data-testid='rd-field-error-title']")?.textContent.trim() ?? "",
             saved: Boolean(document.querySelector("[data-testid='rd-form-saved']")),
             notFoundPath: document.querySelector("[data-testid='rd-not-found-path']")?.textContent.trim() ?? "",
+            resourceStatus: document.querySelector("[data-testid='rd-resource-status']")?.textContent.trim() ?? "",
+            resourceAttempt: document.querySelector("[data-testid='rd-resource-attempt']")?.textContent.trim().match(/\\d+/)?.[0] ?? "",
+            resourceLoading: Boolean(document.querySelector("[data-testid='rd-resource-loading']")),
+            resourceFailed: Boolean(document.querySelector("[data-testid='rd-resource-failed']")),
+            resourceError: document.querySelector("[data-testid='rd-resource-error']")?.textContent.trim() ?? "",
+            boundaryFallback: Boolean(document.querySelector("[data-testid='rd-boundary-fallback']")),
             shellSame: window.__routerDashboardSmokeShell === document.querySelector("[data-testid='rd-shell']"),
             routerViewRenders: window.goframeComponentRenderCounts?.RouterView ?? 0,
             routerRouteRenders: window.goframeComponentRenderCounts?.RouterRoute ?? 0,
@@ -226,6 +339,12 @@ async function waitForRoute(client, route) {
     await waitForCondition(async () => {
         return (await appState(client)).route === route;
     }, `route ${route}`);
+}
+
+async function waitForResourceStatus(client, status) {
+    await waitForCondition(async () => {
+        return (await appState(client)).resourceStatus === status;
+    }, `resource status ${status}`);
 }
 
 function assertState(actual, expected, label) {

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -137,7 +137,7 @@ check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 ||
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 166912 51200 63488 56320 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 230400 77824 94208 81920 || status=1
 check_app "resource" "$(bundle_path resource)" 153600 57344 67584 61440 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Turns router-dashboard into the flagship GoFrame reference app and adds a clear tutorial path for building a small Go-first browser application.

## Changes

- Add the primary project tutorial and reorganize the example learning path
- Load packaged local data through one component-scoped resource owner
- Integrate routing, query filters, loading and failure states, forms, validation, and Error Boundaries
- Preserve resource state across navigation, query changes, and browser history
- Add explicit reload, failure, retry, and safe route-error recovery flows
- Expand browser smoke coverage and update documentation and size baselines

## Scope

No runtime, GOX compiler, or goxc API changes. No route loaders, global cache, Suspense, server resources, or external network dependencies.

## Validation

The full Go, race, vet, debug, GOX, browser smoke, size, documentation, package-matrix, and dashboard DOM-pressure suites pass. Recover-dependent route fallback assertions use Go/WASM; TinyGo remains the size-oriented packaging path.