### PR TITLE
MVP 30: public preview readiness and toolchain safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
   strengthened browser smoke coverage.
 - `docs/tutorial.md` with a recommended learning path through focused,
   reference, pressure, and toolchain examples.
+- MVP 30 public-preview readiness contracts, including API surface
+  classification, component identity policy, manifest/package compatibility,
+  platform support, compatibility/deprecation policy, migration note template,
+  and public-preview release checklist.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.
@@ -93,6 +97,9 @@
   the current crashing route from safely navigating back to the issues list, and
   browser smoke covers recovery from `?panic=render` without reloading the
   resource owner.
+- `goxc` now rejects symlinked entry directories, source files, manifest
+  assets, package output roots, and export output roots at safety-sensitive
+  boundaries instead of following them.
 - Resource loader panics no longer leave the internal effect slot pending, so a
   same-key rerender after failed state does not automatically restart the same
   panicking loader. Explicit retry remains available through `reload` or key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,12 +104,21 @@
   app/workspace/output roots, symlinked package sources, destination symlink
   writes, source/output overlap, false package ownership markers, and package
   asset namespace collisions with generated WASM/runtime/sidecar files.
-- Package/export ownership detection now requires regular, structured GoFrame
-  metadata instead of trusting placeholder filenames such as `{}` or generic
-  web `manifest.json`.
+- `goxc` now detects physical symlink-alias overlaps for external workspaces
+  and explicit build/generate/package/export outputs, preventing output paths
+  from pointing back into authored source through alternate spelling.
+- Manifest `wasm` values now must be relative `.wasm` child paths, preventing
+  build/package output from targeting authored files such as `main.go`,
+  `go.mod`, or `goframe.json`.
+- Package/export ownership detection now requires complete, regular,
+  structured GoFrame metadata instead of trusting placeholder filenames,
+  standalone `asset-manifest.json`, or generic web/Go-WASM `manifest.json`.
+- Legacy package ownership is fail-closed and recognized only for the
+  historical GoFrame `manifest.json` shape found in repository history.
 - Package publication now validates staged source entries before copying and
-  publishes `goframe-package.json` last, reducing the chance of a failed copy
-  leaving misleading completed package metadata.
+  publishes `goframe-package.json` last. Package cleanup removes that
+  authoritative completion marker before destructive cleanup, reducing the
+  chance of partial package trees being treated as complete.
 - Resource loader panics no longer leave the internal effect slot pending, so a
   same-key rerender after failed state does not automatically restart the same
   panicking loader. Explicit retry remains available through `reload` or key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,16 @@
 - `goxc` now rejects symlinked entry directories, source files, manifest
   assets, package output roots, and export output roots at safety-sensitive
   boundaries instead of following them.
+- `goxc` now rejects intermediate symlink components under declared
+  app/workspace/output roots, symlinked package sources, destination symlink
+  writes, source/output overlap, false package ownership markers, and package
+  asset namespace collisions with generated WASM/runtime/sidecar files.
+- Package/export ownership detection now requires regular, structured GoFrame
+  metadata instead of trusting placeholder filenames such as `{}` or generic
+  web `manifest.json`.
+- Package publication now validates staged source entries before copying and
+  publishes `goframe-package.json` last, reducing the chance of a failed copy
+  leaving misleading completed package metadata.
 - Resource loader panics no longer leave the internal effect slot pending, so a
   same-key rerender after failed state does not automatically restart the same
   panicking loader. Explicit retry remains available through `reload` or key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@
   publishes `goframe-package.json` last. Package cleanup removes that
   authoritative completion marker before destructive cleanup, reducing the
   chance of partial package trees being treated as complete.
+- Standalone packages now require a regular root `index.html` declared exactly
+  once in manifest assets before compilation starts. Package/export replacement
+  removes stale managed `index.html`, and successful package/export commands
+  verify current package ownership before printing success.
 - Resource loader panics no longer leave the internal effect slot pending, so a
   same-key rerender after failed state does not automatically restart the same
   panicking loader. Explicit retry remains available through `reload` or key

--- a/README.md
+++ b/README.md
@@ -482,6 +482,10 @@ Start here:
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)
 - [API stability tiers](docs/api-stability.md)
+- [Public Preview Readiness](docs/public-preview-readiness.md)
+- [Compatibility and deprecation policy](docs/compatibility.md)
+- [Migration note template](docs/migrations.md)
+- [Platform support matrix](docs/platform-support.md)
 - [CI and regression gates](docs/ci.md)
 
 Runtime topics:
@@ -502,6 +506,7 @@ Toolchain and delivery:
 
 - [Multi-package GOX workspace](docs/multi-package-workspace.md)
 - [Cache-safe package delivery](docs/deployment.md)
+- [Manifest compatibility](docs/manifest-compatibility.md)
 - [Symlink and file safety policy](docs/security-symlink-policy.md)
 - [Performance baseline](docs/performance-baseline.md)
 - [Release hygiene](docs/release.md)

--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -108,6 +108,9 @@ func buildApp(options buildOptions) (string, error) {
 	outputRoot := layout.BuildDir
 	if options.outDir != "" {
 		outputRoot = options.outDir
+		if err := ensureNoPhysicalOverlap(outputRoot, layout.AppDir, "build output directory", "application directory"); err != nil {
+			return "", err
+		}
 		if err := validateExplicitPathRoot(outputRoot, "build output directory", true); err != nil {
 			return "", err
 		}
@@ -115,6 +118,9 @@ func buildApp(options buildOptions) (string, error) {
 		if err := validatePathBelowRoot(layout.WorkspaceRoot, outputRoot, "build output directory", true); err != nil {
 			return "", err
 		}
+	}
+	if strings.ToLower(filepath.Ext(outputPath)) != ".wasm" {
+		return "", fmt.Errorf("build output %s must end with .wasm", outputPath)
 	}
 	if err := validatePathBelowRoot(outputRoot, outputPath, "build output", true); err != nil {
 		return "", err

--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -97,13 +97,30 @@ func buildApp(options buildOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := validateWorkspaceRoot(layout); err != nil {
+		return "", err
+	}
 	entryPath, err := prepareBuildWorkspace(layout, manifest)
 	if err != nil {
 		return "", fmt.Errorf("prepare build workspace: %w", err)
 	}
 	outputPath := buildOutputPath(options, manifest, layout)
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return "", fmt.Errorf("create build directory: %w", err)
+	outputRoot := layout.BuildDir
+	if options.outDir != "" {
+		outputRoot = options.outDir
+		if err := validateExplicitPathRoot(outputRoot, "build output directory", true); err != nil {
+			return "", err
+		}
+	} else {
+		if err := validatePathBelowRoot(layout.WorkspaceRoot, outputRoot, "build output directory", true); err != nil {
+			return "", err
+		}
+	}
+	if err := validatePathBelowRoot(outputRoot, outputPath, "build output", true); err != nil {
+		return "", err
+	}
+	if err := mkdirAllBelowRoot(outputRoot, filepath.Dir(outputPath), "build output directory"); err != nil {
+		return "", err
 	}
 
 	fmt.Printf("building %s with %s compiler\n", options.appDir, options.compiler)
@@ -143,9 +160,17 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 		commandDir = filepath.Dir(entryPath)
 		entryArg = "./" + filepath.Base(entryPath)
 	}
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return fmt.Errorf("create compiler output directory: %w", err)
+	outputDir := filepath.Dir(outputPath)
+	temp, err := os.CreateTemp(outputDir, ".goframe-build-*.wasm")
+	if err != nil {
+		return fmt.Errorf("create temporary compiler output: %w", err)
 	}
+	tempPath := temp.Name()
+	if err := temp.Close(); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("close temporary compiler output: %w", err)
+	}
+	defer os.Remove(tempPath)
 
 	var command *exec.Cmd
 	if compiler == "go" {
@@ -154,7 +179,7 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 			"-buildvcs=false",
 			"-trimpath",
 			"-ldflags=-s -w -buildid=",
-			"-o", outputPath,
+			"-o", tempPath,
 			entryArg,
 		)
 	} else {
@@ -163,7 +188,7 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 			"-target=wasm",
 			"-no-debug",
 			"-panic=trap",
-			"-o", outputPath,
+			"-o", tempPath,
 			entryArg,
 		)
 	}
@@ -176,6 +201,9 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 	command.Stderr = os.Stderr
 	if err := command.Run(); err != nil {
 		return fmt.Errorf("%s WASM build failed: %w", compiler, err)
+	}
+	if err := copyFile(tempPath, outputPath); err != nil {
+		return err
 	}
 	return nil
 }
@@ -202,6 +230,9 @@ func validateCompiler(compiler string) error {
 }
 
 func ensureAppDirectory(path string) error {
+	if err := directoryNoFollow(path, "application directory"); err != nil {
+		return fmt.Errorf("open application directory: %w", err)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("open application directory: %w", err)

--- a/cmd/goxc/clean.go
+++ b/cmd/goxc/clean.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/graybuton/goframe/pkg/gox"
 )
 
 type cleanOptions struct {
@@ -64,12 +62,15 @@ func cleanApp(options cleanOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := validateWorkspaceRoot(layout); err != nil {
+		return err
+	}
 	for _, directory := range []string{
 		filepath.Join(layout.WorkspaceRoot, "work"),
 		filepath.Join(layout.WorkspaceRoot, "build"),
 		filepath.Join(layout.WorkspaceRoot, "package"),
 	} {
-		if err := removeDirectoryIfExists(directory); err != nil {
+		if err := removeDirectoryIfExistsBelowRoot(layout.WorkspaceRoot, directory); err != nil {
 			return err
 		}
 	}
@@ -86,14 +87,14 @@ func cleanApp(options cleanOptions) error {
 	if !options.generated {
 		return nil
 	}
-	if err := removeDirectoryIfExists(layout.GenDir); err != nil {
+	if err := removeDirectoryIfExistsBelowRoot(layout.WorkspaceRoot, layout.GenDir); err != nil {
 		return err
 	}
 	return nil
 }
 
 func cleanAdjacentGeneratedFiles(appDir string) error {
-	files, err := gox.FindFiles(appDir)
+	files, err := findGOXFiles(appDir)
 	if err != nil {
 		return err
 	}
@@ -110,12 +111,12 @@ func cleanAdjacentGeneratedFiles(appDir string) error {
 }
 
 func cleanLegacyArtifacts(appDir string) error {
-	if err := removeDirectoryIfExists(filepath.Join(appDir, "build")); err != nil {
+	if err := removeDirectoryIfExistsBelowRoot(appDir, filepath.Join(appDir, "build")); err != nil {
 		return err
 	}
 	dist := filepath.Join(appDir, "dist")
 	if isGoframeOwnedExport(dist) {
-		return removeDirectoryIfExists(dist)
+		return removeDirectoryIfExistsBelowRoot(appDir, dist)
 	}
 	if entries, err := os.ReadDir(dist); err == nil && len(entries) > 0 {
 		fmt.Printf("skipped %s; it does not look like a GoFrame package export\n", dist)
@@ -128,6 +129,27 @@ func removeDirectoryIfExists(directory string) error {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("inspect %s: %w", directory, err)
+	}
+	if err := os.RemoveAll(directory); err != nil {
+		return fmt.Errorf("remove %s: %w", directory, err)
+	}
+	fmt.Printf("removed %s\n", directory)
+	return nil
+}
+
+func removeDirectoryIfExistsBelowRoot(root, directory string) error {
+	if err := validatePathBelowRoot(root, filepath.Dir(directory), "cleanup parent", false); err != nil {
+		return err
+	}
+	info, err := os.Lstat(directory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", directory, err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 && !info.IsDir() {
+		return fmt.Errorf("cleanup path %s is not a directory", directory)
 	}
 	if err := os.RemoveAll(directory); err != nil {
 		return fmt.Errorf("remove %s: %w", directory, err)

--- a/cmd/goxc/clean_test.go
+++ b/cmd/goxc/clean_test.go
@@ -54,9 +54,7 @@ func TestCleanLegacyRemovesGoframeOwnedDist(t *testing.T) {
 	if err := os.Mkdir(dist, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dist, packageMetadataName), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeValidPackageMetadata(t, dist)
 	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -74,9 +72,7 @@ func TestCleanLegacyRemovesLegacyManifestDist(t *testing.T) {
 	if err := os.Mkdir(dist, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dist, legacyPackageManifest), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeLegacyPackageSignature(t, dist)
 	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -85,5 +81,29 @@ func TestCleanLegacyRemovesLegacyManifestDist(t *testing.T) {
 	}
 	if _, err := os.Stat(dist); !os.IsNotExist(err) {
 		t.Fatalf("legacy manifest dist still exists: %v", err)
+	}
+}
+
+func TestCleanLegacyPreservesGenericWebManifestDist(t *testing.T) {
+	appDir := t.TempDir()
+	dist := filepath.Join(appDir, "dist")
+	if err := os.Mkdir(dist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userFile := filepath.Join(dist, "user.txt")
+	if err := os.WriteFile(filepath.Join(dist, legacyPackageManifest), []byte(`{"name":"web app"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userFile, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanApp(cleanOptions{appDir: appDir, legacy: true}); err != nil {
+		t.Fatalf("cleanApp(legacy) error: %v", err)
+	}
+	if content, err := os.ReadFile(userFile); err != nil || string(content) != "keep" {
+		t.Fatalf("generic web manifest dist changed: content=%q err=%v", content, err)
 	}
 }

--- a/cmd/goxc/clean_test.go
+++ b/cmd/goxc/clean_test.go
@@ -54,7 +54,7 @@ func TestCleanLegacyRemovesGoframeOwnedDist(t *testing.T) {
 	if err := os.Mkdir(dist, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeValidPackageMetadata(t, dist)
+	writeCompleteCurrentPackage(t, dist)
 	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -106,4 +106,29 @@ func TestCleanLegacyPreservesGenericWebManifestDist(t *testing.T) {
 	if content, err := os.ReadFile(userFile); err != nil || string(content) != "keep" {
 		t.Fatalf("generic web manifest dist changed: content=%q err=%v", content, err)
 	}
+}
+
+func TestCleanLegacyPreservesGenericGoWASMDist(t *testing.T) {
+	appDir := t.TempDir()
+	dist := filepath.Join(appDir, "dist")
+	if err := os.Mkdir(dist, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range map[string]string{
+		legacyPackageManifest: `{"name":"generic wasm app"}`,
+		"main.wasm":           "wasm",
+		runtimeAssetName:      "js",
+		"user.txt":            "keep",
+	} {
+		if err := os.WriteFile(filepath.Join(dist, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte("<div></div>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanApp(cleanOptions{appDir: appDir, legacy: true}); err != nil {
+		t.Fatalf("cleanApp(legacy) error: %v", err)
+	}
+	assertFileContent(t, filepath.Join(dist, "user.txt"), "keep")
 }

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -8,6 +9,19 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestCommandUsage(t *testing.T) {
+	for _, command := range []string{"generate", "build", "package", "export", "serve", "size", "doctor", "clean", "version"} {
+		t.Run(command, func(t *testing.T) {
+			var output bytes.Buffer
+			commandUsage(&output, command)
+			got := output.String()
+			if !strings.Contains(got, "usage: goxc "+command) {
+				t.Fatalf("commandUsage(%q) = %q", command, got)
+			}
+		})
+	}
+}
 
 func TestParseBuildOptions(t *testing.T) {
 	options, err := parseBuildOptions([]string{"app", "--compiler=tinygo", "--out=custom"})

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -145,6 +145,27 @@ func TestLoadManifestAcceptsLegacyMainWASM(t *testing.T) {
 	}
 }
 
+func TestManifestRejectsNonWASMOutputNames(t *testing.T) {
+	tests := []string{
+		`{"wasm":"main.go"}`,
+		`{"wasm":"go.mod"}`,
+		`{"wasm":"bundle"}`,
+		`{"wasm":"bundle.wasm.gz"}`,
+		`{"wasm":"wasm_exec.js"}`,
+	}
+	for _, content := range tests {
+		t.Run(content, func(t *testing.T) {
+			appDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := loadManifest(appDir); err == nil {
+				t.Fatalf("loadManifest() accepted unsafe wasm path from %s", content)
+			}
+		})
+	}
+}
+
 func TestManifestRejectsApplicationRootAsOutput(t *testing.T) {
 	appDir := t.TempDir()
 	content := []byte(`{"output":"."}`)
@@ -420,7 +441,7 @@ func TestValidatePackageDestinationRejectsUnownedNonEmptyDirectory(t *testing.T)
 
 func TestValidatePackageDestinationAllowsPreviousGoFramePackage(t *testing.T) {
 	outDir := t.TempDir()
-	writeValidPackageMetadata(t, outDir)
+	writeCompleteCurrentPackage(t, outDir)
 	if err := validatePackageDestination(outDir); err != nil {
 		t.Fatalf("validatePackageDestination(previous package) error: %v", err)
 	}

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -420,9 +420,7 @@ func TestValidatePackageDestinationRejectsUnownedNonEmptyDirectory(t *testing.T)
 
 func TestValidatePackageDestinationAllowsPreviousGoFramePackage(t *testing.T) {
 	outDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(outDir, packageMetadataName), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeValidPackageMetadata(t, outDir)
 	if err := validatePackageDestination(outDir); err != nil {
 		t.Fatalf("validatePackageDestination(previous package) error: %v", err)
 	}

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -411,6 +411,7 @@ func TestCleanPackageArtifactsRemovesOldCompression(t *testing.T) {
 		"main.wasm.gz",
 		"main.wasm.br",
 		"bundle.wasm",
+		"index.html",
 		"asset-manifest.json",
 		"goframe-package.json",
 		filepath.Join("assets", "bundle.oldhash.wasm"),
@@ -422,7 +423,7 @@ func TestCleanPackageArtifactsRemovesOldCompression(t *testing.T) {
 	if err := cleanPackageArtifacts(directory, "bundle.wasm"); err != nil {
 		t.Fatalf("cleanPackageArtifacts() error: %v", err)
 	}
-	for _, name := range []string{"main.wasm", "main.wasm.gz", "main.wasm.br", "bundle.wasm", "asset-manifest.json", "goframe-package.json", "assets"} {
+	for _, name := range []string{"main.wasm", "main.wasm.gz", "main.wasm.br", "bundle.wasm", "index.html", "asset-manifest.json", "goframe-package.json", "assets"} {
 		if _, err := os.Stat(filepath.Join(directory, name)); !os.IsNotExist(err) {
 			t.Fatalf("%s still exists: %v", name, err)
 		}

--- a/cmd/goxc/export.go
+++ b/cmd/goxc/export.go
@@ -107,6 +107,9 @@ func exportApp(options exportOptions) error {
 	if err := publishPackageArtifacts(layout.PackageDir, options.outDir); err != nil {
 		return err
 	}
+	if err := verifyPublishedPackage(options.outDir); err != nil {
+		return err
+	}
 	fmt.Printf("exported %s -> %s\n", layout.PackageDir, options.outDir)
 	return nil
 }

--- a/cmd/goxc/export.go
+++ b/cmd/goxc/export.go
@@ -68,10 +68,16 @@ func exportApp(options exportOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := rejectSymlinkPath(layout.PackageDir, "standalone package directory"); err != nil {
+		return err
+	}
 	if info, err := os.Stat(layout.PackageDir); err != nil {
 		return fmt.Errorf("no standalone package found; run `goxc package %s` first", options.appDir)
 	} else if !info.IsDir() {
 		return fmt.Errorf("standalone package path is not a directory: %s", layout.PackageDir)
+	}
+	if err := rejectSymlinkPath(options.outDir, "export output directory"); err != nil {
+		return err
 	}
 	if err := validateExportDestination(options.outDir, options.force); err != nil {
 		return err
@@ -90,6 +96,9 @@ func exportApp(options exportOptions) error {
 }
 
 func validateExportDestination(outDir string, force bool) error {
+	if err := rejectSymlinkPath(outDir, "export output directory"); err != nil {
+		return err
+	}
 	entries, err := os.ReadDir(outDir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -104,6 +113,9 @@ func validateExportDestination(outDir string, force bool) error {
 }
 
 func validatePackageDestination(outDir string) error {
+	if err := rejectSymlinkPath(outDir, "package output directory"); err != nil {
+		return err
+	}
 	entries, err := os.ReadDir(outDir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil

--- a/cmd/goxc/export.go
+++ b/cmd/goxc/export.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -68,7 +69,10 @@ func exportApp(options exportOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := rejectSymlinkPath(layout.PackageDir, "standalone package directory"); err != nil {
+	if err := validateWorkspaceRoot(layout); err != nil {
+		return err
+	}
+	if err := validatePathBelowRoot(layout.WorkspaceRoot, layout.PackageDir, "standalone package directory", false); err != nil {
 		return err
 	}
 	if info, err := os.Stat(layout.PackageDir); err != nil {
@@ -76,10 +80,16 @@ func exportApp(options exportOptions) error {
 	} else if !info.IsDir() {
 		return fmt.Errorf("standalone package path is not a directory: %s", layout.PackageDir)
 	}
-	if err := rejectSymlinkPath(options.outDir, "export output directory"); err != nil {
+	if pathsOverlap(layout.PackageDir, options.outDir) {
+		return fmt.Errorf("export output directory %s must not overlap standalone package directory %s", options.outDir, layout.PackageDir)
+	}
+	if err := validateExplicitPathRoot(options.outDir, "export output directory", true); err != nil {
 		return err
 	}
 	if err := validateExportDestination(options.outDir, options.force); err != nil {
+		return err
+	}
+	if err := validateExplicitPathRoot(options.outDir, "export output directory", true); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(options.outDir, 0o755); err != nil {
@@ -96,7 +106,7 @@ func exportApp(options exportOptions) error {
 }
 
 func validateExportDestination(outDir string, force bool) error {
-	if err := rejectSymlinkPath(outDir, "export output directory"); err != nil {
+	if err := validateExplicitPathRoot(outDir, "export output directory", true); err != nil {
 		return err
 	}
 	entries, err := os.ReadDir(outDir)
@@ -113,7 +123,7 @@ func validateExportDestination(outDir string, force bool) error {
 }
 
 func validatePackageDestination(outDir string) error {
-	if err := rejectSymlinkPath(outDir, "package output directory"); err != nil {
+	if err := validateExplicitPathRoot(outDir, "package output directory", true); err != nil {
 		return err
 	}
 	entries, err := os.ReadDir(outDir)
@@ -130,14 +140,102 @@ func validatePackageDestination(outDir string) error {
 }
 
 func isGoframeOwnedExport(directory string) bool {
-	if fileExists(filepath.Join(directory, packageMetadataName)) {
-		return true
+	owned, _ := inspectPackageOwnership(directory)
+	return owned
+}
+
+func inspectPackageOwnership(directory string) (bool, error) {
+	if ok, err := validCurrentPackageMetadata(filepath.Join(directory, packageMetadataName)); ok || err != nil {
+		return ok, err
 	}
-	if fileExists(filepath.Join(directory, assetManifestName)) {
-		return true
+	if ok, err := validAssetManifestMetadata(filepath.Join(directory, assetManifestName)); ok || err != nil {
+		return ok, err
 	}
-	if fileExists(filepath.Join(directory, legacyPackageManifest)) {
-		return true
+	if ok, err := validLegacyPackageSignature(directory); ok || err != nil {
+		return ok, err
 	}
-	return false
+	return false, nil
+}
+
+func validCurrentPackageMetadata(path string) (bool, error) {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	var metadata packageMetadata
+	if err := readJSONRegular(path, "package metadata", &metadata); err != nil {
+		return false, nil
+	}
+	if metadata.Version != 1 || metadata.Name == "" || metadata.AssetsDir != assetDirectoryName {
+		return false, nil
+	}
+	if metadata.Compiler != "go" && metadata.Compiler != "tinygo" {
+		return false, nil
+	}
+	if !safeChildPath(metadata.Entrypoints.HTML) || !safeChildPath(metadata.Entrypoints.WASM) || !safeChildPath(metadata.Entrypoints.Runtime) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func validAssetManifestMetadata(path string) (bool, error) {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	var manifest assetManifest
+	if err := readJSONRegular(path, "asset manifest", &manifest); err != nil {
+		return false, nil
+	}
+	if manifest.Version != 1 || len(manifest.Assets) == 0 {
+		return false, nil
+	}
+	if !safeChildPath(manifest.Entrypoints.WASM) || !safeChildPath(manifest.Entrypoints.Runtime) {
+		return false, nil
+	}
+	for _, asset := range manifest.Assets {
+		if !safeChildPath(asset.Path) || asset.Type == "" {
+			return false, nil
+		}
+		for _, compressed := range asset.Compressed {
+			if !safeChildPath(compressed) {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func validLegacyPackageSignature(directory string) (bool, error) {
+	manifestPath := filepath.Join(directory, legacyPackageManifest)
+	if _, err := os.Lstat(manifestPath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	var generic map[string]any
+	if err := readJSONRegular(manifestPath, "legacy package manifest", &generic); err != nil {
+		return false, nil
+	}
+	wasmRoot := filepath.Join(directory, "main.wasm")
+	if _, err := regularFileNoFollow(wasmRoot, "legacy package WASM"); err != nil {
+		wasmRoot = filepath.Join(directory, "bundle.wasm")
+		if _, err := regularFileNoFollow(wasmRoot, "legacy package WASM"); err != nil {
+			return false, nil
+		}
+	}
+	if _, err := regularFileNoFollow(filepath.Join(directory, runtimeAssetName), "legacy runtime asset"); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
+func readJSONRegular(path string, description string, value any) error {
+	if _, err := regularFileNoFollow(path, description); err != nil {
+		return err
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := json.Unmarshal(content, value); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
 }

--- a/cmd/goxc/export.go
+++ b/cmd/goxc/export.go
@@ -80,8 +80,14 @@ func exportApp(options exportOptions) error {
 	} else if !info.IsDir() {
 		return fmt.Errorf("standalone package path is not a directory: %s", layout.PackageDir)
 	}
-	if pathsOverlap(layout.PackageDir, options.outDir) {
-		return fmt.Errorf("export output directory %s must not overlap standalone package directory %s", options.outDir, layout.PackageDir)
+	if ownership := inspectPackageOwnership(layout.PackageDir); ownership.State != packageOwnedCurrent {
+		return fmt.Errorf("standalone package %s is not a complete current GoFrame package: %s", layout.PackageDir, ownership.Reason)
+	}
+	if err := ensureNoPhysicalOverlap(options.outDir, layout.PackageDir, "export output directory", "standalone package directory"); err != nil {
+		return err
+	}
+	if err := ensureNoPhysicalOverlap(options.outDir, layout.AppDir, "export output directory", "application directory"); err != nil {
+		return err
 	}
 	if err := validateExplicitPathRoot(options.outDir, "export output directory", true); err != nil {
 		return err
@@ -116,7 +122,11 @@ func validateExportDestination(outDir string, force bool) error {
 	if err != nil {
 		return fmt.Errorf("inspect export directory: %w", err)
 	}
-	if len(entries) == 0 || force || isGoframeOwnedExport(outDir) {
+	ownership := inspectPackageOwnership(outDir)
+	if ownership.State == packageIncompleteOrInvalid {
+		return fmt.Errorf("export output directory %s contains incomplete or invalid GoFrame package metadata: %s", outDir, ownership.Reason)
+	}
+	if len(entries) == 0 || force || ownership.IsOwned() {
 		return nil
 	}
 	return fmt.Errorf("export output directory %s is not empty and does not look like a previous GoFrame export; pass --force to treat it as tool-owned and overwrite package artifacts", outDir)
@@ -133,95 +143,188 @@ func validatePackageDestination(outDir string) error {
 	if err != nil {
 		return fmt.Errorf("inspect package output directory: %w", err)
 	}
-	if len(entries) == 0 || isGoframeOwnedExport(outDir) {
+	ownership := inspectPackageOwnership(outDir)
+	if ownership.State == packageIncompleteOrInvalid {
+		return fmt.Errorf("package output directory %s contains incomplete or invalid GoFrame package metadata: %s", outDir, ownership.Reason)
+	}
+	if len(entries) == 0 || ownership.IsOwned() {
 		return nil
 	}
 	return fmt.Errorf("package output directory %s is not empty and does not look like a previous GoFrame package; use the default hidden workspace output, choose an empty directory, or export a package with `goxc export --force` when overwriting is intentional", outDir)
 }
 
 func isGoframeOwnedExport(directory string) bool {
-	owned, _ := inspectPackageOwnership(directory)
-	return owned
+	return inspectPackageOwnership(directory).IsOwned()
 }
 
-func inspectPackageOwnership(directory string) (bool, error) {
-	if ok, err := validCurrentPackageMetadata(filepath.Join(directory, packageMetadataName)); ok || err != nil {
-		return ok, err
-	}
-	if ok, err := validAssetManifestMetadata(filepath.Join(directory, assetManifestName)); ok || err != nil {
-		return ok, err
-	}
-	if ok, err := validLegacyPackageSignature(directory); ok || err != nil {
-		return ok, err
-	}
-	return false, nil
+type packageOwnershipState uint8
+
+const (
+	packageUnowned packageOwnershipState = iota
+	packageOwnedCurrent
+	packageOwnedLegacy
+	packageIncompleteOrInvalid
+)
+
+type packageOwnership struct {
+	State  packageOwnershipState
+	Reason string
 }
 
-func validCurrentPackageMetadata(path string) (bool, error) {
-	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
-		return false, nil
+func (ownership packageOwnership) IsOwned() bool {
+	return ownership.State == packageOwnedCurrent || ownership.State == packageOwnedLegacy
+}
+
+func inspectPackageOwnership(directory string) packageOwnership {
+	if exists, err := pathExistsNoFollow(filepath.Join(directory, packageMetadataName)); err != nil {
+		return packageOwnership{State: packageIncompleteOrInvalid, Reason: err.Error()}
+	} else if exists {
+		return inspectCurrentPackageOwnership(directory)
 	}
+	if exists, err := pathExistsNoFollow(filepath.Join(directory, assetManifestName)); err != nil {
+		return packageOwnership{State: packageIncompleteOrInvalid, Reason: err.Error()}
+	} else if exists {
+		if _, err := readAssetManifestMetadata(filepath.Join(directory, assetManifestName)); err != nil {
+			return packageOwnership{State: packageIncompleteOrInvalid, Reason: err.Error()}
+		}
+		return packageOwnership{State: packageUnowned, Reason: "asset manifest is metadata only; goframe-package.json is required"}
+	}
+	if validLegacyPackageSignature(directory) {
+		return packageOwnership{State: packageOwnedLegacy, Reason: "recognized historical GoFrame package manifest"}
+	}
+	return packageOwnership{State: packageUnowned, Reason: "no complete GoFrame package metadata found"}
+}
+
+func inspectCurrentPackageOwnership(directory string) packageOwnership {
+	metadata, err := readCurrentPackageMetadata(filepath.Join(directory, packageMetadataName))
+	if err != nil {
+		return packageOwnership{State: packageIncompleteOrInvalid, Reason: err.Error()}
+	}
+	manifest, err := readAssetManifestMetadata(filepath.Join(directory, assetManifestName))
+	if err != nil {
+		return packageOwnership{State: packageIncompleteOrInvalid, Reason: "companion asset manifest is required: " + err.Error()}
+	}
+	if metadata.Entrypoints.WASM != manifest.Entrypoints.WASM || metadata.Entrypoints.Runtime != manifest.Entrypoints.Runtime {
+		return packageOwnership{State: packageIncompleteOrInvalid, Reason: "package metadata and asset manifest entrypoints do not match"}
+	}
+	for _, entry := range []struct {
+		path        string
+		description string
+	}{
+		{metadata.Entrypoints.HTML, "package HTML entrypoint"},
+		{metadata.Entrypoints.WASM, "package WASM entrypoint"},
+		{metadata.Entrypoints.Runtime, "package runtime entrypoint"},
+	} {
+		if err := validatePackageOwnedPath(directory, entry.path, entry.description); err != nil {
+			return packageOwnership{State: packageIncompleteOrInvalid, Reason: err.Error()}
+		}
+	}
+	return packageOwnership{State: packageOwnedCurrent, Reason: "complete current GoFrame package metadata found"}
+}
+
+func readCurrentPackageMetadata(path string) (packageMetadata, error) {
 	var metadata packageMetadata
 	if err := readJSONRegular(path, "package metadata", &metadata); err != nil {
-		return false, nil
+		return packageMetadata{}, err
 	}
 	if metadata.Version != 1 || metadata.Name == "" || metadata.AssetsDir != assetDirectoryName {
-		return false, nil
+		return packageMetadata{}, fmt.Errorf("package metadata has unsupported version, empty name, or invalid assetsDir")
 	}
 	if metadata.Compiler != "go" && metadata.Compiler != "tinygo" {
-		return false, nil
+		return packageMetadata{}, fmt.Errorf("package metadata compiler %q is not supported", metadata.Compiler)
 	}
 	if !safeChildPath(metadata.Entrypoints.HTML) || !safeChildPath(metadata.Entrypoints.WASM) || !safeChildPath(metadata.Entrypoints.Runtime) {
-		return false, nil
+		return packageMetadata{}, fmt.Errorf("package metadata entrypoints must stay inside the package")
 	}
-	return true, nil
+	return metadata, nil
 }
 
-func validAssetManifestMetadata(path string) (bool, error) {
-	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
+func readAssetManifestMetadata(path string) (assetManifest, error) {
 	var manifest assetManifest
 	if err := readJSONRegular(path, "asset manifest", &manifest); err != nil {
-		return false, nil
+		return assetManifest{}, err
 	}
 	if manifest.Version != 1 || len(manifest.Assets) == 0 {
-		return false, nil
+		return assetManifest{}, fmt.Errorf("asset manifest has unsupported version or no assets")
 	}
 	if !safeChildPath(manifest.Entrypoints.WASM) || !safeChildPath(manifest.Entrypoints.Runtime) {
-		return false, nil
+		return assetManifest{}, fmt.Errorf("asset manifest entrypoints must stay inside the package")
 	}
 	for _, asset := range manifest.Assets {
 		if !safeChildPath(asset.Path) || asset.Type == "" {
-			return false, nil
+			return assetManifest{}, fmt.Errorf("asset manifest contains an invalid asset path or type")
 		}
 		for _, compressed := range asset.Compressed {
 			if !safeChildPath(compressed) {
-				return false, nil
+				return assetManifest{}, fmt.Errorf("asset manifest contains an invalid compressed asset path")
 			}
 		}
 	}
-	return true, nil
+	return manifest, nil
 }
 
-func validLegacyPackageSignature(directory string) (bool, error) {
+func validatePackageOwnedPath(directory, relative, description string) error {
+	if !safeChildPath(relative) {
+		return fmt.Errorf("%s %q must stay inside the package", description, relative)
+	}
+	path := filepath.Join(directory, filepath.FromSlash(relative))
+	if err := validatePathBelowRoot(directory, path, description, false); err != nil {
+		return err
+	}
+	if _, err := regularFileNoFollow(path, description); err != nil {
+		return err
+	}
+	return nil
+}
+
+type legacyPackageMetadata struct {
+	Name             string   `json:"name"`
+	Compiler         string   `json:"compiler"`
+	WASM             string   `json:"wasm"`
+	Assets           []string `json:"assets"`
+	ToolchainVersion string   `json:"toolchainVersion"`
+}
+
+func validLegacyPackageSignature(directory string) bool {
 	manifestPath := filepath.Join(directory, legacyPackageManifest)
-	if _, err := os.Lstat(manifestPath); errors.Is(err, os.ErrNotExist) {
-		return false, nil
+	if exists, err := pathExistsNoFollow(manifestPath); err != nil || !exists {
+		return false
 	}
-	var generic map[string]any
-	if err := readJSONRegular(manifestPath, "legacy package manifest", &generic); err != nil {
-		return false, nil
+	var legacy legacyPackageMetadata
+	if err := readJSONRegular(manifestPath, "legacy package manifest", &legacy); err != nil {
+		return false
 	}
-	wasmRoot := filepath.Join(directory, "main.wasm")
-	if _, err := regularFileNoFollow(wasmRoot, "legacy package WASM"); err != nil {
-		wasmRoot = filepath.Join(directory, "bundle.wasm")
-		if _, err := regularFileNoFollow(wasmRoot, "legacy package WASM"); err != nil {
-			return false, nil
+	if legacy.Name == "" || legacy.ToolchainVersion == "" {
+		return false
+	}
+	if legacy.Compiler != "go" && legacy.Compiler != "tinygo" {
+		return false
+	}
+	if !safeChildPath(legacy.WASM) || strings.ToLower(filepath.Ext(legacy.WASM)) != ".wasm" {
+		return false
+	}
+	if err := validatePackageOwnedPath(directory, legacy.WASM, "legacy package WASM"); err != nil {
+		return false
+	}
+	if err := validatePackageOwnedPath(directory, runtimeAssetName, "legacy runtime asset"); err != nil {
+		return false
+	}
+	for _, asset := range legacy.Assets {
+		if !safeChildPath(asset) {
+			return false
+		}
+		if _, err := regularFileNoFollow(filepath.Join(directory, filepath.FromSlash(asset)), "legacy package asset"); err != nil {
+			return false
 		}
 	}
-	if _, err := regularFileNoFollow(filepath.Join(directory, runtimeAssetName), "legacy runtime asset"); err != nil {
+	return true
+}
+
+func pathExistsNoFollow(path string) (bool, error) {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
 		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", path, err)
 	}
 	return true, nil
 }

--- a/cmd/goxc/export_test.go
+++ b/cmd/goxc/export_test.go
@@ -42,9 +42,7 @@ func TestExportAllowsPreviousGoframeExport(t *testing.T) {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(outDir, packageMetadataName), []byte("{}"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeValidPackageMetadata(t, outDir)
 	if err := os.MkdirAll(filepath.Join(outDir, "assets"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -89,10 +87,10 @@ func createPackagedTestApp(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(layout.PackageDir, "assets"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	writeValidPackageMetadata(t, layout.PackageDir)
+	writeValidAssetManifest(t, layout.PackageDir)
 	for path, content := range map[string]string{
 		"index.html":             "<html></html>",
-		packageMetadataName:      "{}",
-		assetManifestName:        "{}",
 		"assets/bundle.wasm":     "wasm",
 		"assets/wasm_exec.js":    "js",
 		"assets/styles.app.css":  "body{}",

--- a/cmd/goxc/export_test.go
+++ b/cmd/goxc/export_test.go
@@ -42,7 +42,7 @@ func TestExportAllowsPreviousGoframeExport(t *testing.T) {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeValidPackageMetadata(t, outDir)
+	writeCompleteCurrentPackage(t, outDir)
 	if err := os.MkdirAll(filepath.Join(outDir, "assets"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -87,8 +87,7 @@ func createPackagedTestApp(t *testing.T) string {
 	if err := os.MkdirAll(filepath.Join(layout.PackageDir, "assets"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeValidPackageMetadata(t, layout.PackageDir)
-	writeValidAssetManifest(t, layout.PackageDir)
+	writeCompleteCurrentPackage(t, layout.PackageDir)
 	for path, content := range map[string]string{
 		"index.html":             "<html></html>",
 		"assets/bundle.wasm":     "wasm",

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -122,6 +122,32 @@ func App() gf.Node {
 	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte(source), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(appDir, indexHTMLAssetName), []byte("<!doctype html><div id=\"root\"></div>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMinimalPackageApp(t *testing.T, appDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(`{"name":"demo","compiler":"go","assets":["index.html"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mainSource := `//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}
+`
+	if err := os.WriteFile(filepath.Join(appDir, "main.go"), []byte(mainSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalGOXApp(t, appDir)
 }
 
 func assertFileContent(t *testing.T, path string, want string) {
@@ -707,6 +733,165 @@ func TestPackageAssetPlanAllowsDistinctNestedAssets(t *testing.T) {
 	}
 }
 
+func TestValidateRequiredPackageEntrypoints(t *testing.T) {
+	t.Run("valid index", func(t *testing.T) {
+		appDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(appDir, indexHTMLAssetName), []byte("<html></html>"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := validateRequiredPackageEntrypoints(appDir, []string{indexHTMLAssetName, "styles.css"}); err != nil {
+			t.Fatalf("validateRequiredPackageEntrypoints() error: %v", err)
+		}
+	})
+
+	t.Run("missing declaration", func(t *testing.T) {
+		appDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(appDir, indexHTMLAssetName), []byte("<html></html>"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		err := validateRequiredPackageEntrypoints(appDir, []string{"styles.css"})
+		if err == nil || !strings.Contains(err.Error(), "must include index.html exactly once") {
+			t.Fatalf("error = %v, want required index declaration", err)
+		}
+	})
+
+	t.Run("missing source", func(t *testing.T) {
+		appDir := t.TempDir()
+		err := validateRequiredPackageEntrypoints(appDir, []string{indexHTMLAssetName})
+		if err == nil || !strings.Contains(err.Error(), "was not found") {
+			t.Fatalf("error = %v, want missing index source", err)
+		}
+	})
+
+	t.Run("directory source", func(t *testing.T) {
+		appDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(appDir, indexHTMLAssetName), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		err := validateRequiredPackageEntrypoints(appDir, []string{indexHTMLAssetName})
+		if err == nil || !strings.Contains(err.Error(), "is not a regular file") {
+			t.Fatalf("error = %v, want non-regular index source", err)
+		}
+	})
+}
+
+func TestValidateRequiredPackageEntrypointsRejectsSymlinkIndex(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external-index.html")
+	if err := os.WriteFile(external, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, indexHTMLAssetName)); err != nil {
+		t.Fatal(err)
+	}
+	err := validateRequiredPackageEntrypoints(appDir, []string{indexHTMLAssetName})
+	if err == nil || !strings.Contains(err.Error(), "is a symlink") {
+		t.Fatalf("error = %v, want symlink index source", err)
+	}
+	assertFileContent(t, external, "keep")
+}
+
+func TestPackageRejectsInvalidIndexBeforeOutputMutation(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		manifest string
+		write    func(t *testing.T, appDir string)
+		want     string
+	}{
+		{
+			name:     "explicit empty assets",
+			manifest: `{"name":"demo","compiler":"go","assets":[]}`,
+			write:    func(*testing.T, string) {},
+			want:     "must include index.html exactly once",
+		},
+		{
+			name:     "index omitted",
+			manifest: `{"name":"demo","compiler":"go","assets":["styles.css"]}`,
+			write: func(t *testing.T, appDir string) {
+				writeTestFile(t, appDir, indexHTMLAssetName, "<html></html>")
+				writeTestFile(t, appDir, "styles.css", "body{}")
+			},
+			want: "must include index.html exactly once",
+		},
+		{
+			name:     "declared but missing",
+			manifest: `{"name":"demo","compiler":"go","assets":["index.html"]}`,
+			write:    func(*testing.T, string) {},
+			want:     "was not found",
+		},
+		{
+			name:     "duplicate normalized index",
+			manifest: `{"name":"demo","compiler":"go","assets":["index.html","./index.html"]}`,
+			write: func(t *testing.T, appDir string) {
+				writeTestFile(t, appDir, indexHTMLAssetName, "<html></html>")
+			},
+			want: "collides",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			appDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(test.manifest), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			test.write(t, appDir)
+			outDir := filepath.Join(t.TempDir(), "package")
+			err := packageApp(packageOptions{appDir: appDir, compiler: "go", outDir: outDir, compress: map[string]bool{}})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("packageApp() error = %v, want %q", err, test.want)
+			}
+			if _, statErr := os.Stat(filepath.Join(appDir, defaultWorkspaceName)); !os.IsNotExist(statErr) {
+				t.Fatalf("workspace was created before required index validation: %v", statErr)
+			}
+			if _, statErr := os.Stat(outDir); !os.IsNotExist(statErr) {
+				t.Fatalf("output was mutated before required index validation: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestPackageInvalidIndexPreservesPreviousCompletePackage(t *testing.T) {
+	appDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), []byte(`{"name":"demo","compiler":"go","assets":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(t.TempDir(), "package")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCompleteCurrentPackage(t, outDir)
+	before := map[string]string{}
+	for _, relative := range []string{
+		indexHTMLAssetName,
+		assetManifestName,
+		packageMetadataName,
+		"assets/bundle.12345678.wasm",
+		"assets/wasm_exec.12345678.js",
+	} {
+		content, err := os.ReadFile(filepath.Join(outDir, filepath.FromSlash(relative)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[relative] = string(content)
+	}
+
+	err := packageApp(packageOptions{appDir: appDir, compiler: "go", outDir: outDir, compress: map[string]bool{}})
+	if err == nil || !strings.Contains(err.Error(), "must include index.html exactly once") {
+		t.Fatalf("packageApp() error = %v, want required index validation", err)
+	}
+	for relative, content := range before {
+		assertFileContent(t, filepath.Join(outDir, filepath.FromSlash(relative)), content)
+	}
+	if ownership := inspectPackageOwnership(outDir); ownership.State != packageOwnedCurrent {
+		t.Fatalf("previous package ownership = %v (%s), want current", ownership.State, ownership.Reason)
+	}
+}
+
 func TestPublishRejectsSymlinkedSourceEntries(t *testing.T) {
 	requireSymlinkSupport(t)
 
@@ -801,6 +986,89 @@ func TestCleanPackageArtifactsRemovesCompletionMarkerFirst(t *testing.T) {
 	}
 	if ownership := inspectPackageOwnership(destination); ownership.IsOwned() {
 		t.Fatalf("failed cleanup left directory owned: %v %s", ownership.State, ownership.Reason)
+	}
+}
+
+func TestCleanPackageArtifactsRemovesManagedIndex(t *testing.T) {
+	destination := t.TempDir()
+	writeCompleteCurrentPackage(t, destination)
+	if err := os.WriteFile(filepath.Join(destination, "user.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanPackageArtifacts(destination, "bundle.wasm"); err != nil {
+		t.Fatalf("cleanPackageArtifacts() error: %v", err)
+	}
+	for _, name := range []string{packageMetadataName, indexHTMLAssetName, assetManifestName, assetDirectoryName} {
+		if _, err := os.Stat(filepath.Join(destination, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after cleanup: %v", name, err)
+		}
+	}
+	assertFileContent(t, filepath.Join(destination, "user.txt"), "keep")
+}
+
+func TestVerifyPublishedPackageInvalidatesIncompleteMarker(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(directory, assetDirectoryName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeValidPackageMetadata(t, directory)
+	writeValidAssetManifest(t, directory)
+	if err := os.WriteFile(filepath.Join(directory, "assets", "bundle.12345678.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "assets", "wasm_exec.12345678.js"), []byte("js"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := verifyPublishedPackage(directory)
+	if err == nil || !strings.Contains(err.Error(), "failed integrity verification") {
+		t.Fatalf("verifyPublishedPackage() error = %v, want integrity failure", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(directory, packageMetadataName)); !os.IsNotExist(statErr) {
+		t.Fatalf("completion marker remained after failed verification: %v", statErr)
+	}
+	if ownership := inspectPackageOwnership(directory); ownership.IsOwned() {
+		t.Fatalf("incomplete package considered owned after failed verification: %v %s", ownership.State, ownership.Reason)
+	}
+}
+
+func TestVerifyPublishedPackageAcceptsCompletePackage(t *testing.T) {
+	directory := t.TempDir()
+	writeCompleteCurrentPackage(t, directory)
+	if err := verifyPublishedPackage(directory); err != nil {
+		t.Fatalf("verifyPublishedPackage() error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, packageMetadataName)); err != nil {
+		t.Fatalf("completion marker removed from complete package: %v", err)
+	}
+}
+
+func TestPackageOutputIsImmediatelyOwnedAndExportable(t *testing.T) {
+	appDir := t.TempDir()
+	writeMinimalPackageApp(t, appDir)
+	if err := packageApp(packageOptions{appDir: appDir, compiler: "go", compress: map[string]bool{}}); err != nil {
+		t.Fatalf("packageApp() error: %v", err)
+	}
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir, compiler: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownership := inspectPackageOwnership(layout.PackageDir); ownership.State != packageOwnedCurrent {
+		t.Fatalf("package ownership = %v (%s), want current", ownership.State, ownership.Reason)
+	}
+	for _, name := range []string{packageMetadataName, assetManifestName, indexHTMLAssetName} {
+		if _, err := os.Stat(filepath.Join(layout.PackageDir, name)); err != nil {
+			t.Fatalf("published package missing %s: %v", name, err)
+		}
+	}
+	outDir := filepath.Join(t.TempDir(), "export")
+	if err := exportApp(exportOptions{appDir: appDir, outDir: outDir}); err != nil {
+		t.Fatalf("exportApp() error: %v", err)
+	}
+	if ownership := inspectPackageOwnership(outDir); ownership.State != packageOwnedCurrent {
+		t.Fatalf("export ownership = %v (%s), want current", ownership.State, ownership.Reason)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, indexHTMLAssetName)); err != nil {
+		t.Fatalf("exported package missing index.html: %v", err)
 	}
 }
 

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -1,0 +1,511 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeValidPackageMetadata(t *testing.T, directory string) {
+	t.Helper()
+	content := `{
+  "version": 1,
+  "name": "demo",
+  "compiler": "tinygo",
+  "toolchainVersion": "test",
+  "assetsDir": "assets",
+  "hashAssets": true,
+  "preload": true,
+  "entrypoints": {
+    "html": "index.html",
+    "wasm": "assets/bundle.12345678.wasm",
+    "runtime": "assets/wasm_exec.12345678.js"
+  },
+  "generatedAt": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(directory, packageMetadataName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeValidAssetManifest(t *testing.T, directory string) {
+	t.Helper()
+	content := `{
+  "version": 1,
+  "assets": {
+    "bundle.wasm": {
+      "path": "assets/bundle.12345678.wasm",
+      "hash": "12345678",
+      "type": "application/wasm"
+    },
+    "wasm_exec.js": {
+      "path": "assets/wasm_exec.12345678.js",
+      "hash": "12345678",
+      "type": "text/javascript"
+    }
+  },
+  "entrypoints": {
+    "wasm": "assets/bundle.12345678.wasm",
+    "runtime": "assets/wasm_exec.12345678.js"
+  }
+}`
+	if err := os.WriteFile(filepath.Join(directory, assetManifestName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeLegacyPackageSignature(t *testing.T, directory string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(directory, legacyPackageManifest), []byte(`{"goframe":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "main.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, runtimeAssetName), []byte("js"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMinimalGOXApp(t *testing.T, appDir string) {
+	t.Helper()
+	source := `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main>demo</main>
+}
+`
+	if err := os.WriteFile(filepath.Join(appDir, "app.gox"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContent(t *testing.T, path string, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s = %q, want %q", path, got, want)
+	}
+}
+
+func TestEnsureAppDirectoryRejectsSymlinkedAppRoot(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target-app")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "app-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureAppDirectory(link); err == nil {
+		t.Fatal("ensureAppDirectory() accepted symlinked app root")
+	}
+}
+
+func TestWorkspaceRootSymlinkRejectedBeforeMutation(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalGOXApp(t, appDir)
+	external := filepath.Join(root, "external-workspace")
+	if err := os.Mkdir(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(external, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, defaultWorkspaceName)); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, run := range map[string]func() error{
+		"generate": func() error { return generatePath(generateOptions{path: appDir}, true) },
+		"build":    func() error { _, err := buildApp(buildOptions{appDir: appDir, compiler: "go"}); return err },
+		"package": func() error {
+			return packageApp(packageOptions{appDir: appDir, compiler: "go", compress: map[string]bool{}})
+		},
+		"clean": func() error { return cleanApp(cleanOptions{appDir: appDir}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := run(); err == nil {
+				t.Fatalf("%s accepted symlinked workspace root", name)
+			}
+			assertFileContent(t, sentinel, "keep")
+		})
+	}
+}
+
+func TestWorkspaceIntermediateSymlinkRejectedForBuildPreparation(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(filepath.Join(appDir, defaultWorkspaceName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalGOXApp(t, appDir)
+	external := filepath.Join(root, "external-work")
+	if err := os.Mkdir(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, defaultWorkspaceName, "work")); err != nil {
+		t.Fatal(err)
+	}
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareBuildWorkspace(layout, projectManifest{Entry: "."}); err == nil {
+		t.Fatal("prepareBuildWorkspace() accepted intermediate workspace symlink")
+	}
+}
+
+func TestExternalWorkspaceOverlapRejected(t *testing.T) {
+	appDir := t.TempDir()
+	for _, workspace := range []string{
+		appDir,
+		filepath.Join(appDir, "workspace"),
+	} {
+		t.Run(workspace, func(t *testing.T) {
+			if _, err := newBuildLayout(layoutOptions{appDir: appDir, workspace: workspace}); err == nil {
+				t.Fatalf("newBuildLayout() accepted overlapping workspace %s", workspace)
+			}
+		})
+	}
+	if _, err := newBuildLayout(layoutOptions{appDir: appDir, workspace: filepath.Join(t.TempDir(), "workspace")}); err != nil {
+		t.Fatalf("newBuildLayout(sibling workspace) error: %v", err)
+	}
+}
+
+func TestCopyAuthoredGoFilesAllowsDefaultHiddenWorkspaceOnly(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	if err := copyAuthoredGoFiles(appDir, filepath.Join(appDir, defaultWorkspaceName, "work", "dev", "app")); err != nil {
+		t.Fatalf("copyAuthoredGoFiles(default hidden workspace) error: %v", err)
+	}
+	if err := copyAuthoredGoFiles(appDir, filepath.Join(appDir, "nested-workspace")); err == nil {
+		t.Fatal("copyAuthoredGoFiles() accepted non-tool destination inside source root")
+	}
+}
+
+func TestGenerateRejectsDirectGOXFileSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	external := filepath.Join(root, "external.gox")
+	if err := os.WriteFile(external, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "app.gox")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := generatePath(generateOptions{path: link, outDir: filepath.Join(root, "out")}, true); err == nil {
+		t.Fatal("generatePath() accepted direct symlink .gox file")
+	}
+}
+
+func TestGenerateRejectsDestinationSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	appDir := t.TempDir()
+	writeMinimalGOXApp(t, appDir)
+	external := filepath.Join(t.TempDir(), "external.go")
+	if err := os.WriteFile(external, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outDir := filepath.Join(t.TempDir(), "out")
+	if err := os.Mkdir(outDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(outDir, "app.gox.go")); err != nil {
+		t.Fatal(err)
+	}
+	if err := generatePath(generateOptions{path: appDir, outDir: outDir}, true); err == nil {
+		t.Fatal("generatePath() accepted symlinked destination")
+	}
+	assertFileContent(t, external, "keep")
+}
+
+func TestCleanGeneratedRejectsSymlinkedGOXSourceBeforeMutation(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external.gox")
+	if err := os.WriteFile(external, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, "app.gox")); err != nil {
+		t.Fatal(err)
+	}
+	generated := filepath.Join(appDir, "app.gox.go")
+	if err := os.WriteFile(generated, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanApp(cleanOptions{appDir: appDir, generated: true}); err == nil {
+		t.Fatal("cleanApp(--generated) accepted symlinked GOX source")
+	}
+	assertFileContent(t, generated, "keep")
+}
+
+func TestWriteFileAtomicDoesNotTruncateHardlinkPeer(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "first.txt")
+	second := filepath.Join(root, "second.txt")
+	if err := os.WriteFile(first, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(first, second); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	if err := writeFileAtomic(second, []byte("new"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic() error: %v", err)
+	}
+	assertFileContent(t, first, "keep")
+	assertFileContent(t, second, "new")
+}
+
+func TestOwnershipMarkersAreStructured(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		write   func(t *testing.T, dir string)
+		owned   bool
+		message string
+	}{
+		{name: "empty current marker", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, packageMetadataName), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "malformed current marker", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, packageMetadataName), []byte("{"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "empty asset manifest", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, assetManifestName), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "generic web manifest", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, legacyPackageManifest), []byte(`{"name":"web app"}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "valid current marker", write: writeValidPackageMetadata, owned: true},
+		{name: "valid asset manifest", write: writeValidAssetManifest, owned: true},
+		{name: "valid legacy signature", write: writeLegacyPackageSignature, owned: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.write(t, dir)
+			if got := isGoframeOwnedExport(dir); got != test.owned {
+				t.Fatalf("isGoframeOwnedExport() = %v, want %v", got, test.owned)
+			}
+		})
+	}
+}
+
+func TestPackageDestinationFalseMarkerPreservesFiles(t *testing.T) {
+	outDir := t.TempDir()
+	userFile := filepath.Join(outDir, "user.txt")
+	if err := os.WriteFile(filepath.Join(outDir, packageMetadataName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userFile, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validatePackageDestination(outDir); err == nil {
+		t.Fatal("validatePackageDestination() accepted false marker")
+	}
+	assertFileContent(t, userFile, "keep")
+}
+
+func TestExportRejectsOverlappingDestination(t *testing.T) {
+	appDir := t.TempDir()
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(layout.PackageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeValidPackageMetadata(t, layout.PackageDir)
+	for _, outDir := range []string{
+		layout.PackageDir,
+		filepath.Join(layout.PackageDir, "nested"),
+		filepath.Dir(layout.PackageDir),
+	} {
+		t.Run(outDir, func(t *testing.T) {
+			if err := exportApp(exportOptions{appDir: appDir, outDir: outDir}); err == nil {
+				t.Fatalf("exportApp() accepted overlapping outDir %s", outDir)
+			}
+		})
+	}
+}
+
+func TestPackageRejectsExplicitOutputInsideApp(t *testing.T) {
+	appDir := t.TempDir()
+	writeMinimalGOXApp(t, appDir)
+	if err := packageApp(packageOptions{
+		appDir:   appDir,
+		compiler: "go",
+		outDir:   filepath.Join(appDir, "dist"),
+		compress: map[string]bool{},
+	}); err == nil {
+		t.Fatal("packageApp() accepted explicit output inside app tree")
+	}
+}
+
+func TestPackageAssetPlanRejectsReservedAndDuplicateNames(t *testing.T) {
+	tests := []projectManifest{
+		{WASM: "bundle.wasm", Assets: []string{"bundle.wasm"}},
+		{WASM: "bundle.wasm", Assets: []string{"wasm_exec.js"}},
+		{WASM: "bundle.wasm", Assets: []string{"bundle.wasm.gz"}},
+		{WASM: "bundle.wasm", Assets: []string{"styles.css", "./styles.css"}},
+		{WASM: "bundle.wasm", Assets: []string{"a/../styles.css", "styles.css"}},
+		{WASM: "wasm_exec.js", Assets: []string{"index.html"}},
+	}
+	for _, manifest := range tests {
+		t.Run(strings.Join(manifest.Assets, ","), func(t *testing.T) {
+			if _, err := validatePackageAssetPlan(manifest, filepath.Base(manifest.WASM), packageOptions{compress: map[string]bool{"gzip": true}}); err == nil {
+				t.Fatalf("validatePackageAssetPlan() accepted manifest %+v", manifest)
+			}
+		})
+	}
+}
+
+func TestPackageAssetPlanAllowsDistinctNestedAssets(t *testing.T) {
+	assets, err := validatePackageAssetPlan(projectManifest{
+		WASM:   "bundle.wasm",
+		Assets: []string{"index.html", "styles/app.css", "images/logo.svg"},
+	}, "bundle.wasm", packageOptions{compress: map[string]bool{"gzip": true, "br": true}})
+	if err != nil {
+		t.Fatalf("validatePackageAssetPlan() rejected distinct nested assets: %v", err)
+	}
+	want := []string{"index.html", "styles/app.css", "images/logo.svg"}
+	if strings.Join(assets, ",") != strings.Join(want, ",") {
+		t.Fatalf("assets = %#v, want %#v", assets, want)
+	}
+}
+
+func TestPublishRejectsSymlinkedSourceEntries(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	source := t.TempDir()
+	destination := t.TempDir()
+	external := filepath.Join(t.TempDir(), "external.html")
+	if err := os.WriteFile(external, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(source, "index.html")); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishPackageArtifacts(source, destination); err == nil {
+		t.Fatal("publishPackageArtifacts() accepted symlinked source file")
+	}
+	if _, err := os.Stat(filepath.Join(destination, "index.html")); !os.IsNotExist(err) {
+		t.Fatalf("symlinked source was published: %v", err)
+	}
+}
+
+func TestPublishWritesMetadataLastOnFailure(t *testing.T) {
+	source := t.TempDir()
+	destination := t.TempDir()
+	if err := os.Mkdir(filepath.Join(source, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "assets", "bundle.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeValidPackageMetadata(t, source)
+	if err := os.WriteFile(filepath.Join(destination, "assets"), []byte("not-a-directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishPackageArtifacts(source, destination); err == nil {
+		t.Fatal("publishPackageArtifacts() unexpectedly succeeded")
+	}
+	if _, err := os.Stat(filepath.Join(destination, packageMetadataName)); !os.IsNotExist(err) {
+		t.Fatalf("metadata published after failure: %v", err)
+	}
+}
+
+func TestCleanRemovesFinalSymlinkOnly(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(filepath.Join(appDir, defaultWorkspaceName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external")
+	if err := os.Mkdir(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(external, "keep.txt")
+	if err := os.WriteFile(keep, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(appDir, defaultWorkspaceName, "build")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanApp(cleanOptions{appDir: appDir}); err != nil {
+		t.Fatalf("cleanApp() error: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("final cleanup symlink still exists: %v", err)
+	}
+	assertFileContent(t, keep, "keep")
+}
+
+func TestServeRejectsSymlinkRootAndEntries(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	target := filepath.Join(root, "serve-root")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(root, "serve-link")
+	if err := os.Symlink(target, linkRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := serve(serveOptions{dir: linkRoot, port: 0}); err == nil {
+		t.Fatal("serve() accepted symlinked root")
+	}
+
+	external := filepath.Join(root, "secret.txt")
+	if err := os.WriteFile(external, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(target, "secret.txt")); err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest("GET", "/secret.txt", nil)
+	response := httptest.NewRecorder()
+	staticHandler(target).ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("symlinked serve entry status = %d, want 404", response.Code)
+	}
+}

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -31,6 +31,36 @@ func writeValidPackageMetadata(t *testing.T, directory string) {
 	}
 }
 
+func writeCompleteCurrentPackage(t *testing.T, directory string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(directory, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeValidPackageMetadata(t, directory)
+	writeValidAssetManifest(t, directory)
+	for path, content := range map[string]string{
+		"index.html":                        "<html></html>",
+		"assets/bundle.12345678.wasm":       "wasm",
+		"assets/wasm_exec.12345678.js":      "js",
+		"assets/bundle.wasm":                "wasm",
+		"assets/wasm_exec.js":               "js",
+		"assets/styles.12345678.css":        "body{}",
+		"assets/bundle.12345678.wasm.gz":    "gzip",
+		"assets/bundle.12345678.wasm.br":    "br",
+		"assets/wasm_exec.12345678.js.gz":   "js gzip",
+		"assets/wasm_exec.12345678.js.br":   "js br",
+		"assets/styles.12345678.css.gz":     "css gzip",
+		"assets/styles.12345678.css.br":     "css br",
+		"assets/bundle.12345678.wasm.zstd":  "zstd",
+		"assets/wasm_exec.12345678.js.zstd": "js zstd",
+		"assets/styles.12345678.css.zstd":   "css zstd",
+	} {
+		if err := os.WriteFile(filepath.Join(directory, filepath.FromSlash(path)), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func writeValidAssetManifest(t *testing.T, directory string) {
 	t.Helper()
 	content := `{
@@ -59,13 +89,22 @@ func writeValidAssetManifest(t *testing.T, directory string) {
 
 func writeLegacyPackageSignature(t *testing.T, directory string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(directory, legacyPackageManifest), []byte(`{"goframe":true}`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(directory, legacyPackageManifest), []byte(`{
+  "name": "demo",
+  "compiler": "tinygo",
+  "wasm": "main.wasm",
+  "assets": ["index.html"],
+  "toolchainVersion": "v0.0.0-test"
+}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(directory, "main.wasm"), []byte("wasm"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(directory, runtimeAssetName), []byte("js"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "index.html"), []byte("<html></html>"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -193,6 +232,106 @@ func TestExternalWorkspaceOverlapRejected(t *testing.T) {
 	}
 }
 
+func TestPhysicalPathRelationDetectsSymlinkAliasOverlap(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "app-alias")
+	if err := os.Symlink(appDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	overlap, err := physicalPathsOverlap(appDir, filepath.Join(alias, "out"))
+	if err != nil {
+		t.Fatalf("physicalPathsOverlap() error: %v", err)
+	}
+	if !overlap {
+		t.Fatal("physicalPathsOverlap() missed symlink alias overlap")
+	}
+}
+
+func TestExternalWorkspacePhysicalAliasOverlapRejected(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "app-alias")
+	if err := os.Symlink(appDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := newBuildLayout(layoutOptions{appDir: appDir, workspace: filepath.Join(alias, "workspace")}); err == nil {
+		t.Fatal("newBuildLayout() accepted external workspace alias into app tree")
+	}
+}
+
+func TestBuildRejectsOutputAliasIntoAppSource(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, appDir, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeTestFile(t, appDir, "goframe.json", `{"name":"demo","entry":"."}`)
+	writeTestFile(t, appDir, "main.go", "package main\nfunc main() {}\n")
+	alias := filepath.Join(root, "app-alias")
+	if err := os.Symlink(appDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buildApp(buildOptions{appDir: appDir, compiler: "go", outDir: filepath.Join(alias, "out")}); err == nil {
+		t.Fatal("buildApp() accepted output alias into app source")
+	}
+	assertFileContent(t, filepath.Join(appDir, "main.go"), "package main\nfunc main() {}\n")
+	assertFileContent(t, filepath.Join(appDir, "go.mod"), "module example.com/app\n\ngo 1.22\n")
+	assertFileContent(t, filepath.Join(appDir, "goframe.json"), `{"name":"demo","entry":"."}`)
+}
+
+func TestGenerateRejectsOutputAliasIntoAppSource(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalGOXApp(t, appDir)
+	alias := filepath.Join(root, "app-alias")
+	if err := os.Symlink(appDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := generatePath(generateOptions{path: appDir, outDir: filepath.Join(alias, "gen")}, true); err == nil {
+		t.Fatal("generatePath() accepted output alias into app source")
+	}
+	if _, err := os.Stat(filepath.Join(appDir, "gen", "app.gox.go")); !os.IsNotExist(err) {
+		t.Fatalf("generated file appeared through alias: %v", err)
+	}
+}
+
+func TestPackageRejectsOutputAliasIntoAppSource(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.Mkdir(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeMinimalGOXApp(t, appDir)
+	alias := filepath.Join(root, "app-alias")
+	if err := os.Symlink(appDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := packageApp(packageOptions{appDir: appDir, compiler: "go", outDir: filepath.Join(alias, "package"), compress: map[string]bool{}}); err == nil {
+		t.Fatal("packageApp() accepted output alias into app source")
+	}
+	if _, err := os.Stat(filepath.Join(appDir, "package")); !os.IsNotExist(err) {
+		t.Fatalf("package output appeared through alias: %v", err)
+	}
+}
+
 func TestCopyAuthoredGoFilesAllowsDefaultHiddenWorkspaceOnly(t *testing.T) {
 	appDir := t.TempDir()
 	writeTestFile(t, appDir, "main.go", "package main\n")
@@ -312,8 +451,8 @@ func TestOwnershipMarkersAreStructured(t *testing.T) {
 				t.Fatal(err)
 			}
 		}},
-		{name: "valid current marker", write: writeValidPackageMetadata, owned: true},
-		{name: "valid asset manifest", write: writeValidAssetManifest, owned: true},
+		{name: "valid current package", write: writeCompleteCurrentPackage, owned: true},
+		{name: "valid asset manifest without completion marker", write: writeValidAssetManifest, owned: false},
 		{name: "valid legacy signature", write: writeLegacyPackageSignature, owned: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -321,6 +460,140 @@ func TestOwnershipMarkersAreStructured(t *testing.T) {
 			test.write(t, dir)
 			if got := isGoframeOwnedExport(dir); got != test.owned {
 				t.Fatalf("isGoframeOwnedExport() = %v, want %v", got, test.owned)
+			}
+		})
+	}
+}
+
+func TestCurrentPackageOwnershipRequiresCompanionMetadataAndArtifacts(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(t *testing.T, dir string)
+	}{
+		{name: "metadata without asset manifest", write: writeValidPackageMetadata},
+		{name: "metadata with mismatched asset manifest", write: func(t *testing.T, dir string) {
+			writeValidPackageMetadata(t, dir)
+			writeValidAssetManifest(t, dir)
+			content, err := os.ReadFile(filepath.Join(dir, assetManifestName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			content = []byte(strings.Replace(string(content), "assets/bundle.12345678.wasm", "assets/other.wasm", 1))
+			if err := os.WriteFile(filepath.Join(dir, assetManifestName), content, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "missing referenced files", write: func(t *testing.T, dir string) {
+			writeValidPackageMetadata(t, dir)
+			writeValidAssetManifest(t, dir)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.write(t, dir)
+			ownership := inspectPackageOwnership(dir)
+			if ownership.State != packageIncompleteOrInvalid {
+				t.Fatalf("ownership state = %v (%s), want incomplete/invalid", ownership.State, ownership.Reason)
+			}
+			if isGoframeOwnedExport(dir) {
+				t.Fatal("incomplete package was treated as owned")
+			}
+		})
+	}
+}
+
+func TestAssetManifestAloneDoesNotGrantOwnership(t *testing.T) {
+	dir := t.TempDir()
+	writeValidAssetManifest(t, dir)
+	ownership := inspectPackageOwnership(dir)
+	if ownership.State != packageUnowned {
+		t.Fatalf("ownership state = %v (%s), want unowned", ownership.State, ownership.Reason)
+	}
+	if isGoframeOwnedExport(dir) {
+		t.Fatal("asset manifest alone granted ownership")
+	}
+}
+
+func TestLegacyOwnershipIsFailClosedForGenericGoWASM(t *testing.T) {
+	dir := t.TempDir()
+	for path, content := range map[string]string{
+		legacyPackageManifest: `{"name":"generic wasm app"}`,
+		"main.wasm":           "wasm",
+		runtimeAssetName:      "js",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if isGoframeOwnedExport(dir) {
+		t.Fatal("generic Go/WASM dist was treated as GoFrame-owned legacy package")
+	}
+}
+
+func TestLegacyOwnershipRejectsMalformedOrSymlinkedSignature(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	for _, test := range []struct {
+		name  string
+		write func(t *testing.T, dir string)
+	}{
+		{name: "empty manifest", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, legacyPackageManifest), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "main.wasm"), []byte("wasm"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, runtimeAssetName), []byte("js"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "malformed manifest", write: func(t *testing.T, dir string) {
+			if err := os.WriteFile(filepath.Join(dir, legacyPackageManifest), []byte("{"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "main.wasm"), []byte("wasm"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, runtimeAssetName), []byte("js"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "manifest symlink", write: func(t *testing.T, dir string) {
+			target := filepath.Join(t.TempDir(), "manifest.json")
+			if err := os.WriteFile(target, []byte(`{"name":"demo","compiler":"tinygo","wasm":"main.wasm","toolchainVersion":"test"}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, filepath.Join(dir, legacyPackageManifest)); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "main.wasm"), []byte("wasm"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, runtimeAssetName), []byte("js"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "runtime symlink", write: func(t *testing.T, dir string) {
+			writeLegacyPackageSignature(t, dir)
+			target := filepath.Join(t.TempDir(), "wasm_exec.js")
+			if err := os.WriteFile(target, []byte("js"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(filepath.Join(dir, runtimeAssetName)); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, filepath.Join(dir, runtimeAssetName)); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			test.write(t, dir)
+			if isGoframeOwnedExport(dir) {
+				t.Fatal("invalid legacy signature was treated as owned")
 			}
 		})
 	}
@@ -350,7 +623,7 @@ func TestExportRejectsOverlappingDestination(t *testing.T) {
 	if err := os.MkdirAll(layout.PackageDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeValidPackageMetadata(t, layout.PackageDir)
+	writeCompleteCurrentPackage(t, layout.PackageDir)
 	for _, outDir := range []string{
 		layout.PackageDir,
 		filepath.Join(layout.PackageDir, "nested"),
@@ -361,6 +634,31 @@ func TestExportRejectsOverlappingDestination(t *testing.T) {
 				t.Fatalf("exportApp() accepted overlapping outDir %s", outDir)
 			}
 		})
+	}
+}
+
+func TestExportRejectsPhysicalAliasOverlap(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(layout.PackageDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeCompleteCurrentPackage(t, layout.PackageDir)
+	alias := filepath.Join(root, "package-alias")
+	if err := os.Symlink(layout.PackageDir, alias); err != nil {
+		t.Fatal(err)
+	}
+	if err := exportApp(exportOptions{appDir: appDir, outDir: filepath.Join(alias, "nested")}); err == nil {
+		t.Fatal("exportApp() accepted output alias into package source")
+	}
+	if _, err := os.Stat(filepath.Join(layout.PackageDir, "nested")); !os.IsNotExist(err) {
+		t.Fatalf("export output appeared through alias: %v", err)
 	}
 }
 
@@ -438,7 +736,7 @@ func TestPublishWritesMetadataLastOnFailure(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(source, "assets", "bundle.wasm"), []byte("wasm"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	writeValidPackageMetadata(t, source)
+	writeCompleteCurrentPackage(t, source)
 	if err := os.WriteFile(filepath.Join(destination, "assets"), []byte("not-a-directory"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -447,6 +745,62 @@ func TestPublishWritesMetadataLastOnFailure(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(destination, packageMetadataName)); !os.IsNotExist(err) {
 		t.Fatalf("metadata published after failure: %v", err)
+	}
+}
+
+func TestPartialPublicationDoesNotGrantOwnership(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	source := t.TempDir()
+	destination := t.TempDir()
+	writeCompleteCurrentPackage(t, source)
+	if err := os.MkdirAll(filepath.Join(destination, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(t.TempDir(), "external.wasm")
+	if err := os.WriteFile(external, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(destination, "assets", "bundle.12345678.wasm")); err != nil {
+		t.Fatal(err)
+	}
+	if err := publishPackageArtifacts(source, destination); err == nil {
+		t.Fatal("publishPackageArtifacts() unexpectedly succeeded")
+	}
+	if _, err := os.Stat(filepath.Join(destination, assetManifestName)); err != nil {
+		t.Fatalf("asset manifest was not copied before injected failure: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, packageMetadataName)); !os.IsNotExist(err) {
+		t.Fatalf("completion metadata exists after partial publish: %v", err)
+	}
+	ownership := inspectPackageOwnership(destination)
+	if ownership.IsOwned() {
+		t.Fatalf("partial package considered owned: %v %s", ownership.State, ownership.Reason)
+	}
+	if err := validatePackageDestination(destination); err == nil {
+		t.Fatal("validatePackageDestination() accepted partial package as reusable output")
+	}
+	assertFileContent(t, external, "keep")
+}
+
+func TestCleanPackageArtifactsRemovesCompletionMarkerFirst(t *testing.T) {
+	destination := t.TempDir()
+	writeCompleteCurrentPackage(t, destination)
+	stale := filepath.Join(destination, "bundle.wasm")
+	if err := os.Mkdir(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "child"), []byte("block remove"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanPackageArtifacts(destination, "bundle.wasm"); err == nil {
+		t.Fatal("cleanPackageArtifacts() unexpectedly succeeded")
+	}
+	if _, err := os.Stat(filepath.Join(destination, packageMetadataName)); !os.IsNotExist(err) {
+		t.Fatalf("completion marker still exists after failed cleanup: %v", err)
+	}
+	if ownership := inspectPackageOwnership(destination); ownership.IsOwned() {
+		t.Fatalf("failed cleanup left directory owned: %v %s", ownership.State, ownership.Reason)
 	}
 }
 

--- a/cmd/goxc/generate.go
+++ b/cmd/goxc/generate.go
@@ -85,11 +85,14 @@ func generatePath(options generateOptions, requireFiles bool) error {
 		}
 		fmt.Fprintln(os.Stderr, "warning: --in-place writes generated compiler output into the source tree; use only for debugging or legacy workflows")
 		for _, file := range files {
-			output, err := gox.GenerateFileToWithOptions(file, file+".go", gox.GenerateOptions{
+			output := file + ".go"
+			if err := validatePathBelowRoot(appDir, output, "in-place generated file", true); err != nil {
+				return err
+			}
+			if err := generateFileSafely(file, output, gox.GenerateOptions{
 				Filename:        file,
 				PackageIdentity: packageIdentityForFile(appDir, file),
-			})
-			if err != nil {
+			}); err != nil {
 				return fmt.Errorf("generate failed for %s: %w", file, err)
 			}
 			fmt.Printf("generated %s -> %s\n", file, output)
@@ -107,7 +110,17 @@ func generatePath(options generateOptions, requireFiles bool) error {
 		if err != nil {
 			return err
 		}
+		if err := validateWorkspaceRoot(layout); err != nil {
+			return err
+		}
 		outputRoot = layout.GenDir
+		if err := validatePathBelowRoot(layout.WorkspaceRoot, outputRoot, "generated output directory", true); err != nil {
+			return err
+		}
+	} else {
+		if err := validateExplicitPathRoot(outputRoot, "generated output directory", true); err != nil {
+			return err
+		}
 	}
 
 	for _, file := range files {
@@ -116,11 +129,13 @@ func generatePath(options generateOptions, requireFiles bool) error {
 			return fmt.Errorf("resolve GOX source %s: %w", file, err)
 		}
 		output := filepath.Join(outputRoot, relative+".go")
-		output, err = gox.GenerateFileToWithOptions(file, output, gox.GenerateOptions{
+		if err := validatePathBelowRoot(outputRoot, output, "generated file", true); err != nil {
+			return err
+		}
+		if err := generateFileSafely(file, output, gox.GenerateOptions{
 			Filename:        file,
 			PackageIdentity: packageIdentityForFile(appDir, file),
-		})
-		if err != nil {
+		}); err != nil {
 			return fmt.Errorf("generate failed for %s: %w", file, err)
 		}
 		fmt.Printf("generated %s -> %s\n", file, output)
@@ -129,9 +144,12 @@ func generatePath(options generateOptions, requireFiles bool) error {
 }
 
 func generationAppDir(path string) (string, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("%s is a symlink; symlink paths are not supported", path)
 	}
 	if info.IsDir() {
 		return path, nil

--- a/cmd/goxc/generate.go
+++ b/cmd/goxc/generate.go
@@ -118,6 +118,9 @@ func generatePath(options generateOptions, requireFiles bool) error {
 			return err
 		}
 	} else {
+		if err := ensureNoPhysicalOverlap(outputRoot, appDir, "generated output directory", "application directory"); err != nil {
+			return err
+		}
 		if err := validateExplicitPathRoot(outputRoot, "generated output directory", true); err != nil {
 			return err
 		}

--- a/cmd/goxc/helpers.go
+++ b/cmd/goxc/helpers.go
@@ -77,3 +77,17 @@ func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
 }
+
+func rejectSymlinkPath(path string, description string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect %s %s: %w", description, path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s %s is a symlink; symlink paths are not supported", description, path)
+	}
+	return nil
+}

--- a/cmd/goxc/helpers.go
+++ b/cmd/goxc/helpers.go
@@ -102,8 +102,13 @@ func writeStreamAtomic(destinationPath string, source io.Reader, mode os.FileMod
 }
 
 func samePath(first, second string) bool {
-	firstPath, firstErr := filepath.Abs(first)
-	secondPath, secondErr := filepath.Abs(second)
+	if firstInfo, firstErr := os.Stat(first); firstErr == nil {
+		if secondInfo, secondErr := os.Stat(second); secondErr == nil && os.SameFile(firstInfo, secondInfo) {
+			return true
+		}
+	}
+	firstPath, firstErr := canonicalPathForComparison(first)
+	secondPath, secondErr := canonicalPathForComparison(second)
 	return firstErr == nil && secondErr == nil && firstPath == secondPath
 }
 
@@ -269,6 +274,88 @@ func pathContains(root, child string) bool {
 }
 
 func pathsOverlap(first, second string) bool {
-	relation, err := pathRelation(first, second)
+	relation, err := physicalPathRelation(first, second)
+	if err != nil {
+		return true
+	}
 	return err == nil && relation != "separate"
+}
+
+func ensureNoPhysicalOverlap(first, second, firstDescription, secondDescription string) error {
+	overlap, err := physicalPathsOverlap(first, second)
+	if err != nil {
+		return fmt.Errorf("compare %s %s with %s %s: %w", firstDescription, first, secondDescription, second, err)
+	}
+	if overlap {
+		return fmt.Errorf("%s %s must not overlap %s %s", firstDescription, first, secondDescription, second)
+	}
+	return nil
+}
+
+func physicalPathsOverlap(first, second string) (bool, error) {
+	relation, err := physicalPathRelation(first, second)
+	if err != nil {
+		return false, err
+	}
+	return relation != "separate", nil
+}
+
+func physicalPathRelation(first, second string) (string, error) {
+	firstPath, err := canonicalPathForComparison(first)
+	if err != nil {
+		return "", err
+	}
+	secondPath, err := canonicalPathForComparison(second)
+	if err != nil {
+		return "", err
+	}
+	return pathRelation(firstPath, secondPath)
+}
+
+func canonicalPathForComparison(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return filepath.Clean(resolved), nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("resolve symlinks in %s: %w", absolute, err)
+	}
+
+	ancestor, err := nearestExistingAncestor(absolute)
+	if err != nil {
+		return "", err
+	}
+	resolvedAncestor, err := filepath.EvalSymlinks(ancestor)
+	if err != nil {
+		return "", fmt.Errorf("resolve symlinks in %s: %w", ancestor, err)
+	}
+	relative, err := filepath.Rel(ancestor, absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolve missing path tail for %s: %w", absolute, err)
+	}
+	if relative == "." {
+		return filepath.Clean(resolvedAncestor), nil
+	}
+	return filepath.Clean(filepath.Join(resolvedAncestor, relative)), nil
+}
+
+func nearestExistingAncestor(path string) (string, error) {
+	current := filepath.Clean(path)
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			return current, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("inspect %s: %w", current, err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("no existing ancestor found for %s", path)
+		}
+		current = parent
+	}
 }

--- a/cmd/goxc/helpers.go
+++ b/cmd/goxc/helpers.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -39,30 +41,62 @@ func copyFile(sourcePath, destinationPath string) error {
 	if samePath(sourcePath, destinationPath) {
 		return nil
 	}
+	info, err := regularFileNoFollow(sourcePath, "source file")
+	if err != nil {
+		return err
+	}
 	source, err := os.Open(sourcePath)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", sourcePath, err)
 	}
 	defer source.Close()
 
-	info, err := source.Stat()
-	if err != nil {
-		return fmt.Errorf("inspect %s: %w", sourcePath, err)
-	}
 	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
 		return fmt.Errorf("create directory for %s: %w", destinationPath, err)
 	}
-	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
-	if err != nil {
-		return fmt.Errorf("create %s: %w", destinationPath, err)
+	return writeStreamAtomic(destinationPath, source, info.Mode().Perm())
+}
+
+func writeFileAtomic(path string, content []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", path, err)
 	}
-	_, copyErr := io.Copy(destination, source)
-	closeErr := destination.Close()
+	return writeStreamAtomic(path, bytes.NewReader(content), mode)
+}
+
+func writeStreamAtomic(destinationPath string, source io.Reader, mode os.FileMode) error {
+	directory := filepath.Dir(destinationPath)
+	if info, err := os.Lstat(destinationPath); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("destination %s is a symlink; symlink paths are not supported", destinationPath)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("destination %s is a directory", destinationPath)
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect destination %s: %w", destinationPath, err)
+	}
+	temp, err := os.CreateTemp(directory, ".goframe-write-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file for %s: %w", destinationPath, err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+
+	_, copyErr := io.Copy(temp, source)
+	chmodErr := temp.Chmod(mode)
+	closeErr := temp.Close()
 	if copyErr != nil {
-		return fmt.Errorf("copy %s: %w", sourcePath, copyErr)
+		return fmt.Errorf("write %s: %w", destinationPath, copyErr)
+	}
+	if chmodErr != nil {
+		return fmt.Errorf("chmod %s: %w", tempPath, chmodErr)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("close %s: %w", destinationPath, closeErr)
+		return fmt.Errorf("close %s: %w", tempPath, closeErr)
+	}
+	if err := os.Rename(tempPath, destinationPath); err != nil {
+		return fmt.Errorf("replace %s: %w", destinationPath, err)
 	}
 	return nil
 }
@@ -90,4 +124,151 @@ func rejectSymlinkPath(path string, description string) error {
 		return fmt.Errorf("%s %s is a symlink; symlink paths are not supported", description, path)
 	}
 	return nil
+}
+
+func regularFileNoFollow(path string, description string) (os.FileInfo, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s %s: %w", description, path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("%s %s is a symlink; symlink paths are not supported", description, path)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s %s is not a regular file", description, path)
+	}
+	return info, nil
+}
+
+func directoryNoFollow(path string, description string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect %s %s: %w", description, path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s %s is a symlink; symlink paths are not supported", description, path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s %s is not a directory", description, path)
+	}
+	return nil
+}
+
+func validatePathBelowRoot(root, target, description string, allowMissingTail bool) error {
+	root, target, err := cleanRootAndTarget(root, target)
+	if err != nil {
+		return err
+	}
+	if err := rejectSymlinkPath(root, description+" root"); err != nil {
+		return err
+	}
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("resolve %s %s below %s: %w", description, target, root, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("%s %s must stay inside %s", description, target, root)
+	}
+	if relative == "." {
+		return rejectSymlinkPath(root, description)
+	}
+	return rejectSymlinkComponents(root, target, description, allowMissingTail)
+}
+
+func cleanRootAndTarget(root, target string) (string, string, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve root %s: %w", root, err)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve path %s: %w", target, err)
+	}
+	return filepath.Clean(root), filepath.Clean(target), nil
+}
+
+func rejectSymlinkComponents(root, target, description string, allowMissingTail bool) error {
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("resolve %s %s below %s: %w", description, target, root, err)
+	}
+	if relative == "." {
+		return rejectSymlinkPath(root, description)
+	}
+	current := root
+	for _, part := range strings.Split(relative, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if errors.Is(err, os.ErrNotExist) {
+			if allowMissingTail {
+				return nil
+			}
+			return fmt.Errorf("inspect %s %s: %w", description, current, err)
+		}
+		if err != nil {
+			return fmt.Errorf("inspect %s %s: %w", description, current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%s %s is a symlink; symlink paths are not supported", description, current)
+		}
+	}
+	return nil
+}
+
+func mkdirAllBelowRoot(root, directory, description string) error {
+	if err := validatePathBelowRoot(root, directory, description, true); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("create %s %s: %w", description, directory, err)
+	}
+	return validatePathBelowRoot(root, directory, description, false)
+}
+
+func validateExplicitPathRoot(path string, description string, allowMissing bool) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve %s %s: %w", description, path, err)
+	}
+	parent := filepath.Dir(path)
+	return validatePathBelowRoot(parent, path, description, allowMissing)
+}
+
+func pathRelation(first, second string) (string, error) {
+	first, err := filepath.Abs(first)
+	if err != nil {
+		return "", err
+	}
+	second, err = filepath.Abs(second)
+	if err != nil {
+		return "", err
+	}
+	first = filepath.Clean(first)
+	second = filepath.Clean(second)
+	if first == second {
+		return "same", nil
+	}
+	if pathContains(first, second) {
+		return "contains", nil
+	}
+	if pathContains(second, first) {
+		return "inside", nil
+	}
+	return "separate", nil
+}
+
+func pathContains(root, child string) bool {
+	relative, err := filepath.Rel(root, child)
+	if err != nil {
+		return false
+	}
+	return relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func pathsOverlap(first, second string) bool {
+	relation, err := pathRelation(first, second)
+	return err == nil && relation != "separate"
 }

--- a/cmd/goxc/layout.go
+++ b/cmd/goxc/layout.go
@@ -71,12 +71,12 @@ func newBuildLayout(options layoutOptions) (BuildLayout, error) {
 		if err != nil {
 			return BuildLayout{}, fmt.Errorf("resolve workspace directory: %w", err)
 		}
-		if pathsOverlap(appDir, workspaceRoot) {
-			return BuildLayout{}, fmt.Errorf("workspace directory %s must not overlap application directory %s", workspaceRoot, appDir)
+		if err := ensureNoPhysicalOverlap(workspaceRoot, appDir, "workspace directory", "application directory"); err != nil {
+			return BuildLayout{}, err
 		}
 		workspaceRoot = filepath.Join(workspaceRoot, appWorkspaceSlug(appDir))
-		if pathsOverlap(appDir, workspaceRoot) {
-			return BuildLayout{}, fmt.Errorf("workspace root %s must not overlap application directory %s", workspaceRoot, appDir)
+		if err := ensureNoPhysicalOverlap(workspaceRoot, appDir, "workspace root", "application directory"); err != nil {
+			return BuildLayout{}, err
 		}
 	}
 

--- a/cmd/goxc/layout.go
+++ b/cmd/goxc/layout.go
@@ -22,7 +22,9 @@ const (
 type BuildLayout struct {
 	AppDir string
 
-	WorkspaceRoot string
+	WorkspaceRoot     string
+	WorkspaceBase     string
+	ExternalWorkspace bool
 
 	GenDir     string
 	WorkDir    string
@@ -57,30 +59,40 @@ func newBuildLayout(options layoutOptions) (BuildLayout, error) {
 	}
 
 	workspaceRoot := options.workspace
+	externalWorkspace := false
 	if workspaceRoot == "" {
 		workspaceRoot = os.Getenv("GOFRAME_WORKSPACE")
 	}
 	if workspaceRoot == "" {
 		workspaceRoot = filepath.Join(appDir, defaultWorkspaceName)
 	} else {
+		externalWorkspace = true
 		workspaceRoot, err = filepath.Abs(workspaceRoot)
 		if err != nil {
 			return BuildLayout{}, fmt.Errorf("resolve workspace directory: %w", err)
 		}
+		if pathsOverlap(appDir, workspaceRoot) {
+			return BuildLayout{}, fmt.Errorf("workspace directory %s must not overlap application directory %s", workspaceRoot, appDir)
+		}
 		workspaceRoot = filepath.Join(workspaceRoot, appWorkspaceSlug(appDir))
+		if pathsOverlap(appDir, workspaceRoot) {
+			return BuildLayout{}, fmt.Errorf("workspace root %s must not overlap application directory %s", workspaceRoot, appDir)
+		}
 	}
 
 	return BuildLayout{
-		AppDir:        appDir,
-		WorkspaceRoot: workspaceRoot,
-		GenDir:        filepath.Join(workspaceRoot, "gen"),
-		WorkDir:       filepath.Join(workspaceRoot, "work", profile),
-		BuildDir:      filepath.Join(workspaceRoot, "build", compiler, profile),
-		PackageDir:    filepath.Join(workspaceRoot, "package", standalonePackage),
-		CacheDir:      filepath.Join(workspaceRoot, "cache"),
-		LogsDir:       filepath.Join(workspaceRoot, "logs"),
-		Compiler:      compiler,
-		Profile:       profile,
+		AppDir:            appDir,
+		WorkspaceRoot:     workspaceRoot,
+		WorkspaceBase:     filepath.Dir(workspaceRoot),
+		ExternalWorkspace: externalWorkspace,
+		GenDir:            filepath.Join(workspaceRoot, "gen"),
+		WorkDir:           filepath.Join(workspaceRoot, "work", profile),
+		BuildDir:          filepath.Join(workspaceRoot, "build", compiler, profile),
+		PackageDir:        filepath.Join(workspaceRoot, "package", standalonePackage),
+		CacheDir:          filepath.Join(workspaceRoot, "cache"),
+		LogsDir:           filepath.Join(workspaceRoot, "logs"),
+		Compiler:          compiler,
+		Profile:           profile,
 	}, nil
 }
 

--- a/cmd/goxc/main.go
+++ b/cmd/goxc/main.go
@@ -19,22 +19,58 @@ func main() {
 	case "help", "--help", "-h":
 		usage(os.Stdout)
 	case "version":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "version")
+			return
+		}
 		err = versionCommand(os.Args[2:])
 	case "doctor":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "doctor")
+			return
+		}
 		err = doctorCommand(os.Args[2:])
 	case "generate":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "generate")
+			return
+		}
 		err = generateCommand(os.Args[2:])
 	case "build":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "build")
+			return
+		}
 		err = buildCommand(os.Args[2:])
 	case "package":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "package")
+			return
+		}
 		err = packageCommand(os.Args[2:])
 	case "export":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "export")
+			return
+		}
 		err = exportCommand(os.Args[2:])
 	case "size":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "size")
+			return
+		}
 		err = sizeCommand(os.Args[2:])
 	case "serve":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "serve")
+			return
+		}
 		err = serveCommand(os.Args[2:])
 	case "clean":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "clean")
+			return
+		}
 		err = cleanCommand(os.Args[2:])
 	default:
 		fmt.Fprintf(os.Stderr, "goxc: unknown command %q\n\n", os.Args[1])
@@ -64,4 +100,51 @@ func usage(output io.Writer) {
 	fmt.Fprintln(output, "  doctor                inspect the local toolchain")
 	fmt.Fprintln(output, "  version               print goxc and compiler versions")
 	fmt.Fprintln(output, "  help                  print this help")
+}
+
+func commandHelpRequested(args []string) bool {
+	if len(args) != 1 {
+		return false
+	}
+	switch args[0] {
+	case "help", "--help", "-h":
+		return true
+	default:
+		return false
+	}
+}
+
+func commandUsage(output io.Writer, command string) {
+	switch command {
+	case "generate":
+		fmt.Fprintln(output, "usage: goxc generate <file-or-directory> [--out=directory] [--workspace=directory] [--in-place]")
+		fmt.Fprintln(output, "generate .go compiler output from .gox files; default output is .goframe/gen/")
+	case "build":
+		fmt.Fprintln(output, "usage: goxc build <app-directory> [--compiler=go|tinygo] [--out=directory] [--workspace=directory]")
+		fmt.Fprintln(output, "compile raw WASM into .goframe/build/<compiler>/dev/")
+	case "package":
+		fmt.Fprintln(output, "usage: goxc package <app-directory> [--compiler=go|tinygo] [--out=directory] [--workspace=directory] [--asset-hash] [--preload] [--compress=gzip,br]")
+		fmt.Fprintln(output, "create a runnable standalone bundle in .goframe/package/standalone/")
+	case "export":
+		fmt.Fprintln(output, "usage: goxc export <app-directory> --out=directory [--workspace=directory] [--force]")
+		fmt.Fprintln(output, "copy the latest standalone package to an explicit deploy directory")
+	case "serve":
+		fmt.Fprintln(output, "usage: goxc serve <app-directory> [--port=8080] [--workspace=directory]")
+		fmt.Fprintln(output, "       goxc serve --dir=directory [--port=8080]")
+		fmt.Fprintln(output, "serve a packaged application locally on 127.0.0.1")
+	case "size":
+		fmt.Fprintln(output, "usage: goxc size <app-directory-or-package-directory> [--workspace=directory]")
+		fmt.Fprintln(output, "report raw and compressed package artifact sizes")
+	case "doctor":
+		fmt.Fprintln(output, "usage: goxc doctor")
+		fmt.Fprintln(output, "inspect Go, TinyGo, compression tools, runtime shims, and local directories")
+	case "clean":
+		fmt.Fprintln(output, "usage: goxc clean <app-directory> [--generated] [--legacy] [--workspace=directory]")
+		fmt.Fprintln(output, "remove tool-owned build/package workspace artifacts")
+	case "version":
+		fmt.Fprintln(output, "usage: goxc version")
+		fmt.Fprintln(output, "print goxc, Go, and TinyGo versions")
+	default:
+		usage(output)
+	}
 }

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -83,6 +83,9 @@ func loadManifest(appDir string) (projectManifest, error) {
 			return projectManifest{}, fmt.Errorf("%s %q in %s must be a child path inside the application", name, value, manifestName)
 		}
 	}
+	if strings.ToLower(filepath.Ext(manifest.WASM)) != ".wasm" {
+		return projectManifest{}, fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
+	}
 	if manifest.Compiler != "go" && manifest.Compiler != "tinygo" {
 		return projectManifest{}, fmt.Errorf("compiler %q in %s must be go or tinygo", manifest.Compiler, manifestName)
 	}

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -162,6 +162,11 @@ func safeRelativePath(path string) bool {
 	if path == "" || filepath.IsAbs(path) {
 		return false
 	}
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return false
+		}
+	}
 	clean := filepath.Clean(path)
 	return clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator))
 }

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -182,15 +182,23 @@ func packageApp(options packageOptions) error {
 	if err != nil {
 		return err
 	}
-	explicitOutDir := options.outDir != ""
-	options.outDir = packageOutputDirectory(options, layout)
-	if err := rejectSymlinkPath(options.outDir, "package output directory"); err != nil {
+	if err := validateWorkspaceRoot(layout); err != nil {
 		return err
 	}
+	explicitOutDir := options.outDir != ""
+	options.outDir = packageOutputDirectory(options, layout)
 	if explicitOutDir {
+		if pathsOverlap(options.appDir, options.outDir) {
+			return fmt.Errorf("package output directory %s must not overlap application directory %s", options.outDir, options.appDir)
+		}
+		if err := validateExplicitPathRoot(options.outDir, "package output directory", true); err != nil {
+			return err
+		}
 		if err := validatePackageDestination(options.outDir); err != nil {
 			return err
 		}
+	} else if err := validatePathBelowRoot(layout.WorkspaceRoot, options.outDir, "package output directory", true); err != nil {
+		return err
 	}
 	entryPath, err := prepareBuildWorkspace(layout, manifest)
 	if err != nil {
@@ -204,6 +212,16 @@ func packageApp(options packageOptions) error {
 	defer os.RemoveAll(tempDir)
 
 	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
+	if strings.ToLower(path.Ext(wasmLogicalName)) != ".wasm" {
+		return fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
+	}
+	if wasmLogicalName == runtimeAssetName {
+		return fmt.Errorf("wasm %q in %s collides with runtime asset %s", manifest.WASM, manifestName, runtimeAssetName)
+	}
+	plannedAssets, err := validatePackageAssetPlan(manifest, wasmLogicalName, options)
+	if err != nil {
+		return err
+	}
 	tempWASM := filepath.Join(tempDir, wasmLogicalName)
 	fmt.Printf("packaging %s with %s compiler\n", options.appDir, options.compiler)
 	if err := compileWASM(options.compiler, entryPath, tempWASM); err != nil {
@@ -241,7 +259,7 @@ func packageApp(options packageOptions) error {
 
 	copiedAssets := make([]string, 0, len(manifest.Assets))
 	styleRewrites := map[string]string{}
-	for _, asset := range manifest.Assets {
+	for _, asset := range plannedAssets {
 		asset, source, exists, err := resolvePackageAssetSource(options.appDir, asset)
 		if err != nil {
 			return err
@@ -304,8 +322,15 @@ func packageApp(options packageOptions) error {
 		return err
 	}
 
-	if err := os.MkdirAll(options.outDir, 0o755); err != nil {
-		return fmt.Errorf("create package directory: %w", err)
+	if explicitOutDir {
+		if err := validateExplicitPathRoot(options.outDir, "package output directory", true); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(options.outDir, 0o755); err != nil {
+			return fmt.Errorf("create package directory: %w", err)
+		}
+	} else if err := mkdirAllBelowRoot(layout.WorkspaceRoot, options.outDir, "package output directory"); err != nil {
+		return err
 	}
 	if err := cleanPackageArtifacts(options.outDir, manifest.WASM); err != nil {
 		return err
@@ -321,15 +346,75 @@ func packageApp(options packageOptions) error {
 func resolvePackageAssetSource(appDir, asset string) (string, string, bool, error) {
 	asset = path.Clean(filepath.ToSlash(asset))
 	source := filepath.Join(appDir, asset)
-	if err := rejectSymlinkPath(source, "asset path"); err != nil {
+	if err := validatePathBelowRoot(appDir, source, "asset path", true); err != nil {
 		return "", "", false, err
 	}
-	if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+	info, err := os.Lstat(source)
+	if errors.Is(err, os.ErrNotExist) {
 		return asset, source, false, nil
 	} else if err != nil {
 		return "", "", false, fmt.Errorf("inspect asset %s: %w", source, err)
 	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", "", false, fmt.Errorf("asset path %s is a symlink; symlink paths are not supported", source)
+	}
+	if !info.Mode().IsRegular() {
+		return "", "", false, fmt.Errorf("asset path %s is not a regular file", source)
+	}
 	return asset, source, true, nil
+}
+
+func validatePackageAssetPlan(manifest projectManifest, wasmLogicalName string, options packageOptions) ([]string, error) {
+	occupied := map[string]string{}
+	reserve := func(name, owner string) error {
+		name = path.Clean(filepath.ToSlash(name))
+		if previous, ok := occupied[name]; ok {
+			return fmt.Errorf("package asset %q collides with %s", name, previous)
+		}
+		occupied[name] = owner
+		return nil
+	}
+	for _, name := range []string{wasmLogicalName, runtimeAssetName} {
+		if err := reserve(name, "generated asset"); err != nil {
+			return nil, err
+		}
+		if isCompressiblePackageAsset(name) {
+			if options.compress["gzip"] {
+				if err := reserve(name+".gz", "generated compressed sidecar"); err != nil {
+					return nil, err
+				}
+			}
+			if options.compress["br"] {
+				if err := reserve(name+".br", "generated compressed sidecar"); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	cleaned := make([]string, 0, len(manifest.Assets))
+	for _, raw := range manifest.Assets {
+		asset, err := cleanPackageAssetName(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := reserve(asset, "manifest asset"); err != nil {
+			return nil, err
+		}
+		if isCompressiblePackageAsset(asset) {
+			if options.compress["gzip"] {
+				if err := reserve(asset+".gz", "manifest compressed sidecar"); err != nil {
+					return nil, err
+				}
+			}
+			if options.compress["br"] {
+				if err := reserve(asset+".br", "manifest compressed sidecar"); err != nil {
+					return nil, err
+				}
+			}
+		}
+		cleaned = append(cleaned, asset)
+	}
+	return cleaned, nil
 }
 
 func packageOutputDirectory(options packageOptions, layout BuildLayout) string {
@@ -383,7 +468,7 @@ func writeJSONFile(path string, value any, description string) error {
 		return fmt.Errorf("encode %s: %w", description, err)
 	}
 	content = append(content, '\n')
-	if err := os.WriteFile(path, content, 0o644); err != nil {
+	if err := writeFileAtomic(path, content, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
 	return nil
@@ -398,12 +483,15 @@ type htmlRewriteOptions struct {
 }
 
 func writeRewrittenIndex(sourcePath, destinationPath string, options htmlRewriteOptions) error {
+	if _, err := regularFileNoFollow(sourcePath, "index asset"); err != nil {
+		return err
+	}
 	content, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", sourcePath, err)
 	}
 	rewritten := rewriteIndexHTML(string(content), options)
-	if err := os.WriteFile(destinationPath, []byte(rewritten), 0o644); err != nil {
+	if err := writeFileAtomic(destinationPath, []byte(rewritten), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", destinationPath, err)
 	}
 	return nil
@@ -472,6 +560,9 @@ func writePackageAsset(sourcePath, assetsDir, logicalName string, options packag
 	if err != nil {
 		return packageAsset{}, err
 	}
+	if _, err := regularFileNoFollow(sourcePath, "package asset"); err != nil {
+		return packageAsset{}, err
+	}
 	content, err := os.ReadFile(sourcePath)
 	if err != nil {
 		return packageAsset{}, fmt.Errorf("read %s: %w", sourcePath, err)
@@ -485,7 +576,7 @@ func writePackageAsset(sourcePath, assetsDir, logicalName string, options packag
 	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
 		return packageAsset{}, fmt.Errorf("create package asset directory for %s: %w", outputName, err)
 	}
-	if err := os.WriteFile(destinationPath, content, 0o644); err != nil {
+	if err := writeFileAtomic(destinationPath, content, 0o644); err != nil {
 		return packageAsset{}, fmt.Errorf("write package asset %s: %w", outputName, err)
 	}
 
@@ -580,29 +671,61 @@ func containsString(values []string, target string) bool {
 }
 
 func publishPackageArtifacts(sourceDir, destinationDir string) error {
-	return filepath.WalkDir(sourceDir, func(sourcePath string, entry os.DirEntry, err error) error {
+	var directories []string
+	var files []string
+	err := filepath.WalkDir(sourceDir, func(sourcePath string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("inspect package artifact %s: %w", sourcePath, err)
 		}
 		if sourcePath == sourceDir {
 			return nil
 		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("package artifact %s is a symlink; symlink paths are not supported", sourcePath)
+		}
 		relative, err := filepath.Rel(sourceDir, sourcePath)
 		if err != nil {
 			return fmt.Errorf("resolve package artifact %s: %w", sourcePath, err)
 		}
-		destinationPath := filepath.Join(destinationDir, relative)
 		if entry.IsDir() {
-			if err := os.MkdirAll(destinationPath, 0o755); err != nil {
-				return fmt.Errorf("create package artifact directory %s: %w", destinationPath, err)
-			}
+			directories = append(directories, relative)
 			return nil
+		}
+		if _, err := regularFileNoFollow(sourcePath, "package artifact"); err != nil {
+			return err
+		}
+		files = append(files, relative)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(files, func(first, second int) bool {
+		if files[first] == packageMetadataName {
+			return false
+		}
+		if files[second] == packageMetadataName {
+			return true
+		}
+		return files[first] < files[second]
+	})
+	for _, relative := range directories {
+		destinationPath := filepath.Join(destinationDir, relative)
+		if err := mkdirAllBelowRoot(destinationDir, destinationPath, "package artifact directory"); err != nil {
+			return err
+		}
+	}
+	for _, relative := range files {
+		sourcePath := filepath.Join(sourceDir, relative)
+		destinationPath := filepath.Join(destinationDir, relative)
+		if err := validatePathBelowRoot(destinationDir, destinationPath, "package artifact", true); err != nil {
+			return err
 		}
 		if err := copyFile(sourcePath, destinationPath); err != nil {
 			return err
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 func gzipFile(sourcePath, destinationPath string) error {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -184,6 +184,9 @@ func packageApp(options packageOptions) error {
 	}
 	explicitOutDir := options.outDir != ""
 	options.outDir = packageOutputDirectory(options, layout)
+	if err := rejectSymlinkPath(options.outDir, "package output directory"); err != nil {
+		return err
+	}
 	if explicitOutDir {
 		if err := validatePackageDestination(options.outDir); err != nil {
 			return err
@@ -239,13 +242,13 @@ func packageApp(options packageOptions) error {
 	copiedAssets := make([]string, 0, len(manifest.Assets))
 	styleRewrites := map[string]string{}
 	for _, asset := range manifest.Assets {
-		asset = path.Clean(filepath.ToSlash(asset))
-		source := filepath.Join(options.appDir, asset)
-		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+		asset, source, exists, err := resolvePackageAssetSource(options.appDir, asset)
+		if err != nil {
+			return err
+		}
+		if !exists {
 			fmt.Printf("asset %s not found; skipping\n", source)
 			continue
-		} else if err != nil {
-			return fmt.Errorf("inspect asset %s: %w", source, err)
 		}
 		if asset == indexHTMLAssetName {
 			copiedAssets = append(copiedAssets, asset)
@@ -313,6 +316,20 @@ func packageApp(options packageOptions) error {
 
 	fmt.Printf("packaged %s\n", options.outDir)
 	return nil
+}
+
+func resolvePackageAssetSource(appDir, asset string) (string, string, bool, error) {
+	asset = path.Clean(filepath.ToSlash(asset))
+	source := filepath.Join(appDir, asset)
+	if err := rejectSymlinkPath(source, "asset path"); err != nil {
+		return "", "", false, err
+	}
+	if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+		return asset, source, false, nil
+	} else if err != nil {
+		return "", "", false, fmt.Errorf("inspect asset %s: %w", source, err)
+	}
+	return asset, source, true, nil
 }
 
 func packageOutputDirectory(options packageOptions, layout BuildLayout) string {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -173,6 +173,20 @@ func packageApp(options packageOptions) error {
 	if err := ensureAppDirectory(options.appDir); err != nil {
 		return err
 	}
+	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
+	if strings.ToLower(path.Ext(filepath.ToSlash(manifest.WASM))) != ".wasm" || strings.ToLower(path.Ext(wasmLogicalName)) != ".wasm" {
+		return fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
+	}
+	if wasmLogicalName == runtimeAssetName {
+		return fmt.Errorf("wasm %q in %s collides with runtime asset %s", manifest.WASM, manifestName, runtimeAssetName)
+	}
+	plannedAssets, err := validatePackageAssetPlan(manifest, wasmLogicalName, options)
+	if err != nil {
+		return err
+	}
+	if err := validateRequiredPackageEntrypoints(options.appDir, plannedAssets); err != nil {
+		return err
+	}
 	layout, err := newBuildLayout(layoutOptions{
 		appDir:    options.appDir,
 		compiler:  options.compiler,
@@ -211,17 +225,6 @@ func packageApp(options packageOptions) error {
 	}
 	defer os.RemoveAll(tempDir)
 
-	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
-	if strings.ToLower(path.Ext(filepath.ToSlash(manifest.WASM))) != ".wasm" || strings.ToLower(path.Ext(wasmLogicalName)) != ".wasm" {
-		return fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
-	}
-	if wasmLogicalName == runtimeAssetName {
-		return fmt.Errorf("wasm %q in %s collides with runtime asset %s", manifest.WASM, manifestName, runtimeAssetName)
-	}
-	plannedAssets, err := validatePackageAssetPlan(manifest, wasmLogicalName, options)
-	if err != nil {
-		return err
-	}
 	tempWASM := filepath.Join(tempDir, wasmLogicalName)
 	fmt.Printf("packaging %s with %s compiler\n", options.appDir, options.compiler)
 	if err := compileWASM(options.compiler, entryPath, tempWASM); err != nil {
@@ -338,6 +341,9 @@ func packageApp(options packageOptions) error {
 	if err := publishPackageArtifacts(stageDir, options.outDir); err != nil {
 		return err
 	}
+	if err := verifyPublishedPackage(options.outDir); err != nil {
+		return err
+	}
 
 	fmt.Printf("packaged %s\n", options.outDir)
 	return nil
@@ -417,6 +423,37 @@ func validatePackageAssetPlan(manifest projectManifest, wasmLogicalName string, 
 	return cleaned, nil
 }
 
+func validateRequiredPackageEntrypoints(appDir string, plannedAssets []string) error {
+	indexCount := 0
+	for _, asset := range plannedAssets {
+		if asset == indexHTMLAssetName {
+			indexCount++
+		}
+	}
+	if indexCount != 1 {
+		return fmt.Errorf("standalone package assets must include %s exactly once", indexHTMLAssetName)
+	}
+
+	source := filepath.Join(appDir, indexHTMLAssetName)
+	if err := validatePathBelowRoot(appDir, source, "required standalone entrypoint index.html", true); err != nil {
+		return err
+	}
+	info, err := os.Lstat(source)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("required standalone entrypoint %s was not found", indexHTMLAssetName)
+	}
+	if err != nil {
+		return fmt.Errorf("inspect required standalone entrypoint %s: %w", source, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("required standalone entrypoint %s is a symlink", indexHTMLAssetName)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("required standalone entrypoint %s is not a regular file", indexHTMLAssetName)
+	}
+	return nil
+}
+
 func packageOutputDirectory(options packageOptions, layout BuildLayout) string {
 	if options.outDir != "" {
 		return options.outDir
@@ -446,6 +483,7 @@ func cleanPackageArtifacts(directory, wasmName string) error {
 		"wasm_exec.js",
 		"wasm_exec.tiny.js",
 		"service-worker.js",
+		indexHTMLAssetName,
 		"styles.css",
 		legacyPackageManifest,
 		assetManifestName,
@@ -462,6 +500,17 @@ func cleanPackageArtifacts(directory, wasmName string) error {
 		return fmt.Errorf("remove stale package assets directory: %w", err)
 	}
 	return nil
+}
+
+func verifyPublishedPackage(directory string) error {
+	ownership := inspectPackageOwnership(directory)
+	if ownership.State == packageOwnedCurrent {
+		return nil
+	}
+	if err := os.Remove(filepath.Join(directory, packageMetadataName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("published package failed integrity verification: %s; remove completion marker: %w", ownership.Reason, err)
+	}
+	return fmt.Errorf("published package failed integrity verification: %s", ownership.Reason)
 }
 
 func writeJSONFile(path string, value any, description string) error {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -188,8 +188,8 @@ func packageApp(options packageOptions) error {
 	explicitOutDir := options.outDir != ""
 	options.outDir = packageOutputDirectory(options, layout)
 	if explicitOutDir {
-		if pathsOverlap(options.appDir, options.outDir) {
-			return fmt.Errorf("package output directory %s must not overlap application directory %s", options.outDir, options.appDir)
+		if err := ensureNoPhysicalOverlap(options.outDir, layout.AppDir, "package output directory", "application directory"); err != nil {
+			return err
 		}
 		if err := validateExplicitPathRoot(options.outDir, "package output directory", true); err != nil {
 			return err
@@ -212,7 +212,7 @@ func packageApp(options packageOptions) error {
 	defer os.RemoveAll(tempDir)
 
 	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
-	if strings.ToLower(path.Ext(wasmLogicalName)) != ".wasm" {
+	if strings.ToLower(path.Ext(filepath.ToSlash(manifest.WASM))) != ".wasm" || strings.ToLower(path.Ext(wasmLogicalName)) != ".wasm" {
 		return fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
 	}
 	if wasmLogicalName == runtimeAssetName {
@@ -425,6 +425,9 @@ func packageOutputDirectory(options packageOptions, layout BuildLayout) string {
 }
 
 func cleanPackageArtifacts(directory, wasmName string) error {
+	if err := os.Remove(filepath.Join(directory, packageMetadataName)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale package artifact %s: %w", packageMetadataName, err)
+	}
 	names := []string{
 		wasmName,
 		wasmName + ".gz",
@@ -446,7 +449,6 @@ func cleanPackageArtifacts(directory, wasmName string) error {
 		"styles.css",
 		legacyPackageManifest,
 		assetManifestName,
-		packageMetadataName,
 	}
 	for _, name := range names {
 		if err := os.Remove(filepath.Join(directory, name)); errors.Is(err, os.ErrNotExist) {
@@ -615,6 +617,11 @@ func writePackageAsset(sourcePath, assetsDir, logicalName string, options packag
 }
 
 func cleanPackageAssetName(name string) (string, error) {
+	for _, part := range strings.Split(filepath.ToSlash(name), "/") {
+		if part == ".." {
+			return "", fmt.Errorf("package asset logical name %q must not contain .. components", name)
+		}
+	}
 	clean := path.Clean(filepath.ToSlash(name))
 	if clean == "." || clean == ".." || strings.HasPrefix(clean, "../") || path.IsAbs(clean) {
 		return "", fmt.Errorf("package asset logical name %q must be a relative child path", name)

--- a/cmd/goxc/serve.go
+++ b/cmd/goxc/serve.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	pathpkg "path"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -86,6 +88,12 @@ func parseServeOptions(args []string) (serveOptions, error) {
 }
 
 func serve(options serveOptions) error {
+	if err := directoryNoFollow(options.dir, "serve directory"); err != nil {
+		if options.appDir != "" && errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("no standalone package found; run `goxc package %s` first", options.appDir)
+		}
+		return err
+	}
 	info, err := os.Stat(options.dir)
 	if err != nil {
 		if options.appDir != "" {
@@ -105,6 +113,15 @@ func serve(options serveOptions) error {
 func staticHandler(directory string) http.Handler {
 	files := http.FileServer(http.Dir(directory))
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		localPath := filepath.Join(directory, filepath.FromSlash(strings.TrimPrefix(pathpkg.Clean("/"+request.URL.Path), "/")))
+		if err := validatePathBelowRoot(directory, localPath, "serve path", false); err != nil {
+			http.NotFound(response, request)
+			return
+		}
+		if info, err := os.Lstat(localPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			http.NotFound(response, request)
+			return
+		}
 		path := request.URL.Path
 		if strings.HasSuffix(path, ".br") {
 			response.Header().Set("Content-Encoding", "br")

--- a/cmd/goxc/symlink_test.go
+++ b/cmd/goxc/symlink_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func requireSymlinkSupport(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	link := filepath.Join(root, "link")
+	if err := os.WriteFile(target, []byte("target"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+}
+
+func TestResolveEntryPackageDirRejectsSymlinkedEntry(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalEntry := filepath.Join(root, "external-entry")
+	if err := os.MkdirAll(externalEntry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalEntry, filepath.Join(appDir, "cmd")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := resolveEntryPackageDir(appDir, "cmd"); err == nil {
+		t.Fatal("resolveEntryPackageDir() accepted a symlinked entry")
+	}
+}
+
+func TestFindGOXFilesRejectsSymlinkedGOXSource(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalSource := filepath.Join(root, "external.gox")
+	if err := os.WriteFile(externalSource, []byte("package main\nfunc App() any { return <div></div> }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalSource, filepath.Join(appDir, "app.gox")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := findGOXFiles(appDir); err == nil {
+		t.Fatal("findGOXFiles() accepted a symlinked GOX source")
+	}
+}
+
+func TestCopyAuthoredGoFilesRejectsSymlinkedGoSource(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalSource := filepath.Join(root, "external.go")
+	if err := os.WriteFile(externalSource, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalSource, filepath.Join(appDir, "main.go")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyAuthoredGoFiles(appDir, filepath.Join(t.TempDir(), "work")); err == nil {
+		t.Fatal("copyAuthoredGoFiles() accepted a symlinked Go source")
+	}
+}
+
+func TestResolvePackageAssetSourceRejectsSymlinkedAsset(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalAsset := filepath.Join(root, "secret.css")
+	if err := os.WriteFile(externalAsset, []byte("body{color:red}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalAsset, filepath.Join(appDir, "styles.css")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := resolvePackageAssetSource(appDir, "styles.css"); err == nil {
+		t.Fatal("resolvePackageAssetSource() accepted a symlinked asset")
+	}
+}
+
+func TestResolvePackageAssetSourceRejectsBrokenSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	appDir := t.TempDir()
+	if err := os.Symlink(filepath.Join(appDir, "missing.css"), filepath.Join(appDir, "styles.css")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := resolvePackageAssetSource(appDir, "styles.css"); err == nil {
+		t.Fatal("resolvePackageAssetSource() accepted a broken symlink")
+	}
+}
+
+func TestValidatePackageDestinationRejectsSymlinkDirectory(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, packageMetadataName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "package-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validatePackageDestination(link); err == nil {
+		t.Fatal("validatePackageDestination() accepted a symlinked output directory")
+	}
+}
+
+func TestValidateExportDestinationRejectsSymlinkDirectory(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, packageMetadataName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "export-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateExportDestination(link, true); err == nil {
+		t.Fatal("validateExportDestination() accepted a symlinked output directory")
+	}
+}
+
+func TestCleanDoesNotTraverseWorkspaceSymlinkTarget(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	if err := os.MkdirAll(filepath.Join(appDir, defaultWorkspaceName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external-package")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(external, "keep.txt")
+	if err := os.WriteFile(keep, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, defaultWorkspaceName, "package")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cleanApp(cleanOptions{appDir: appDir}); err != nil {
+		t.Fatalf("cleanApp() error: %v", err)
+	}
+	if content, err := os.ReadFile(keep); err != nil || string(content) != "keep" {
+		t.Fatalf("clean traversed symlink target: content=%q err=%v", content, err)
+	}
+	if _, err := os.Lstat(filepath.Join(appDir, defaultWorkspaceName, "package")); !os.IsNotExist(err) {
+		t.Fatalf("workspace package symlink still exists: %v", err)
+	}
+}
+
+func TestExternalWorkspaceStillWorks(t *testing.T) {
+	appDir := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalWorkspace := filepath.Join(t.TempDir(), "workspace")
+
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir, workspace: externalWorkspace})
+	if err != nil {
+		t.Fatalf("newBuildLayout(external workspace) error: %v", err)
+	}
+	if got := filepath.Dir(layout.WorkspaceRoot); got != externalWorkspace {
+		t.Fatalf("workspace root = %q, want child of %q", layout.WorkspaceRoot, externalWorkspace)
+	}
+}

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -99,8 +99,8 @@ func refreshDirectory(directory string) error {
 
 func validateWorkspaceRoot(layout BuildLayout) error {
 	if layout.ExternalWorkspace {
-		if pathsOverlap(layout.AppDir, layout.WorkspaceRoot) {
-			return fmt.Errorf("workspace root %s must not overlap application directory %s", layout.WorkspaceRoot, layout.AppDir)
+		if err := ensureNoPhysicalOverlap(layout.WorkspaceRoot, layout.AppDir, "workspace root", "application directory"); err != nil {
+			return err
 		}
 		return validatePathBelowRoot(layout.WorkspaceBase, layout.WorkspaceRoot, "workspace root", true)
 	}

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -16,8 +16,14 @@ var (
 )
 
 func prepareBuildWorkspace(layout BuildLayout, manifest projectManifest) (string, error) {
+	if err := validateWorkspaceRoot(layout); err != nil {
+		return "", err
+	}
 	entry, err := resolveEntryPackageDir(layout.AppDir, manifest.Entry)
 	if err != nil {
+		return "", err
+	}
+	if err := validatePathBelowRoot(layout.WorkspaceRoot, layout.WorkDir, "workspace work directory", true); err != nil {
 		return "", err
 	}
 	if err := refreshDirectory(layout.WorkDir); err != nil {
@@ -60,7 +66,7 @@ func resolveEntryPackageDir(appDir, entry string) (string, error) {
 	if entry != "." {
 		entryDir = filepath.Join(appDir, filepath.FromSlash(entry))
 	}
-	if err := rejectSymlinkPath(entryDir, "entry directory"); err != nil {
+	if err := validatePathBelowRoot(appDir, entryDir, "entry directory", false); err != nil {
 		return "", err
 	}
 	relative, err := filepath.Rel(appDir, entryDir)
@@ -91,7 +97,20 @@ func refreshDirectory(directory string) error {
 	return nil
 }
 
+func validateWorkspaceRoot(layout BuildLayout) error {
+	if layout.ExternalWorkspace {
+		if pathsOverlap(layout.AppDir, layout.WorkspaceRoot) {
+			return fmt.Errorf("workspace root %s must not overlap application directory %s", layout.WorkspaceRoot, layout.AppDir)
+		}
+		return validatePathBelowRoot(layout.WorkspaceBase, layout.WorkspaceRoot, "workspace root", true)
+	}
+	return validatePathBelowRoot(layout.AppDir, layout.WorkspaceRoot, "workspace root", true)
+}
+
 func copyAuthoredGoFiles(sourceRoot, destinationRoot string) error {
+	if pathsOverlap(sourceRoot, destinationRoot) && !isToolOwnedDestinationBelowSource(sourceRoot, destinationRoot) {
+		return fmt.Errorf("copy destination %s must not overlap source root %s", destinationRoot, sourceRoot)
+	}
 	return filepath.WalkDir(sourceRoot, func(sourcePath string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return fmt.Errorf("inspect source file %s: %w", sourcePath, err)
@@ -118,8 +137,31 @@ func copyAuthoredGoFiles(sourceRoot, destinationRoot string) error {
 		if filepath.Ext(sourcePath) != ".go" || strings.HasSuffix(sourcePath, ".gox.go") {
 			return nil
 		}
+		if _, err := regularFileNoFollow(sourcePath, "source file"); err != nil {
+			return err
+		}
+		if err := validatePathBelowRoot(destinationRoot, filepath.Join(destinationRoot, relative), "workspace authored file", true); err != nil {
+			return err
+		}
 		return copyFile(sourcePath, filepath.Join(destinationRoot, relative))
 	})
+}
+
+func isToolOwnedDestinationBelowSource(sourceRoot, destinationRoot string) bool {
+	sourceRoot, err := filepath.Abs(sourceRoot)
+	if err != nil {
+		return false
+	}
+	destinationRoot, err = filepath.Abs(destinationRoot)
+	if err != nil {
+		return false
+	}
+	relative, err := filepath.Rel(sourceRoot, destinationRoot)
+	if err != nil || relative == "." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || relative == ".." {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(relative), "/")
+	return len(parts) > 0 && parts[0] == defaultWorkspaceName
 }
 
 func generateIntoDirectory(sourceRoot, destinationRoot string, requireFiles bool) error {
@@ -139,12 +181,37 @@ func generateIntoDirectory(sourceRoot, destinationRoot string, requireFiles bool
 			return fmt.Errorf("resolve GOX source %s: %w", file, err)
 		}
 		output := filepath.Join(destinationRoot, relative+".go")
-		if _, err := gox.GenerateFileToWithOptions(file, output, gox.GenerateOptions{
+		if err := generateFileSafely(file, output, gox.GenerateOptions{
 			Filename:        file,
 			PackageIdentity: packageIdentityForFile(sourceRoot, file),
 		}); err != nil {
 			return fmt.Errorf("generate failed for %s: %w", file, err)
 		}
+	}
+	return nil
+}
+
+func generateFileSafely(file, output string, options gox.GenerateOptions) error {
+	source, err := regularFileNoFollow(file, "GOX source file")
+	if err != nil {
+		return err
+	}
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", file, err)
+	}
+	if source.Size() < 0 {
+		return fmt.Errorf("inspect %s: invalid source size", file)
+	}
+	generated, err := gox.GenerateWithOptions(content, options)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(output), 0o755); err != nil {
+		return fmt.Errorf("create generated directory for %s: %w", output, err)
+	}
+	if err := writeFileAtomic(output, generated, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", output, err)
 	}
 	return nil
 }
@@ -207,13 +274,19 @@ func shouldSkipWorkspaceSource(relative string, entry os.DirEntry) bool {
 }
 
 func findGOXFiles(path string) ([]string, error) {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("GOX source path %s is a symlink; symlinked source files are not supported", path)
 	}
 	if !info.IsDir() {
 		if filepath.Ext(path) != ".gox" {
 			return nil, fmt.Errorf("%s is not a .gox file", path)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("%s is not a regular .gox file", path)
 		}
 		return []string{path}, nil
 	}

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -60,6 +60,9 @@ func resolveEntryPackageDir(appDir, entry string) (string, error) {
 	if entry != "." {
 		entryDir = filepath.Join(appDir, filepath.FromSlash(entry))
 	}
+	if err := rejectSymlinkPath(entryDir, "entry directory"); err != nil {
+		return "", err
+	}
 	relative, err := filepath.Rel(appDir, entryDir)
 	if err != nil {
 		return "", fmt.Errorf("resolve entry %q: %w", entry, err)
@@ -105,6 +108,9 @@ func copyAuthoredGoFiles(sourceRoot, destinationRoot string) error {
 				return filepath.SkipDir
 			}
 			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("source path %s is a symlink; symlinked source files are not supported", sourcePath)
 		}
 		if entry.IsDir() {
 			return nil
@@ -229,6 +235,9 @@ func findGOXFiles(path string) ([]string, error) {
 				return filepath.SkipDir
 			}
 			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("GOX source path %s is a symlink; symlinked source files are not supported", current)
 		}
 		if !entry.IsDir() && filepath.Ext(current) == ".gox" {
 			files = append(files, current)

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -298,23 +298,28 @@ func Layout() gf.Node {
 }
 `)
 
-	layout := BuildLayout{
-		AppDir:  appDir,
-		WorkDir: filepath.Join(t.TempDir(), "work"),
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(t.TempDir(), "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 	entryDir, err := prepareBuildWorkspace(layout, projectManifest{Entry: "cmd/app"})
 	if err != nil {
 		t.Fatalf("prepareBuildWorkspace(child entry) error: %v", err)
 	}
-	wantEntry := filepath.Join(layout.WorkDir, "apps", "demo", "cmd", "app")
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
+	wantEntry := filepath.Join(appWorkDir, "cmd", "app")
 	if entryDir != wantEntry {
 		t.Fatalf("entry dir = %q, want %q", entryDir, wantEntry)
 	}
 	for _, path := range []string{
-		"apps/demo/cmd/app/app.gox.go",
-		"apps/demo/internal/ui/layout.gox.go",
+		"cmd/app/app.gox.go",
+		"internal/ui/layout.gox.go",
 	} {
-		if _, err := os.Stat(filepath.Join(layout.WorkDir, path)); err != nil {
+		if _, err := os.Stat(filepath.Join(appWorkDir, path)); err != nil {
 			t.Fatalf("workspace generated file %s missing: %v", path, err)
 		}
 	}
@@ -342,19 +347,24 @@ func Button() gf.Node {
 }
 `)
 
-	layout := BuildLayout{
-		AppDir:  appDir,
-		WorkDir: filepath.Join(t.TempDir(), "work"),
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(t.TempDir(), "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 	entryDir, err := prepareBuildWorkspace(layout, projectManifest{Entry: "./src/app"})
 	if err != nil {
 		t.Fatalf("prepareBuildWorkspace(src entry) error: %v", err)
 	}
-	wantEntry := filepath.Join(layout.WorkDir, "apps", "demo", "src", "app")
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
+	wantEntry := filepath.Join(appWorkDir, "src", "app")
 	if entryDir != wantEntry {
 		t.Fatalf("entry dir = %q, want %q", entryDir, wantEntry)
 	}
-	if _, err := os.Stat(filepath.Join(layout.WorkDir, "apps/demo/src/components/button.gox.go")); err != nil {
+	if _, err := os.Stat(filepath.Join(appWorkDir, "src/components/button.gox.go")); err != nil {
 		t.Fatalf("workspace did not generate non-entry package GOX file: %v", err)
 	}
 }

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -44,17 +44,11 @@ After public preview, this policy should be revisited and tightened.
 
 ## Current API Classification
 
-### Public-Candidate
+### User-Facing Public-Candidate
 
 Runtime:
 
 - `gf.Node`
-- `gf.El`
-- `gf.Text`
-- `gf.Fragment`
-- `gf.Child`
-- `gf.Key`
-- `gf.Props`
 - `gf.Component`
 - `gf.C`
 - `gf.NewComponentType`
@@ -64,11 +58,13 @@ Runtime:
 - `gf.UseEffect`
 - `gf.UseUnmount`
 - `gf.Deps`
+- `gf.Once`
 - `gf.EveryRender`
 - `gf.CreateContext`
 - `gf.ProvideContext`
 - `gf.UseContext`
 - `gf.UseContextSelector`
+- props-level `MemoEqual` convention
 - `gf.VirtualList`
 - `gf.VirtualTable`
 - `gf.RoutePath`
@@ -81,6 +77,13 @@ Runtime:
 - `gf.QueryValues`
 - `gf.ParseQuery`
 - `gf.WithQuery`
+- `gf.ResourceStatus`
+- `gf.Resource`
+- `gf.ResourceLoader`
+- `gf.UseResource`
+- `gf.ErrorBoundary`
+- `gf.ErrorBoundaryProps`
+- `gf.ErrorBoundaryContext`
 - basic event facades such as `gf.Event`, `gf.InputEvent`, and
   `gf.ScrollEvent`
 
@@ -99,11 +102,61 @@ Tooling:
 These are public-candidate because examples and docs rely on them, but their
 exact shapes can still change before public preview.
 
-Low-level node helpers such as `gf.El`, `gf.Text`, `gf.Fragment`, `gf.Child`,
-`gf.Key`, `gf.Props`, `gf.If`, `gf.IfElse`, `gf.Map`, and `gf.MapIndexed` are
-also compiler-facing exported primitives. GOX-generated code uses them
-directly, and handwritten low-level Go can use them when needed. Most app code
-should prefer GOX markup for structure.
+### Exported Compiler-Facing / Low-Level
+
+Runtime helpers:
+
+- `gf.El`
+- `gf.Text`
+- `gf.Fragment`
+- `gf.Empty`
+- `gf.Child`
+- `gf.Key`
+- `gf.WithKey`
+- `gf.Props`
+- `gf.If`
+- `gf.IfElse`
+- `gf.Map`
+- `gf.MapIndexed`
+- `gf.ToString`
+- node structs such as `gf.VNode`, `gf.TextNode`, `gf.FragmentNode`,
+  `gf.EmptyNode`, and `gf.KeyedNode`
+
+These remain exported because GOX-generated code and handwritten low-level Go
+need them. Most application authors should prefer GOX markup for structure.
+
+Compiler package:
+
+- `gox.Generate`
+- `gox.GenerateNamed`
+- `gox.GenerateWithOptions`
+- `gox.GenerateOptions`
+- `gox.GenerateFile`
+- `gox.GenerateFileTo`
+- `gox.GenerateFileToWithOptions`
+- `gox.FindFiles`
+- `gox.Codegen`
+- `gox.ParseElement`
+- `gox.Diagnostic`
+- `gox.DiagnosticError`
+
+These are exported for the toolchain and tests. `Generate`, `GenerateNamed`,
+`GenerateWithOptions`, diagnostics, and file generation are tooling contracts.
+The AST, lexer, and parser structs are exported today but should be treated as
+compiler-facing and experimental rather than stable user APIs.
+
+Tooling contracts:
+
+- `goframe.json` user-authored manifest input;
+- `asset-manifest.json` generated package metadata;
+- `goframe-package.json` generated package metadata and ownership marker;
+- `GOFRAME_WORKSPACE` / `--workspace` external workspace override;
+- default hidden `.goframe` workspace behavior.
+
+VS Code extension:
+
+- syntax highlighting, snippets, and command wrappers over `goxc` are
+  experimental tooling contracts, not language-server stability promises.
 
 ### Experimental
 
@@ -118,10 +171,9 @@ should prefer GOX markup for structure.
 - Runtime error reporting API and exact phase containment behavior:
   `gf.SetErrorHandler`, `gf.ErrorInfo`, `gf.ErrorHandler`, and
   `gf.ErrorPhase`.
-- Scoped render Error Boundary API: `gf.ErrorBoundary`,
-  `gf.ErrorBoundaryProps`, and `gf.ErrorBoundaryContext`.
-  Internal boundary phases such as protected, captured, and fallback are not
-  public API.
+- Scoped render Error Boundary reset/fallback semantics beyond the current
+  public-candidate API shape. Internal boundary phases such as protected,
+  captured, and fallback are not public API.
 - Component-scoped resource API and exact lifecycle semantics:
   `gf.ResourceStatus`, `gf.Resource`, `gf.ResourceLoader`, and
   `gf.UseResource`.
@@ -133,6 +185,7 @@ should prefer GOX markup for structure.
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands and snippets.
+- `pkg/gox` AST/lexer/parser structures.
 
 ### Internal
 
@@ -147,6 +200,10 @@ should prefer GOX markup for structure.
 - debug globals and browser probe object shapes;
 - package staging directories;
 - smoke harness implementation details.
+- generated component variable names;
+- exact generated `.goframe/gen` filenames;
+- browser debug global object shapes;
+- package/export staging temporary directories.
 
 ### Legacy / Deprecated
 
@@ -159,6 +216,24 @@ should prefer GOX markup for structure.
 - `goxc generate --in-place`: debug/legacy only. Generated `.gox.go` files
   should live under `.goframe/gen` or an explicit output directory.
 - `UseMount`: deprecated alias for once-after-mount effect behavior.
+- `NoDeps`: deprecated alias for `Once`.
+- `AlwaysDeps`: deprecated alias for `EveryRender`.
+- `DepsOf` and `Dep*` explicit helpers: retained for compatibility; prefer
+  `Deps`.
+- `For` and `ForIndexed`: deprecated aliases for `Map` and `MapIndexed`.
+
+## Questionable APIs And Decisions
+
+| Surface | Decision | Rationale |
+|---|---|---|
+| `Component` vs `ComponentT` | Keep both. | `Component` preserves handwritten compatibility; generated GOX uses typed identity. |
+| `El`/`Text`/`Fragment`/`Props` | Compiler-facing but available. | Needed by generated code and low-level Go; GOX remains the recommended authoring path. |
+| `UseMount`/deps aliases | Deprecated, not removed. | Existing code may use them; replacement APIs are already present. |
+| `ErrorHandler` and ErrorBoundary | Experimental/Public-Candidate split. | Useful and tested, but full route-level/error-boundary policy is not final. |
+| Resources | Experimental. | Component-scoped lifecycle is tested, but no global cache, Suspense, or route loader contract exists. |
+| Router query helpers | Public-Candidate with limitations. | Good for simple URL state; not a typed query-state manager. |
+| Virtualization | Public-Candidate fixed-height contract. | Dynamic measurement and advanced accessibility remain future work. |
+| `pkg/gox` parser/AST exports | Compiler-facing experimental. | Exported today for tooling/tests, but not a stable language-service API. |
 
 ## Deprecation Policy
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -148,8 +148,10 @@ compiler-facing and experimental rather than stable user APIs.
 Tooling contracts:
 
 - `goframe.json` user-authored manifest input;
-- `asset-manifest.json` generated package metadata;
-- `goframe-package.json` generated package metadata and ownership marker;
+- `asset-manifest.json` generated package metadata and companion entrypoint
+  manifest;
+- `goframe-package.json` generated package metadata and authoritative current
+  package completion/ownership marker;
 - `GOFRAME_WORKSPACE` / `--workspace` external workspace override;
 - default hidden `.goframe` workspace behavior.
 
@@ -211,8 +213,9 @@ VS Code extension:
   belongs to `goxc package`.
 - Explicit `"wasm": "main.wasm"` manifests: still supported, but examples and
   docs use `bundle.wasm`.
-- Legacy `manifest.json` package marker: recognized for migration, but
-  `goframe-package.json` is current.
+- Legacy `manifest.json` package marker: fail-closed migration support only
+  for the historical GoFrame package manifest shape; `goframe-package.json` is
+  current.
 - `goxc generate --in-place`: debug/legacy only. Generated `.gox.go` files
   should live under `.goframe/gen` or an explicit output directory.
 - `UseMount`: deprecated alias for once-after-mount effect behavior.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,7 +110,8 @@ hints:
 goxc package ./app --asset-hash --preload --compress=gzip,br
 ```
 
-See `docs/deployment.md` for the cache policy and manifest contract.
+See `docs/deployment.md` for cache-safe package delivery and
+`docs/manifest-compatibility.md` for manifest/package compatibility policy.
 
 Use `goxc export ./app --out ./dist` to copy the latest standalone package to a
 deployment directory. Export is intentionally explicit so normal build/package

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,9 +25,10 @@ It checks:
 - GOX golden tests, including source-oriented error diagnostics.
 
 The `cmd/goxc` test suite includes manifest/path/package/export/workspace
-regression tests, including symlink safety checks for entry directories,
-source files, manifest assets, package/export output roots, and workspace
-cleanup behavior.
+regression tests, including root-aware symlink checks for app roots, entry
+directories, source files, manifest assets, package/export roots, generated
+outputs, workspace cleanup behavior, package ownership markers, asset
+namespace collisions, source/output overlap, and dev-server symlink entries.
 
 ### WASM Size
 
@@ -136,7 +137,7 @@ Public-preview readiness spot checks:
 
 ```bash
 go test ./pkg/gox -run 'Identity|Package|Golden|ErrorGolden|Qualified'
-go test ./cmd/goxc -run 'Manifest|Package|Export|Workspace|Clean|Symlink|Path'
+go test ./cmd/goxc -run 'Symlink|Path|Workspace|Generate|Build|Package|Export|Clean|Manifest|Ownership|Collision|Publish|Serve'
 ```
 
 No separate public-preview script is required yet; the readiness checks are

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,8 +29,8 @@ regression tests, including root-aware symlink checks for app roots, entry
 directories, source files, manifest assets, package/export roots, generated
 outputs, workspace cleanup behavior, package ownership markers, asset
 namespace collisions, lexical and physical source/output overlap, partial
-publication metadata, fail-closed legacy ownership, and dev-server symlink
-entries.
+publication metadata, required standalone `index.html` integrity, fail-closed
+legacy ownership, and dev-server symlink entries.
 
 ### WASM Size
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -28,7 +28,9 @@ The `cmd/goxc` test suite includes manifest/path/package/export/workspace
 regression tests, including root-aware symlink checks for app roots, entry
 directories, source files, manifest assets, package/export roots, generated
 outputs, workspace cleanup behavior, package ownership markers, asset
-namespace collisions, source/output overlap, and dev-server symlink entries.
+namespace collisions, lexical and physical source/output overlap, partial
+publication metadata, fail-closed legacy ownership, and dev-server symlink
+entries.
 
 ### WASM Size
 
@@ -137,7 +139,7 @@ Public-preview readiness spot checks:
 
 ```bash
 go test ./pkg/gox -run 'Identity|Package|Golden|ErrorGolden|Qualified'
-go test ./cmd/goxc -run 'Symlink|Path|Workspace|Generate|Build|Package|Export|Clean|Manifest|Ownership|Collision|Publish|Serve'
+go test ./cmd/goxc -run 'Physical|Canonical|Alias|Overlap|Build|Generate|Ownership|Completion|Marker|Legacy|Partial|Publish|Cleanup|Manifest|Symlink|Path'
 ```
 
 No separate public-preview script is required yet; the readiness checks are

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -24,6 +24,11 @@ It checks:
 - `go test -tags=goframe_debug ./...`;
 - GOX golden tests, including source-oriented error diagnostics.
 
+The `cmd/goxc` test suite includes manifest/path/package/export/workspace
+regression tests, including symlink safety checks for entry directories,
+source files, manifest assets, package/export output roots, and workspace
+cleanup behavior.
+
 ### WASM Size
 
 `.github/workflows/ci-wasm-size.yml` runs on pull requests, pushes to `main`,
@@ -126,6 +131,16 @@ go vet ./...
 go test -tags=goframe_debug ./...
 go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
 ```
+
+Public-preview readiness spot checks:
+
+```bash
+go test ./pkg/gox -run 'Identity|Package|Golden|ErrorGolden|Qualified'
+go test ./cmd/goxc -run 'Manifest|Package|Export|Workspace|Clean|Symlink|Path'
+```
+
+No separate public-preview script is required yet; the readiness checks are
+small enough to stay inside the existing Go test and docs-check gates.
 
 Full local gate, including TinyGo packaging and benchmarks:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,89 @@
+# Compatibility and Deprecation Policy
+
+## Purpose
+
+GoFrame is still pre-preview. This document defines compatibility expectations
+for the first public preview preparation phase.
+
+It does not promise SemVer 1.0 stability.
+
+## Pre-Preview Rules
+
+Status: Ready with limitations.
+
+Before public preview:
+
+- breaking changes are allowed when they fix unsafe behavior, correct a wrong
+  public shape, or unblock the architecture;
+- breaking changes must be documented in `CHANGELOG.md`;
+- user-facing changes should include migration notes when user action is
+  required;
+- generated workspace internals may change without migration support;
+- security/path-safety hardening may reject previously accepted unsafe input.
+
+## Post-Preview Expectations
+
+After public preview:
+
+- Public-Candidate APIs should not break without a migration note;
+- deprecated APIs should remain for at least one planned release stage unless
+  safety requires faster removal;
+- CLI command and flag changes should include replacement commands;
+- user-authored manifest compatibility should be stricter than generated
+  metadata compatibility;
+- generated output should remain an implementation detail unless documented as
+  a tooling contract.
+
+## Deprecation Requirements
+
+A deprecation must include:
+
+- a GoDoc `Deprecated:` comment for exported Go symbols when applicable;
+- replacement guidance;
+- test coverage while the deprecated behavior remains accepted;
+- documentation in `docs/api-stability.md`;
+- a `CHANGELOG.md` note when visible to users.
+
+Current deprecated/legacy surfaces:
+
+- `gf.UseMount`: use `gf.UseEffect` with no dependency argument or `gf.Once`;
+- `gf.NoDeps`: use `gf.Once` or omit deps;
+- `gf.AlwaysDeps`: use `gf.EveryRender`;
+- `gf.DepsOf` and explicit `gf.Dep*` helpers: prefer `gf.Deps`;
+- `gf.For` and `gf.ForIndexed`: use `gf.Map` and `gf.MapIndexed`;
+- `goxc build --release`: use `goxc package`;
+- `goxc generate --in-place`: debug/legacy only;
+- explicit `wasm: "main.wasm"` manifests: use `bundle.wasm`;
+- legacy package `manifest.json` marker: current metadata is
+  `goframe-package.json`.
+
+## Migration Policy
+
+Migration notes are required when:
+
+- a Public-Candidate API changes;
+- GOX syntax changes in a way that invalidates existing source;
+- manifest input changes require user edits;
+- CLI command/flag behavior changes;
+- package output contract changes affect deployment.
+
+Migration notes should follow `docs/migrations.md`.
+
+## Exceptions
+
+The project may break compatibility without a full deprecation window for:
+
+- path traversal or symlink escape fixes;
+- destructive output behavior fixes;
+- security-sensitive package/export ownership behavior;
+- CI-only smoke harness internals;
+- generated workspace internals.
+
+## Non-Goals
+
+This document does not define:
+
+- SemVer 1.0 guarantees;
+- npm/VS Code Marketplace publishing policy;
+- production server support;
+- compatibility for private debug globals or smoke harness variables.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -82,6 +82,8 @@ The project may break compatibility without a full deprecation window for:
 - physical path overlap rejection for explicit build/generate/package/export
   outputs and external workspaces;
 - requiring manifest `wasm` values to end in `.wasm`;
+- requiring standalone package assets to declare a regular root `index.html`
+  entrypoint exactly once;
 - treating `asset-manifest.json` as companion metadata rather than standalone
   destructive ownership evidence;
 - CI-only smoke harness internals;

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -55,7 +55,8 @@ Current deprecated/legacy surfaces:
 - `goxc generate --in-place`: debug/legacy only;
 - explicit `wasm: "main.wasm"` manifests: use `bundle.wasm`;
 - legacy package `manifest.json` marker: current metadata is
-  `goframe-package.json`.
+  `goframe-package.json`; legacy ownership is fail-closed and only recognized
+  for the historical GoFrame package manifest shape.
 
 ## Migration Policy
 
@@ -78,6 +79,11 @@ The project may break compatibility without a full deprecation window for:
 - security-sensitive package/export ownership behavior;
 - manifest path canonicalization that rejects ambiguous raw `..` components;
 - package asset namespace collision rejection;
+- physical path overlap rejection for explicit build/generate/package/export
+  outputs and external workspaces;
+- requiring manifest `wasm` values to end in `.wasm`;
+- treating `asset-manifest.json` as companion metadata rather than standalone
+  destructive ownership evidence;
 - CI-only smoke harness internals;
 - generated workspace internals.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -76,6 +76,8 @@ The project may break compatibility without a full deprecation window for:
 - path traversal or symlink escape fixes;
 - destructive output behavior fixes;
 - security-sensitive package/export ownership behavior;
+- manifest path canonicalization that rejects ambiguous raw `..` components;
+- package asset namespace collision rejection;
 - CI-only smoke harness internals;
 - generated workspace internals.
 

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -41,6 +41,36 @@ Direct Go calls such as `Header(HeaderProps{...})` remain ordinary function
 calls. They do not create a component boundary, state scope, or independent
 dirty update target.
 
+## Canonical Policy For Public Preview
+
+Status: Ready with limitations.
+
+Generated and typed component identity follows this policy:
+
+- typed/generated identity is based on canonical Go import path plus component
+  symbol;
+- the import alias is a debug label and generated-code selector, not runtime
+  identity;
+- generated variable names and source filename discriminators are not runtime
+  identity;
+- identical import path plus symbol should produce identical runtime identity;
+- different import paths should produce different runtime identity even when
+  the selected symbol name is the same;
+- semantic import version suffixes such as `/v2` are part of the import path
+  and therefore part of identity;
+- module path rename or fork is an identity change and can remount state;
+- `gf.Component` legacy string identity is namespaced separately from typed
+  identity, so `gf.Component("Header", ...)` does not collide with
+  `gf.ComponentT(gf.NewComponentType("Header", "Header"), ...)`;
+- `gf.ComponentT` identity is explicit and should be preferred by generated
+  code and handwritten component adapters that need stronger identity.
+
+Evidence:
+
+- `pkg/goframe/component_identity_test.go`;
+- `pkg/gox/generate_test.go`;
+- `cmd/goxc/workspace_test.go`.
+
 Package-qualified GOX component tags create the same kind of boundary across
 packages:
 
@@ -126,6 +156,23 @@ Recommendation: keep the token path as the generated default while retaining
 `entry: "."` apps with child packages, and MVP 22 applies the same model to
 child entry packages such as `./cmd/app`. They are not a complete multi-module
 identity policy.
+
+## Multi-Module Conclusion
+
+Status: Blocker for broader package ecosystem claims.
+
+The current policy is strong enough for single-module apps, child entry
+packages, and package-qualified components inside the same Go module. It is
+not a complete reusable package ecosystem or multi-module workspace promise.
+
+Before claiming broad multi-module support, the project still needs to decide:
+
+- how generated identity behaves when multiple module roots are materialized;
+- how replace directives, forks, and local module paths should be described to
+  users;
+- whether public reusable component packages need additional documentation or
+  generated metadata;
+- how migration notes should handle module path rename/remount behavior.
 
 ## Alternative C: Function Identity
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,16 +38,17 @@ Only the export step creates `./dist`.
 
 If you intentionally pass `goxc package --out <dir>`, that directory is also
 treated as package output owned by goxc. It must be empty or already contain a
-valid GoFrame package marker; otherwise package fails before removing any
-existing `assets/` directory. Empty `{}` marker placeholders, malformed
-metadata, symlinked markers, and generic web `manifest.json` files are not
-treated as GoFrame ownership. The recommended visible deployment flow remains
-`goxc package` followed by `goxc export`.
+complete current GoFrame package marker; otherwise package fails before
+removing any existing `assets/` directory. Empty `{}` marker placeholders,
+malformed metadata, standalone `asset-manifest.json`, symlinked markers, and
+generic web `manifest.json` files are not treated as GoFrame ownership. The
+recommended visible deployment flow remains `goxc package` followed by
+`goxc export`.
 
 The export directory is tool-owned. If `--out` already exists, is non-empty,
-and does not contain `goframe-package.json`, `asset-manifest.json`, or legacy
-`manifest.json` with recognizable GoFrame package structure from a previous
-GoFrame export, `goxc export` fails before touching it:
+and does not contain complete `goframe-package.json` metadata plus matching
+regular companion files, or a recognized historical GoFrame `manifest.json`
+package signature, `goxc export` fails before touching it:
 
 ```bash
 goxc export ./examples/todo --out ./dist
@@ -157,6 +158,9 @@ CSS preload is included only when CSS assets are declared in `goframe.json`.
 
 In dev packages, hash fields are omitted.
 
+`asset-manifest.json` is companion metadata only. It is not an ownership or
+completion marker without complete `goframe-package.json` metadata.
+
 See [Manifest Compatibility](manifest-compatibility.md) for the input/generated
 metadata compatibility policy.
 
@@ -181,6 +185,12 @@ metadata compatibility policy.
   "generatedAt": "2026-06-17T00:00:00Z"
 }
 ```
+
+`goframe-package.json` is the authoritative current package completion marker.
+`goxc` publishes it last and removes it first during destructive package
+cleanup. A directory is considered a complete current GoFrame package only
+when this marker, the companion asset manifest, and the referenced
+HTML/WASM/runtime files are all regular files inside the package root.
 
 ## Clean App Workspace
 
@@ -210,7 +220,8 @@ Default command outputs:
 `GOFRAME_WORKSPACE=/work/goframe` or `--workspace /work/goframe` moves this
 workspace outside the source tree. With an external workspace, goxc creates a
 safe app-specific subdirectory to avoid collisions between apps. External
-workspaces must not overlap the app source tree.
+workspaces must not overlap the app source tree, including through symlink
+aliases.
 
 `goxc generate --in-place` is available only for debugging or legacy workflows.
 It writes adjacent `.gox.go` files and prints a warning. Normal source trees
@@ -227,8 +238,11 @@ The toolchain rejects symlinked app roots, entry directories, authored source
 files, package assets, package/export roots, and symlinked package sources at
 safety-sensitive boundaries. Cleanup removes final tool-owned symlinks as
 links and rejects intermediate workspace symlinks instead of traversing
-external targets. This is best-effort protection for static repository trees;
-hostile concurrent filesystem mutation is outside the threat model.
+external targets. Explicit build/generate/package/export output roots are
+also compared against app/package roots using physical path resolution so a
+symlink alias cannot point output back into authored source. This is
+best-effort protection for static repository trees; hostile concurrent
+filesystem mutation is outside the threat model.
 
 The materialized hidden workspace supports `"entry": "."` apps and child entry
 packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -150,6 +150,9 @@ CSS preload is included only when CSS assets are declared in `goframe.json`.
 
 In dev packages, hash fields are omitted.
 
+See [Manifest Compatibility](manifest-compatibility.md) for the input/generated
+metadata compatibility policy.
+
 ## Package Metadata
 
 `goframe-package.json` records package-level metadata:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,14 +38,16 @@ Only the export step creates `./dist`.
 
 If you intentionally pass `goxc package --out <dir>`, that directory is also
 treated as package output owned by goxc. It must be empty or already contain a
-GoFrame package marker; otherwise package fails before removing any existing
-`assets/` directory. The recommended visible deployment flow remains
+valid GoFrame package marker; otherwise package fails before removing any
+existing `assets/` directory. Empty `{}` marker placeholders, malformed
+metadata, symlinked markers, and generic web `manifest.json` files are not
+treated as GoFrame ownership. The recommended visible deployment flow remains
 `goxc package` followed by `goxc export`.
 
 The export directory is tool-owned. If `--out` already exists, is non-empty,
 and does not contain `goframe-package.json`, `asset-manifest.json`, or legacy
-`manifest.json` from a previous GoFrame export, `goxc export` fails before
-touching it:
+`manifest.json` with recognizable GoFrame package structure from a previous
+GoFrame export, `goxc export` fails before touching it:
 
 ```bash
 goxc export ./examples/todo --out ./dist
@@ -84,6 +86,11 @@ examples/todo/.goframe/package/standalone/
 
 CSS assets are emitted under `assets/` too, for example
 `assets/styles.77a1de20.css`.
+
+Before packaging, goxc builds an asset namespace plan. Manifest assets cannot
+collide with generated names such as `bundle.wasm`, `wasm_exec.js`, generated
+metadata, or `.gz`/`.br` sidecars. Duplicate assets after path normalization
+are rejected before publication.
 
 ## HTML Rewriting
 
@@ -202,7 +209,8 @@ Default command outputs:
 
 `GOFRAME_WORKSPACE=/work/goframe` or `--workspace /work/goframe` moves this
 workspace outside the source tree. With an external workspace, goxc creates a
-safe app-specific subdirectory to avoid collisions between apps.
+safe app-specific subdirectory to avoid collisions between apps. External
+workspaces must not overlap the app source tree.
 
 `goxc generate --in-place` is available only for debugging or legacy workflows.
 It writes adjacent `.gox.go` files and prints a warning. Normal source trees
@@ -214,6 +222,13 @@ and adjacent legacy `.gox.go` files. `goxc clean <app> --legacy` helps migrate
 old workspaces by removing legacy `build/` and adjacent generated `.gox.go`
 files. Legacy `dist/` is removed only if it looks like a GoFrame export; user
 directories are skipped instead of silently deleted.
+
+The toolchain rejects symlinked app roots, entry directories, authored source
+files, package assets, package/export roots, and symlinked package sources at
+safety-sensitive boundaries. Cleanup removes final tool-owned symlinks as
+links and rejects intermediate workspace symlinks instead of traversing
+external targets. This is best-effort protection for static repository trees;
+hostile concurrent filesystem mutation is outside the threat model.
 
 The materialized hidden workspace supports `"entry": "."` apps and child entry
 packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -93,6 +93,15 @@ collide with generated names such as `bundle.wasm`, `wasm_exec.js`, generated
 metadata, or `.gz`/`.br` sidecars. Duplicate assets after path normalization
 are rejected before publication.
 
+`index.html` is the required standalone package entrypoint. It must be
+declared exactly once in `goframe.json` assets after normalization and must
+exist at the app root as a regular non-symlink file. `goxc package` checks this
+before materializing the build workspace or compiling WASM, so a missing or
+invalid `index.html` does not clean or replace a previous complete package.
+Other declared assets remain optional in the current public-preview contract:
+when a non-required CSS/data/image asset is missing, packaging prints a message
+and skips it.
+
 ## HTML Rewriting
 
 Example `index.html` files use explicit package blocks:
@@ -191,6 +200,10 @@ metadata compatibility policy.
 cleanup. A directory is considered a complete current GoFrame package only
 when this marker, the companion asset manifest, and the referenced
 HTML/WASM/runtime files are all regular files inside the package root.
+Package and export commands verify this ownership state after publication and
+before printing success. If verification fails, goxc removes
+`goframe-package.json` so the directory is not marked as a completed current
+package.
 
 ## Clean App Workspace
 
@@ -243,6 +256,12 @@ also compared against app/package roots using physical path resolution so a
 symlink alias cannot point output back into authored source. This is
 best-effort protection for static repository trees; hostile concurrent
 filesystem mutation is outside the threat model.
+
+During package or export replacement, managed standalone artifacts include
+`index.html`, metadata files, generated WASM/runtime assets, compressed
+sidecars, and the `assets/` directory. Stale `index.html` from a previous
+package is removed before the new package is published, after the old
+completion marker has already been invalidated.
 
 The materialized hidden workspace supports `"entry": "."` apps and child entry
 packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when

--- a/docs/manifest-compatibility.md
+++ b/docs/manifest-compatibility.md
@@ -29,7 +29,7 @@ Supported fields:
 | `entry` | `.` | Go package entry. Supports `.` and relative child package directories such as `./cmd/app`, `cmd/app`, `./src/app`, and `app`. |
 | `output` | `dist` | Legacy/export-oriented output hint. Current package output defaults to `.goframe/package/standalone`; explicit package/export flags are preferred. |
 | `compiler` | `go` | Must be `go` or `tinygo`. CLI `--compiler` overrides it. |
-| `wasm` | `bundle.wasm` | Logical WASM filename. `main.wasm` remains accepted for legacy apps. |
+| `wasm` | `bundle.wasm` | Logical WASM filename. Must be a relative `.wasm` child path. `main.wasm` remains accepted for legacy apps. |
 | `assets` | `["index.html"]` | Static child paths copied by `goxc package`. Missing assets are skipped with a message. |
 
 Validation evidence:
@@ -48,6 +48,8 @@ Current input behavior:
 - absolute paths, raw `..` components, parent traversal, and tool-owned entry
   roots such as `.goframe`, `build`, `dist`, `node_modules`, and `.git` are
   rejected;
+- `wasm` must end in `.wasm`; names such as `main.go`, `go.mod`,
+  `bundle.wasm.gz`, and `wasm_exec.js` are rejected;
 - entry paths must point to directories, not files;
 - symlinked entry directories and symlinked assets are rejected.
 
@@ -83,10 +85,13 @@ Recommended follow-up:
 Status: Ready with limitations.
 
 `asset-manifest.json` is generated package metadata, not a user-authored input
-file. It records final asset paths and entrypoints for packaged output. It is
-also considered package ownership evidence only when it is a regular file with
-versioned, recognizable GoFrame structure; an empty or malformed file with the
-same name is not enough.
+file. It records final asset paths and entrypoints for packaged output.
+
+It is not an authoritative ownership or completion marker. A standalone
+`asset-manifest.json`, even when valid, does not let `goxc package`, `goxc
+export`, or `goxc clean --legacy` treat a directory as GoFrame-owned. Current
+ownership requires complete `goframe-package.json` metadata plus matching
+regular companion files.
 
 Current fields:
 
@@ -111,6 +116,7 @@ Compatibility policy:
 - consumers may read existing fields after public preview;
 - adding fields is backward-compatible;
 - removing or renaming fields requires migration notes;
+- the file is companion metadata, not destructive ownership evidence;
 - hidden staging paths and package internals are not stable.
 
 ## `goframe-package.json`
@@ -138,8 +144,14 @@ Current fields:
 Compatibility policy:
 
 - the ownership-marker role is part of the tooling contract;
-- ownership recognition is fail-closed: the marker must be regular, parseable,
-  versioned metadata with sane entrypoint paths;
+- current package ownership is fail-closed: the marker must be regular,
+  parseable, versioned metadata with sane entrypoint paths;
+- the companion `asset-manifest.json` must be regular, parseable, versioned,
+  and must match the WASM/runtime entrypoints in `goframe-package.json`;
+- referenced HTML, WASM, and runtime files must exist as regular files inside
+  the package root;
+- `goframe-package.json` is published last and removed first during destructive
+  package cleanup so partial packages are not marked complete;
 - adding metadata fields is backward-compatible;
 - removing the marker or changing ownership detection is breaking unless it is
   required for a safety fix;
@@ -149,11 +161,21 @@ Compatibility policy:
 
 Status: Ready with limitations.
 
-Legacy `manifest.json` is recognized only as a previous GoFrame package/export
-marker when the surrounding package has an unmistakable GoFrame legacy
-signature, such as a regular root WASM file plus a regular `wasm_exec.js`
-runtime shim. A generic web app manifest or `{}` file does not grant ownership
-and must not cause `dist/` or package output deletion.
+Repository history shows the historical GoFrame package manifest was a
+`manifest.json` containing GoFrame-specific fields:
+
+- `name`;
+- `compiler`;
+- `wasm`;
+- `assets`;
+- `toolchainVersion`.
+
+Legacy ownership is recognized only for that shape with supported compiler
+value, safe `.wasm` path, regular WASM/runtime companion files, and regular
+declared assets. A generic web manifest, empty `{}`, malformed JSON, symlinked
+manifest, or generic Go/WASM dist containing only `manifest.json`,
+`main.wasm`, and `wasm_exec.js` does not grant ownership and must not cause
+`dist/` or package output deletion.
 
 Evidence:
 

--- a/docs/manifest-compatibility.md
+++ b/docs/manifest-compatibility.md
@@ -1,0 +1,167 @@
+# Manifest Compatibility
+
+## Purpose
+
+This document records the current manifest and generated package metadata
+contracts for public-preview readiness. It separates user-authored input from
+generated metadata and hidden workspace internals.
+
+Status labels:
+
+- Ready
+- Ready with limitations
+- Needs hardening
+- Blocker
+- Deferred / non-goal
+
+## `goframe.json`
+
+Status: Ready with limitations.
+
+`goframe.json` is the user-authored application input contract. The file is
+optional; when it is absent, `goxc` uses defaults.
+
+Supported fields:
+
+| Field | Default | Contract |
+|---|---|---|
+| `name` | app directory base name | Human-readable package name. Empty means default. |
+| `entry` | `.` | Go package entry. Supports `.` and relative child package directories such as `./cmd/app`, `cmd/app`, `./src/app`, and `app`. |
+| `output` | `dist` | Legacy/export-oriented output hint. Current package output defaults to `.goframe/package/standalone`; explicit package/export flags are preferred. |
+| `compiler` | `go` | Must be `go` or `tinygo`. CLI `--compiler` overrides it. |
+| `wasm` | `bundle.wasm` | Logical WASM filename. `main.wasm` remains accepted for legacy apps. |
+| `assets` | `["index.html"]` | Static child paths copied by `goxc package`. Missing assets are skipped with a message. |
+
+Validation evidence:
+
+- `cmd/goxc/manifest.go`
+- `cmd/goxc/cli_test.go`
+- `cmd/goxc/workspace_test.go`
+- `cmd/goxc/symlink_test.go`
+
+Current input behavior:
+
+- unknown fields are rejected with `DisallowUnknownFields`;
+- malformed JSON and trailing JSON are rejected;
+- empty explicit `entry` is rejected;
+- path fields must be relative child paths;
+- absolute paths, `..`, parent traversal, and tool-owned entry roots such as
+  `.goframe`, `build`, `dist`, `node_modules`, and `.git` are rejected;
+- entry paths must point to directories, not files;
+- symlinked entry directories and symlinked assets are rejected.
+
+Compatibility policy:
+
+- adding an optional manifest field is backward-compatible only when old
+  manifests continue to load with the same behavior;
+- changing a default, changing accepted values, or making an optional field
+  required is a breaking change;
+- tightening unsafe path behavior is allowed as a security fix, even if it
+  rejects previously accepted unsafe layouts;
+- legacy `wasm: "main.wasm"` remains supported through public preview unless a
+  migration note says otherwise.
+
+## Schema Version Decision
+
+Status: Needs hardening.
+
+There is no required `version` field in `goframe.json` today. MVP 30 does not
+add one because doing so would either be optional metadata with limited value
+or a breaking input requirement.
+
+Recommended follow-up:
+
+- decide before public preview whether a future optional `version` marker is
+  useful for diagnostics;
+- do not make it mandatory without a migration note and compatibility window.
+
+## `asset-manifest.json`
+
+Status: Ready with limitations.
+
+`asset-manifest.json` is generated package metadata, not a user-authored input
+file. It records final asset paths and entrypoints for packaged output.
+
+Current fields:
+
+- `version`;
+- `assets`;
+- `assets[*].path`;
+- `assets[*].hash`;
+- `assets[*].type`;
+- `assets[*].compressed`;
+- `entrypoints.wasm`;
+- `entrypoints.runtime`;
+- `entrypoints.styles`.
+
+Evidence:
+
+- `cmd/goxc/package.go`
+- `docs/deployment.md`
+- `scripts/size-budget.sh`
+
+Compatibility policy:
+
+- consumers may read existing fields after public preview;
+- adding fields is backward-compatible;
+- removing or renaming fields requires migration notes;
+- hidden staging paths and package internals are not stable.
+
+## `goframe-package.json`
+
+Status: Ready with limitations.
+
+`goframe-package.json` is generated package metadata and an ownership marker.
+It also lets `goxc package` and `goxc export` distinguish previous GoFrame
+output from arbitrary user directories.
+
+Current fields:
+
+- `version`;
+- `name`;
+- `compiler`;
+- `toolchainVersion`;
+- `assetsDir`;
+- `hashAssets`;
+- `preload`;
+- `entrypoints.html`;
+- `entrypoints.wasm`;
+- `entrypoints.runtime`;
+- `generatedAt`.
+
+Compatibility policy:
+
+- the ownership-marker role is part of the tooling contract;
+- adding metadata fields is backward-compatible;
+- removing the marker or changing ownership detection is breaking unless it is
+  required for a safety fix;
+- exact timestamps are not stable.
+
+## Legacy Metadata
+
+Status: Ready with limitations.
+
+Legacy `manifest.json` is recognized only as a previous GoFrame package/export
+marker. It is not the current package metadata format.
+
+Evidence:
+
+- `cmd/goxc/package.go`
+- `cmd/goxc/export.go`
+- `cmd/goxc/clean_test.go`
+
+## Breaking Changes
+
+Breaking manifest/package changes require:
+
+- a `CHANGELOG.md` entry;
+- a migration note in `docs/migrations.md` when user action is needed;
+- tests for old accepted input when compatibility is retained;
+- explicit mention in release notes.
+
+## Current Limitations
+
+- No mandatory user-authored schema version yet.
+- No signed package metadata.
+- No machine-readable JSON schema file.
+- Generated workspace layout under `.goframe` remains internal.

--- a/docs/manifest-compatibility.md
+++ b/docs/manifest-compatibility.md
@@ -45,8 +45,9 @@ Current input behavior:
 - malformed JSON and trailing JSON are rejected;
 - empty explicit `entry` is rejected;
 - path fields must be relative child paths;
-- absolute paths, `..`, parent traversal, and tool-owned entry roots such as
-  `.goframe`, `build`, `dist`, `node_modules`, and `.git` are rejected;
+- absolute paths, raw `..` components, parent traversal, and tool-owned entry
+  roots such as `.goframe`, `build`, `dist`, `node_modules`, and `.git` are
+  rejected;
 - entry paths must point to directories, not files;
 - symlinked entry directories and symlinked assets are rejected.
 
@@ -58,6 +59,8 @@ Compatibility policy:
   required is a breaking change;
 - tightening unsafe path behavior is allowed as a security fix, even if it
   rejects previously accepted unsafe layouts;
+- tightening package ownership detection is allowed as a security fix, even if
+  it rejects placeholder metadata such as `{}`;
 - legacy `wasm: "main.wasm"` remains supported through public preview unless a
   migration note says otherwise.
 
@@ -80,7 +83,10 @@ Recommended follow-up:
 Status: Ready with limitations.
 
 `asset-manifest.json` is generated package metadata, not a user-authored input
-file. It records final asset paths and entrypoints for packaged output.
+file. It records final asset paths and entrypoints for packaged output. It is
+also considered package ownership evidence only when it is a regular file with
+versioned, recognizable GoFrame structure; an empty or malformed file with the
+same name is not enough.
 
 Current fields:
 
@@ -132,6 +138,8 @@ Current fields:
 Compatibility policy:
 
 - the ownership-marker role is part of the tooling contract;
+- ownership recognition is fail-closed: the marker must be regular, parseable,
+  versioned metadata with sane entrypoint paths;
 - adding metadata fields is backward-compatible;
 - removing the marker or changing ownership detection is breaking unless it is
   required for a safety fix;
@@ -142,7 +150,10 @@ Compatibility policy:
 Status: Ready with limitations.
 
 Legacy `manifest.json` is recognized only as a previous GoFrame package/export
-marker. It is not the current package metadata format.
+marker when the surrounding package has an unmistakable GoFrame legacy
+signature, such as a regular root WASM file plus a regular `wasm_exec.js`
+runtime shim. A generic web app manifest or `{}` file does not grant ownership
+and must not cause `dist/` or package output deletion.
 
 Evidence:
 

--- a/docs/manifest-compatibility.md
+++ b/docs/manifest-compatibility.md
@@ -30,7 +30,7 @@ Supported fields:
 | `output` | `dist` | Legacy/export-oriented output hint. Current package output defaults to `.goframe/package/standalone`; explicit package/export flags are preferred. |
 | `compiler` | `go` | Must be `go` or `tinygo`. CLI `--compiler` overrides it. |
 | `wasm` | `bundle.wasm` | Logical WASM filename. Must be a relative `.wasm` child path. `main.wasm` remains accepted for legacy apps. |
-| `assets` | `["index.html"]` | Static child paths copied by `goxc package`. Missing assets are skipped with a message. |
+| `assets` | `["index.html"]` | Static child paths copied by `goxc package`. Root `index.html` is the required standalone HTML entrypoint and must be declared exactly once. Missing non-required assets are skipped with a message. |
 
 Validation evidence:
 
@@ -50,6 +50,9 @@ Current input behavior:
   rejected;
 - `wasm` must end in `.wasm`; names such as `main.go`, `go.mod`,
   `bundle.wasm.gz`, and `wasm_exec.js` are rejected;
+- standalone packages require a root `index.html` asset declared exactly once;
+- the required `index.html` must exist before compilation and must be a
+  regular non-symlink file;
 - entry paths must point to directories, not files;
 - symlinked entry directories and symlinked assets are rejected.
 
@@ -152,6 +155,11 @@ Compatibility policy:
   the package root;
 - `goframe-package.json` is published last and removed first during destructive
   package cleanup so partial packages are not marked complete;
+- successful `goxc package` and `goxc export` runs verify the published
+  directory as a complete current package before printing success. If
+  verification fails, the completion marker is removed;
+- `index.html` is a managed package artifact and is removed during package or
+  export replacement so stale bootstraps cannot survive a later package run;
 - adding metadata fields is backward-compatible;
 - removing the marker or changing ownership detection is breaking unless it is
   required for a safety fix;

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,64 @@
+# Migration Notes
+
+## Purpose
+
+This document defines when migration notes are required and provides a template
+for future changes. It does not invent migrations for unreleased behavior.
+
+## When A Migration Note Is Required
+
+Add a migration note when a change affects:
+
+- Public-Candidate runtime API;
+- GOX syntax or generated-code expectations visible to users;
+- `goframe.json` input behavior;
+- `goxc` command or flag behavior;
+- package/export output contracts;
+- documented browser/runtime semantics.
+
+Security hardening still needs a note when users may see new rejections.
+
+## Template
+
+```md
+## <version or stage>: <short title>
+
+### Affected Surface
+
+### Reason
+
+### Old Usage
+
+### New Usage
+
+### Compatibility Window
+
+### Removal Timing
+
+### Automated Migration
+```
+
+## Historical Examples
+
+### `main.wasm` to `bundle.wasm`
+
+Status: legacy compatibility retained.
+
+New examples and docs use `bundle.wasm`. Explicit manifests that set
+`"wasm": "main.wasm"` still load and package.
+
+### Adjacent generated files to `.goframe`
+
+Status: legacy/debug compatibility retained.
+
+Normal `goxc generate`, `build`, and `package` workflows write generated
+`.gox.go` files under `.goframe`. `goxc generate --in-place` remains available
+only for debugging or legacy workflows and prints a warning.
+
+### Function-call cross-package components to package-qualified GOX tags
+
+Status: old Go function calls remain valid.
+
+Package-qualified GOX tags such as `<layout.Shell />` are now preferred for
+component boundaries across packages. Ordinary function calls still work when
+you intentionally do not need a component boundary.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,86 @@
+# Platform Support
+
+## Purpose
+
+This document records what GoFrame currently tests, what is expected but not
+verified, and what remains unsupported. It is a public-preview readiness matrix,
+not a production support promise.
+
+Labels:
+
+- CI-tested
+- expected
+- unverified
+- unsupported
+
+## Toolchain Hosts
+
+| Host | Status | Evidence |
+|---|---|---|
+| Linux amd64 | CI-tested | GitHub Actions and local validation run Go, TinyGo, Node, Chrome, size, smoke, and DOM pressure gates. |
+| macOS | expected | Go/TinyGo/Node should work, but there is no CI gate yet. |
+| Windows | unverified | Go code is mostly `filepath`-based, but browser smoke, shell scripts, symlink tests, and extension scripts are not CI-tested on Windows. |
+
+Symlink safety tests skip when `os.Symlink` is unavailable or restricted.
+
+## Compilers
+
+| Compiler target | Status | Notes |
+|---|---|---|
+| Go/WASM | CI-tested for selected smoke fixtures | Used for recover-capable runtime error and Error Boundary scenarios. Larger bundle size is expected. |
+| TinyGo/WASM | CI-tested for packaging, size, and most browser smoke | Preferred size-oriented path. Current CI uses TinyGo `0.41.1`. Default package path uses `-panic=trap`. |
+| Native Go runtime | CI-tested for pure tests | Pure runtime/compiler/tooling tests run with normal Go. Browser runtime requires `js/wasm`. |
+
+Minimum module declaration is `go 1.22`. Current local/CI baselines use newer Go
+toolchains.
+
+## Browser Targets
+
+| Browser | Status | Evidence |
+|---|---|---|
+| Chrome/Chromium | CI-tested | Browser smoke and dashboard DOM pressure use Chrome/CDP. |
+| Firefox | unverified | Runtime uses standard browser APIs but has no CI coverage. |
+| Safari/WebKit | unverified | Runtime uses standard browser APIs but has no CI coverage. |
+| Non-browser WASM hosts | unsupported | Current runtime assumes browser DOM APIs. |
+
+Required browser APIs:
+
+- WebAssembly;
+- DOM node creation and event listeners;
+- `requestAnimationFrame`;
+- `hashchange`;
+- `fetch` for example-local resource transports;
+- `AbortController` for resource example cancellation;
+- localStorage for the Todo example.
+
+## Runtime Behavior Matrix
+
+| Capability | Go/WASM | TinyGo/WASM | Notes |
+|---|---|---|---|
+| rendering/state/effects/context | CI-tested | CI-tested | Main browser app path. |
+| hash router/query helpers | CI-tested | CI-tested | Router smoke uses TinyGo; reference ErrorBoundary route uses Go. |
+| resources | expected | CI-tested | Resource smoke uses TinyGo for lifecycle and stale completion. |
+| runtime panic containment | CI-tested | limited | Recover-based containment is asserted with Go/WASM. TinyGo trap builds may terminate instead. |
+| scoped render Error Boundaries | CI-tested | compile-compatible but not containment proof | Use Go/WASM for intentional panic demos. |
+| fixed-height virtualization | expected | CI-tested | DOM pressure and virtualized smoke use TinyGo. |
+
+## Deployment
+
+Status: Ready with limitations.
+
+Supported deployment shape:
+
+- static hosting of `goxc package` output;
+- hash-based routing, so app routes stay after `#` and do not need server
+  rewrites;
+- correct `application/wasm` MIME type;
+- optional gzip/brotli sidecars from `goxc package --compress=gzip,br`;
+- long-cache immutable headers for hashed assets when deployment
+  infrastructure supports them.
+
+Unsupported:
+
+- production server;
+- TLS/cache/compression negotiation automation;
+- history-mode fallback configuration;
+- SSR/hydration.

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -18,8 +18,9 @@ MVP 30 closes part of the readiness gap by documenting API tiers, component
 identity, manifest/package compatibility, symlink policy, platform support,
 compatibility/deprecation policy, migration policy, and release checklist. The
 filesystem/package corrective pass hardens the goxc package/export/generate/
-build/clean/serve paths against common symlink traversal, false ownership, path
-overlap, and generated-asset collision mistakes.
+build/clean/serve paths against common symlink traversal, false ownership,
+physical alias overlap, authored-source output, partial package ownership, and
+generated-asset collision mistakes.
 
 ## Current Status
 
@@ -109,11 +110,16 @@ Evidence:
 Decision:
 
 - `goframe.json` is the public input contract;
-- `asset-manifest.json` and `goframe-package.json` are generated metadata and
-  package/export ownership markers;
+- `asset-manifest.json` and `goframe-package.json` are generated metadata, but
+  only complete `goframe-package.json` metadata is the authoritative current
+  package completion marker;
 - package/export ownership is granted only by structured, regular, valid
-  metadata; generic `{}` files and generic web `manifest.json` files are not
-  ownership markers;
+  current metadata with matching companion asset manifest and regular
+  referenced files; generic `{}` files, standalone `asset-manifest.json`, and
+  generic web `manifest.json` files are not ownership markers;
+- legacy ownership is fail-closed and limited to the historical GoFrame
+  `manifest.json` shape found in repository history;
+- manifest `wasm` values must be relative `.wasm` child paths;
 - package assets are planned before publication so user assets cannot collide
   with the generated WASM, `wasm_exec.js`, or compressed sidecars;
 - no mandatory manifest schema version is added in MVP 30.
@@ -133,6 +139,13 @@ Evidence:
   markers;
 - entry/source/assets/package-source symlinks and non-regular files are
   rejected;
+- lexical and physical symlink-alias output overlap is rejected for external
+  workspaces and explicit build/generate/package/export outputs;
+- build/generate explicit outputs cannot physically point back into authored
+  source, and manifest `wasm` cannot name authored files such as `main.go` or
+  `go.mod`;
+- package completion requires complete current metadata, and partial
+  publication without `goframe-package.json` is not considered owned;
 - output overlap and generated asset namespace collisions are rejected before
   publication.
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -16,7 +16,10 @@ contracts still need final decisions before a preview tag:
 
 MVP 30 closes part of the readiness gap by documenting API tiers, component
 identity, manifest/package compatibility, symlink policy, platform support,
-compatibility/deprecation policy, migration policy, and release checklist.
+compatibility/deprecation policy, migration policy, and release checklist. The
+filesystem/package corrective pass hardens the goxc package/export/generate/
+build/clean/serve paths against common symlink traversal, false ownership, path
+overlap, and generated-asset collision mistakes.
 
 ## Current Status
 
@@ -24,7 +27,7 @@ compatibility/deprecation policy, migration policy, and release checklist.
 |---|---|---|
 | Runtime primitives | Ready with limitations | `pkg/goframe/*_test.go`, `docs/runtime-model.md`, browser smoke. |
 | GOX compiler | Ready with limitations | `pkg/gox` golden/error tests, source diagnostics, package-qualified component tests. |
-| Toolchain | Ready with limitations | `cmd/goxc` tests, browser smoke, size budget, package matrix. |
+| Toolchain | Ready with limitations | `cmd/goxc` tests, browser smoke, size budget, package matrix, filesystem/package safety matrix. |
 | Public docs | Ready with limitations | README, tutorial, API stability docs, docs-check. |
 | Platform support | Needs hardening | Chrome/Linux are tested; macOS/Windows/Firefox/Safari are not CI-tested. |
 | Public preview release process | Needs hardening | `docs/release.md` now contains a preview checklist; no preview tag has been cut. |
@@ -108,6 +111,11 @@ Decision:
 - `goframe.json` is the public input contract;
 - `asset-manifest.json` and `goframe-package.json` are generated metadata and
   package/export ownership markers;
+- package/export ownership is granted only by structured, regular, valid
+  metadata; generic `{}` files and generic web `manifest.json` files are not
+  ownership markers;
+- package assets are planned before publication so user assets cannot collide
+  with the generated WASM, `wasm_exec.js`, or compressed sidecars;
 - no mandatory manifest schema version is added in MVP 30.
 
 ## Filesystem And Symlink Safety
@@ -118,13 +126,22 @@ Evidence:
 
 - `docs/security-symlink-policy.md`;
 - `cmd/goxc/symlink_test.go`;
-- package/export validation rejects symlinked output roots;
-- entry/source/assets symlinks are rejected.
+- `cmd/goxc/filesystem_safety_test.go`;
+- root-aware validation rejects intermediate symlink components below declared
+  roots;
+- package/export validation rejects symlinked output roots and false ownership
+  markers;
+- entry/source/assets/package-source symlinks and non-regular files are
+  rejected;
+- output overlap and generated asset namespace collisions are rejected before
+  publication.
 
 Remaining risk:
 
-- symlinked app roots are not a promised workflow;
-- serve path hardening remains development-server scoped.
+- concurrent filesystem mutation between validation and operation remains out
+  of scope;
+- Windows path behavior is not CI-verified;
+- `goxc serve` remains development-server scoped.
 
 ## Platform Support Matrix
 
@@ -199,6 +216,7 @@ Recommendation:
 | High | Platform support is Linux/Chrome-heavy. | `docs/platform-support.md` | Add macOS/Windows and Firefox/Safari verification or mark preview scope narrowly. |
 | Medium | `goframe.json` has no schema version decision. | `docs/manifest-compatibility.md` | Decide optional schema marker before preview. |
 | Medium | Production deployment server remains out of scope. | `docs/deployment.md` | Keep preview messaging static-hosting/hash-router focused. |
+| Medium | Package publication is hardened but not a full transactional installer. | `cmd/goxc/package.go` | Metadata is written last and sources are prevalidated; a future transaction/rollback design can further protect existing packages from mid-copy failures. |
 | Documentation-only | Public API classification must be kept current. | `docs/api-stability.md` | Optional exported-symbol classification gate can be added later. |
 
 ## Deferred Non-goals

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -1,0 +1,225 @@
+# Public Preview Readiness
+
+## Executive Summary
+
+Status: Needs hardening.
+
+GoFrame has enough runtime, GOX, toolchain, examples, and CI coverage to start
+formal public-preview preparation. It is not yet preview-ready because several
+contracts still need final decisions before a preview tag:
+
+- package/manifest schema version decision;
+- multi-module/reusable package identity policy;
+- Windows/macOS support evidence;
+- first public migration notes and release notes;
+- issue-tracker follow-up for remaining compatibility blockers.
+
+MVP 30 closes part of the readiness gap by documenting API tiers, component
+identity, manifest/package compatibility, symlink policy, platform support,
+compatibility/deprecation policy, migration policy, and release checklist.
+
+## Current Status
+
+| Area | Status | Evidence |
+|---|---|---|
+| Runtime primitives | Ready with limitations | `pkg/goframe/*_test.go`, `docs/runtime-model.md`, browser smoke. |
+| GOX compiler | Ready with limitations | `pkg/gox` golden/error tests, source diagnostics, package-qualified component tests. |
+| Toolchain | Ready with limitations | `cmd/goxc` tests, browser smoke, size budget, package matrix. |
+| Public docs | Ready with limitations | README, tutorial, API stability docs, docs-check. |
+| Platform support | Needs hardening | Chrome/Linux are tested; macOS/Windows/Firefox/Safari are not CI-tested. |
+| Public preview release process | Needs hardening | `docs/release.md` now contains a preview checklist; no preview tag has been cut. |
+
+## Public Preview Definition
+
+A first public preview should mean:
+
+- users can evaluate GoFrame with the tutorial and examples;
+- Public-Candidate APIs have documented compatibility expectations;
+- known Experimental APIs are clearly labelled;
+- manifests and package metadata have a documented compatibility model;
+- safety-sensitive filesystem behavior has tests;
+- the release tag and notes make limitations explicit.
+
+It should not mean production readiness, 1.0 API stability, SSR/hydration,
+history routing, route loaders, Suspense, server resources, or a production
+deployment server.
+
+## API Surface
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/api-stability.md`;
+- `go doc -all ./pkg/goframe`;
+- `go doc -all ./pkg/gox`;
+- `pkg/goframe` and `pkg/gox` tests.
+
+Findings:
+
+- app-author APIs and compiler-facing helpers were mixed in older docs;
+- low-level node helpers remain exported for GOX and handwritten low-level Go;
+- resource, router, ErrorBoundary, and runtime error APIs are promising but
+  still Experimental/Public-Candidate, not stable 1.0.
+
+Decision:
+
+- keep API shape unchanged in MVP 30;
+- classify surfaces more explicitly;
+- require future public exports to be classified before preview.
+
+## Component Identity
+
+Status: Ready with limitations.
+
+Canonical policy:
+
+- generated typed identity uses canonical Go import path plus component symbol;
+- import aliases are debug labels, not identity;
+- generated variable names and file discriminators are not runtime identity;
+- legacy `gf.Component` string identity lives in a separate namespace;
+- module path/version changes are identity changes and may remount state.
+
+Evidence:
+
+- `docs/component-identity.md`;
+- `pkg/goframe/component_identity_test.go`;
+- `pkg/gox/generate_test.go`;
+- `cmd/goxc/workspace_test.go`.
+
+Blocker:
+
+- full multi-module workspace/reusable package identity is not promised yet.
+
+## Manifest And Package Contracts
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/manifest-compatibility.md`;
+- `cmd/goxc/manifest.go`;
+- `cmd/goxc/package.go`;
+- `cmd/goxc/cli_test.go`;
+- `cmd/goxc/symlink_test.go`.
+
+Decision:
+
+- `goframe.json` is the public input contract;
+- `asset-manifest.json` and `goframe-package.json` are generated metadata and
+  package/export ownership markers;
+- no mandatory manifest schema version is added in MVP 30.
+
+## Filesystem And Symlink Safety
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/security-symlink-policy.md`;
+- `cmd/goxc/symlink_test.go`;
+- package/export validation rejects symlinked output roots;
+- entry/source/assets symlinks are rejected.
+
+Remaining risk:
+
+- symlinked app roots are not a promised workflow;
+- serve path hardening remains development-server scoped.
+
+## Platform Support Matrix
+
+Status: Needs hardening.
+
+Evidence:
+
+- `docs/platform-support.md`;
+- CI and local validation on Linux/Chrome;
+- TinyGo `0.41.1` size and smoke gates;
+- Go/WASM recover-capable smoke fixtures.
+
+Blocker:
+
+- no macOS/Windows/Firefox/Safari CI evidence yet.
+
+## Browser Support
+
+Status: Ready with limitations.
+
+Chrome/Chromium is CI-tested. Firefox and Safari are unverified. The runtime
+requires browser DOM APIs, WebAssembly, `requestAnimationFrame`, `hashchange`,
+and example-specific APIs such as `fetch` and `AbortController`.
+
+## Compatibility And Deprecation Policy
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/compatibility.md`;
+- `docs/migrations.md`;
+- deprecated GoDoc comments for current aliases.
+
+Decision:
+
+- pre-preview breaking changes remain allowed but documented;
+- post-preview Public-Candidate changes require migration notes;
+- deprecated APIs should survive at least one planned release stage unless
+  safety requires immediate removal.
+
+## Migration Policy
+
+Status: Ready.
+
+Evidence:
+
+- `docs/migrations.md`;
+- historical examples for `main.wasm`, `.goframe` generation, and
+  package-qualified GOX.
+
+## Release Checklist
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/release.md`;
+- current local baseline and package matrix.
+
+Recommendation:
+
+- first preview tag: `v0.1.0-preview.1`;
+- later previews: `v0.1.0-preview.2`, etc.;
+- final `v0.1.0` only after blockers are closed.
+
+## Known Blockers
+
+| Severity | Finding | Evidence | Recommendation |
+|---|---|---|---|
+| High | Multi-module/reusable package identity is not final. | `docs/component-identity.md` | Focused MVP before claiming reusable package ecosystem. |
+| High | Platform support is Linux/Chrome-heavy. | `docs/platform-support.md` | Add macOS/Windows and Firefox/Safari verification or mark preview scope narrowly. |
+| Medium | `goframe.json` has no schema version decision. | `docs/manifest-compatibility.md` | Decide optional schema marker before preview. |
+| Medium | Production deployment server remains out of scope. | `docs/deployment.md` | Keep preview messaging static-hosting/hash-router focused. |
+| Documentation-only | Public API classification must be kept current. | `docs/api-stability.md` | Optional exported-symbol classification gate can be added later. |
+
+## Deferred Non-goals
+
+- SSR/hydration;
+- history-mode router;
+- route loaders;
+- Suspense/server resources;
+- global resource cache;
+- formatter/LSP;
+- Player/Engine and `.gfapp`;
+- production deployment server;
+- full multi-module monorepo support.
+
+## Recommended Next Stage
+
+MVP 31 should focus on public-preview blockers, not new app features:
+
+1. decide manifest schema/version strategy;
+2. decide multi-module/reusable package identity scope;
+3. add platform verification or narrow preview support claims;
+4. draft release notes and migration notes for `v0.1.0-preview.1`;
+5. optionally add an exported API classification gate if it remains small and
+   robust.

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -120,8 +120,13 @@ Decision:
 - legacy ownership is fail-closed and limited to the historical GoFrame
   `manifest.json` shape found in repository history;
 - manifest `wasm` values must be relative `.wasm` child paths;
+- root `index.html` is the required standalone package entrypoint, must be
+  declared exactly once in manifest assets, and must exist as a regular
+  non-symlink file before package compilation starts;
 - package assets are planned before publication so user assets cannot collide
   with the generated WASM, `wasm_exec.js`, or compressed sidecars;
+- successful package/export commands verify that the published output is
+  immediately recognized as a complete current GoFrame package;
 - no mandatory manifest schema version is added in MVP 30.
 
 ## Filesystem And Symlink Safety
@@ -146,6 +151,9 @@ Evidence:
   `go.mod`;
 - package completion requires complete current metadata, and partial
   publication without `goframe-package.json` is not considered owned;
+- stale managed `index.html` is removed during package/export replacement, and
+  invalid input preserves any previous complete package because required
+  entrypoint validation runs before compilation and cleanup;
 - output overlap and generated asset namespace collisions are rejected before
   publication.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,22 +11,26 @@ Current milestone tag:
 v0.1.0-mvp10
 ```
 
-Future public experimental releases should use normal semantic tags such as:
+Recommended first public preview tag:
 
 ```text
-v0.1.0
+v0.1.0-preview.1
 ```
 
-Use annotated tags:
+Subsequent previews should increment the pre-release number:
 
-```bash
-git tag -a v0.1.0-mvp10 -m "MVP 10: GOX expression ergonomics and public API cleanup"
+```text
+v0.1.0-preview.2
 ```
 
-Push tags explicitly:
+The current MVP tags remain historical milestone tags. They are not public API
+release tags.
+
+Use annotated, signed tags when possible:
 
 ```bash
-git push origin v0.1.0-mvp10
+git tag -s v0.1.0-preview.1 -m "GoFrame public preview 1"
+git push origin v0.1.0-preview.1
 ```
 
 ## Pre-Release Checklist
@@ -71,3 +75,74 @@ go install github.com/graybuton/goframe/cmd/goxc@latest
 
 For now, release notes can be drafted from `CHANGELOG.md`. Keep milestone notes
 clear about API instability and experimental status.
+
+## Public Preview Checklist
+
+### Repository
+
+- `main` is clean and contains the intended merge commit;
+- no generated artifacts are tracked;
+- module path is `github.com/graybuton/goframe`;
+- release commit and tag are signed;
+- `CHANGELOG.md` is current;
+- no unresolved Critical or High readiness findings remain without explicit
+  release-note acknowledgement.
+
+### API
+
+- exported `pkg/goframe` and `pkg/gox` API inventory reviewed;
+- every new public export is classified in `docs/api-stability.md`;
+- deprecated APIs have replacement guidance;
+- migration notes exist for user-visible breaking changes;
+- manifest/package compatibility policy is current.
+
+### Tests
+
+- `go fmt ./...` and clean diff check;
+- `go test ./...`;
+- `go test -race ./pkg/... ./cmd/...`;
+- `go vet ./...`;
+- `go test -tags=goframe_debug ./...`;
+- GOX golden and error golden tests;
+- browser smoke;
+- TinyGo WASM size budgets;
+- dashboard DOM pressure;
+- artifact and module path gates;
+- docs consistency;
+- package matrix for all examples with TinyGo and selected Go compiler paths.
+
+### Docs
+
+- README current;
+- tutorial current;
+- API stability current;
+- platform support current;
+- public-preview readiness document current;
+- known limitations current;
+- examples aligned with docs.
+
+### Packaging
+
+- `goxc package --asset-hash --preload --compress=gzip,br` checked for
+  representative examples;
+- `asset-manifest.json` and `goframe-package.json` present;
+- export ownership safety checked;
+- clean workspace checked;
+- sample static-host deploy notes current.
+
+### Release Notes
+
+- tag format documented;
+- install command documented;
+- compatibility/deprecation notes included;
+- migration notes linked;
+- rollback/revert plan noted for preview users.
+
+## Versioning Decision
+
+The recommended first public-preview tag is `v0.1.0-preview.1`. It is a Go
+module pre-release tag. Later previews increment the numeric suffix.
+
+`v0.1.0` final should wait until public-preview blockers in
+`docs/public-preview-readiness.md` are closed or consciously accepted in release
+notes.

--- a/docs/release.md
+++ b/docs/release.md
@@ -130,6 +130,9 @@ clear about API instability and experimental status.
   representative examples;
 - `asset-manifest.json` and `goframe-package.json` present, with
   `goframe-package.json` published as the authoritative completion marker;
+- root `index.html` present as the required standalone HTML entrypoint and
+  managed package artifact;
+- package/export success verified against current package ownership metadata;
 - package/export ownership safety checked with complete structured metadata,
   not placeholder files or standalone asset manifests;
 - manifest assets checked for collisions with generated WASM, runtime, and

--- a/docs/release.md
+++ b/docs/release.md
@@ -53,6 +53,9 @@ Before creating a tag:
 - `scripts/module-path-check.sh` passes;
 - release package layout is checked with `goxc package --asset-hash --preload`
   for affected examples;
+- filesystem/package safety spot checks pass for symlink rejection, ownership
+  markers, output overlap, asset collisions, publish, clean, and serve
+  behavior;
 - README, docs, and changelog are updated;
 - no `dist/`, `build/`, `.goframe`, `.gox.go`, `.wasm`, `.wasm.gz`,
   `.wasm.br`, `.wasm.zst`, `node_modules`, `.vsix`, or `.test` files are
@@ -126,7 +129,10 @@ clear about API instability and experimental status.
 - `goxc package --asset-hash --preload --compress=gzip,br` checked for
   representative examples;
 - `asset-manifest.json` and `goframe-package.json` present;
-- export ownership safety checked;
+- package/export ownership safety checked with structured markers, not
+  placeholder files;
+- manifest assets checked for collisions with generated WASM, runtime, and
+  compressed sidecar names;
 - clean workspace checked;
 - sample static-host deploy notes current.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,8 +54,8 @@ Before creating a tag:
 - release package layout is checked with `goxc package --asset-hash --preload`
   for affected examples;
 - filesystem/package safety spot checks pass for symlink rejection, ownership
-  markers, output overlap, asset collisions, publish, clean, and serve
-  behavior;
+  markers, physical output overlap aliases, asset collisions, partial publish,
+  clean, legacy ownership, and serve behavior;
 - README, docs, and changelog are updated;
 - no `dist/`, `build/`, `.goframe`, `.gox.go`, `.wasm`, `.wasm.gz`,
   `.wasm.br`, `.wasm.zst`, `node_modules`, `.vsix`, or `.test` files are
@@ -128,11 +128,14 @@ clear about API instability and experimental status.
 
 - `goxc package --asset-hash --preload --compress=gzip,br` checked for
   representative examples;
-- `asset-manifest.json` and `goframe-package.json` present;
-- package/export ownership safety checked with structured markers, not
-  placeholder files;
+- `asset-manifest.json` and `goframe-package.json` present, with
+  `goframe-package.json` published as the authoritative completion marker;
+- package/export ownership safety checked with complete structured metadata,
+  not placeholder files or standalone asset manifests;
 - manifest assets checked for collisions with generated WASM, runtime, and
   compressed sidecar names;
+- explicit output paths checked for physical overlap with authored source or
+  package source;
 - clean workspace checked;
 - sample static-host deploy notes current.
 

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -98,6 +98,11 @@ entrypoint, and HTML entrypoint are present as regular files inside the package
 root. `asset-manifest.json` is generated metadata only; by itself it does not
 grant destructive ownership.
 
+The standalone HTML entrypoint is root `index.html`. It must be declared
+exactly once in manifest assets and must exist as a regular non-symlink file
+before `goxc package` compiles or cleans output. Missing optional assets may
+still be skipped with a message, but missing `index.html` is a package error.
+
 Legacy `manifest.json` ownership is fail-closed and recognized only for the
 historical GoFrame package format that contained GoFrame-specific fields such
 as `name`, `compiler`, `wasm`, `assets`, and `toolchainVersion`, plus regular
@@ -223,9 +228,13 @@ Evidence:
 Before publishing, `goxc` validates the staged package tree and rejects symlinks
 and non-regular file entries. Package metadata is copied last so a mid-copy
 failure cannot leave `goframe-package.json` describing a newly completed tree.
-Before destructive cleanup of an existing package, `goxc` removes the
-authoritative `goframe-package.json` marker first. If cleanup fails, the
-directory is no longer considered a complete current package.
+After publish, package and export commands verify that the destination is
+recognized as a complete current GoFrame package before printing success; if
+verification fails, they remove the completion marker. Before destructive
+cleanup of an existing package, `goxc` removes the authoritative
+`goframe-package.json` marker first, then removes managed artifacts including
+stale root `index.html`. If cleanup fails, the directory is no longer
+considered a complete current package.
 
 This is not a full transactional installer. If a copy fails after old
 package-owned files were cleaned, the destination may need another successful

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -119,38 +119,70 @@ infrastructure.
 
 ## Symlink Policy
 
-Current path validation is lexical: paths must be relative child paths and must
-not contain escapes such as `..` or absolute roots.
+Current path validation is lexical first and symlink-aware at safety-sensitive
+boundaries.
 
-The current baseline does not yet deeply specify all symlink behavior. Treat
-the following as not fully hardened:
+Policy:
 
-- symlinked asset files;
-- symlinked app directories;
-- symlinked export directories;
-- symlinks inside `.goframe`;
-- symlinked legacy `dist/` during `clean --legacy`;
-- symlinks that resolve outside the app after lexical validation.
+- entry package directories must not be symlinks;
+- `.go` and `.gox` source files discovered for workspace materialization must
+  not be symlinks;
+- manifest-declared package assets must not be symlinks, including broken
+  symlinks;
+- explicit package/export output directories must not be symlinks;
+- the standalone package directory used as export source must not be a symlink;
+- `goxc clean` removes the symlink itself for tool-owned workspace paths and
+  must not traverse into external symlink targets;
+- explicit external workspaces remain allowed because the user opted into that
+  root directly.
 
-Until explicit tests are added, avoid relying on symlinks for package assets or
-tool-owned output directories.
+The preferred security direction is reject rather than follow when a symlink
+could make source, asset, package, export, or cleanup operations escape the
+declared root.
+
+Evidence:
+
+- `cmd/goxc/symlink_test.go`;
+- `cmd/goxc/workspace.go`;
+- `cmd/goxc/package.go`;
+- `cmd/goxc/export.go`.
+
+## Symlink Matrix
+
+| Scenario | Status | Policy |
+|---|---|---|
+| app root is symlink | Ready with limitations | Not a documented workflow; commands resolve the app path but public support is not promised. |
+| entry directory is symlink | Ready | Rejected. |
+| `.go`/`.gox` source file is symlink | Ready | Rejected during discovery/materialization. |
+| asset is symlink | Ready | Rejected, including broken symlinks. |
+| symlink target stays inside app root | Ready with limitations | Still rejected for entry/source/assets; the policy is simpler and safer. |
+| symlink target escapes app root | Ready | Rejected for entry/source/assets/output roots. |
+| broken symlink | Ready | Rejected for manifest assets and source discovery. |
+| symlink loop | Ready with limitations | Rejected at Lstat boundaries; broader loops are not supported. |
+| external `GOFRAME_WORKSPACE` | Ready | Allowed and scoped under an app-specific slug. |
+| workspace path collides between apps | Ready | External workspace slug includes a hash of app path. |
+| read-only source tree | Ready with limitations | Use external workspace. |
+| package output path is symlink | Ready | Rejected. |
+| export destination is symlink | Ready | Rejected. |
+| `clean --legacy` sees symlinked `dist` | Ready with limitations | Cleanup removes symlink path, not target; relying on symlinked legacy `dist` is not a supported workflow. |
+| explicit `--out` path | Ready | Must be empty, GoFrame-owned, or rejected; symlink root rejected. |
+| generated `.goframe` path | Ready with limitations | Tool-owned; cleanup must not traverse symlink targets. |
 
 ## Current Limitations
 
-- No full `EvalSymlinks` policy for every path boundary yet.
+- Symlinked app roots are not a promised workflow.
 - No production static server hardening beyond local development needs.
 - No signed package/export metadata.
 - No permission model for future Player or `.gfapp` bundles.
 - No full multi-module workspace model.
+- `goxc serve` remains development-only and is not a hardened static server.
 
 ## Recommended Future Tests
 
-Add focused tests before public preview for:
+Keep adding focused tests for:
 
-- asset symlink pointing outside app;
 - app directory symlink;
 - external `GOFRAME_WORKSPACE` symlink;
-- export target symlink;
 - `clean --legacy` with symlinked `dist`;
 - package staging failure with existing package output preserved;
 - serve path traversal behavior through `http.FileServer`.

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -26,10 +26,14 @@ Normal `generate`, `build`, and `package` commands should not create visible
 Current protection focuses on:
 
 - rejecting manifest paths that are not relative child paths;
+- requiring `wasm` manifest output to be a relative `.wasm` child path;
 - rejecting unknown manifest fields;
 - refusing non-empty non-GoFrame package/export output directories;
 - validating GoFrame ownership markers as regular, structured metadata instead
   of trusting filenames alone;
+- comparing independently supplied roots with physical/canonical path
+  resolution so symlink aliases cannot bypass source/output/workspace overlap
+  checks;
 - rejecting intermediate symlink components below declared app/workspace/output
   roots before reading, writing, copying, deleting, or serving files;
 - publishing generated files through temporary sibling files and replacement so
@@ -45,6 +49,10 @@ Current protection focuses on:
 Manifest fields such as `entry`, `output`, `wasm`, and `assets` are validated
 as relative child paths. Absolute paths, `..`, and paths escaping the
 application directory are rejected.
+
+`wasm` must end in `.wasm`. Names such as `main.go`, `go.mod`,
+`bundle.wasm.gz`, and `wasm_exec.js` are rejected before build/package output
+paths are computed.
 
 `entry` supports `"."` and relative child package directories such as
 `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"`. Entries that point to
@@ -83,15 +91,18 @@ Explicit `goxc package --out <dir>` treats `<dir>` as tool-owned package
 output. If the directory is non-empty and does not look like a previous GoFrame
 package, the command fails instead of deleting user files.
 
-GoFrame-owned markers:
+The authoritative current completion marker is `goframe-package.json`.
+Ownership requires that marker to be a regular, valid, supported metadata file
+and that its companion `asset-manifest.json`, WASM entrypoint, runtime
+entrypoint, and HTML entrypoint are present as regular files inside the package
+root. `asset-manifest.json` is generated metadata only; by itself it does not
+grant destructive ownership.
 
-- `goframe-package.json`
-- `asset-manifest.json`
-- legacy `manifest.json`
-
-These markers must be regular files with recognizable GoFrame package
-structure. An empty `{}` file, malformed JSON, symlinked marker, or generic web
-`manifest.json` is not enough to grant ownership.
+Legacy `manifest.json` ownership is fail-closed and recognized only for the
+historical GoFrame package format that contained GoFrame-specific fields such
+as `name`, `compiler`, `wasm`, `assets`, and `toolchainVersion`, plus regular
+WASM/runtime companion files. An empty `{}` file, malformed JSON, symlinked
+marker, or generic web `manifest.json` is not enough to grant ownership.
 
 ## Export Output
 
@@ -146,6 +157,8 @@ Policy:
   symlinks;
 - explicit package/export output directories and intermediate parents must not
   be symlinks;
+- explicit build, generate, package, and export output roots must not
+  physically overlap authored source or package source through a symlink alias;
 - the standalone package directory used as export source must not be a symlink;
 - `goxc clean` removes final tool-owned symlinks as links and rejects
   intermediate workspace symlinks instead of traversing targets;
@@ -182,14 +195,21 @@ Evidence:
 | symlink loop | Ready with limitations | Rejected at Lstat boundaries; broader loops are not supported. |
 | external `GOFRAME_WORKSPACE` | Ready | Allowed and scoped under an app-specific slug when it does not overlap the app tree. |
 | external workspace inside app tree | Ready | Rejected before workspace refresh/copy. |
+| external workspace alias physically inside app tree | Ready | Rejected with canonical path overlap checks. |
 | workspace path collides between apps | Ready | External workspace slug includes a hash of app path. |
 | read-only source tree | Ready with limitations | Use external workspace. |
+| build `--out` alias points inside app tree | Ready | Rejected before compiler publication; manifest `wasm` must be `.wasm`. |
+| generate `--out` alias points inside app tree | Ready | Rejected unless `--in-place` is explicitly used. |
+| package `--out` alias points inside app tree | Ready | Rejected before build/publication. |
+| export `--out` alias overlaps package source/app tree | Ready | Rejected before cleanup/copy. |
 | package output path is symlink | Ready | Rejected. |
 | export destination is symlink | Ready | Rejected. |
 | destination file is symlink | Ready | Rejected before atomic replacement. |
 | package source contains symlink | Ready | Rejected before copy; external content is not published. |
 | package source contains FIFO/socket/device | Ready with limitations | Non-regular entries are rejected; platform-specific special-file coverage may vary. |
 | generic `manifest.json` in `dist` | Ready | Not considered GoFrame-owned; user files are preserved. |
+| generic Go/WASM dist with `manifest.json`, `main.wasm`, and `wasm_exec.js` | Ready | Not considered GoFrame-owned; only historical GoFrame `manifest.json` fields grant legacy ownership. |
+| standalone `asset-manifest.json` | Ready | Metadata only; does not grant ownership without complete `goframe-package.json`. |
 | `clean --legacy` sees symlinked `dist` | Ready with limitations | Final symlink is removed as a link when it is a tool-owned cleanup target; relying on symlinked legacy `dist` is not a supported workflow. |
 | explicit `--out` path | Ready | Must be empty, GoFrame-owned, or rejected; symlink root rejected. |
 | generated `.goframe` path | Ready with limitations | Intermediate symlinks are rejected; final cleanup symlinks are removed as links. |
@@ -203,6 +223,9 @@ Evidence:
 Before publishing, `goxc` validates the staged package tree and rejects symlinks
 and non-regular file entries. Package metadata is copied last so a mid-copy
 failure cannot leave `goframe-package.json` describing a newly completed tree.
+Before destructive cleanup of an existing package, `goxc` removes the
+authoritative `goframe-package.json` marker first. If cleanup fails, the
+directory is no longer considered a complete current package.
 
 This is not a full transactional installer. If a copy fails after old
 package-owned files were cleaned, the destination may need another successful

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -28,6 +28,14 @@ Current protection focuses on:
 - rejecting manifest paths that are not relative child paths;
 - rejecting unknown manifest fields;
 - refusing non-empty non-GoFrame package/export output directories;
+- validating GoFrame ownership markers as regular, structured metadata instead
+  of trusting filenames alone;
+- rejecting intermediate symlink components below declared app/workspace/output
+  roots before reading, writing, copying, deleting, or serving files;
+- publishing generated files through temporary sibling files and replacement so
+  destination symlinks and hardlink peers are not truncated;
+- planning package asset output names before publication so user assets cannot
+  overwrite generated WASM, runtime shims, metadata, or compressed sidecars;
 - using staging directories before publishing packages;
 - cleaning only known GoFrame-owned artifacts;
 - binding the development server to `127.0.0.1`.
@@ -81,6 +89,10 @@ GoFrame-owned markers:
 - `asset-manifest.json`
 - legacy `manifest.json`
 
+These markers must be regular files with recognizable GoFrame package
+structure. An empty `{}` file, malformed JSON, symlinked marker, or generic web
+`manifest.json` is not enough to grant ownership.
+
 ## Export Output
 
 `goxc export <app> --out <dir>` copies the latest standalone package to an
@@ -119,22 +131,29 @@ infrastructure.
 
 ## Symlink Policy
 
-Current path validation is lexical first and symlink-aware at safety-sensitive
-boundaries.
+Current path validation is root-aware and symlink-aware at safety-sensitive
+boundaries. `goxc` validates paths relative to the declared app, workspace,
+package, export, or serve root and checks each existing component inside that
+controlled subtree with `os.Lstat`.
 
 Policy:
 
+- app roots that are themselves symlinks are rejected;
 - entry package directories must not be symlinks;
 - `.go` and `.gox` source files discovered for workspace materialization must
   not be symlinks;
 - manifest-declared package assets must not be symlinks, including broken
   symlinks;
-- explicit package/export output directories must not be symlinks;
+- explicit package/export output directories and intermediate parents must not
+  be symlinks;
 - the standalone package directory used as export source must not be a symlink;
-- `goxc clean` removes the symlink itself for tool-owned workspace paths and
-  must not traverse into external symlink targets;
+- `goxc clean` removes final tool-owned symlinks as links and rejects
+  intermediate workspace symlinks instead of traversing targets;
+- `goxc serve` rejects symlinked roots and symlinked entries inside the served
+  tree;
 - explicit external workspaces remain allowed because the user opted into that
-  root directly.
+  root directly, but the final app-scoped workspace root must not overlap the
+  app source tree.
 
 The preferred security direction is reject rather than follow when a symlink
 could make source, asset, package, export, or cleanup operations escape the
@@ -143,6 +162,7 @@ declared root.
 Evidence:
 
 - `cmd/goxc/symlink_test.go`;
+- `cmd/goxc/filesystem_safety_test.go`;
 - `cmd/goxc/workspace.go`;
 - `cmd/goxc/package.go`;
 - `cmd/goxc/export.go`.
@@ -151,41 +171,69 @@ Evidence:
 
 | Scenario | Status | Policy |
 |---|---|---|
-| app root is symlink | Ready with limitations | Not a documented workflow; commands resolve the app path but public support is not promised. |
+| app root is symlink | Ready | Rejected before mutation. |
 | entry directory is symlink | Ready | Rejected. |
-| `.go`/`.gox` source file is symlink | Ready | Rejected during discovery/materialization. |
+| intermediate entry component is symlink | Ready | Rejected before read/copy/generation. |
+| `.go`/`.gox` source file is symlink | Ready | Rejected during discovery/materialization and direct-file generation. |
 | asset is symlink | Ready | Rejected, including broken symlinks. |
 | symlink target stays inside app root | Ready with limitations | Still rejected for entry/source/assets; the policy is simpler and safer. |
 | symlink target escapes app root | Ready | Rejected for entry/source/assets/output roots. |
 | broken symlink | Ready | Rejected for manifest assets and source discovery. |
 | symlink loop | Ready with limitations | Rejected at Lstat boundaries; broader loops are not supported. |
-| external `GOFRAME_WORKSPACE` | Ready | Allowed and scoped under an app-specific slug. |
+| external `GOFRAME_WORKSPACE` | Ready | Allowed and scoped under an app-specific slug when it does not overlap the app tree. |
+| external workspace inside app tree | Ready | Rejected before workspace refresh/copy. |
 | workspace path collides between apps | Ready | External workspace slug includes a hash of app path. |
 | read-only source tree | Ready with limitations | Use external workspace. |
 | package output path is symlink | Ready | Rejected. |
 | export destination is symlink | Ready | Rejected. |
-| `clean --legacy` sees symlinked `dist` | Ready with limitations | Cleanup removes symlink path, not target; relying on symlinked legacy `dist` is not a supported workflow. |
+| destination file is symlink | Ready | Rejected before atomic replacement. |
+| package source contains symlink | Ready | Rejected before copy; external content is not published. |
+| package source contains FIFO/socket/device | Ready with limitations | Non-regular entries are rejected; platform-specific special-file coverage may vary. |
+| generic `manifest.json` in `dist` | Ready | Not considered GoFrame-owned; user files are preserved. |
+| `clean --legacy` sees symlinked `dist` | Ready with limitations | Final symlink is removed as a link when it is a tool-owned cleanup target; relying on symlinked legacy `dist` is not a supported workflow. |
 | explicit `--out` path | Ready | Must be empty, GoFrame-owned, or rejected; symlink root rejected. |
-| generated `.goframe` path | Ready with limitations | Tool-owned; cleanup must not traverse symlink targets. |
+| generated `.goframe` path | Ready with limitations | Intermediate symlinks are rejected; final cleanup symlinks are removed as links. |
+| user asset named `bundle.wasm` or `wasm_exec.js` | Ready | Rejected as a generated namespace collision. |
+| user asset compressed sidecar collision | Ready | Rejected before package publication. |
+| export source/output overlap | Ready | Rejected before cleanup/copy. |
+| serve tree symlink entry | Ready with limitations | Dev server returns 404 for symlink entries; it remains development-only. |
+
+## Package Publication Integrity
+
+Before publishing, `goxc` validates the staged package tree and rejects symlinks
+and non-regular file entries. Package metadata is copied last so a mid-copy
+failure cannot leave `goframe-package.json` describing a newly completed tree.
+
+This is not a full transactional installer. If a copy fails after old
+package-owned files were cleaned, the destination may need another successful
+`goxc package` or `goxc export` run to restore all files. The package is not
+marked complete until metadata is present.
+
+## Residual TOCTOU Risk
+
+The policy is designed for static repository trees and ordinary user mistakes.
+It does not attempt to sandbox a hostile local process that concurrently
+replaces paths between validation and an operation. Obvious final symlink
+write-through and cleanup traversal cases are still checked immediately at the
+operation boundary, but full adversarial filesystem mutation is out of scope.
 
 ## Current Limitations
 
-- Symlinked app roots are not a promised workflow.
 - No production static server hardening beyond local development needs.
 - No signed package/export metadata.
 - No permission model for future Player or `.gfapp` bundles.
 - No full multi-module workspace model.
 - `goxc serve` remains development-only and is not a hardened static server.
+- Windows filesystem behavior is not CI-verified.
 
 ## Recommended Future Tests
 
 Keep adding focused tests for:
 
-- app directory symlink;
-- external `GOFRAME_WORKSPACE` symlink;
-- `clean --legacy` with symlinked `dist`;
-- package staging failure with existing package output preserved;
-- serve path traversal behavior through `http.FileServer`.
+- Windows path edge cases;
+- package rollback behavior when replacing an existing valid package;
+- additional special file types where the platform can create them safely;
+- serve path traversal behavior on non-Linux platforms.
 
 ## Non-Goals
 

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -200,6 +200,8 @@ var (
 
 // UseMount runs effect once after this component instance is first mounted.
 // The returned cleanup, when non-nil, runs when the instance unmounts.
+//
+// Deprecated: use UseEffect with no dependency argument or Once.
 func UseMount(effect func() Cleanup) {
 	useEffect(effectMount, effect, Once())
 }

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -248,6 +248,99 @@ func View() gf.Node {
 	}
 }
 
+func TestGenerateQualifiedComponentImportAliasDoesNotDefineIdentity(t *testing.T) {
+	source := []byte(`package demo
+
+import (
+	widgets "github.com/example/app/internal/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func View() gf.Node {
+	return <widgets.Header Title="Hello" />
+}
+`)
+
+	generated, err := GenerateNamed("qualified_alias_rename.gox", source)
+	if err != nil {
+		t.Fatalf("GenerateNamed() error: %v", err)
+	}
+	text := string(generated)
+	if !strings.Contains(text, `gf.NewComponentType("github.com/example/app/internal/ui.Header", "widgets.Header")`) {
+		t.Fatalf("generated source does not preserve import-path identity across alias rename:\n%s", text)
+	}
+	if strings.Contains(text, `gf.NewComponentType("widgets.Header"`) {
+		t.Fatalf("generated source used local alias as component identity:\n%s", text)
+	}
+}
+
+func TestGenerateWithOptionsFilenameDoesNotDefineRuntimeIdentity(t *testing.T) {
+	source := []byte(`package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Header />
+}
+`)
+
+	first, err := GenerateWithOptions(source, GenerateOptions{
+		Filename:        "internal/ui/header.gox",
+		PackageIdentity: "github.com/example/app/internal/ui",
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithOptions(first) error: %v", err)
+	}
+	second, err := GenerateWithOptions(source, GenerateOptions{
+		Filename:        "internal/ui/alt_header.gox",
+		PackageIdentity: "github.com/example/app/internal/ui",
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithOptions(second) error: %v", err)
+	}
+	const want = `gf.NewComponentType("github.com/example/app/internal/ui.Header", "Header")`
+	if strings.Count(string(first), want) != 1 || strings.Count(string(second), want) != 1 {
+		t.Fatalf("generated output missing stable runtime identity:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if string(first) == string(second) {
+		t.Fatalf("different filenames should still produce distinct generated variable names")
+	}
+}
+
+func TestGenerateQualifiedComponentVersionedImportPathsDiffer(t *testing.T) {
+	source := []byte(`package demo
+
+import (
+	v1 "github.com/example/widgets"
+	v2 "github.com/example/widgets/v2"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func View() gf.Node {
+	return (
+		<div>
+			<v1.Card />
+			<v2.Card />
+		</div>
+	)
+}
+`)
+
+	generated, err := GenerateNamed("qualified_versions.gox", source)
+	if err != nil {
+		t.Fatalf("GenerateNamed() error: %v", err)
+	}
+	text := string(generated)
+	for _, want := range []string{
+		`gf.NewComponentType("github.com/example/widgets.Card", "v1.Card")`,
+		`gf.NewComponentType("github.com/example/widgets/v2.Card", "v2.Card")`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated source does not contain %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestGenerateQualifiedComponentCollisions(t *testing.T) {
 	source := []byte(`package demo
 


### PR DESCRIPTION
## Summary

Establishes the public-preview contract baseline and hardens goxc filesystem and package operations without changing runtime or GOX semantics.

## Changes

- Classify public, experimental, compiler-facing, and deprecated APIs
- Document compatibility, migration, identity, manifest, platform, and release policies
- Harden path, symlink, workspace, build, generate, package, export, clean, and serve boundaries
- Require complete structured package ownership metadata
- Prevent physical path overlap, asset collisions, partial ownership, and stale package entrypoints
- Require and verify a regular root index.html before standalone packaging
- Add extensive filesystem and package-integrity regression coverage

## Status

Public-preview readiness remains honest: ready with limitations, with multi-module identity, manifest versioning, broader platform verification, and transactional publication still deferred.

## Validation

The full Go, race, vet, debug, GOX, example, browser smoke, size, package-matrix, documentation, and dashboard DOM-pressure suites pass.