### PR TITLE
docs(preview): define component identity contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
   browser smoke, and VS Code extension compile checks.
 - Artifact and module path regression gates.
 - CI and release hygiene documentation.
+- Pre-preview action plan and vision-preserving preview contract wording that
+  separates first-preview scope from long-term GoFrame platform direction.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
   steps, and symlink/file safety policy.
 - Component identity v2 prototype with `gf.NewComponentType`, `gf.ComponentT`,
   generated GOX component tokens, and legacy `gf.Component` compatibility.
+- Component identity preview contract clarifies stable API shape vs experimental
+  edge-case semantics for cross-package identity, remount expectations, and
+  multi-module frontier behavior in docs.
 - Multi-package GOX workspace support for `entry: "."` apps, including hidden
   workspace materialization for child packages, import-path-aware generated
   component identities, and a focused multipackage example plus browser smoke.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ syntax, manifests, packaging details, and runtime internals may still change
 between MVPs. The browser/WASM target is the current implementation; the
 Player/Engine idea remains future design work, not a shipped product.
 
+The first public preview scope is intentionally narrower than the project
+vision: it should validate the current browser/WASM application layer without
+removing or hiding working experimental surfaces such as the router, resources,
+and Error Boundaries.
+
 ## Status
 
 Current baseline includes:
@@ -483,6 +488,7 @@ Start here:
 - [GOX language and diagnostics](docs/gox-language.md)
 - [API stability tiers](docs/api-stability.md)
 - [Public Preview Readiness](docs/public-preview-readiness.md)
+- [Pre-preview action plan](docs/pre-preview-action-plan.md)
 - [Compatibility and deprecation policy](docs/compatibility.md)
 - [Migration note template](docs/migrations.md)
 - [Platform support matrix](docs/platform-support.md)

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -10,20 +10,33 @@ with clear expectations. It does not create a stable 1.0 compatibility promise.
 
 ## Stability Tiers
 
-### Experimental
-
-Can change between MVPs. Changes should be documented, but migration support is
-best-effort.
-
 ### Public-Candidate
 
 Intended direction for user-facing APIs. Changes should include migration
 notes, tests, and a compatibility reason.
 
+### Experimental Frontier
+
+Can change between MVPs. Changes should be documented, but migration support is
+best-effort. Experimental frontier surfaces are real working surfaces, not
+hidden or deprecated features; they need more contract hardening before broad
+preview promises.
+
+### Compiler-Facing / Low-Level
+
+Exported for GOX, `goxc`, generated-code-like use, or third-party tooling. These
+surfaces are not the preferred high-level app authoring path unless explicitly
+documented.
+
 ### Internal
 
 Runtime, compiler, toolchain, or smoke-test implementation details. These are
 not user APIs and may change without compatibility guarantees.
+
+### Future Vision
+
+Strategic direction that should remain visible but is not a current preview
+promise.
 
 ### Legacy / Deprecated
 
@@ -160,7 +173,7 @@ VS Code extension:
 - syntax highlighting, snippets, and command wrappers over `goxc` are
   experimental tooling contracts, not language-server stability promises.
 
-### Experimental
+### Experimental Frontier
 
 - GOX syntax surface.
 - GOX expression ergonomics.
@@ -188,6 +201,22 @@ VS Code extension:
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands and snippets.
 - `pkg/gox` AST/lexer/parser structures.
+
+These surfaces should be hardened, tested, and documented before wider
+promises. They should not be removed from project positioning merely because
+their contracts are still maturing.
+
+### Future Vision
+
+- Player/Engine host and bundle model.
+- `.gfapp` package format.
+- Broader host/runtime story beyond the browser DOM target.
+- Stronger editor tooling such as LSP/formatter behavior.
+- Future package ecosystem and reusable component distribution story.
+- Production deployment/server integration, if the project chooses that path in
+  a later phase.
+
+These are not part of the first public preview promise.
 
 ### Internal
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -99,6 +99,7 @@ Runtime:
 - `gf.ErrorBoundaryContext`
 - basic event facades such as `gf.Event`, `gf.InputEvent`, and
   `gf.ScrollEvent`
+- `gf.ComponentT` and generated typed component identity contracts
 
 Tooling:
 
@@ -178,6 +179,12 @@ VS Code extension:
 - GOX syntax surface.
 - GOX expression ergonomics.
 - GOX package-qualified component tags (`packageAlias.Component`).
+- Component boundary API shape that is already public-facing (for example
+  `gf.ComponentT` and typed identity tokens) can still have experimental
+  semantics in specific lifecycle, remount, and edge-case compatibility areas.
+  The exported surface is documented for preview usage, while deep behavior
+  under module/version/package-path edge cases remains experimental until
+  broader identity guarantees are proven.
 - GOX diagnostic wording beyond the filename/line/column/source-line contract.
 - Context topology behavior and selector limitations.
 - Virtualization details such as fixed-height range buffering and table spacer

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -99,7 +99,7 @@ Runtime:
 - `gf.ErrorBoundaryContext`
 - basic event facades such as `gf.Event`, `gf.InputEvent`, and
   `gf.ScrollEvent`
-- `gf.ComponentT` and generated typed component identity contracts
+- generated typed component identity contracts
 
 Tooling:
 

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -9,6 +9,10 @@ For the first public preview, the following behavior is considered stable enough
 
 - Handwritten components can still use function-call style:
   `Header(HeaderProps{...})`.
+- Direct Go calls are ordinary function composition and are not runtime component
+  boundaries.
+- They do not create independent component state/effect/context scope, and they do
+  not create an independent dirty-update target.
 - Generated GOX boundaries use explicit typed identity:
   `gf.ComponentT(gf.NewComponentType("importpath.Symbol", "Debug"), props, Header)`.
 - Identity defaults are derived from canonical component import/package path plus symbol name.
@@ -55,7 +59,9 @@ For users running one module/application tree:
 
 ## Experimental frontier under preview
 
-These behaviors are working but not yet a broad portability promise:
+These areas are experimental or only partially evidenced. Single-module
+multi-package composition is covered; broad multi-module or reusable package
+identity is not yet promised.
 
 - Multi-module or module-reused component package identity.
 - Identity under `replace`, workspace aliasing, and non-trivial module path churn.
@@ -66,8 +72,8 @@ These behaviors are working but not yet a broad portability promise:
 ### Practical implication
 
 The API shape is usable and documented.
-The deeper contract under module/path edges remains experimental until the
-`design/component-identity-preview-contract` branch resolves follow-up decisions.
+The deeper contract under module/path edges remains experimental until later
+identity-hardening work explicitly documents and tests those edges.
 
 ## Remount and state expectations
 
@@ -79,10 +85,13 @@ The deeper contract under module/path edges remains experimental until the
 
 ## Public preview recommendation
 
-Use package-qualified GOX tags and typed components for non-trivial, multi-file apps.
-Use `gf.Component` with direct calls for simple compatibility helpers.
+Use package-qualified GOX tags and typed components for non-trivial, multi-file
+apps.
+Use `gf.ComponentT` for runtime-visible typed boundaries, and keep
+`gf.Component` as a compatibility path for direct composition.
+Use direct function calls only for ordinary helper composition.
 Do not assume stable behavior across module path edits, module replacement,
- or cross-module ecosystem sharing in this preview window.
+or cross-module ecosystem sharing in this preview window.
 
 ## Risks and non-goals
 

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -1,225 +1,99 @@
 # Component Identity
 
-This document records the component identity strategy and the options
-considered through MVP 22.
+This document defines the first-preview component identity contract.
+It distinguishes stable usage guidance from experimental edge-case behavior.
 
-## Current Model
+## What is stable enough for preview users
 
-`goframe` has two compatible component identity paths.
+For the first public preview, the following behavior is considered stable enough to rely on:
 
-Legacy handwritten components identify instances by:
+- Handwritten components can still use function-call style:
+  `Header(HeaderProps{...})`.
+- Generated GOX boundaries use explicit typed identity:
+  `gf.ComponentT(gf.NewComponentType("importpath.Symbol", "Debug"), props, Header)`.
+- Identity defaults are derived from canonical component import/package path plus symbol name.
+- Import aliases are diagnostic labels and `gf.ComponentT` debug names, not identity keys.
+- Package-qualified GOX tags (`<layout.Shell />`, `<ui.Header />`) are stable when imports resolve to a package identity.
+- Typed identity can be combined with keys (`gf.Key` / `Key`) for explicit list locality control.
 
-```text
-component name + key/position
-```
+GoFrame examples and docs rely on these assumptions when composing multi-package trees inside one app/root.
 
-GOX capitalized tags generate runtime-visible component boundaries:
+## Preview contract by API kind
 
-```go
-gf.Component("Header", HeaderProps{
-	Title: "Demo",
-}, Header)
-```
+### `gf.Component`
 
-Generated GOX now uses explicit component identity tokens:
+- API shape remains public for compatibility and continues to exist.
+- Its identity is the legacy string-based namespace.
+- It is accepted for existing examples and manual wiring.
+- It is a compatibility path, not the recommended basis for stable cross-package identity assertions.
 
-```go
-var _goxComponent_app_Header = gf.NewComponentType("main.Header", "Header")
+### `gf.ComponentT`, `gf.NewComponentType`, generated GOX code
 
-gf.ComponentT(_goxComponent_app_Header, HeaderProps{
-	Title: "Demo",
-}, Header)
-```
+- API shape is public-candidate for the preview phase.
+- Generated token identity is the intended way to reason about component identity.
+- Two tags that resolve to the same import path and symbol share identity.
+- Debug names can differ from import alias without changing runtime identity.
+- Variable naming in generated code is not part of runtime identity.
 
-The mounted runtime reuses an existing component instance when:
+### Package-qualified tags and `PackageIdentity`
 
-- the component identity is the same;
-- the key is the same when a key is present;
-- otherwise the sibling position is the same.
+- Generated tags use package import resolution from GOX selectors and the supplied
+  `PackageIdentity` in `gox` generation options when explicit.
+- For cross-package composition in the same app, this gives predictable reuse and avoids local alias collisions.
+- `PackageIdentity` exists to make emitted identity deterministic where default resolution
+  cannot infer module-relative canonical package import path.
 
-Direct Go calls such as `Header(HeaderProps{...})` remain ordinary function
-calls. They do not create a component boundary, state scope, or independent
-dirty update target.
+## Stable preview expectations
 
-## Canonical Policy For Public Preview
+For users running one module/application tree:
 
-Status: Ready with limitations.
+- Same canonical component identity + same key preserves component instance.
+- Different package-qualified identity, even with same symbol name, does not.
+- Duplicate symbol names in different packages do not collide.
+- Same package path with alias changes (`ui.Header` vs `widgets.Header`) should not alter identity.
+- Direct `v2` path suffixes are part of the identity key.
 
-Generated and typed component identity follows this policy:
+## Experimental frontier under preview
 
-- typed/generated identity is based on canonical Go import path plus component
-  symbol;
-- the import alias is a debug label and generated-code selector, not runtime
-  identity;
-- generated variable names and source filename discriminators are not runtime
-  identity;
-- identical import path plus symbol should produce identical runtime identity;
-- different import paths should produce different runtime identity even when
-  the selected symbol name is the same;
-- semantic import version suffixes such as `/v2` are part of the import path
-  and therefore part of identity;
-- module path rename or fork is an identity change and can remount state;
-- `gf.Component` legacy string identity is namespaced separately from typed
-  identity, so `gf.Component("Header", ...)` does not collide with
-  `gf.ComponentT(gf.NewComponentType("Header", "Header"), ...)`;
-- `gf.ComponentT` identity is explicit and should be preferred by generated
-  code and handwritten component adapters that need stronger identity.
+These behaviors are working but not yet a broad portability promise:
 
-Evidence:
+- Multi-module or module-reused component package identity.
+- Identity under `replace`, workspace aliasing, and non-trivial module path churn.
+- Remount behavior for module/version and package relocation edges.
+- Legacy `gf.Component` behavior as a full cross-package identity strategy.
+- Reusing generated component tokens across independently built package sets.
 
-- `pkg/goframe/component_identity_test.go`;
-- `pkg/gox/generate_test.go`;
-- `cmd/goxc/workspace_test.go`.
+### Practical implication
 
-Package-qualified GOX component tags create the same kind of boundary across
-packages:
+The API shape is usable and documented.
+The deeper contract under module/path edges remains experimental until the
+`design/component-identity-preview-contract` branch resolves follow-up decisions.
 
-```gox
-<ui.Header Title="Demo" />
-```
+## Remount and state expectations
 
-When `ui` imports `github.com/example/app/internal/ui`, generated identity is:
+- Preserve state when identity and key are stable across renders.
+- Remount is expected when identity changes or key changes.
+- A module or import path change is treated as an identity change and may remount.
+- Render-time component renaming changes identity.
+- Stateful components without keys can still remount when sibling position changes.
 
-```text
-github.com/example/app/internal/ui.Header
-```
+## Public preview recommendation
 
-The debug label remains `ui.Header` so browser smoke and debug counters stay
-readable when several packages define a `Header`.
+Use package-qualified GOX tags and typed components for non-trivial, multi-file apps.
+Use `gf.Component` with direct calls for simple compatibility helpers.
+Do not assume stable behavior across module path edits, module replacement,
+ or cross-module ecosystem sharing in this preview window.
 
-## Risks
+## Risks and non-goals
 
-Name-based identity is compact and easy to debug, but it has limits:
+- No new migration layer is introduced in preview.
+- No broader reusable package ecosystem promise.
+- No hidden identity migration protocol.
+- No production/1.0 compatibility commitment.
 
-- two different component functions can use the same declared name;
-- package path is not part of legacy string identity;
-- the runtime does not know the Go function implementation behind a name;
-- renaming a component resets its identity;
-- duplicate sibling keys are still a user error, although debug builds now
-  warn about them.
+## Evidence
 
-These risks are acceptable for the current MVP examples but should be revisited
-before larger applications or reusable component packages.
-
-## Alternative A: Keep Name/Key/Position
-
-Pros:
-
-- smallest runtime shape;
-- works with current GOX codegen;
-- readable debug output;
-- no migration cost;
-- TinyGo-friendly.
-
-Cons:
-
-- possible collisions across packages or generated code;
-- function implementation is not part of identity;
-- name changes are identity changes.
-
-This remains the legacy compatibility strategy. Generated GOX now uses the
-typed token path by default.
-
-## Alternative B: Generated Stable Type Token
-
-GOX codegen now emits prototype component tokens:
-
-```go
-var _goxComponentHeader = gf.NewComponentType("main.Header", "Header")
-
-gf.ComponentT(_goxComponentHeader, HeaderProps{
-	Title: "Demo",
-}, Header)
-```
-
-Pros:
-
-- can include package/import context;
-- avoids accidental same-name collisions;
-- does not require comparing Go function values;
-- can preserve readable names for debug output.
-
-Remaining cons:
-
-- `goxc` generated ids use package import path plus component name when the
-  module path is known;
-- package-qualified component tags use the resolved import path plus selected
-  component name, not the local alias alone;
-- lower-level generation helpers can still fall back to package name plus
-  component name;
-- token variable names are generated-code details;
-- multi-module workspace support still needs more identity design;
-- may increase bundle size if token metadata grows.
-
-Recommendation: keep the token path as the generated default while retaining
-`gf.Component` as compatibility API. MVP 20's import-aware `goxc` ids cover
-`entry: "."` apps with child packages, and MVP 22 applies the same model to
-child entry packages such as `./cmd/app`. They are not a complete multi-module
-identity policy.
-
-## Multi-Module Conclusion
-
-Status: Blocker for broader package ecosystem claims.
-
-The current policy is strong enough for single-module apps, child entry
-packages, and package-qualified components inside the same Go module. It is
-not a complete reusable package ecosystem or multi-module workspace promise.
-
-Before claiming broad multi-module support, the project still needs to decide:
-
-- how generated identity behaves when multiple module roots are materialized;
-- how replace directives, forks, and local module paths should be described to
-  users;
-- whether public reusable component packages need additional documentation or
-  generated metadata;
-- how migration notes should handle module path rename/remount behavior.
-
-## Alternative C: Function Identity
-
-Using Go function identity directly is not recommended now.
-
-Go function values are not comparable except to `nil`. Reflection or unsafe
-runtime tricks would be needed to derive implementation identity, and both are
-bad fits for this project:
-
-- `reflect` is intentionally kept out of the production runtime;
-- unsafe/runtime internals are risky across Go and TinyGo;
-- TinyGo compatibility is uncertain;
-- the likely size cost is not worth it for the current MVP.
-
-## Recommendation
-
-Use generated typed identity for GOX, with these hardening rules:
-
-- keep generated identity ids stable within an application;
-- use keys for reordered lists;
-- treat duplicate keys as a bug;
-- keep duplicate-key diagnostics in `goframe_debug` builds only;
-- revisit multi-module and reusable component package identity before claiming
-  a public package ecosystem.
-
-## Migration Plan For Tokens
-
-The current migration path:
-
-1. Keep the optional token API while keeping `gf.Component`:
-
-   ```go
-   gf.NewComponentType("main.Header", "Header")
-   ```
-
-2. Use `gf.ComponentT` in generated GOX output.
-3. Keep string-based `gf.Component` as a compatibility API.
-4. Measure TinyGo sizes after token codegen changes.
-5. Continue hardening import-path identity before claiming reusable component
-   package or multi-module workspace support.
-
-## Size Considerations
-
-Any identity strategy must preserve the current size posture:
-
-- no `reflect`;
-- no `unsafe` runtime identity tricks;
-- no large metadata tables;
-- debug diagnostics behind `goframe_debug`;
-- measured TinyGo budget checks before and after the change.
+- `pkg/goframe/component.go`
+- `pkg/goframe/component_identity_test.go`
+- `pkg/gox/generate_test.go`
+- `pkg/goxc/workspace_test.go`

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -6,6 +6,10 @@ This document records what GoFrame currently tests, what is expected but not
 verified, and what remains unsupported. It is a public-preview readiness matrix,
 not a production support promise.
 
+The current strongest evidence is Linux plus Chrome/Chromium. macOS, Windows,
+Firefox, and Safari are not rejected platforms; they are under-verified for the
+first preview until CI or external validation expands.
+
 Labels:
 
 - CI-tested

--- a/docs/player-vision.md
+++ b/docs/player-vision.md
@@ -1,6 +1,7 @@
 # GoFrame Player vision
 
-The player is a future architectural direction, not a current implementation:
+The player is a future architectural direction, not a current implementation or
+first-preview promise:
 
 ```text
 .gox source
@@ -25,5 +26,6 @@ include sandboxing, updates, native capabilities, rendering, debugging, bundle
 signing, and portability.
 
 The project should first validate the browser runtime, manifest, toolchain, and
-application model. No custom browser, desktop shell, or player is implemented
-in the current MVP.
+application model. Keeping Player/Engine visible as future vision does not mean
+the first public preview promises a custom browser, desktop shell, `.gfapp`
+runtime, or player implementation.

--- a/docs/pre-preview-action-plan.md
+++ b/docs/pre-preview-action-plan.md
@@ -1,0 +1,236 @@
+# GoFrame Pre-Preview Action Plan
+
+## Snapshot
+
+- Audited SHA: `8c5744560dfad9ef4cb1bd3510c1fc6fb4ffaaa2`.
+- Codex audit branch: `chore/pre-preview-deep-audit-i`.
+- Codex report path: `docs/pre-preview-deep-audit-i.md`.
+- Independent research report was also reviewed externally by the project owner.
+
+This plan synthesizes both audits into the next pre-preview work. It does not
+merge the report branch and does not change runtime, compiler, toolchain,
+examples, scripts, or CI behavior.
+
+## Operating Principle
+
+Scope preview != scope project.
+
+The first public preview should validate the browser/WASM application layer that
+already has evidence: runtime components, GOX generation, `goxc`, packaging,
+router, resources, Error Boundaries, examples, docs, and CI gates. That narrower
+preview scope must not be confused with a smaller project vision.
+
+GoFrame should not remove or hide working surfaces merely because they are not
+perfect yet. Valuable but risky areas should be hardened, documented, tested, or
+marked experimental. The project remains an ambitious Go-first application
+platform; preview contracts should make maturity visible rather than amputating
+the roadmap.
+
+## Current Product Identity
+
+GoFrame is an experimental Go-first application platform whose first validated
+public layer is browser/WASM interactive applications.
+
+Current real layers:
+
+- `pkg/goframe` runtime;
+- `pkg/gox` GOX compiler;
+- `cmd/goxc` toolchain;
+- examples and reference apps;
+- package/export workflow;
+- docs, CI, and release policy.
+
+The current preview candidate is not a production platform and does not claim
+SSR, hydration, history-mode routing, route loaders, server resources,
+production deployment hosting, or Player/Engine delivery. Those boundaries are
+preview boundaries, not statements that the future platform should avoid them.
+
+## Maturity Tiers
+
+| Tier | Meaning | Current surfaces |
+|---|---|---|
+| Core / public-candidate | Real user-facing surface with examples, tests, and intended direction, but no 1.0 guarantee. | Component model, state/reducer/effects hooks, context, basic events, GOX basic syntax and generation workflow, `goxc generate/build/package/export` basics, static browser/WASM package workflow. |
+| Experimental frontier | Working and valuable, but contract details still need staged hardening before broad promises. | Resources, Error Boundaries, hash router details, runtime error APIs, virtualization beyond the current fixed-height contract, advanced GOX syntax and diagnostics, package metadata details. |
+| Future vision | Strategic direction that should remain visible but is not promised by the first preview. | Player/Engine, richer app platform, broader host/runtime story, stronger editor tooling, future package ecosystem, future deployment/bundle contracts. |
+| Internal / implementation detail | Needed by the implementation and tests, not an external compatibility promise. | Hidden `.goframe` workspace layout, mounted tree internals, dirty queues, debug probes, staging directories, smoke harness details. |
+
+## Confirmed Risks
+
+The audits did not identify a confirmed Critical blocker at the audited SHA.
+They did confirm readiness risks that should be handled before broad public
+preview or explicitly scoped in release notes:
+
+- reusable/multi-module component identity contract;
+- platform/browser evidence beyond Linux/Chrome;
+- manifest/versioning decision for public preview;
+- GOX parser/codegen fuzzing;
+- `pkg/gox` file helper safety contract for direct library callers;
+- package publication transactionality;
+- supply-chain scanner evidence;
+- CLI/helper direct coverage;
+- docs/status clarity.
+
+These are contract and evidence risks, not reasons to reduce GoFrame to a
+smaller product category.
+
+## What We Will Not Do
+
+- No feature removal just to reduce audit surface.
+- No runtime/toolchain rewrites in this docs/planning phase.
+- No pretending experimental surfaces do not exist.
+- No production claims.
+- No SSR, hydration, history-router, route-loader, server-resource, or
+  Player/Engine promises for the first preview.
+
+## Roadmap
+
+### 1. `docs/vision-preserving-preview-contract`
+
+Scope: define the vision-preserving preview contract, maturity tiers, and
+action plan.
+
+Findings addressed: docs/status clarity, release framing, audit synthesis.
+
+Acceptance criteria:
+
+- `docs/pre-preview-action-plan.md` exists;
+- readiness/API/platform/release docs clearly separate project vision from first
+  preview scope;
+- no code, examples, scripts, CI, manifests, or tests change.
+
+Non-goals:
+
+- no runtime/toolchain fixes;
+- no new preview tag;
+- no CI matrix expansion.
+
+### 2. `design/component-identity-preview-contract`
+
+Scope: define the first-preview component identity contract for reusable
+packages and multi-module expectations.
+
+Findings addressed: reusable/multi-module component identity contract.
+
+Acceptance criteria:
+
+- preview explicitly states whether reusable components are supported only
+  within one module/app-root or across multiple modules;
+- remount expectations for module path/version changes are documented;
+- fixtures or design examples cover the accepted scope.
+
+Non-goals:
+
+- no broad monorepo support unless intentionally designed;
+- no hidden identity migration scheme.
+
+### 3. `ci/minimal-platform-evidence`
+
+Scope: add or document minimal platform/browser evidence for the first preview.
+
+Findings addressed: platform/browser evidence.
+
+Acceptance criteria:
+
+- Linux/Chrome remains the strongest evidence;
+- macOS/Windows pure Go/toolchain checks are added or explicitly deferred with
+  release-note wording;
+- at least one non-Chrome browser lane is added or a clear external validation
+  plan is recorded.
+
+Non-goals:
+
+- no production support matrix;
+- no promise that every browser has equivalent behavior.
+
+### 4. `test/gox-fuzz-seeds`
+
+Scope: seed short fuzz targets or fuzz-ready corpora for GOX parsing/codegen.
+
+Findings addressed: GOX fuzzing.
+
+Acceptance criteria:
+
+- fuzz targets exist for parser/codegen entry points or a documented initial
+  corpus is checked in;
+- existing golden/error golden fixtures are reused as seeds;
+- CI impact is bounded.
+
+Non-goals:
+
+- no full language redesign;
+- no LSP/formatter work.
+
+### 5. `toolchain/goxc-preview-safety-closeout`
+
+Scope: close remaining toolchain contract gaps that are still relevant after
+MVP 30.
+
+Findings addressed: `pkg/gox` file helper safety contract, package publication
+transactionality, command/helper direct coverage, supply-chain evidence where it
+belongs to tooling.
+
+Acceptance criteria:
+
+- decide whether exported `pkg/gox` file helpers are hardened or documented as
+  trusted-filesystem convenience helpers;
+- package publication limitation is either accepted in release notes or moved
+  toward transactional replacement;
+- command-level coverage is improved where it protects user-facing behavior.
+
+Non-goals:
+
+- no runtime API changes;
+- no package ecosystem design.
+
+### 6. `runtime/experimental-surface-hardening`
+
+Scope: harden working experimental surfaces without demoting them from the
+project vision.
+
+Findings addressed: experimental router/resource/Error Boundary/runtime error
+contract clarity.
+
+Acceptance criteria:
+
+- resources, router details, Error Boundaries, and runtime error APIs have
+  precise preview wording;
+- any risky edge behavior is tested or documented;
+- examples continue to show the integrated platform path.
+
+Non-goals:
+
+- no Suspense, route loaders, global cache, server resources, or full
+  ErrorBoundary framework.
+
+### 7. `docs/v0.1.0-preview-release-story`
+
+Scope: prepare release notes and evaluator guidance for `v0.1.0-preview.1`.
+
+Findings addressed: release clarity, maturity tiers, known limitations,
+platform evidence, identity scope.
+
+Acceptance criteria:
+
+- release notes state maturity tiers;
+- known risks are linked to follow-up branches;
+- first-preview claims are limited to the validated browser/WASM layer;
+- future Player/Engine/platform direction remains visible but explicitly not
+  promised by the preview.
+
+Non-goals:
+
+- no production support claim;
+- no final `v0.1.0` stability promise.
+
+## Preview Verdict
+
+| Decision target | Verdict | Meaning |
+|---|---|---|
+| Continued development | Go | The project direction is coherent and the audited baseline is strong enough for continued feature and hardening work. |
+| Narrow evaluator preview | Conditional Go | Reasonable after contract, platform, and identity closeout, with Linux/Chrome evidence and explicit maturity tiers. |
+| Broad public preview | No-Go until High risks are addressed or explicitly scoped | Multi-module/reusable identity and platform evidence are not yet broad-preview complete. |
+| Production use | No-Go | GoFrame remains experimental and does not provide production server, SSR/hydration, history routing, route loaders, or a 1.0 API promise. |
+
+The broad-preview No-Go is not a rejection of GoFrame's ambition. It means the
+project should harden and label its current browser/WASM layer before widening
+public promises.

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -4,6 +4,10 @@
 
 Status: Needs hardening.
 
+How to read this status: several subsystems are already "Ready with
+limitations", but the project as a public preview remains "Needs hardening"
+until High readiness risks are closed or explicitly scoped in release notes.
+
 GoFrame has enough runtime, GOX, toolchain, examples, and CI coverage to start
 formal public-preview preparation. It is not yet preview-ready because several
 contracts still need final decisions before a preview tag:
@@ -21,6 +25,36 @@ filesystem/package corrective pass hardens the goxc package/export/generate/
 build/clean/serve paths against common symlink traversal, false ownership,
 physical alias overlap, authored-source output, partial package ownership, and
 generated-asset collision mistakes.
+
+The first preview scope is narrower than the project vision. GoFrame remains an
+experimental Go-first application platform; the preview candidate validates the
+current browser/WASM application layer rather than reducing the long-term
+project to a small dashboard-only framework.
+
+See `docs/pre-preview-action-plan.md` for the post-audit action plan.
+
+## Project Vision And First Preview Scope
+
+Project vision:
+
+- GoFrame is an experimental Go-first application platform.
+- Browser/WASM interactive applications are the first validated public layer.
+- Runtime, GOX, `goxc`, packaging, router, resources, Error Boundaries,
+  examples, docs, and release policy are real project layers.
+- Player/Engine, richer host/runtime stories, stronger editor tooling, and a
+  future package ecosystem remain future vision.
+
+First preview scope:
+
+- validate the current browser/WASM layer with clear maturity tiers;
+- keep static hash-router deployment as the documented delivery path;
+- label experimental frontier surfaces honestly instead of hiding them;
+- avoid production, SSR/hydration, history-router, route-loader, server-resource,
+  or Player/Engine promises.
+
+Preview scope is not project scope. Risky but valuable surfaces should be
+hardened, documented, tested, or marked experimental, not removed merely to make
+the preview smaller.
 
 ## Current Status
 
@@ -47,6 +81,15 @@ A first public preview should mean:
 It should not mean production readiness, 1.0 API stability, SSR/hydration,
 history routing, route loaders, Suspense, server resources, or a production
 deployment server.
+
+## Maturity Tiers
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| Core / Public-Candidate | User-facing surfaces with real examples/tests and intended direction, still pre-1.0. | Component model, state/reducer/effects, GOX basic syntax/generation workflow, `goxc generate/build/package/export`, static browser/WASM packaging. |
+| Experimental frontier | Working surfaces that should stay visible while contracts are hardened. | Resources, Error Boundaries, router details, runtime error APIs, virtualization beyond fixed-height guarantees, advanced GOX diagnostics, package metadata details. |
+| Future vision | Strategic direction outside the first preview promise. | Player/Engine, broader host/runtime story, stronger editor tooling, future package ecosystem. |
+| Internal / implementation detail | Implementation and harness details with no compatibility promise. | Hidden `.goframe` workspace layout, mounted tree internals, debug probes, staging directories, smoke harness internals. |
 
 ## API Surface
 
@@ -254,7 +297,12 @@ Recommendation:
 
 ## Recommended Next Stage
 
-MVP 31 should focus on public-preview blockers, not new app features:
+The next branches should follow `docs/pre-preview-action-plan.md`: focus on
+contract, platform evidence, identity, fuzzing, safety closeout, experimental
+surface hardening, and preview release notes rather than deleting working
+surfaces.
+
+Immediate public-preview blockers remain:
 
 1. decide manifest schema/version strategy;
 2. decide multi-module/reusable package identity scope;

--- a/docs/release.md
+++ b/docs/release.md
@@ -146,6 +146,14 @@ clear about API instability and experimental status.
 
 - tag format documented;
 - install command documented;
+- maturity tiers included: public-candidate, experimental frontier,
+  compiler-facing, internal, and future vision;
+- platform evidence stated explicitly, including Linux/Chrome as the strongest
+  current evidence and unverified platforms as under-verified rather than
+  rejected;
+- reusable/multi-module component identity scope stated explicitly;
+- experimental surfaces named rather than hidden;
+- future Player/Engine direction bounded as vision, not a preview promise;
 - compatibility/deprecation notes included;
 - migration notes linked;
 - rollback/revert plan noted for preview users.


### PR DESCRIPTION
## Summary

This PR defines the first-preview component identity contract for GoFrame.

It follows the pre-preview principle:

> Scope preview != scope project

The goal is not to reduce GoFrame's long-term platform vision, but to clearly state which component identity behavior is stable enough for the first browser/WASM preview and which areas remain experimental frontier.

## What Changed

- Clarified the API stability distinction between public-candidate API shape and experimental deeper semantics.
- Reworked `docs/component-identity.md` into a preview-facing contract.
- Documented the expected behavior of:
  - `gf.Component`
  - `gf.ComponentT`
  - `gf.NewComponentType`
  - generated GOX component identity
  - package-qualified tags
  - `PackageIdentity`
- Clarified that direct Go calls are ordinary function composition, not runtime component boundaries.
- Documented remount/state expectations around identity and keys.
- Marked broad multi-module and reusable package identity as experimental / partially evidenced.
- Added a concise changelog entry.

## Preview Contract

For the first preview, users can rely on component identity within one app-root/module, including package-qualified GOX composition where imports resolve to stable package identities.

The following remain experimental frontier:

- reusable component identity across independent modules;
- `replace`, workspace aliasing, and package relocation edge cases;
- module path/version churn;
- generated token reuse across independently built package sets;
- legacy `gf.Component` as a full cross-package identity strategy.

## Non-Goals

- No runtime or toolchain behavior changes.
- No new migration layer.
- No broad reusable package ecosystem promise.
- No production or 1.0 compatibility guarantee.
- No reduction of GoFrame to a dashboard-only framework.

## Validation

Reported validation:

- `git diff --check` — OK
- `node scripts/docs-check.mjs` — OK
- `go test ./...` — OK