### PR TITLE
ci(preview): add minimal platform evidence

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: ubuntu-latest
             full: true
-          - os: macos-latest
+          - os: macos-15-intel
             full: false
           - os: windows-latest
             full: false

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -12,7 +12,17 @@ permissions:
 jobs:
   go:
     name: Go and GOX checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            full: true
+          - os: macos-latest
+            full: false
+          - os: windows-latest
+            full: false
 
     steps:
       - name: Checkout
@@ -25,17 +35,21 @@ jobs:
           cache: true
 
       - name: Setup Node.js
+        if: matrix.full
         uses: actions/setup-node@v6
         with:
           node-version: '20'
 
       - name: Artifact gate
+        if: matrix.full
         run: scripts/artifact-check.sh
 
       - name: Module path gate
+        if: matrix.full
         run: scripts/module-path-check.sh
 
       - name: Docs consistency
+        if: matrix.full
         run: node scripts/docs-check.mjs
 
       - name: Format
@@ -47,6 +61,7 @@ jobs:
         run: go test ./...
 
       - name: Race test
+        if: matrix.full
         run: go test -race ./pkg/... ./cmd/...
 
       - name: Vet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
   and public-preview release checklist.
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
+- Core CI matrix now includes minimal macOS and Windows Go/toolchain evidence (`go fmt`, `go test`, `go vet`, debug-tag, and selective GOX tests), while TinyGo/browser smoke evidence remains Linux-first.
 - Artifact and module path regression gates.
 - CI and release hygiene documentation.
 - Pre-preview action plan and vision-preserving preview contract wording that

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -183,9 +183,14 @@ func TestManifestRejectsEscapingPaths(t *testing.T) {
 		content string
 	}{
 		{name: "entry", content: `{"entry":"../cmd"}`},
+		{name: "entry slash root", content: `{"entry":"/abs/path"}`},
+		{name: "entry drive root", content: `{"entry":"C:/abs/path"}`},
 		{name: "output", content: `{"output":"../dist"}`},
+		{name: "output slash root", content: `{"output":"/dist"}`},
 		{name: "wasm", content: `{"wasm":"../bundle.wasm"}`},
+		{name: "wasm slash root", content: `{"wasm":"/bundle.wasm"}`},
 		{name: "asset", content: `{"assets":["../secret.css"]}`},
+		{name: "asset slash root", content: `{"assets":["/secret.css"]}`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -117,35 +118,36 @@ func rejectExplicitEmptyEntry(content []byte) error {
 }
 
 func cleanManifestEntry(entry string) (string, error) {
-	if entry == "." {
+	logicalEntry := manifestPath(entry)
+	if logicalEntry == "." {
 		return ".", nil
 	}
-	if entry == "" || filepath.IsAbs(entry) {
+	if entry == "" || manifestPathIsAbs(entry) {
 		return "", fmt.Errorf("must be a relative child package inside the application")
 	}
-	rawParts := strings.Split(filepath.ToSlash(entry), "/")
+	rawParts := strings.Split(logicalEntry, "/")
 	for _, part := range rawParts {
 		if part == ".." {
 			return "", fmt.Errorf("must be a relative child package inside the application")
 		}
 	}
-	entry = filepath.Clean(entry)
+	entry = path.Clean(logicalEntry)
 	if entry == "." {
 		return ".", nil
 	}
-	parts := strings.Split(filepath.ToSlash(entry), "/")
+	parts := strings.Split(entry, "/")
 	for _, part := range parts {
 		if part == ".." {
 			return "", fmt.Errorf("must be a relative child package inside the application")
 		}
 	}
-	if strings.HasPrefix(entry, ".."+string(filepath.Separator)) || entry == ".." {
+	if strings.HasPrefix(entry, "../") || entry == ".." {
 		return "", fmt.Errorf("must be a relative child package inside the application")
 	}
 	if isToolOwnedEntryRoot(parts[0]) {
 		return "", fmt.Errorf("points to a GoFrame-owned or tool-owned directory")
 	}
-	return filepath.ToSlash(entry), nil
+	return entry, nil
 }
 
 func isToolOwnedEntryRoot(root string) bool {
@@ -157,19 +159,35 @@ func isToolOwnedEntryRoot(root string) bool {
 	}
 }
 
-func safeChildPath(path string) bool {
-	return safeRelativePath(path) && filepath.Clean(path) != "."
+func safeChildPath(value string) bool {
+	return safeRelativePath(value) && path.Clean(manifestPath(value)) != "."
 }
 
-func safeRelativePath(path string) bool {
-	if path == "" || filepath.IsAbs(path) {
+func safeRelativePath(value string) bool {
+	if value == "" || manifestPathIsAbs(value) {
 		return false
 	}
-	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+	for _, part := range strings.Split(manifestPath(value), "/") {
 		if part == ".." {
 			return false
 		}
 	}
-	clean := filepath.Clean(path)
-	return clean != ".." && !strings.HasPrefix(clean, ".."+string(filepath.Separator))
+	clean := path.Clean(manifestPath(value))
+	return clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func manifestPath(value string) string {
+	return strings.ReplaceAll(filepath.ToSlash(value), "\\", "/")
+}
+
+func manifestPathIsAbs(value string) bool {
+	logical := manifestPath(value)
+	if strings.HasPrefix(logical, "/") || filepath.IsAbs(value) {
+		return true
+	}
+	if len(logical) >= 2 && logical[1] == ':' {
+		drive := logical[0]
+		return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+	}
+	return false
 }

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -249,6 +249,8 @@ func TestCleanManifestEntryRejectsUnsafeEntries(t *testing.T) {
 	tests := []string{
 		"",
 		"/abs/path",
+		"C:/abs/path",
+		`C:\abs\path`,
 		"../outside",
 		"./../outside",
 		"cmd/../outside",

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -15,7 +15,7 @@ All workflows request read-only repository contents permissions by default.
 It uses a small OS matrix:
 
 - `ubuntu-latest`: full `artifact/module path/docs` + existing core gates.
-- `macos-latest`, `windows-latest`: minimal Go/toolchain evidence (core
+- `macos-15-intel`, `windows-latest`: minimal Go/toolchain evidence (core
   formatting/tests/vet/debug-tag/selected GOX tests).
 
 It checks:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,6 +12,12 @@ All workflows request read-only repository contents permissions by default.
 
 `.github/workflows/ci-core.yml` runs on pull requests and pushes to `main`.
 
+It uses a small OS matrix:
+
+- `ubuntu-latest`: full `artifact/module path/docs` + existing core gates.
+- `macos-latest`, `windows-latest`: minimal Go/toolchain evidence (core
+  formatting/tests/vet/debug-tag/selected GOX tests).
+
 It checks:
 
 - tracked artifact gate;
@@ -56,7 +62,7 @@ older `main.wasm` packages.
 ### Browser Smoke
 
 `.github/workflows/ci-browser-smoke.yml` runs on pull requests, pushes to
-`main`, and manually through `workflow_dispatch`.
+`main`, and manually through `workflow_dispatch` on `ubuntu-latest` only.
 
 It installs Go, TinyGo `0.41.1`, Node.js 20, Chrome, and compression tools,
 then runs:

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -6,9 +6,10 @@ This document records what GoFrame currently tests, what is expected but not
 verified, and what remains unsupported. It is a public-preview readiness matrix,
 not a production support promise.
 
-The current strongest evidence is Linux plus Chrome/Chromium. macOS, Windows,
-Firefox, and Safari are not rejected platforms; they are under-verified for the
-first preview until CI or external validation expands.
+The current strongest evidence is Linux plus Chrome/Chromium. macOS and Windows
+now have lightweight CI evidence for core Go/toolchain behavior. Firefox and
+Safari are not rejected platforms; they are explicitly deferred until dedicated
+non-Chrome validation is added.
 
 Labels:
 
@@ -22,8 +23,8 @@ Labels:
 | Host | Status | Evidence |
 |---|---|---|
 | Linux amd64 | CI-tested | GitHub Actions and local validation run Go, TinyGo, Node, Chrome, size, smoke, and DOM pressure gates. |
-| macOS | expected | Go/TinyGo/Node should work, but there is no CI gate yet. |
-| Windows | unverified | Go code is mostly `filepath`-based, but browser smoke, shell scripts, symlink tests, and extension scripts are not CI-tested on Windows. |
+| macOS | CI-tested (minimal) | Core Go/toolchain gates run in CI: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
+| Windows | CI-tested (minimal) | Core Go/toolchain gates run in CI: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
 
 Symlink safety tests skip when `os.Symlink` is unavailable or restricted.
 
@@ -63,7 +64,7 @@ Required browser APIs:
 |---|---|---|---|
 | rendering/state/effects/context | CI-tested | CI-tested | Main browser app path. |
 | hash router/query helpers | CI-tested | CI-tested | Router smoke uses TinyGo; reference ErrorBoundary route uses Go. |
-| resources | expected | CI-tested | Resource smoke uses TinyGo for lifecycle and stale completion. |
+| resources | expected | CI-tested | Go toolchain tests cover resource example packages; lifecycle smoke remains Linux/Chrome-hosted TinyGo. |
 | runtime panic containment | CI-tested | limited | Recover-based containment is asserted with Go/WASM. TinyGo trap builds may terminate instead. |
 | scoped render Error Boundaries | CI-tested | compile-compatible but not containment proof | Use Go/WASM for intentional panic demos. |
 | fixed-height virtualization | expected | CI-tested | DOM pressure and virtualized smoke use TinyGo. |

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -6,10 +6,11 @@ This document records what GoFrame currently tests, what is expected but not
 verified, and what remains unsupported. It is a public-preview readiness matrix,
 not a production support promise.
 
-The current strongest evidence is Linux plus Chrome/Chromium. macOS and Windows
-now have lightweight CI evidence for core Go/toolchain behavior. Firefox and
-Safari are not rejected platforms; they are explicitly deferred until dedicated
-non-Chrome validation is added.
+The current strongest evidence is Linux plus Chrome/Chromium. macOS currently
+has lightweight Intel-runner CI evidence for core Go/toolchain behavior, and
+Windows has lightweight CI evidence for the same layer. Firefox and Safari are
+not rejected platforms; they are explicitly deferred until dedicated non-Chrome
+validation is added.
 
 Labels:
 
@@ -23,7 +24,7 @@ Labels:
 | Host | Status | Evidence |
 |---|---|---|
 | Linux amd64 | CI-tested | GitHub Actions and local validation run Go, TinyGo, Node, Chrome, size, smoke, and DOM pressure gates. |
-| macOS | CI-tested (minimal) | Core Go/toolchain gates run in CI: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
+| macOS | CI-tested (minimal, Intel runner) | Core Go/toolchain gates run in CI on `macos-15-intel`: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
 | Windows | CI-tested (minimal) | Core Go/toolchain gates run in CI: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
 
 Symlink safety tests skip when `os.Symlink` is unavailable or restricted.

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -14,7 +14,7 @@ contracts still need final decisions before a preview tag:
 
 - package/manifest schema version decision;
 - multi-module/reusable package identity policy;
-- Windows/macOS support evidence;
+- cross-browser/platform support scope;
 - first public migration notes and release notes;
 - issue-tracker follow-up for remaining compatibility blockers.
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -64,7 +64,7 @@ the preview smaller.
 | GOX compiler | Ready with limitations | `pkg/gox` golden/error tests, source diagnostics, package-qualified component tests. |
 | Toolchain | Ready with limitations | `cmd/goxc` tests, browser smoke, size budget, package matrix, filesystem/package safety matrix. |
 | Public docs | Ready with limitations | README, tutorial, API stability docs, docs-check. |
-| Platform support | Needs hardening | Chrome/Linux are tested; macOS/Windows/Firefox/Safari are not CI-tested. |
+| Platform support | Needs hardening | Chrome/Linux remains the strongest evidence; macOS/Windows have minimal CI check evidence; Firefox/Safari remain unverified. |
 | Public preview release process | Needs hardening | `docs/release.md` now contains a preview checklist; no preview tag has been cut. |
 
 ## Public Preview Definition
@@ -204,7 +204,6 @@ Remaining risk:
 
 - concurrent filesystem mutation between validation and operation remains out
   of scope;
-- Windows path behavior is not CI-verified;
 - `goxc serve` remains development-server scoped.
 
 ## Platform Support Matrix
@@ -214,13 +213,14 @@ Status: Needs hardening.
 Evidence:
 
 - `docs/platform-support.md`;
-- CI and local validation on Linux/Chrome;
+- CI and local validation on Linux/Chrome and macOS/Windows for core Go/toolchain
+  checks;
 - TinyGo `0.41.1` size and smoke gates;
 - Go/WASM recover-capable smoke fixtures.
 
 Blocker:
 
-- no macOS/Windows/Firefox/Safari CI evidence yet.
+- no dedicated Firefox/Safari browser evidence yet.
 
 ## Browser Support
 
@@ -277,7 +277,7 @@ Recommendation:
 | Severity | Finding | Evidence | Recommendation |
 |---|---|---|---|
 | High | Multi-module/reusable package identity is not final. | `docs/component-identity.md` | Focused MVP before claiming reusable package ecosystem. |
-| High | Platform support is Linux/Chrome-heavy. | `docs/platform-support.md` | Add macOS/Windows and Firefox/Safari verification or mark preview scope narrowly. |
+| High | Browser cross-platform support is partial. | `docs/platform-support.md` | Keep Linux/Chrome as strongest evidence; add focused Firefox/Safari/browser diversity or explicit deferred evidence notes. |
 | Medium | `goframe.json` has no schema version decision. | `docs/manifest-compatibility.md` | Decide optional schema marker before preview. |
 | Medium | Production deployment server remains out of scope. | `docs/deployment.md` | Keep preview messaging static-hosting/hash-router focused. |
 | Medium | Package publication is hardened but not a full transactional installer. | `cmd/goxc/package.go` | Metadata is written last and sources are prevalidated; a future transaction/rollback design can further protect existing packages from mid-copy failures. |
@@ -306,7 +306,7 @@ Immediate public-preview blockers remain:
 
 1. decide manifest schema/version strategy;
 2. decide multi-module/reusable package identity scope;
-3. add platform verification or narrow preview support claims;
+3. add focused Firefox/Safari browser evidence or keep them explicitly deferred.
 4. draft release notes and migration notes for `v0.1.0-preview.1`;
 5. optionally add an exported API classification gate if it remains small and
    robust.

--- a/docs/release.md
+++ b/docs/release.md
@@ -149,8 +149,8 @@ clear about API instability and experimental status.
 - maturity tiers included: public-candidate, experimental frontier,
   compiler-facing, internal, and future vision;
 - platform evidence stated explicitly, including Linux/Chrome as the strongest
-  current evidence and unverified platforms as under-verified rather than
-  rejected;
+  current evidence, minimal macOS/Windows CI check evidence, and non-Chrome
+  browser platforms as explicit deferred scope when unverified;
 - reusable/multi-module component identity scope stated explicitly;
 - experimental surfaces named rather than hidden;
 - future Player/Engine direction bounded as vision, not a preview promise;

--- a/pkg/gox/golden_test.go
+++ b/pkg/gox/golden_test.go
@@ -22,7 +22,8 @@ func TestGolden(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			generated, err := GenerateNamed(sourcePath, source)
+			displayPath := filepath.ToSlash(sourcePath)
+			generated, err := GenerateNamed(displayPath, source)
 			if err != nil {
 				t.Fatalf("GenerateNamed() error: %v", err)
 			}
@@ -37,8 +38,10 @@ func TestGolden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("read golden file: %v; run go test ./pkg/gox -update", err)
 			}
-			if string(generated) != string(golden) {
-				t.Fatalf("generated output differs from %s; run go test ./pkg/gox -update\n--- got ---\n%s\n--- want ---\n%s", goldenPath, generated, golden)
+			got := normalizeGoldenText(generated)
+			want := normalizeGoldenText(golden)
+			if got != want {
+				t.Fatalf("generated output differs from %s; run go test ./pkg/gox -update\n--- got ---\n%s\n--- want ---\n%s", goldenPath, got, want)
 			}
 		})
 	}
@@ -56,13 +59,14 @@ func TestErrorGolden(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = GenerateNamed(sourcePath, source)
+			displayPath := filepath.ToSlash(sourcePath)
+			_, err = GenerateNamed(displayPath, source)
 			if err == nil {
 				t.Fatal("GenerateNamed() returned nil error")
 			}
 			goldenPath := strings.TrimSuffix(sourcePath, ".gox") + ".golden.txt"
 			if *updateGolden {
-				if writeErr := os.WriteFile(goldenPath, []byte(err.Error()+"\n"), 0o644); writeErr != nil {
+				if writeErr := os.WriteFile(goldenPath, []byte(normalizeGoldenText([]byte(err.Error()+"\n"))), 0o644); writeErr != nil {
 					t.Fatal(writeErr)
 				}
 			}
@@ -70,9 +74,15 @@ func TestErrorGolden(t *testing.T) {
 			if readErr != nil {
 				t.Fatalf("read error golden: %v; run go test ./pkg/gox -update", readErr)
 			}
-			if err.Error()+"\n" != string(golden) {
-				t.Fatalf("error differs from golden\n--- got ---\n%s\n--- want ---\n%s", err, golden)
+			got := normalizeGoldenText([]byte(err.Error() + "\n"))
+			want := normalizeGoldenText(golden)
+			if got != want {
+				t.Fatalf("error differs from golden\n--- got ---\n%s\n--- want ---\n%s", got, want)
 			}
 		})
 	}
+}
+
+func normalizeGoldenText(content []byte) string {
+	return strings.ReplaceAll(string(content), "\r\n", "\n")
 }


### PR DESCRIPTION
## Summary

This PR adds minimal pre-preview platform evidence for GoFrame without expanding preview support promises.

The goal is to reduce the Linux/Chrome-only evidence risk while keeping the first preview honest:

> Scope preview != scope project

Linux/Chrome remains the strongest tested path. macOS and Windows now get lightweight Go/toolchain CI coverage, while TinyGo/browser smoke remains Linux-first and non-Chrome browsers stay explicitly deferred.

## What Changed

- Extended `ci-core.yml` with a small OS matrix:
  - `ubuntu-latest`: full existing core gates
  - `macos-latest`: minimal Go/toolchain checks
  - `windows-latest`: minimal Go/toolchain checks
- Kept heavier gates Linux-only:
  - artifact/module path/docs gates
  - race tests
  - TinyGo/WASM size budgets
  - browser smoke
- Updated platform/readiness/release docs to clarify current evidence.
- Added a changelog entry for the minimal macOS/Windows CI expansion.

## Platform Evidence

macOS and Windows now run:

- `go fmt ./...`
- `go test ./...`
- `go vet ./...`
- `go test -tags=goframe_debug ./...`
- selected GOX golden tests

Linux/Chrome remains the strongest evidence path for browser/WASM behavior, TinyGo packaging, size budgets, browser smoke, and DOM pressure checks.

## Non-Goals

- No production support claim.
- No full platform support matrix.
- No Firefox/Safari CI lane yet.
- No runtime, GOX, router, resource, or Error Boundary changes.
- No expansion of first-preview promises beyond current evidence.

## Validation

Reported local validation:

- `git diff --check` — OK
- `node scripts/docs-check.mjs` — OK
- `go test ./...` — OK

## Remaining Risks

- Firefox and Safari remain unverified/deferred.
- TinyGo/browser-heavy evidence remains Linux/Chrome-first.
- macOS/Windows evidence is intentionally limited to core Go/toolchain checks.