### PR TITLE
test(gox): add bounded fuzz seeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,9 @@
 - GitHub Actions workflows for core Go/GOX checks, TinyGo WASM size budgets,
   browser smoke, and VS Code extension compile checks.
 - Core CI matrix now includes minimal macOS and Windows Go/toolchain evidence (`go fmt`, `go test`, `go vet`, debug-tag, and selective GOX tests), while TinyGo/browser smoke evidence remains Linux-first.
+- Initial bounded GOX fuzz targets for whole-file generation and element
+  parser/codegen, seeded from existing golden/error fixtures and small inline
+  snippets.
 - Artifact and module path regression gates.
 - CI and release hygiene documentation.
 - Pre-preview action plan and vision-preserving preview contract wording that

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -29,6 +29,7 @@ It checks:
 - `go vet ./...`;
 - `go test -tags=goframe_debug ./...`;
 - GOX golden tests, including source-oriented error diagnostics.
+- GOX fuzz seed targets through the normal `go test ./...` seed pass.
 
 The `cmd/goxc` test suite includes manifest/path/package/export/workspace
 regression tests, including root-aware symlink checks for app roots, entry
@@ -147,6 +148,16 @@ Public-preview readiness spot checks:
 go test ./pkg/gox -run 'Identity|Package|Golden|ErrorGolden|Qualified'
 go test ./cmd/goxc -run 'Physical|Canonical|Alias|Overlap|Build|Generate|Ownership|Completion|Marker|Legacy|Partial|Publish|Cleanup|Manifest|Symlink|Path'
 ```
+
+GOX parser/codegen fuzz smoke, for manual use during compiler work:
+
+```bash
+go test ./pkg/gox -run=Fuzz -fuzz=FuzzGenerate -fuzztime=30s
+go test ./pkg/gox -run=Fuzz -fuzz=FuzzParseElement -fuzztime=30s
+```
+
+These targets reuse the existing golden/error fixtures and small inline seeds.
+They are bounded fuzz entry points, not exhaustive GOX language verification.
 
 No separate public-preview script is required yet; the readiness checks are
 small enough to stay inside the existing Go test and docs-check gates.

--- a/docs/pre-preview-action-plan.md
+++ b/docs/pre-preview-action-plan.md
@@ -63,7 +63,8 @@ preview or explicitly scoped in release notes:
 - reusable/multi-module component identity contract;
 - platform/browser evidence beyond Linux/Chrome;
 - manifest/versioning decision for public preview;
-- GOX parser/codegen fuzzing;
+- GOX parser/codegen fuzzing, now reduced by initial bounded fuzz targets but
+  still not a formal exhaustive language verification story;
 - `pkg/gox` file helper safety contract for direct library callers;
 - package publication transactionality;
 - supply-chain scanner evidence;
@@ -154,6 +155,10 @@ Acceptance criteria:
   corpus is checked in;
 - existing golden/error golden fixtures are reused as seeds;
 - CI impact is bounded.
+
+Current status: initial bounded fuzz targets exist for whole-file generation and
+element parser/codegen entry points. Longer fuzz campaigns remain manual and
+future evidence should be added as the language surface grows.
 
 Non-goals:
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -61,7 +61,7 @@ the preview smaller.
 | Area | Status | Evidence |
 |---|---|---|
 | Runtime primitives | Ready with limitations | `pkg/goframe/*_test.go`, `docs/runtime-model.md`, browser smoke. |
-| GOX compiler | Ready with limitations | `pkg/gox` golden/error tests, source diagnostics, package-qualified component tests. |
+| GOX compiler | Ready with limitations | `pkg/gox` golden/error tests, source diagnostics, package-qualified component tests, and initial bounded fuzz seed targets. |
 | Toolchain | Ready with limitations | `cmd/goxc` tests, browser smoke, size budget, package matrix, filesystem/package safety matrix. |
 | Public docs | Ready with limitations | README, tutorial, API stability docs, docs-check. |
 | Platform support | Needs hardening | Chrome/Linux remains the strongest evidence; macOS/Windows have minimal CI check evidence; Firefox/Safari remain unverified. |

--- a/pkg/gox/fuzz_test.go
+++ b/pkg/gox/fuzz_test.go
@@ -1,0 +1,145 @@
+package gox
+
+import (
+	"go/parser"
+	gotoken "go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const maxFuzzInputSize = 4096
+
+func FuzzGenerate(f *testing.F) {
+	addGOXFileSeeds(f, "testdata/*.gox")
+	addGOXFileSeeds(f, "testdata/errors/*.gox")
+	for _, seed := range []string{
+		`package main
+
+func View() any {
+	return <main><h1>Hello</h1></main>
+}
+`,
+		`package main
+
+func View(show bool) any {
+	return <>{show && <span>Visible</span>}</>
+}
+`,
+		`package main
+
+func View(ok bool) any {
+	return <section>{ok ? <p>Yes</p> : <p>No</p>}</section>
+}
+`,
+		`package main
+
+func View(id string) any {
+	return <Button Key={id} Label="Save" />
+}
+`,
+		`package main
+
+import ui "github.com/example/app/internal/ui"
+
+func View() any {
+	return <ui.Shell Title="Dashboard"><p>Body</p></ui.Shell>
+}
+`,
+		`package main
+
+func View() any {
+	return <input type="text" value={value} />
+}
+`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, source string) {
+		if len(source) > maxFuzzInputSize {
+			t.Skip("bounded fuzz input size")
+		}
+		generated, err := GenerateWithOptions([]byte(source), GenerateOptions{
+			Filename:        "fuzz/input.gox",
+			PackageIdentity: "github.com/graybuton/goframe/fuzz",
+		})
+		if err != nil {
+			return
+		}
+		if !hasPackageDeclaration(source) {
+			return
+		}
+		if _, err := parser.ParseFile(gotoken.NewFileSet(), "fuzz_output.go", generated, parser.AllErrors); err != nil {
+			t.Fatalf("generated Go does not parse: %v\n%s", err, generated)
+		}
+	})
+}
+
+func FuzzParseElement(f *testing.F) {
+	for _, seed := range []string{
+		`<div />`,
+		`<main class="page"><p>Hello {name}</p></main>`,
+		`<><span>One</span><span>Two</span></>`,
+		`<Button Key={id} Label="Save" />`,
+		`<List>{gf.Map(items, func(item Item) gf.Node { return <Row Key={item.ID} Item={item} /> })}</List>`,
+		`<section>{visible && <p>Visible</p>}</section>`,
+		`<section>{ok ? <p>Yes</p> : <p>No</p>}</section>`,
+		`<ui.Shell Title="Dashboard"><gf.RouterLink To="/issues">Issues</gf.RouterLink></ui.Shell>`,
+		`<input type="text" />`,
+		`<ui:Shell />`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, snippet string) {
+		if len(snippet) > maxFuzzInputSize {
+			t.Skip("bounded fuzz input size")
+		}
+		node, consumed, err := ParseElement(snippet)
+		if err != nil {
+			return
+		}
+		if consumed <= 0 || consumed > len(snippet) {
+			t.Fatalf("consumed bytes = %d for input length %d", consumed, len(snippet))
+		}
+		generated, err := Codegen(node)
+		if err != nil {
+			return
+		}
+		if strings.TrimSpace(generated) == "" {
+			t.Fatalf("Codegen returned empty output for %q", snippet)
+		}
+		if !strings.Contains(snippet, "{") {
+			if _, err := parser.ParseExpr(generated); err != nil {
+				t.Fatalf("generated expression does not parse: %v\n%s", err, generated)
+			}
+		}
+	})
+}
+
+func addGOXFileSeeds(f *testing.F, pattern string) {
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		f.Fatal(err)
+	}
+	for _, path := range files {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatal(err)
+		}
+		if len(source) <= maxFuzzInputSize {
+			f.Add(string(source))
+		}
+	}
+}
+
+func hasPackageDeclaration(source string) bool {
+	for _, line := range strings.Split(source, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "package ") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

This PR adds initial bounded fuzz coverage for the GOX parser/codegen layer.

It addresses the pre-preview audit risk around missing GOX fuzz targets without changing GOX language semantics, codegen behavior, runtime behavior, or preview promises.

## What Changed

- Added `FuzzGenerate` for whole-file GOX generation.
- Added `FuzzParseElement` for element-level `ParseElement` + `Codegen`.
- Seeded fuzz targets from:
  - existing `pkg/gox/testdata/*.gox` fixtures;
  - existing `pkg/gox/testdata/errors/*.gox` fixtures;
  - small inline snippets for fragments, keyed components, child expressions, package-qualified tags, ternary / `&&` lowering, lowercase tags, and unsupported namespace syntax.
- Updated docs to describe manual GOX fuzz smoke commands.
- Updated readiness/action-plan docs to mark GOX fuzzing as reduced by initial bounded targets.
- Added a changelog entry.

## Fuzz Behavior

`FuzzGenerate`:

- runs `GenerateWithOptions` over whole-file inputs;
- treats compiler errors as acceptable fuzz outcomes;
- checks successful generation with `go/parser`.

`FuzzParseElement`:

- runs `ParseElement` followed by `Codegen`;
- treats parser/codegen errors as acceptable fuzz outcomes;
- checks consumed bounds and non-empty generated output;
- parses generated expressions when the input does not contain embedded Go expressions.

## Non-Goals

- No GOX syntax redesign.
- No codegen semantics changes.
- No runtime/toolchain behavior changes.
- No browser/TinyGo CI changes.
- No long-running fuzz campaigns in default CI.
- No claim of exhaustive GOX language verification.

## Validation

Reported validation:

- `git diff --check` — OK
- `go test ./pkg/gox` — OK
- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'` — OK
- `go test ./pkg/gox -run=Fuzz -fuzz=FuzzGenerate -fuzztime=10s` — OK
- `go test ./pkg/gox -run=Fuzz -fuzz=FuzzParseElement -fuzztime=10s` — OK
- `go test ./...` — OK
- `node scripts/docs-check.mjs` — OK

## Remaining Risk

This is initial bounded/manual fuzz coverage, not a formal exhaustive verification story for the full GOX language surface.