### PR TITLE
test(toolchain): cover preview tooling contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@
 - Package preview closeout coverage for manifest/assets error paths, generated
   and custom package `index.html` output, versioned metadata presence,
   package ownership verification, and fact-checked package/manifest docs.
+- Preview tooling closeout coverage for `pkg/gox` trusted-filesystem file
+  helper classification, export destination false-marker rejection, package
+  publication limitation wording, and lightweight supply-chain/tooling evidence.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -641,6 +641,21 @@ func TestPackageDestinationFalseMarkerPreservesFiles(t *testing.T) {
 	assertFileContent(t, userFile, "keep")
 }
 
+func TestExportDestinationFalseMarkerPreservesFiles(t *testing.T) {
+	outDir := t.TempDir()
+	userFile := filepath.Join(outDir, "user.txt")
+	if err := os.WriteFile(filepath.Join(outDir, packageMetadataName), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userFile, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateExportDestination(outDir, false); err == nil {
+		t.Fatal("validateExportDestination() accepted false marker")
+	}
+	assertFileContent(t, userFile, "keep")
+}
+
 func TestExportRejectsOverlappingDestination(t *testing.T) {
 	appDir := t.TempDir()
 	layout, err := newBuildLayout(layoutOptions{appDir: appDir})

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -154,10 +154,19 @@ Compiler package:
 - `gox.Diagnostic`
 - `gox.DiagnosticError`
 
-These are exported for the toolchain and tests. `Generate`, `GenerateNamed`,
-`GenerateWithOptions`, diagnostics, and file generation are tooling contracts.
-The AST, lexer, and parser structs are exported today but should be treated as
-compiler-facing and experimental rather than stable user APIs.
+These are exported for the toolchain, editor integrations, and tests.
+`Generate`, `GenerateNamed`, and `GenerateWithOptions` are the primary
+in-memory generation boundary for callers that choose their own source bytes.
+`GenerateFile`, `GenerateFileTo`, `GenerateFileToWithOptions`, and `FindFiles`
+are trusted-filesystem convenience helpers for tooling/editor/test workflows.
+They use ordinary standard-library file operations and do not inherit `goxc`'s
+root-aware symlink rejection, physical output-overlap checks, package ownership
+checks, or package publication guarantees. Use `goxc` or add a caller-side
+filesystem policy when processing untrusted repository trees.
+
+Diagnostics and file generation are tooling contracts. The AST, lexer, and
+parser structs are exported today but should be treated as compiler-facing and
+experimental rather than stable user APIs.
 
 Tooling contracts:
 
@@ -276,6 +285,7 @@ These are not part of the first public preview promise.
 | Router query helpers | Public-Candidate with limitations. | Good for simple URL state; not a typed query-state manager. |
 | Virtualization | Public-Candidate fixed-height contract. | Dynamic measurement and advanced accessibility remain future work. |
 | `pkg/gox` parser/AST exports | Compiler-facing experimental. | Exported today for tooling/tests, but not a stable language-service API. |
+| `pkg/gox` file helpers | Trusted-filesystem convenience. | Useful for editor/test tooling; hardened untrusted filesystem handling belongs to `goxc` or caller-side policy. |
 
 ## Deprecation Policy
 
@@ -284,7 +294,7 @@ For now, deprecations should:
 - keep a clear warning or documentation note;
 - have a replacement path;
 - remain covered by tests if behavior is still accepted;
-- be removed only in a planned cleanup MVP.
+- be removed only in a documented cleanup stage.
 
 ## What Is Not Stable Yet
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -128,6 +128,20 @@ Security alerts and security updates should be enabled from the GitHub
 repository security settings. Recommended labels are `dependencies`,
 `github-actions`, `go`, `vscode`, and `npm`.
 
+Current supply-chain evidence is lightweight:
+
+- GitHub Actions workflows use read-only repository contents permissions by
+  default;
+- Dependabot checks GitHub Actions, Go modules, and VS Code extension npm
+  dependencies;
+- the VS Code extension workflow installs from `package-lock.json` with
+  `npm ci`;
+- the root Go module currently has no third-party module requirements beyond
+  the standard library.
+
+No SBOM, package signing, or heavyweight dependency scanner is part of the
+current preview CI contract.
+
 ## Local Checks
 
 Core local verification:

--- a/docs/pre-preview-action-plan.md
+++ b/docs/pre-preview-action-plan.md
@@ -65,9 +65,14 @@ preview or explicitly scoped in release notes:
 - manifest/package contract evidence for public preview;
 - GOX parser/codegen fuzzing, now reduced by initial bounded fuzz targets but
   still not a formal exhaustive language verification story;
-- `pkg/gox` file helper safety contract for direct library callers;
-- package publication transactionality;
-- supply-chain scanner evidence;
+- `pkg/gox` file helper safety contract for direct library callers, now
+  classified as trusted-filesystem convenience rather than a hardened command
+  boundary;
+- package publication transactionality, now documented as metadata-last,
+  marker-first cleanup, and fail-closed ownership verification rather than a
+  rollback installer;
+- supply-chain/tooling evidence, currently limited to CI gates, Dependabot,
+  lockfile-based VS Code extension installs, and a stdlib-only root Go module;
 - CLI/helper direct coverage;
 - docs/status clarity.
 
@@ -183,18 +188,21 @@ belongs to tooling.
 
 Acceptance criteria:
 
-- decide whether exported `pkg/gox` file helpers are hardened or documented as
-  trusted-filesystem convenience helpers;
-- package publication limitation is either accepted in release notes or moved
-  toward transactional replacement;
-- command-level coverage is improved where it protects user-facing behavior.
+- exported `pkg/gox` file helpers are documented as trusted-filesystem
+  convenience helpers, while in-memory `pkg/gox` APIs remain the safer boundary
+  for callers that control source bytes;
+- package publication limitation is accepted in release/release-readiness docs
+  as metadata-last/fail-closed behavior, not transactional rollback;
+- command-level coverage is improved where it protects user-facing behavior;
+- current supply-chain/tooling evidence is stated without scanner or signing
+  claims.
 
 Current package/manifest closeout status: the preview-facing assets contract,
 generated/custom package `index.html` behavior, package metadata verification,
 and CLI package validation coverage are covered by
-`toolchain/package-preview-closeout`. Remaining items in this area are limited
-to documented package publication transactionality and direct `pkg/gox` file
-helper safety classification.
+`toolchain/package-preview-closeout`. Toolchain closeout further classifies
+direct `pkg/gox` file helpers, documents publication transactionality limits,
+and records lightweight supply-chain/tooling evidence.
 
 Non-goals:
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -28,6 +28,10 @@ generated-asset collision mistakes.
 The package preview closeout fixes the `v0.1.0-preview.1` manifest/assets
 contract around versionless `goframe.json`, directory-mode assets, generated
 default `index.html`, package metadata verification, and CLI error coverage.
+The preview tooling closeout classifies exported `pkg/gox` file helpers as
+trusted-filesystem convenience APIs, records package publication as
+metadata-last/fail-closed rather than transactional rollback, and documents the
+current lightweight supply-chain evidence.
 
 The first preview scope is narrower than the project vision. GoFrame remains an
 experimental Go-first application platform; the preview candidate validates the
@@ -117,6 +121,30 @@ Decision:
 - keep API shape unchanged in MVP 30;
 - classify surfaces more explicitly;
 - new public exports need explicit classification before preview.
+
+## GOX File Helper Contract
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `docs/api-stability.md`;
+- `pkg/gox/generate.go`;
+- `pkg/gox/generate_test.go`;
+- `cmd/goxc/workspace.go`;
+- `cmd/goxc/filesystem_safety_test.go`.
+
+Decision:
+
+- `gox.Generate`, `gox.GenerateNamed`, and `gox.GenerateWithOptions` are the
+  in-memory compiler boundary for callers that control source bytes;
+- `gox.GenerateFile`, `gox.GenerateFileTo`,
+  `gox.GenerateFileToWithOptions`, and `gox.FindFiles` are
+  trusted-filesystem convenience helpers for tooling/editor/test workflows;
+- those file helpers do not claim `goxc`'s root-aware symlink, physical
+  overlap, package ownership, or publication guarantees;
+- `goxc` remains the hardened command path for application/workspace/package
+  workflows.
 
 ## Component Identity
 
@@ -253,7 +281,7 @@ Decision:
 
 - pre-preview breaking changes remain allowed but documented;
 - post-preview Public-Candidate changes require migration notes;
-- deprecated APIs should survive at least one planned release stage unless
+- deprecated APIs should survive at least one documented release stage unless
   safety requires immediate removal.
 
 ## Migration Policy
@@ -281,15 +309,16 @@ Recommendation:
 - later previews: `v0.1.0-preview.2`, etc.;
 - final `v0.1.0` only after blockers are closed.
 
-## Known Blockers
+## Known Blockers And Limitations
 
 | Severity | Finding | Evidence | Recommendation |
 |---|---|---|---|
-| High | Multi-module/reusable package identity is not final. | `docs/component-identity.md` | Focused MVP before claiming reusable package ecosystem. |
-| High | Browser cross-platform support is partial. | `docs/platform-support.md` | Keep Linux/Chrome as strongest evidence; add focused Firefox/Safari/browser diversity or explicit deferred evidence notes. |
+| High | Multi-module/reusable package identity is not final. | `docs/component-identity.md` | Current preview does not claim a broad reusable component package ecosystem. |
+| High | Browser cross-platform support is partial. | `docs/platform-support.md` | Current preview notes must state Linux/Chrome as strongest evidence and Firefox/Safari as unverified. |
 | Medium | Production deployment server remains out of scope. | `docs/deployment.md` | Keep preview messaging static-hosting/hash-router focused. |
-| Medium | Package publication is hardened but not a full transactional installer. | `cmd/goxc/package.go` | Metadata is written last and sources are prevalidated; full transaction/rollback semantics remain out of scope for the current preview. |
-| Documentation-only | Public API classification must be kept current. | `docs/api-stability.md` | Optional exported-symbol classification gate can be added later. |
+| Medium | Package publication is hardened but not a full transactional installer. | `cmd/goxc/package.go`, `docs/security-symlink-policy.md` | Current preview contract is metadata-last, marker-first cleanup, fail-closed ownership verification; rollback installer semantics are out of scope. |
+| Medium | Supply-chain evidence is lightweight. | `docs/ci.md` | Current preview evidence is read-only workflow permissions, Dependabot configuration, `npm ci` from lockfile, and stdlib-only root Go module; SBOM/scanner gates are not part of the preview contract. |
+| Documentation-only | Public API classification must be kept current. | `docs/api-stability.md` | Classification remains a manual docs/review gate in the current preview. |
 
 ## Deferred Non-goals
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -94,6 +94,7 @@ clear about API instability and experimental status.
 ### API
 
 - exported `pkg/goframe` and `pkg/gox` API inventory reviewed;
+- `pkg/gox` in-memory APIs and trusted-filesystem file helpers classified;
 - every new public export is classified in `docs/api-stability.md`;
 - deprecated APIs have replacement guidance;
 - migration notes exist for user-visible breaking changes;
@@ -155,6 +156,8 @@ clear about API instability and experimental status.
 - experimental surfaces named rather than hidden;
 - future Player/Engine direction bounded as vision, not a preview promise;
 - compatibility/deprecation notes included;
+- supply-chain/tooling evidence stated as lightweight CI/Dependabot/lockfile
+  coverage, with no SBOM or scanner claim in the current preview contract;
 - migration notes linked;
 - rollback/revert plan noted for preview users.
 

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -44,6 +44,18 @@ Current protection focuses on:
 - cleaning only known GoFrame-owned artifacts;
 - binding the development server to `127.0.0.1`.
 
+## Scope Boundary For `pkg/gox`
+
+This policy applies to `goxc` command paths. Exported `pkg/gox` file helpers
+such as `GenerateFile`, `GenerateFileTo`, `GenerateFileToWithOptions`, and
+`FindFiles` are trusted-filesystem convenience helpers for tooling, editor, and
+test workflows. They use ordinary standard-library filesystem operations and
+do not provide the root-aware symlink, physical overlap, package ownership, or
+publication checks described here.
+
+For untrusted repository trees, use `goxc` command paths or add a caller-side
+filesystem policy around the in-memory `pkg/gox` APIs.
+
 ## Manifest Paths
 
 Manifest fields such as `entry`, `output`, `wasm`, and `assets` are validated
@@ -175,9 +187,9 @@ Policy:
   root directly, but the final app-scoped workspace root must not overlap the
   app source tree.
 
-The preferred security direction is reject rather than follow when a symlink
-could make source, asset, package, export, or cleanup operations escape the
-declared root.
+The current `goxc` policy is reject rather than follow when a symlink could
+make source, asset, package, export, or cleanup operations escape the declared
+root.
 
 Evidence:
 
@@ -256,20 +268,11 @@ operation boundary, but full adversarial filesystem mutation is out of scope.
 
 - No production static server hardening beyond local development needs.
 - No signed package/export metadata.
-- No permission model for future Player or `.gfapp` bundles.
+- No Player or `.gfapp` permission model in the current preview contract.
 - No full multi-module workspace model.
 - `goxc serve` remains development-only and is not a hardened static server.
 - Windows has minimal Go/toolchain CI evidence, but full filesystem and browser
   parity remain under-verified.
-
-## Recommended Future Tests
-
-Keep adding focused tests for:
-
-- Windows path edge cases;
-- package rollback behavior when replacing an existing valid package;
-- additional special file types where the platform can create them safely;
-- serve path traversal behavior on non-Linux platforms.
 
 ## Non-Goals
 

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"go/parser"
 	gotoken "go/token"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -71,6 +73,93 @@ func App() gf.Node {
 	}
 	if !strings.Contains(string(generated), "if count < max") {
 		t.Fatalf("Go comparison was not preserved:\n%s", generated)
+	}
+}
+
+func TestGenerateFileToWithOptionsWritesExplicitOutput(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "src", "view.gox")
+	outputPath := filepath.Join(root, "generated", "view.gox.go")
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := []byte(`package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Card />
+}
+`)
+	if err := os.WriteFile(sourcePath, source, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wrote, err := GenerateFileToWithOptions(sourcePath, outputPath, GenerateOptions{
+		Filename:        "internal/ui/view.gox",
+		PackageIdentity: "github.com/example/app/internal/ui",
+	})
+	if err != nil {
+		t.Fatalf("GenerateFileToWithOptions() error: %v", err)
+	}
+	if wrote != outputPath {
+		t.Fatalf("generated path = %q, want %q", wrote, outputPath)
+	}
+	generated, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read generated output: %v", err)
+	}
+	text := string(generated)
+	for _, want := range []string{
+		generatedHeader,
+		`gf.NewComponentType("github.com/example/app/internal/ui.Card", "Card")`,
+		`gf.ComponentT(_goxComponent_view_Card`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestFindFilesReturnsStableGOXFiles(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{
+		"b.gox",
+		"a.gox",
+		"nested/c.gox",
+		"nested/ignore.txt",
+	} {
+		fullPath := filepath.Join(root, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fullPath, []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := FindFiles(root)
+	if err != nil {
+		t.Fatalf("FindFiles(directory) error: %v", err)
+	}
+	want := []string{
+		filepath.Join(root, "a.gox"),
+		filepath.Join(root, "b.gox"),
+		filepath.Join(root, "nested", "c.gox"),
+	}
+	if strings.Join(files, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("FindFiles() = %#v, want %#v", files, want)
+	}
+
+	direct, err := FindFiles(filepath.Join(root, "a.gox"))
+	if err != nil {
+		t.Fatalf("FindFiles(file) error: %v", err)
+	}
+	if len(direct) != 1 || direct[0] != filepath.Join(root, "a.gox") {
+		t.Fatalf("FindFiles(file) = %#v", direct)
+	}
+	if _, err := FindFiles(filepath.Join(root, "nested", "ignore.txt")); err == nil {
+		t.Fatal("FindFiles(non-gox file) returned nil error")
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR closes the remaining toolchain-focused preview readiness items before moving into runtime experimental-surface hardening.

It classifies pkg/gox file helpers, adds focused regression coverage for export destination ownership checks, and updates readiness/security/CI docs with fact-first wording around the current preview tooling contract.

## What Changed

* Classified pkg/gox file helpers as trusted-filesystem convenience helpers.
* Clarified that Generate, GenerateNamed, and GenerateWithOptions are the in-memory compiler boundary for callers that control source bytes.
* Clarified that goxc remains the hardened command boundary for symlink rejection, physical overlap checks, package ownership, and publication verification.
* Added coverage for export destinations with invalid GoFrame package markers, preserving user files when ownership is not granted.
* Documented package publication as metadata-last, marker-first cleanup, and fail-closed ownership verification.
* Stated explicitly that package publication is not a transactional rollback installer.
* Documented lightweight supply-chain/tooling evidence without claiming SBOM, signing, or scanner coverage.
* Removed stale future-test wording from the symlink/security policy.

## Commit Structure

* 9772b9f — test(gox): cover file helper safety contract
* 273505a — test(goxc): cover export destination false markers
* 962c883 — docs: document preview tooling closeout contract

The branch is split into reviewable commits: pkg/gox coverage, goxc safety regression coverage, and docs/readiness/changelog updates.

## Preview Contract

For v0.1.0-preview.1:

* pkg/gox in-memory generation APIs are the safer boundary for callers that control source bytes;
* pkg/gox file helpers are trusted-filesystem helpers for tooling, editor, and test workflows;
* goxc is the hardened path for app/workspace/package operations;
* package/export publication is fail-closed and metadata-last;
* package/export publication does not claim full rollback transactionality;
* current supply-chain evidence is lightweight CI, Dependabot, npm lockfile install, and stdlib-only root Go module.

## Non-Goals

* No runtime API changes.
* No GOX language changes.
* No parser/codegen redesign.
* No package/assets feature expansion.
* No browser or platform matrix expansion.
* No Firefox/Safari lane.
* No production deployment claim.
* No package signing, SBOM, or heavyweight scanner gate.
* No transactional package installer.

## Validation

* go fmt ./...
* git diff --check
* node scripts/docs-check.mjs
* go test ./pkg/gox
* go test ./cmd/goxc
* go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
* go test ./...
* go test -race ./pkg/... ./cmd/...
* scripts/size-budget.sh
* scripts/browser-smoke.sh

## Remaining Limitations

pkg/gox file helpers are not a hardened filesystem boundary.

Package publication is not a rollback or transactional installer.

SBOM, scanner, and signing gates are not part of the current preview CI contract.

Non-Chrome browser evidence and broad reusable multi-module identity remain outside the current preview evidence.
