### PR TITLE
test(runtime): cover experimental surface contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@
 - Preview tooling closeout coverage for `pkg/gox` trusted-filesystem file
   helper classification, export destination false-marker rejection, package
   publication limitation wording, and lightweight supply-chain/tooling evidence.
+- Runtime experimental-surface hardening coverage for resource reload/stale
+  callback edges, ErrorBoundary reset/new-incident behavior, router route-key
+  remount policy, and preview contract docs alignment.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -202,16 +202,27 @@ VS Code extension:
 - Component identity id format for generated GOX component tokens.
 - Runtime error reporting API and exact phase containment behavior:
   `gf.SetErrorHandler`, `gf.ErrorInfo`, `gf.ErrorHandler`, and
-  `gf.ErrorPhase`.
+  `gf.ErrorPhase`. Current tests cover event, effect, cleanup, memo, context,
+  virtual callback, render, and boundary-related reporting paths, but this is
+  still not a production error framework.
 - Scoped render Error Boundary reset/fallback semantics beyond the current
   public-candidate API shape. Internal boundary phases such as protected,
-  captured, and fallback are not public API.
+  captured, and fallback are not public API. Current tests cover containment,
+  nested fallback bubbling, reset, `ResetKey`, pending effect cancellation, and
+  cleanup release for failed subtrees.
 - Component-scoped resource API and exact lifecycle semantics:
   `gf.ResourceStatus`, `gf.Resource`, `gf.ResourceLoader`, and
-  `gf.UseResource`.
+  `gf.UseResource`. Current tests cover loading/ready/failed state, reload,
+  key changes, stale completions, cleanup, loader panic containment, and
+  ErrorBoundary interaction. Global caching, deduplication, retry policy,
+  route loaders, and Suspense-style semantics are outside the preview
+  contract.
 - Hash router details such as route remount policy, declaration-order matching
   edge cases, link props, query helper edge cases, and browser listener
-  internals.
+  internals. Current tests cover route matching, params, query helpers,
+  not-found fallback, hash hrefs, and route subtree keys by route pattern;
+  browser back/forward and listener behavior are covered by smoke tests rather
+  than a stable low-level listener API.
 - Form and validation patterns. MVP 25 documents controlled-input patterns but
   intentionally does not add a runtime form framework.
 - Package manifest field stability.

--- a/docs/pre-preview-action-plan.md
+++ b/docs/pre-preview-action-plan.md
@@ -224,6 +224,10 @@ Acceptance criteria:
 - any risky edge behavior is tested or documented;
 - examples continue to show the integrated platform path.
 
+Current status: focused runtime tests cover resource reload and stale-callback
+edges, ErrorBoundary reset/new-incident behavior, and router route-key/remount
+policy. The runtime API shape remains unchanged.
+
 Non-goals:
 
 - no Suspense, route loaders, global cache, server resources, or full

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -32,6 +32,10 @@ The preview tooling closeout classifies exported `pkg/gox` file helpers as
 trusted-filesystem convenience APIs, records package publication as
 metadata-last/fail-closed rather than transactional rollback, and documents the
 current lightweight supply-chain evidence.
+The runtime experimental-surface hardening pass adds focused evidence for
+resource reload/stale-callback behavior, ErrorBoundary reset/new-incident
+behavior, and router route-key/remount policy without changing public runtime
+APIs.
 
 The first preview scope is narrower than the project vision. GoFrame remains an
 experimental Go-first application platform; the preview candidate validates the
@@ -266,6 +270,38 @@ Status: Ready with limitations.
 Chrome/Chromium is CI-tested. Firefox and Safari are unverified. The runtime
 requires browser DOM APIs, WebAssembly, `requestAnimationFrame`, `hashchange`,
 and example-specific APIs such as `fetch` and `AbortController`.
+
+## Runtime Experimental Surfaces
+
+Status: Ready with limitations.
+
+Evidence:
+
+- `pkg/goframe/resource_test.go`;
+- `pkg/goframe/error_boundary_test.go`;
+- `pkg/goframe/error_handling_test.go`;
+- `pkg/goframe/router_test.go`;
+- `pkg/goframe/router_query_test.go`;
+- router, resource, runtime-error, and ErrorBoundary browser smoke fixtures.
+
+Decision:
+
+- resources remain component-scoped: no global cache, deduplication, automatic
+  retry, polling, Suspense, server resource, or route-loader contract exists;
+- resource reload/key changes invalidate old generations, clear the public
+  snapshot back to loading state, run cleanup once for the invalidated
+  generation, and ignore stale callbacks;
+- ordinary `ResourceFailed` state is application UI state, not an ErrorBoundary
+  failure;
+- ErrorBoundaries remain scoped render fallback primitives. Reset retries the
+  same protected subtree and a repeated panic is a new incident; reset does not
+  change route params, query values, resource state, or application data;
+- the router remains hash-based. Route matching, params, query helpers,
+  not-found fallback, and route keys by route pattern are covered; history mode,
+  file routing, middleware, route loaders, and production server fallback are
+  outside the current preview contract;
+- runtime error APIs remain phase-specific reporting/containment hooks, not a
+  production observability or recovery framework.
 
 ## Compatibility And Deprecation Policy
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -108,6 +108,8 @@ clear about API instability and experimental status.
 - `go vet ./...`;
 - `go test -tags=goframe_debug ./...`;
 - GOX golden and error golden tests;
+- focused runtime experimental-surface tests for resources, ErrorBoundaries,
+  runtime error reporting, and router matching/remount policy;
 - browser smoke;
 - TinyGo WASM size budgets;
 - dashboard DOM pressure;

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -269,7 +269,8 @@ var router = gf.NewHashRouter([]gf.Route{
 subscribes to `hashchange`, and renders the matched route handler. The route
 subtree is keyed by route pattern. Navigating between different patterns
 remounts the route subtree; navigating between the same pattern with different
-params updates the route context and may preserve route-local state.
+params or query text updates the route context and may preserve route-local
+state. The not-found route uses its own fallback route key.
 
 `RouteContext.RawQuery` stores query text after `?`, and
 `RouteContext.Query()` parses it into `QueryValues` for small URL-driven state
@@ -300,6 +301,8 @@ no global cache or shared registry: two components that use the same key own
 independent resources. Changing the key or calling `reload` invalidates the
 current generation, returns to loading state, runs the previous cleanup exactly
 once, and ignores stale completions before they can dirty the component.
+Reload also clears the previous `Value` and `Err` from the public snapshot while
+the new generation is loading.
 
 Loaders are transport-agnostic. Browser `fetch`, parsing, timers, abort
 controllers, local storage, or test fakes live in application/example code.
@@ -406,7 +409,9 @@ Boundary, the runtime renders `gf.Empty()` for that pass. With a nearest active
 `gf.ErrorBoundary`, the failed render still returns `gf.Empty()` immediately,
 but the boundary records the incident, cancels pending effects under the
 protected subtree, and patches to fallback UI. Manual reset or `ResetKey`
-clears the incident and remounts children fresh.
+clears the incident and remounts children fresh. Reset retries the same
+protected subtree; if the same props, route params, or query values still cause
+a render panic, the retry is a new incident rather than an automatic recovery.
 
 Error Boundary state is internally modeled as protected, captured, or fallback.
 The displaying boundary is skipped while rendering its fallback subtree, so a

--- a/pkg/goframe/error_boundary_test.go
+++ b/pkg/goframe/error_boundary_test.go
@@ -273,6 +273,45 @@ func TestErrorBoundaryManualResetRemountsProtectedSubtree(t *testing.T) {
 	reset()
 }
 
+func TestErrorBoundaryResetAllowsNewIncident(t *testing.T) {
+	resetRuntimeBoundaryTestState()
+	errors := captureRuntimeErrors(t)
+	var reset func()
+	boundary := testErrorBoundaryInstance("", func(ctx ErrorBoundaryContext) Node {
+		reset = ctx.Reset
+		return Text("fallback")
+	}, nil)
+	renderComponentInstance(boundary)
+
+	renderComponentInstance(testComponentInstanceWithParent("RiskyFirst", boundary, func() Node {
+		panic("first")
+	}))
+	renderComponentInstance(boundary)
+	if boundary.errorBoundary.phase != errorBoundaryFallback || reset == nil {
+		t.Fatalf("boundary phase=%d reset nil=%v, want fallback with reset", boundary.errorBoundary.phase, reset == nil)
+	}
+
+	reset()
+	renderComponentInstance(boundary)
+	if boundary.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("boundary phase after reset = %d, want protected", boundary.errorBoundary.phase)
+	}
+
+	renderComponentInstance(testComponentInstanceWithParent("RiskySecond", boundary, func() Node {
+		panic("second")
+	}))
+	renderComponentInstance(boundary)
+
+	if got := boundary.errorBoundary.info.Panic; got != "second" {
+		t.Fatalf("captured panic after reset = %v, want second", got)
+	}
+	if len(errors()) != 2 {
+		t.Fatalf("runtime reports = %d, want first and second incidents: %#v", len(errors()), errors())
+	}
+	requireRuntimeError(t, errors(), ErrorPhaseRender, "RiskyFirst", "component render", "first")
+	requireRuntimeError(t, errors(), ErrorPhaseRender, "RiskySecond", "component render", "second")
+}
+
 func TestErrorBoundaryResetKeyClearsFailedBoundaryOnly(t *testing.T) {
 	resetRuntimeBoundaryTestState()
 	boundary := testErrorBoundaryInstance("a", func(ErrorBoundaryContext) Node {

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -284,6 +284,51 @@ func TestUseResourceManualReloadInvalidatesLateCallbacks(t *testing.T) {
 	}
 }
 
+func TestUseResourceReloadClearsReadySnapshotAndIgnoresLateCallbacks(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	schedules := 0
+	var reload func()
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceReloadReady", func() Node {
+		resource, reload = UseResource("same", loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldResolve := loader.resolves[0]
+	oldReject := loader.rejects[0]
+	oldResolve("ready")
+	renderComponentInstance(instance)
+	if !resource.Ready() || resource.Value != "ready" || resource.Err != nil {
+		t.Fatalf("resource before reload = %#v, want ready", resource)
+	}
+
+	reload()
+	renderComponentInstance(instance)
+	if !resource.Loading() || resource.Value != "" || resource.Err != nil {
+		t.Fatalf("resource after reload render = %#v, want loading zero snapshot", resource)
+	}
+	oldReject(errors.New("late failure"))
+	oldResolve("late ready")
+	if schedules != 2 || instance.dirty {
+		t.Fatalf("late callbacks schedules=%d dirty=%v, want no extra dirty update after reload", schedules, instance.dirty)
+	}
+
+	flushPendingEffects()
+	if loader.cleanups != 1 || len(loader.starts) != 2 {
+		t.Fatalf("cleanups=%d starts=%d, want cleanup old and start new", loader.cleanups, len(loader.starts))
+	}
+	loader.resolves[1]("ready again")
+	renderComponentInstance(instance)
+	if !resource.Ready() || resource.Value != "ready again" || resource.Err != nil {
+		t.Fatalf("resource after reload resolve = %#v, want ready again", resource)
+	}
+}
+
 func TestUseResourceOldReloadClosureUsesLatestKey(t *testing.T) {
 	resetEffectsForTest()
 	loader := &resourceTestLoader{}
@@ -392,6 +437,38 @@ func TestUseResourceCleanupTriggeredCompletionIsIgnored(t *testing.T) {
 	}
 	if !resource.Loading() {
 		t.Fatalf("resource after key change cleanup = %#v, want loading", resource)
+	}
+}
+
+func TestUseResourceCleanupTriggeredRejectIsIgnored(t *testing.T) {
+	resetEffectsForTest()
+	loader := &resourceTestLoader{}
+	key := "a"
+	schedules := 0
+	var oldReject func(error)
+	var resource Resource[string]
+	loader.cleanup = func() {
+		oldReject(errors.New("from-cleanup"))
+	}
+	instance := testComponentInstance("ResourceCleanupReject", func() Node {
+		resource, _ = UseResource(key, loader.load)
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	oldReject = loader.rejects[0]
+	key = "b"
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	if schedules != 0 || instance.dirty {
+		t.Fatalf("cleanup-triggered reject schedules=%d dirty=%v, want no stale update", schedules, instance.dirty)
+	}
+	if !resource.Loading() || resource.Err != nil {
+		t.Fatalf("resource after key change cleanup reject = %#v, want loading without error", resource)
 	}
 }
 

--- a/pkg/goframe/router_test.go
+++ b/pkg/goframe/router_test.go
@@ -177,6 +177,44 @@ func TestRouterViewCreatesRouteBoundaryKeyedByPattern(t *testing.T) {
 	}
 }
 
+func TestRouteMatchKeyUsesPatternForRemountPolicy(t *testing.T) {
+	routes := []Route{
+		RoutePath("/issues", routeTestNode("issues")),
+		RoutePath("/issues/:id", routeTestNode("details")),
+		NotFoundRoute(routeTestNode("missing")),
+	}
+
+	first, ok := matchRouterTarget(routes, "#/issues/1")
+	if !ok {
+		t.Fatal("expected first detail route match")
+	}
+	second, ok := matchRouterTarget(routes, "#/issues/2?tab=activity")
+	if !ok {
+		t.Fatal("expected second detail route match")
+	}
+	list, ok := matchRouterTarget(routes, "#/issues")
+	if !ok {
+		t.Fatal("expected list route match")
+	}
+	missing, ok := matchRouterTarget(routes, "#/unknown")
+	if !ok {
+		t.Fatal("expected not-found route match")
+	}
+
+	if first.key != "route:/issues/:id" || second.key != first.key {
+		t.Fatalf("detail route keys = %q/%q, want same pattern key", first.key, second.key)
+	}
+	if first.context.Param("id") != "1" || second.context.Param("id") != "2" || second.context.RawQuery != "tab=activity" {
+		t.Fatalf("detail contexts = %#v %#v", first.context, second.context)
+	}
+	if list.key == first.key || list.key != "route:/issues" {
+		t.Fatalf("list key = %q, want distinct route:/issues", list.key)
+	}
+	if missing.key != "route:not-found" || missing.context.Path != "/unknown" {
+		t.Fatalf("not-found match = %#v", missing)
+	}
+}
+
 func TestRouteContextParamHandlesNilParams(t *testing.T) {
 	if got := (RouteContext{}).Param("id"); got != "" {
 		t.Fatalf("nil params Param = %q, want empty", got)


### PR DESCRIPTION
## Summary

This PR strengthens preview evidence for existing runtime experimental surfaces without changing public runtime APIs or behavior.

It adds focused coverage for resource lifecycle edges, ErrorBoundary reset behavior, router route-key remount policy, and updates preview docs to describe the current runtime contract factually.

## What Changed

* Added resource lifecycle coverage for reload after ready state.
* Verified that reload clears previous Value and Err while the new generation is loading.
* Verified that stale resolve and reject callbacks after reload cannot dirty the component.
* Verified that cleanup-triggered reject callbacks are ignored as stale.
* Added ErrorBoundary coverage for reset followed by a repeated render panic.
* Verified that reset retries the protected subtree instead of fixing the cause.
* Verified that repeated panic after reset is reported as a new incident.
* Added router coverage for route keys based on route pattern.
* Verified that params and query changes within the same pattern preserve the same route key.
* Verified that different route patterns and not-found fallback use distinct route keys.
* Updated runtime, API stability, readiness, release, action-plan, and changelog docs.

## Commit Structure

* c73129d — test(runtime): cover resource lifecycle edges
* ad538bd — test(runtime): cover error boundary reset edges
* 32943f5 — test(router): cover preview navigation contract
* c2e7f52 — docs(preview): document runtime experimental contracts

The branch is split into reviewable units: resource tests, ErrorBoundary tests, router tests, and docs/readiness updates.

## Preview Contract

For v0.1.0-preview.1:

* resources remain component-scoped;
* resource reload and key changes invalidate old generations;
* stale resource callbacks are ignored before dirtying the component;
* ResourceFailed is application UI state, not an ErrorBoundary failure;
* ErrorBoundaries remain scoped render fallback primitives;
* reset retries the protected subtree and repeated panic is a new incident;
* the router remains hash-based;
* route subtree keys are based on route pattern;
* runtime error APIs remain phase-specific reporting and containment hooks, not a production recovery framework.

## Non-Goals

* No runtime API changes.
* No GOX language changes.
* No global resource cache.
* No Suspense.
* No route loaders.
* No history router.
* No middleware.
* No production error framework.
* No SSR or hydration.
* No Player or Engine work.
* No browser or platform matrix expansion.

## Validation

* go fmt ./...
* git diff --check
* node scripts/docs-check.mjs
* go test ./pkg/goframe
* go test ./pkg/goframe -run 'Resource|ErrorBoundary|Error|Router|Effect|Cleanup'
* go test ./...
* go test -tags=goframe_debug ./...
* go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
* go test -race ./pkg/... ./cmd/...
* scripts/size-budget.sh
* scripts/browser-smoke.sh

## Remaining Limitations

Resources, router, ErrorBoundary, and runtime error APIs remain ready with limitations.

Global cache, Suspense, route loaders, history routing, production recovery, and broader browser evidence are outside the current preview contract.
