### PR TITLE
docs(community): add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible problem in GoFrame.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. GoFrame is an experimental preview project, so precise reproduction details are especially helpful.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - runtime
+        - GOX
+        - goxc
+        - docs
+        - examples
+        - CI
+        - VS Code extension
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the smallest steps or commands that reproduce the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the fields that apply.
+      value: |
+        - OS:
+        - Go version:
+        - TinyGo version, if relevant:
+        - Browser, if relevant:
+        - goxc version/commit/tag:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or output
+      description: Paste relevant command output, browser console output, or stack traces.
+      render: text
+  - type: textarea
+    id: example
+    attributes:
+      label: Minimal example or link
+      description: Link a small repository, paste a small snippet, or describe why a minimal example is not available.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I understand GoFrame is experimental and the preview is not a production-readiness claim.
+          required: true
+        - label: I searched existing issues and pull requests for a similar report.
+          required: true
+        - label: I included enough environment and reproduction information for maintainers to investigate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: Propose a scoped improvement or new capability for GoFrame.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome, but they are not preview promises. Please keep the proposal tied to a concrete problem and the current experimental scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem or maintainer pain does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_scope
+    attributes:
+      label: Proposed scope
+      description: Describe the smallest useful shape of the change.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - runtime
+        - GOX
+        - goxc
+        - docs
+        - examples
+        - CI
+        - VS Code extension
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: How do users handle this today, if at all?
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility or preview-scope impact
+      description: Note possible API, manifest, package, docs, CI, or example impact.
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this request explicitly not try to solve?
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I understand v0.1.0-preview.1 is experimental and this request is not a preview promise.
+          required: true
+        - label: I described the smallest useful scope rather than a broad rewrite.
+          required: true
+        - label: I noted compatibility or preview-scope impact where relevant.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,30 @@
 ## Summary
 
-## Checks
+## Scope
 
+## Changed Files / Areas
+
+## Behavior, API, Or Docs Impact
+
+## Validation
+
+- [ ] `scripts/check.sh`
 - [ ] `go test ./...`
 - [ ] `go test -race ./pkg/... ./cmd/...`
 - [ ] `go vet ./...`
+- [ ] `node scripts/docs-check.mjs`, if docs changed
 - [ ] `scripts/size-budget.sh`
 - [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
 - [ ] VS Code extension compile, if `extensions/vscode-gox` changed
+
+## Non-Goals
+
+## Checklist
+
+- [ ] This PR has no unrelated changes.
+- [ ] Docs were updated if behavior, contracts, examples, CLI output, or package behavior changed.
+- [ ] This PR does not add a production-readiness claim.
+- [ ] Relevant tests/checks are listed above.
+- [ ] This branch is based on current `main`.
 
 ## Notes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+GoFrame is an experimental open-source project. The project works best when
+discussion stays respectful, specific, and grounded in the current repository.
+
+## Expected Behavior
+
+- Be respectful of different backgrounds, experience levels, and use cases.
+- Critique ideas, code, docs, and tradeoffs without attacking people.
+- Keep issues and pull requests focused on actionable project work.
+- Be honest about uncertainty, limitations, and preview scope.
+
+## Unacceptable Behavior
+
+Unacceptable behavior includes harassment, discriminatory language, personal
+attacks, threats, doxxing, sexualized attention, sustained disruption, or
+publishing private security details in a public issue.
+
+## Reporting And Enforcement
+
+For security-sensitive reports, follow [SECURITY.md](SECURITY.md): do not post
+exploit details publicly; open only a minimal public issue asking for a private
+disclosure channel if no private maintainer contact is available.
+
+For conduct concerns, open a focused issue if the concern can be discussed
+publicly without exposing private information. Maintainers may edit, hide, or
+close disruptive comments and may restrict participation when needed to keep the
+project usable for contributors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,29 +6,75 @@ By contributing to this repository, you agree that your contributions are
 licensed under the Apache License, Version 2.0, the same license as the
 project.
 
+GoFrame is an experimental Go-first application platform. The first preview
+validates the browser/WASM application layer; it is not a production-readiness
+claim or a 1.0 API guarantee.
+
+## Workflow
+
+Use short-lived topic branches from current `main`, then open a pull request
+before merge. Keep each pull request focused on one reviewable concern.
+
+Branch names should make the work area obvious. Common prefixes include:
+
+- `docs/...`
+- `test/...`
+- `fix/...`
+- `ci/...`
+- `design/...`
+- `toolchain/...`
+- `runtime/...`
+
+Pull request titles should use:
+
+```text
+type(scope): action object
+```
+
+Examples:
+
+- `docs(preview): clarify platform evidence`
+- `test(runtime): cover resource cleanup`
+- `toolchain(package): reject unsafe asset paths`
+- `ci(preview): add minimal platform evidence`
+
 ## Development Checks
 
-Run the local checks before opening a pull request:
+Run the local checks before opening a pull request when practical:
 
 ```bash
 scripts/check.sh
 ```
 
-Optional browser regression checks:
+For Go changes, also run:
+
+```bash
+go test ./...
+```
+
+For docs changes, run:
+
+```bash
+node scripts/docs-check.mjs
+```
+
+For browser, runtime, package, or toolchain behavior changes, run the browser
+smoke checks when the local environment has the required browser tooling:
 
 ```bash
 scripts/browser-smoke.sh
 ```
 
-## Branches
+If a check cannot run locally, explain the blocker in the pull request.
 
-Use focused feature branches:
+## Documentation Policy
 
-- `feature/runtime/*`
-- `feature/gox/*`
-- `feature/goxc/*`
-- `feature/vscode-extension/*`
-- `docs/*`
-- `chore/*`
+GoFrame documentation is fact-first. Product docs should describe current
+behavior, current limitations, current evidence, and current non-goals.
+
+Avoid roadmap-style promise wording such as `planned`, `will add`, `future
+follow-up`, or `may be added later` in product docs. Prefer factual wording such
+as `outside current preview scope`, `not part of v0.1.0-preview.1`, or `current
+non-goal`.
 
 The VS Code extension lives in `extensions/vscode-gox`.


### PR DESCRIPTION
### Summary

Adds the initial community health files for the public GoFrame preview repository.

This PR documents the expected contribution flow, adds structured issue/PR templates, and adds a lightweight Code of Conduct without changing runtime, GOX, goxc, tests, examples, workflows, release notes, or release tags.

### What Changed

* Added `CODE_OF_CONDUCT.md`.
* Added GitHub issue forms:

  * `.github/ISSUE_TEMPLATE/bug_report.yml`
  * `.github/ISSUE_TEMPLATE/feature_request.yml`
  * `.github/ISSUE_TEMPLATE/config.yml`
* Added `.github/pull_request_template.md`.
* Updated `CONTRIBUTING.md` with the current public contribution flow:

  * short-lived topic branches from `main`;
  * PR-based changes;
  * strict PR title style: `type(scope): action object`;
  * expected validation commands;
  * fact-first documentation expectations for preview docs.

### Preview Scope

The templates keep GoFrame’s current status explicit:

* GoFrame is experimental.
* `v0.1.0-preview.1` is not a production-readiness claim.
* Feature requests are not preview promises.
* Bugs and proposals should identify the affected area: runtime, GOX, goxc, docs, examples, CI, VS Code extension, or other.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No goxc/toolchain changes.
* No tests or examples changes.
* No workflow changes.
* No release notes changes.
* No release/tag changes.
* No production-readiness claims.

### Validation

* `git diff --check`
* `node scripts/docs-check.mjs`
* Issue form YAML manually inspected for structure.

### Notes

This PR is repository/community hygiene only. Security behavior and CodeQL alert remediation are handled separately in focused follow-up PRs.
