### PR TITLE
fix(goxc): harden static serve path handling

### DIFF
--- a/cmd/goxc/serve.go
+++ b/cmd/goxc/serve.go
@@ -160,7 +160,7 @@ func sanitizeServePath(requestPath, rawPath string) (string, error) {
 	if requestPath == "" {
 		requestPath = "/"
 	}
-	if strings.Contains(requestPath, `\`) || strings.Contains(rawPath, `\`) {
+	if strings.ContainsRune(requestPath, '\\') || strings.ContainsRune(rawPath, '\\') {
 		return "", errors.New("serve path contains backslash")
 	}
 	if !strings.HasPrefix(requestPath, "/") {

--- a/cmd/goxc/serve.go
+++ b/cmd/goxc/serve.go
@@ -113,7 +113,16 @@ func serve(options serveOptions) error {
 func staticHandler(directory string) http.Handler {
 	files := http.FileServer(http.Dir(directory))
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		localPath := filepath.Join(directory, filepath.FromSlash(strings.TrimPrefix(pathpkg.Clean("/"+request.URL.Path), "/")))
+		if request.URL == nil {
+			http.NotFound(response, request)
+			return
+		}
+		sanitizedPath, err := sanitizeServePath(request.URL.Path, request.URL.RawPath)
+		if err != nil {
+			http.NotFound(response, request)
+			return
+		}
+		localPath := filepath.Join(directory, filepath.FromSlash(strings.TrimPrefix(sanitizedPath, "/")))
 		if err := validatePathBelowRoot(directory, localPath, "serve path", false); err != nil {
 			http.NotFound(response, request)
 			return
@@ -122,7 +131,7 @@ func staticHandler(directory string) http.Handler {
 			http.NotFound(response, request)
 			return
 		}
-		path := request.URL.Path
+		path := sanitizedPath
 		if strings.HasSuffix(path, ".br") {
 			response.Header().Set("Content-Encoding", "br")
 			path = strings.TrimSuffix(path, ".br")
@@ -138,6 +147,36 @@ func staticHandler(directory string) http.Handler {
 		case strings.HasSuffix(path, ".css"):
 			response.Header().Set("Content-Type", "text/css")
 		}
-		files.ServeHTTP(response, request)
+		sanitizedRequest := request.Clone(request.Context())
+		urlCopy := *request.URL
+		urlCopy.Path = sanitizedPath
+		urlCopy.RawPath = ""
+		sanitizedRequest.URL = &urlCopy
+		files.ServeHTTP(response, sanitizedRequest)
 	})
+}
+
+func sanitizeServePath(requestPath, rawPath string) (string, error) {
+	if requestPath == "" {
+		requestPath = "/"
+	}
+	if strings.Contains(requestPath, `\`) || strings.Contains(rawPath, `\`) {
+		return "", errors.New("serve path contains backslash")
+	}
+	if !strings.HasPrefix(requestPath, "/") {
+		return "", errors.New("serve path must start with /")
+	}
+	for _, segment := range strings.Split(requestPath, "/") {
+		if segment == ".." {
+			return "", errors.New("serve path must not contain parent traversal")
+		}
+	}
+	cleaned := pathpkg.Clean(requestPath)
+	if cleaned == "." {
+		return "/", nil
+	}
+	if !strings.HasPrefix(cleaned, "/") {
+		cleaned = "/" + cleaned
+	}
+	return cleaned, nil
 }

--- a/cmd/goxc/serve_test.go
+++ b/cmd/goxc/serve_test.go
@@ -103,6 +103,10 @@ func TestStaticHandlerRejectsBackslashPaths(t *testing.T) {
 	directory := t.TempDir()
 	writeServeFixture(t, directory, "public.txt", "public")
 
+	// The "\\" escape in this Go string literal is one URL backslash rune.
+	const oneBackslashPath = "/..\\secret.txt"
+	assertSingleBackslashFixture(t, oneBackslashPath)
+
 	for _, tt := range []struct {
 		name   string
 		mutate func(*http.Request)
@@ -110,13 +114,13 @@ func TestStaticHandlerRejectsBackslashPaths(t *testing.T) {
 		{
 			name: "decoded path",
 			mutate: func(request *http.Request) {
-				request.URL.Path = `/..\secret.txt`
+				request.URL.Path = oneBackslashPath
 			},
 		},
 		{
 			name: "raw path",
 			mutate: func(request *http.Request) {
-				request.URL.RawPath = `/..\secret.txt`
+				request.URL.RawPath = oneBackslashPath
 			},
 		},
 	} {
@@ -129,6 +133,43 @@ func TestStaticHandlerRejectsBackslashPaths(t *testing.T) {
 				t.Fatalf("status = %d, want 404", response.Code)
 			}
 		})
+	}
+}
+
+func TestStaticHandlerRejectsSymlinkEntry(t *testing.T) {
+	root := t.TempDir()
+	directory := filepath.Join(root, "serve")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external.txt")
+	if err := os.WriteFile(external, []byte("external"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(directory, "link.txt")); err != nil {
+		t.Skipf("symlink creation is not available: %v", err)
+	}
+
+	response := httptest.NewRecorder()
+	staticHandler(directory).ServeHTTP(response, httptest.NewRequest("GET", "/link.txt", nil))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("symlink entry status = %d, want 404", response.Code)
+	}
+	if got := response.Body.String(); got == "external" {
+		t.Fatalf("served symlink target body: %q", got)
+	}
+}
+
+func assertSingleBackslashFixture(t *testing.T, value string) {
+	t.Helper()
+	count := 0
+	for _, r := range value {
+		if r == '\\' {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("test fixture must contain exactly one backslash rune, got %d in %q", count, value)
 	}
 }
 

--- a/cmd/goxc/serve_test.go
+++ b/cmd/goxc/serve_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStaticHandlerServesRootAndStaticFiles(t *testing.T) {
+	directory := t.TempDir()
+	writeServeFixture(t, directory, "index.html", "root")
+	writeServeFixture(t, directory, "assets/app.js", "console.log('ok')")
+
+	handler := staticHandler(directory)
+
+	rootResponse := httptest.NewRecorder()
+	handler.ServeHTTP(rootResponse, httptest.NewRequest("GET", "/", nil))
+	if rootResponse.Code != http.StatusOK {
+		t.Fatalf("root status = %d, want 200", rootResponse.Code)
+	}
+	if got := rootResponse.Body.String(); got != "root" {
+		t.Fatalf("root body = %q, want root", got)
+	}
+
+	fileResponse := httptest.NewRecorder()
+	handler.ServeHTTP(fileResponse, httptest.NewRequest("GET", "/assets/app.js?cache=ignored", nil))
+	if fileResponse.Code != http.StatusOK {
+		t.Fatalf("static file status = %d, want 200", fileResponse.Code)
+	}
+	if got := fileResponse.Body.String(); got != "console.log('ok')" {
+		t.Fatalf("static file body = %q, want app fixture", got)
+	}
+	if got := fileResponse.Header().Get("Content-Type"); got != "text/javascript" {
+		t.Fatalf("Content-Type = %q, want text/javascript", got)
+	}
+}
+
+func TestStaticHandlerServesCompressedWASMHeaders(t *testing.T) {
+	directory := t.TempDir()
+	writeServeFixture(t, directory, "assets/bundle.wasm.gz", "gzip")
+	writeServeFixture(t, directory, "assets/bundle.wasm.br", "brotli")
+
+	for _, tt := range []struct {
+		name     string
+		path     string
+		encoding string
+		body     string
+	}{
+		{name: "gzip", path: "/assets/bundle.wasm.gz", encoding: "gzip", body: "gzip"},
+		{name: "brotli", path: "/assets/bundle.wasm.br", encoding: "br", body: "brotli"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			staticHandler(directory).ServeHTTP(response, httptest.NewRequest("GET", tt.path, nil))
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", response.Code)
+			}
+			if got := response.Header().Get("Content-Encoding"); got != tt.encoding {
+				t.Fatalf("Content-Encoding = %q, want %q", got, tt.encoding)
+			}
+			if got := response.Header().Get("Content-Type"); got != "application/wasm" {
+				t.Fatalf("Content-Type = %q, want application/wasm", got)
+			}
+			if got := response.Body.String(); got != tt.body {
+				t.Fatalf("body = %q, want %q", got, tt.body)
+			}
+		})
+	}
+}
+
+func TestStaticHandlerRejectsTraversalPaths(t *testing.T) {
+	root := t.TempDir()
+	directory := filepath.Join(root, "serve")
+	if err := os.Mkdir(directory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeServeFixture(t, directory, "public.txt", "public")
+	if err := os.WriteFile(filepath.Join(root, "secret.txt"), []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, target := range []string{
+		"/../secret.txt",
+		"/%2e%2e/secret.txt",
+		"/assets/../public.txt",
+	} {
+		t.Run(target, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			staticHandler(directory).ServeHTTP(response, httptest.NewRequest("GET", target, nil))
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404", response.Code)
+			}
+			if got := response.Body.String(); got == "secret" || got == "public" {
+				t.Fatalf("served body for rejected path: %q", got)
+			}
+		})
+	}
+}
+
+func TestStaticHandlerRejectsBackslashPaths(t *testing.T) {
+	directory := t.TempDir()
+	writeServeFixture(t, directory, "public.txt", "public")
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*http.Request)
+	}{
+		{
+			name: "decoded path",
+			mutate: func(request *http.Request) {
+				request.URL.Path = `/..\secret.txt`
+			},
+		},
+		{
+			name: "raw path",
+			mutate: func(request *http.Request) {
+				request.URL.RawPath = `/..\secret.txt`
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest("GET", "/public.txt", nil)
+			tt.mutate(request)
+			response := httptest.NewRecorder()
+			staticHandler(directory).ServeHTTP(response, request)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want 404", response.Code)
+			}
+		})
+	}
+}
+
+func writeServeFixture(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/security-symlink-policy.md
+++ b/docs/security-symlink-policy.md
@@ -42,7 +42,8 @@ Current protection focuses on:
   overwrite generated WASM, runtime shims, metadata, or compressed sidecars;
 - using staging directories before publishing packages;
 - cleaning only known GoFrame-owned artifacts;
-- binding the development server to `127.0.0.1`.
+- binding the development server to `127.0.0.1` and rejecting traversal,
+  backslash, and symlink paths below the served package root.
 
 ## Scope Boundary For `pkg/gox`
 
@@ -153,11 +154,13 @@ looks GoFrame-owned. User-owned `dist/` directories are left alone.
 
 `goxc serve` is development-only. It serves from `.goframe/package/standalone`
 or an explicit `--dir`, binds to localhost, and sets common content types for
-WASM, JavaScript, CSS, gzip, and brotli sidecars.
+WASM, JavaScript, CSS, gzip, and brotli sidecars. Request paths are normalized
+as slash paths; traversal attempts, backslash paths, symlinked roots, and
+symlinked entries below the served root return 404.
 
 It is not a production server. Production compression negotiation, cache
-headers, TLS, path hardening, and access controls belong to deployment
-infrastructure.
+headers, TLS, broader static-server hardening, and access controls belong to
+deployment infrastructure.
 
 ## Symlink Policy
 
@@ -181,8 +184,8 @@ Policy:
 - the standalone package directory used as export source must not be a symlink;
 - `goxc clean` removes final tool-owned symlinks as links and rejects
   intermediate workspace symlinks instead of traversing targets;
-- `goxc serve` rejects symlinked roots and symlinked entries inside the served
-  tree;
+- `goxc serve` rejects traversal, backslash paths, symlinked roots, and
+  symlinked entries inside the served tree;
 - explicit external workspaces remain allowed because the user opted into that
   root directly, but the final app-scoped workspace root must not overlap the
   app source tree.
@@ -236,6 +239,7 @@ Evidence:
 | user asset named `bundle.wasm` or `wasm_exec.js` | Ready | Rejected as a generated namespace collision. |
 | user asset compressed sidecar collision | Ready | Rejected before package publication. |
 | export source/output overlap | Ready | Rejected before cleanup/copy. |
+| serve traversal or backslash path | Ready with limitations | Dev server returns 404 after slash-path normalization; it remains development-only. |
 | serve tree symlink entry | Ready with limitations | Dev server returns 404 for symlink entries; it remains development-only. |
 
 ## Package Publication Integrity


### PR DESCRIPTION
### Summary

Hardens `goxc serve` static file handling for development use.

This PR sanitizes incoming request paths before filesystem resolution and before delegating to `http.FileServer`, while preserving the existing development-server behavior for normal package assets.

### CodeQL Alert

Targets CodeQL alert #6:

* `Uncontrolled data used in path expression`
* Severity: High
* Location: `cmd/goxc/serve.go`

Final alert closure should be confirmed after GitHub code scanning reruns on this PR.

### What Changed

* Sanitized static serve request paths before constructing local filesystem paths.
* Rejected traversal-style request paths and backslash-containing paths.
* Preserved root path handling.
* Preserved existing symlink rejection / fail-closed behavior.
* Preserved static asset headers for WASM, JavaScript, CSS, gzip, and Brotli paths.
* Passed sanitized request paths to the file server instead of the original user-controlled path.
* Added focused regression coverage for static serving safety edges.

### Scope

This PR is limited to `goxc serve` path handling and nearest regression tests.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No package/export semantics changes.
* No manifest/assets semantics changes.
* No examples changes.
* No workflow changes.
* No release note or tag changes.
* No production-server claim for `goxc serve`.

### Validation

* `git diff --check`
* `go test ./cmd/goxc`
* `go test ./...`
* `go vet ./...`
* `node scripts/docs-check.mjs`

### Notes

`goxc serve` remains a development-only static server. This PR hardens request path handling but does not turn it into a production deployment server.
