### PR TITLE
test(browser): avoid dynamic eval alert patterns

### DIFF
--- a/scripts/context-browser-smoke.mjs
+++ b/scripts/context-browser-smoke.mjs
@@ -171,24 +171,26 @@ async function contextState(client) {
 }
 
 async function setSelectValue(client, selector, value) {
-    await client.evaluate(`(() => {
-        const select = document.querySelector(${JSON.stringify(selector)});
-        select.value = ${JSON.stringify(value)};
+    await client.callFunction(`function(selector, value) {
+        const select = document.querySelector(selector);
+        select.value = value;
         select.dispatchEvent(new Event("change", { bubbles: true }));
         return true;
-    })()`);
+    }`, selector, value);
     await wait(140);
 }
 
 async function startScenario(client, label) {
-    await client.evaluate(`(() => {
-        window.__contextAudit.start(${JSON.stringify(label)});
+    await client.callFunction(`function(label) {
+        window.__contextAudit.start(label);
         return true;
-    })()`);
+    }`, label);
 }
 
 async function finishScenario(client, label) {
-    const report = await client.evaluate(`(() => window.__contextAudit.finish(${JSON.stringify(label)}))()`);
+    const report = await client.callFunction(`function(label) {
+        return window.__contextAudit.finish(label);
+    }`, label);
     console.log(`context perf ${label}: ${JSON.stringify(report)}`);
     return report;
 }
@@ -385,6 +387,21 @@ async function connect(url) {
             pending.set(id, { resolve, reject });
             socket.send(JSON.stringify({ id, method, params }));
         });
+    let globalObjectID = "";
+    const getGlobalObjectID = async () => {
+        if (globalObjectID) {
+            return globalObjectID;
+        }
+        const result = await call("Runtime.evaluate", {
+            expression: "globalThis",
+            returnByValue: false,
+        });
+        if (result.exceptionDetails) {
+            throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+        }
+        globalObjectID = result.result.objectId;
+        return globalObjectID;
+    };
 
     return {
         call,
@@ -392,6 +409,19 @@ async function connect(url) {
         evaluate: async (expression) => {
             const result = await call("Runtime.evaluate", {
                 expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        callFunction: async (functionDeclaration, ...args) => {
+            const result = await call("Runtime.callFunctionOn", {
+                objectId: await getGlobalObjectID(),
+                functionDeclaration,
+                arguments: args.map((value) => ({ value })),
                 returnByValue: true,
                 awaitPromise: true,
             });

--- a/scripts/dashboard-browser-smoke.mjs
+++ b/scripts/dashboard-browser-smoke.mjs
@@ -523,44 +523,44 @@ async function clearClientStorage(client) {
 }
 
 async function setInputValue(client, selector, value) {
-    await client.evaluate(`(() => {
-        const input = document.querySelector(${JSON.stringify(selector)});
+    await client.callFunction(`function(selector, value) {
+        const input = document.querySelector(selector);
         input.focus();
-        input.value = ${JSON.stringify(value)};
+        input.value = value;
         input.dispatchEvent(new Event("input", { bubbles: true }));
         return true;
-    })()`);
+    }`, selector, value);
     await wait(140);
 }
 
 async function setSelectValue(client, selector, value) {
-    await client.evaluate(`(() => {
-        const select = document.querySelector(${JSON.stringify(selector)});
-        select.value = ${JSON.stringify(value)};
+    await client.callFunction(`function(selector, value) {
+        const select = document.querySelector(selector);
+        select.value = value;
         select.dispatchEvent(new Event("change", { bubbles: true }));
         return true;
-    })()`);
+    }`, selector, value);
     await wait(140);
 }
 
 async function clickButtonByText(client, text) {
-    await client.evaluate(`(() => {
-        const button = [...document.querySelectorAll("button")].find((node) => node.textContent.trim() === ${JSON.stringify(text)});
+    await client.callFunction(`function(text) {
+        const button = [...document.querySelectorAll("button")].find((node) => node.textContent.trim() === text);
         if (!button) return false;
         button.click();
         return true;
-    })()`);
+    }`, text);
 }
 
 async function metricValue(client, label) {
-    return await client.evaluate(`(() => {
+    return await client.callFunction(`function(label) {
         for (const card of document.querySelectorAll(".metric-card")) {
-            if (card.querySelector("span")?.textContent === ${JSON.stringify(label)}) {
+            if (card.querySelector("span")?.textContent === label) {
                 return Number(card.querySelector("strong")?.textContent);
             }
         }
         return -1;
-    })()`);
+    }`, label);
 }
 
 async function firstRowStatus(client) {
@@ -568,16 +568,18 @@ async function firstRowStatus(client) {
 }
 
 async function startScenario(client, label) {
-    await client.evaluate(`(() => {
+    await client.callFunction(`function(label) {
         const audit = window.__dashboardAudit;
         if (!audit) return false;
-        audit.start(${JSON.stringify(label)});
+        audit.start(label);
         return true;
-    })()`);
+    }`, label);
 }
 
 async function finishScenario(client, label) {
-    const report = await client.evaluate(`(() => window.__dashboardAudit.finish(${JSON.stringify(label)}))()`);
+    const report = await client.callFunction(`function(label) {
+        return window.__dashboardAudit.finish(label);
+    }`, label);
     performanceReports.push(report);
     console.log(`dashboard perf ${label}: ${JSON.stringify(report)}`);
     return report;
@@ -703,12 +705,12 @@ function assertWithinRowScrollReport(report, beforeState, state) {
 }
 
 async function captureVirtualTableDom(client, key) {
-    return await client.evaluate(`(() => {
+    return await client.callFunction(`function(key) {
         const tbody = document.querySelector("[data-testid='issue-table'] tbody");
         const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
         const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
         const rows = [...document.querySelectorAll(".issue-row")];
-        window[${JSON.stringify(key)}] = {
+        window[key] = {
             top,
             bottom,
             rowIDs: rows.map((node) => node.id),
@@ -722,12 +724,12 @@ async function captureVirtualTableDom(client, key) {
             topExists: Boolean(top),
             bottomExists: Boolean(bottom),
         };
-    })()`);
+    }`, key);
 }
 
 async function readVirtualTableDom(client, key) {
-    return await client.evaluate(`(() => {
-        const before = window[${JSON.stringify(key)}] || {};
+    return await client.callFunction(`function(key) {
+        const before = window[key] || {};
         const tbody = document.querySelector("[data-testid='issue-table'] tbody");
         const top = tbody?.querySelector(".gf-virtual-table-spacer-top") || null;
         const bottom = tbody?.querySelector(".gf-virtual-table-spacer-bottom") || null;
@@ -742,7 +744,7 @@ async function readVirtualTableDom(client, key) {
             rowIDsSame: JSON.stringify(before.rowIDs || []) === JSON.stringify(rows.map((node) => node.id)),
             childCountSame: before.childCount === (tbody?.children.length ?? 0),
         };
-    })()`);
+    }`, key);
 }
 
 function assertInsideBufferScrollReport(report, beforeState, state) {
@@ -987,6 +989,21 @@ async function connect(url) {
             pending.set(id, { resolve, reject });
             socket.send(JSON.stringify({ id, method, params }));
         });
+    let globalObjectID = "";
+    const getGlobalObjectID = async () => {
+        if (globalObjectID) {
+            return globalObjectID;
+        }
+        const result = await call("Runtime.evaluate", {
+            expression: "globalThis",
+            returnByValue: false,
+        });
+        if (result.exceptionDetails) {
+            throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+        }
+        globalObjectID = result.result.objectId;
+        return globalObjectID;
+    };
 
     return {
         call,
@@ -994,6 +1011,19 @@ async function connect(url) {
         evaluate: async (expression) => {
             const result = await call("Runtime.evaluate", {
                 expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        callFunction: async (functionDeclaration, ...args) => {
+            const result = await call("Runtime.callFunctionOn", {
+                objectId: await getGlobalObjectID(),
+                functionDeclaration,
+                arguments: args.map((value) => ({ value })),
                 returnByValue: true,
                 awaitPromise: true,
             });

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -381,9 +381,9 @@ function connect(url) {
                         returnByValue: true,
                     });
                     if (response.exceptionDetails) {
-                        throw new Error(response.exceptionDetails.text);
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
                     }
-                    return response.result.result.value;
+                    return response.result.value;
                 },
                 async callFunction(functionDeclaration, ...args) {
                     if (!this.globalObjectID) {
@@ -391,10 +391,10 @@ function connect(url) {
                             expression: "globalThis",
                             returnByValue: false,
                         });
-                        if (globalResponse.result.exceptionDetails) {
-                            throw new Error(globalResponse.result.exceptionDetails.text);
+                        if (globalResponse.exceptionDetails) {
+                            throw new Error(`browser evaluation failed: ${JSON.stringify(globalResponse.exceptionDetails)}`);
                         }
-                        this.globalObjectID = globalResponse.result.result.objectId;
+                        this.globalObjectID = globalResponse.result.objectId;
                     }
                     const response = await this.call("Runtime.callFunctionOn", {
                         objectId: this.globalObjectID,
@@ -403,10 +403,10 @@ function connect(url) {
                         awaitPromise: true,
                         returnByValue: true,
                     });
-                    if (response.result.exceptionDetails) {
-                        throw new Error(response.result.exceptionDetails.text);
+                    if (response.exceptionDetails) {
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
                     }
-                    return response.result.result.value;
+                    return response.result.value;
                 },
                 close() {
                     socket.close();
@@ -425,7 +425,7 @@ function connect(url) {
                 request.reject(new Error(message.error.message));
                 return;
             }
-            request.resolve(message);
+            request.resolve(message.result);
         });
     });
 }

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -163,12 +163,12 @@ async function probe(client) {
 }
 
 async function click(client, selector) {
-    const result = await client.evaluate(`(() => {
-        const element = document.querySelector(${JSON.stringify(selector)});
+    const result = await client.callFunction(`function(selector) {
+        const element = document.querySelector(selector);
         if (!element) return false;
         element.click();
         return true;
-    })()`);
+    }`, selector);
     if (!result) {
         throw new Error(`APP FAILURE: missing element for click ${selector}`);
     }
@@ -206,25 +206,32 @@ async function assertListenerNetStable(client, label) {
 }
 
 async function waitForSelector(client, selector, label) {
-    await waitUntil(client, label, `(() => Boolean(document.querySelector(${JSON.stringify(selector)})))()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(selector) {
+            return Boolean(document.querySelector(selector));
+        }`, selector));
 }
 
 async function waitForText(client, selector, expected, label) {
-    await waitUntil(client, label, `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)});
-        return element ? element.textContent === ${JSON.stringify(expected)} : false;
-    })()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(selector, expected) {
+            const element = document.querySelector(selector);
+            return element ? element.textContent === expected : false;
+        }`, selector, expected));
 }
 
 async function waitForAbsent(client, selector, label) {
-    await waitUntil(client, label, `(() => !document.querySelector(${JSON.stringify(selector)}))()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(selector) {
+            return !document.querySelector(selector);
+        }`, selector));
 }
 
-async function waitUntil(client, label, expression) {
+async function waitUntil(client, label, predicate) {
     const started = Date.now();
     let lastValue = null;
     while (Date.now() - started < 5000) {
-        lastValue = await client.evaluate(expression);
+        lastValue = await predicate();
         if (lastValue === true) {
             return;
         }
@@ -375,6 +382,29 @@ function connect(url) {
                     });
                     if (response.exceptionDetails) {
                         throw new Error(response.exceptionDetails.text);
+                    }
+                    return response.result.result.value;
+                },
+                async callFunction(functionDeclaration, ...args) {
+                    if (!this.globalObjectID) {
+                        const globalResponse = await this.call("Runtime.evaluate", {
+                            expression: "globalThis",
+                            returnByValue: false,
+                        });
+                        if (globalResponse.result.exceptionDetails) {
+                            throw new Error(globalResponse.result.exceptionDetails.text);
+                        }
+                        this.globalObjectID = globalResponse.result.result.objectId;
+                    }
+                    const response = await this.call("Runtime.callFunctionOn", {
+                        objectId: this.globalObjectID,
+                        functionDeclaration,
+                        arguments: args.map((value) => ({ value })),
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.result.exceptionDetails) {
+                        throw new Error(response.result.exceptionDetails.text);
                     }
                     return response.result.result.value;
                 },

--- a/scripts/runtime-errors-browser-smoke.mjs
+++ b/scripts/runtime-errors-browser-smoke.mjs
@@ -267,9 +267,9 @@ function connect(url) {
                         returnByValue: true,
                     });
                     if (response.exceptionDetails) {
-                        throw new Error(response.exceptionDetails.text);
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
                     }
-                    return response.result.result.value;
+                    return response.result.value;
                 },
                 async callFunction(functionDeclaration, ...args) {
                     if (!this.globalObjectID) {
@@ -277,10 +277,10 @@ function connect(url) {
                             expression: "globalThis",
                             returnByValue: false,
                         });
-                        if (globalResponse.result.exceptionDetails) {
-                            throw new Error(globalResponse.result.exceptionDetails.text);
+                        if (globalResponse.exceptionDetails) {
+                            throw new Error(`browser evaluation failed: ${JSON.stringify(globalResponse.exceptionDetails)}`);
                         }
-                        this.globalObjectID = globalResponse.result.result.objectId;
+                        this.globalObjectID = globalResponse.result.objectId;
                     }
                     const response = await this.call("Runtime.callFunctionOn", {
                         objectId: this.globalObjectID,
@@ -289,10 +289,10 @@ function connect(url) {
                         awaitPromise: true,
                         returnByValue: true,
                     });
-                    if (response.result.exceptionDetails) {
-                        throw new Error(response.result.exceptionDetails.text);
+                    if (response.exceptionDetails) {
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
                     }
-                    return response.result.result.value;
+                    return response.result.value;
                 },
                 close() {
                     socket.close();
@@ -311,7 +311,7 @@ function connect(url) {
                 request.reject(new Error(message.error.message));
                 return;
             }
-            request.resolve(message);
+            request.resolve(message.result);
         });
     });
 }

--- a/scripts/runtime-errors-browser-smoke.mjs
+++ b/scripts/runtime-errors-browser-smoke.mjs
@@ -79,40 +79,45 @@ try {
 }
 
 async function click(client, selector) {
-    const result = await client.evaluate(`(() => {
-        const element = document.querySelector(${JSON.stringify(selector)});
+    const result = await client.callFunction(`function(selector) {
+        const element = document.querySelector(selector);
         if (!element) return false;
         element.click();
         return true;
-    })()`);
+    }`, selector);
     if (!result) {
         throw new Error(`APP FAILURE: missing element for click ${selector}`);
     }
 }
 
 async function waitForReport(client, phase, label) {
-    await waitUntil(client, label, `(() => {
-        const reports = globalThis.goframeRuntimeErrorReports || [];
-        return reports.some((report) => report.phase === ${JSON.stringify(phase)});
-    })()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(phase) {
+            const reports = globalThis.goframeRuntimeErrorReports || [];
+            return reports.some((report) => report.phase === phase);
+        }`, phase));
 }
 
 async function waitForText(client, selector, expected, label) {
-    await waitUntil(client, label, `(() => {
-        const element = document.querySelector(${JSON.stringify(selector)});
-        return element ? element.textContent === ${JSON.stringify(expected)} : false;
-    })()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(selector, expected) {
+            const element = document.querySelector(selector);
+            return element ? element.textContent === expected : false;
+        }`, selector, expected));
 }
 
 async function waitForAbsent(client, selector, label) {
-    await waitUntil(client, label, `(() => !document.querySelector(${JSON.stringify(selector)}))()`);
+    await waitUntil(client, label, () =>
+        client.callFunction(`function(selector) {
+            return !document.querySelector(selector);
+        }`, selector));
 }
 
-async function waitUntil(client, label, expression) {
+async function waitUntil(client, label, predicate) {
     const started = Date.now();
     let lastValue = null;
     while (Date.now() - started < 5000) {
-        lastValue = await client.evaluate(expression);
+        lastValue = await predicate();
         if (lastValue === true) {
             return;
         }
@@ -263,6 +268,29 @@ function connect(url) {
                     });
                     if (response.exceptionDetails) {
                         throw new Error(response.exceptionDetails.text);
+                    }
+                    return response.result.result.value;
+                },
+                async callFunction(functionDeclaration, ...args) {
+                    if (!this.globalObjectID) {
+                        const globalResponse = await this.call("Runtime.evaluate", {
+                            expression: "globalThis",
+                            returnByValue: false,
+                        });
+                        if (globalResponse.result.exceptionDetails) {
+                            throw new Error(globalResponse.result.exceptionDetails.text);
+                        }
+                        this.globalObjectID = globalResponse.result.result.objectId;
+                    }
+                    const response = await this.call("Runtime.callFunctionOn", {
+                        objectId: this.globalObjectID,
+                        functionDeclaration,
+                        arguments: args.map((value) => ({ value })),
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.result.exceptionDetails) {
+                        throw new Error(response.result.exceptionDetails.text);
                     }
                     return response.result.result.value;
                 },


### PR DESCRIPTION
### Summary

Refactors targeted browser smoke scripts to avoid passing test-controlled values through dynamically interpolated `Runtime.evaluate` expressions.

The smoke coverage and runtime assertions remain the same, but selectors, labels, phases, and expected values are now passed as CDP function arguments where CodeQL previously flagged dynamic JavaScript construction patterns.

### CodeQL Alerts

Targets CodeQL “Improper code sanitization” alerts in browser smoke scripts:

* `scripts/context-browser-smoke.mjs`
* `scripts/dashboard-browser-smoke.mjs`
* `scripts/error-boundary-browser-smoke.mjs`
* `scripts/runtime-errors-browser-smoke.mjs`

Final alert closure should be confirmed after GitHub code scanning reruns on this PR.

### What Changed

* Added/used CDP `Runtime.callFunctionOn`-style helpers for dynamic browser assertions.
* Replaced dynamic interpolation of selectors, labels, phases, and expected text with argument passing.
* Preserved existing smoke-script behavior and assertions.
* Kept static `Runtime.evaluate` probes where no dynamic test-controlled values are interpolated.
* Left runtime, GOX, goxc, examples, workflows, release notes, and tags unchanged.

### Scope

This PR is limited to browser smoke test harness hardening.

### Non-Goals

* No Go runtime changes.
* No GOX changes.
* No goxc/toolchain behavior changes.
* No example behavior changes.
* No workflow changes.
* No public API or preview-contract changes.
* No reduction of browser smoke coverage.
* No CodeQL suppression-only fix.

### Validation

* `node --check scripts/context-browser-smoke.mjs`
* `node --check scripts/dashboard-browser-smoke.mjs`
* `node --check scripts/error-boundary-browser-smoke.mjs`
* `node --check scripts/runtime-errors-browser-smoke.mjs`
* `git diff --check`
* `go test ./...`
* `node scripts/docs-check.mjs`
* `scripts/browser-smoke.sh`

### Notes

This is test-harness hardening only. It does not change browser runtime behavior; it only reduces CodeQL noise by avoiding dynamic executable JavaScript construction for test-controlled values.
