### PR TITLE
docs(release): polish preview.1 release note status

### DIFF
--- a/docs/release-notes-v0.1.0-preview.1.md
+++ b/docs/release-notes-v0.1.0-preview.1.md
@@ -1,8 +1,5 @@
 # Release Notes: v0.1.0-preview.1
 
-Status: draft release notes. No `v0.1.0-preview.1` tag is created by this
-document.
-
 ## Summary
 
 GoFrame is an experimental Go-first application platform. This preview


### PR DESCRIPTION
### Summary

Removes stale draft-status wording from the `v0.1.0-preview.1` release notes.

The release has already been published, so the release notes should no longer say that they are draft notes or that no preview tag exists.

### What Changed

* Removed the stale status paragraph from `docs/release-notes-v0.1.0-preview.1.md`.
* Left the actual `v0.1.0-preview.1` release notes content unchanged.

### Scope

This PR is documentation-only.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No goxc/toolchain changes.
* No tests or examples changes.
* No workflow changes.
* No release tag changes.
* No GitHub Release body changes.
* No compatibility or preview-scope changes.

### Validation

* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`

### Notes

This does not move or recreate the `v0.1.0-preview.1` tag. It only removes stale wording from the repository copy of the release notes.
