### PR TITLE
docs(release): prepare preview.2 maintenance notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@
 - `v0.1.0-preview.1` release-story docs, including draft release notes,
   evaluator guidance, compatibility/readiness alignment, and fact-first preview
   documentation cleanup.
+- `v0.1.0-preview.2` maintenance release notes documenting post-preview.1
+  community health files, `goxc serve` path hardening, browser smoke CodeQL
+  eval-pattern cleanup, and no runtime/API/GOX/package semantics expansion.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Start here:
 - [GoFrame Tutorial](docs/tutorial.md)
 - [Evaluator guide](docs/evaluator-guide.md)
 - [v0.1.0-preview.1 release notes](docs/release-notes-v0.1.0-preview.1.md)
+- [v0.1.0-preview.2 release notes](docs/release-notes-v0.1.0-preview.2.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/docs/release-notes-v0.1.0-preview.2.md
+++ b/docs/release-notes-v0.1.0-preview.2.md
@@ -1,0 +1,108 @@
+# Release Notes: v0.1.0-preview.2
+
+## Summary
+
+`v0.1.0-preview.2` is a maintenance preview after
+`v0.1.0-preview.1`. It focuses on public repository hygiene and security/test
+harness hardening that landed on `main` after the first evaluator preview.
+
+GoFrame remains an experimental Go-first application platform. This maintenance
+preview does not expand the runtime/API stability promise, does not make
+`goxc serve` a production server, and keeps the preview scope centered on
+browser/WASM evaluator use.
+
+Scope preview != scope project. The first preview remains narrower than the
+project vision without removing or hiding working experimental surfaces.
+
+## What Changed Since v0.1.0-preview.1
+
+### Community Health
+
+The repository now includes minimal public-preview community files:
+
+- issue templates for bug reports and feature requests;
+- a pull request template;
+- updated contribution guidance;
+- a short Code of Conduct.
+
+These files describe contribution expectations for an experimental public
+preview repository. They do not change runtime, toolchain, package, or example
+behavior.
+
+### `goxc serve` Path Hardening
+
+`goxc serve` now hardens static request path handling:
+
+- request paths are sanitized before filesystem resolution and before handing
+  the request to `http.FileServer`;
+- traversal and backslash paths return 404;
+- symlinked served entries remain fail-closed;
+- existing static asset headers for WASM, JavaScript, CSS, gzip, and brotli
+  sidecars are preserved.
+
+`goxc serve` remains development-only. Production static hosting, cache
+headers, TLS, access control, and broader server hardening remain outside the
+current preview contract.
+
+### Browser Smoke Harness Hardening
+
+Browser smoke scripts no longer construct dynamic executable JavaScript from
+test-controlled selectors, labels, or expected values in the targeted CodeQL
+alert patterns. The harness passes those values as Chrome DevTools Protocol
+function arguments instead.
+
+This is test-harness hardening only. Browser runtime behavior and smoke
+assertions are unchanged.
+
+## Compatibility
+
+This maintenance preview has no intended:
+
+- runtime API changes;
+- GOX language changes;
+- manifest, package, or export semantics changes;
+- workflow support expansion;
+- preview promise expansion.
+
+The `v0.1.0-preview.1` compatibility boundaries still apply: public-candidate
+API shapes remain pre-1.0, experimental semantics remain explicitly scoped, and
+production readiness is not claimed.
+
+## Validation
+
+Expected release-branch validation includes:
+
+```bash
+git diff --check
+node scripts/docs-check.mjs
+go test ./...
+```
+
+Additional checks may be run by CI or release maintainers, but this maintenance
+release note only records commands that are part of the documented local
+release-prep validation set.
+
+## Notes For Evaluators
+
+After release publication, install the exact CLI tag when exact preview
+selection matters:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@v0.1.0-preview.2
+```
+
+`@latest` may depend on Go module proxy and cache timing. Use the exact tag
+when immediate reproducibility matters after publication.
+
+## Non-Goals
+
+`v0.1.0-preview.2` does not include:
+
+- production readiness;
+- stable 1.0 API compatibility;
+- runtime feature changes;
+- GOX language changes;
+- manifest/package/export contract changes;
+- browser/platform support expansion;
+- turning `goxc serve` into a production static server;
+- SSR, hydration, history routing, Player/Engine, or `.gfapp` packaging.

--- a/docs/release.md
+++ b/docs/release.md
@@ -76,12 +76,16 @@ go install github.com/graybuton/goframe/cmd/goxc@latest
 
 ## After Tagging
 
-Use the dedicated release notes document for the preview tag:
-`docs/release-notes-v0.1.0-preview.1.md`. `CHANGELOG.md` remains the factual
-change log; release notes should summarize preview scope, maturity tiers,
-validation evidence, compatibility notes, and known limitations.
-`docs/evaluator-guide.md` is the evaluator-facing quick path for trying the
-preview.
+Use the dedicated release notes document for the preview tag being released.
+Current preview release note documents:
+
+- `docs/release-notes-v0.1.0-preview.1.md`
+- `docs/release-notes-v0.1.0-preview.2.md`
+
+`CHANGELOG.md` remains the factual change log; release notes should summarize
+preview scope, maturity tiers, validation evidence, compatibility notes, and
+known limitations. `docs/evaluator-guide.md` is the evaluator-facing quick path
+for trying the preview.
 
 ## Public Preview Checklist
 


### PR DESCRIPTION
### Summary

Prepares maintenance release notes for `v0.1.0-preview.2`.

This documents the post-`v0.1.0-preview.1` maintenance changes already merged to `main`: community health files, `goxc serve` static path hardening, and browser smoke harness CodeQL cleanup.

### What Changed

* Added `docs/release-notes-v0.1.0-preview.2.md`.
* Updated `CHANGELOG.md` with a factual preview.2 maintenance note.
* Added the preview.2 release notes to the README documentation map.
* Updated release-process docs to refer to the release notes document for the specific preview tag being published.

### Scope

Documentation-only release preparation.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No `goxc` behavior changes.
* No package/export/manifest semantics changes.
* No workflow changes.
* No generated artifacts.
* No tag creation.
* No GitHub Release publication.
* No preview promise expansion.

### Validation

* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`

### Notes

This PR prepares release documentation only. The `v0.1.0-preview.2` tag and GitHub pre-release should be created only after this PR is merged and required checks are green.