### PR TITLE
docs(preview): polish residual fact-first wording

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,14 +305,15 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
 - `goxc serve` is a development server without compression negotiation.
 - Debug-tag performance probes are observations, not rigorous benchmarks.
 
-## Roadmap
+## Preview Boundaries
 
-1. Keep public docs, examples, and regression gates aligned with the actual
-   toolchain surface.
-2. Harden component identity and workspace behavior before claiming reusable
-   package ecosystem support.
-3. Add deeper symlink/path-safety tests before public preview.
-4. Continue measuring size, DOM pressure, and browser smoke invariants before
-   taking on larger features.
-5. Explore path/history routing, Player/Engine, SSR/hydration, and `.gfapp`
-   only as separate design efforts, not incidental cleanup.
+- Public docs, examples, and regression gates describe the current toolchain
+  surface.
+- Reusable package ecosystem support is outside the current preview contract.
+- Filesystem safety evidence is scoped to the documented `goxc` checks and
+  supported command paths; hostile concurrent filesystem mutation remains out
+  of scope.
+- Size, DOM pressure, and browser smoke results are current evidence, not
+  production benchmarks.
+- Path/history routing, Player/Engine, SSR/hydration, and `.gfapp` are outside
+  the current preview contract.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,7 +26,7 @@ Before public preview:
 After public preview:
 
 - Public-Candidate APIs should not break without a migration note;
-- deprecated APIs should remain for at least one planned release stage unless
+- deprecated APIs should remain for at least one documented release stage unless
   safety requires faster removal;
 - CLI command and flag changes should include replacement commands;
 - user-authored manifest compatibility should be stricter than generated

--- a/docs/player-vision.md
+++ b/docs/player-vision.md
@@ -1,7 +1,7 @@
 # GoFrame Player vision
 
-The player is a future architectural direction, not a current implementation or
-first-preview promise:
+Player/Engine is a long-term architectural direction, not a current
+implementation or first-preview promise:
 
 ```text
 .gox source
@@ -13,19 +13,19 @@ goxc compiler/toolchain
 GoFrame Player / Engine
 ```
 
-The current separation prepares for that possibility:
+The current separation keeps that project direction visible:
 
 - GOX describes declarative application UI;
 - `goframe` provides the application runtime API;
 - `goxc` owns compilation and packaging workflows;
-- a future player could host a versioned bundle contract.
+- Player/Engine remains outside the current preview contract.
 
-A `.gfapp` bundle could eventually describe application code, assets,
-permissions, runtime requirements, and platform API versions. Open questions
-include sandboxing, updates, native capabilities, rendering, debugging, bundle
-signing, and portability.
+A `.gfapp` bundle is not implemented in the current preview. Open design
+questions include application code, assets, permissions, runtime requirements,
+platform API versions, sandboxing, updates, native capabilities, rendering,
+debugging, bundle signing, and portability.
 
 The project should first validate the browser runtime, manifest, toolchain, and
-application model. Keeping Player/Engine visible as future vision does not mean
+application model. Keeping Player/Engine visible as project vision does not mean
 the first public preview promises a custom browser, desktop shell, `.gfapp`
 runtime, or player implementation.

--- a/docs/pre-preview-action-plan.md
+++ b/docs/pre-preview-action-plan.md
@@ -23,8 +23,8 @@ preview scope must not be confused with a smaller project vision.
 GoFrame should not remove or hide working surfaces merely because they are not
 perfect yet. Valuable but risky areas should be hardened, documented, tested, or
 marked experimental. The project remains an ambitious Go-first application
-platform; preview contracts should make maturity visible rather than amputating
-the roadmap.
+platform; preview contracts should make maturity visible rather than narrowing
+the project vision.
 
 ## Current Product Identity
 
@@ -86,7 +86,7 @@ migration notes and a compatibility window.
 These are contract and evidence risks, not reasons to reduce GoFrame to a
 smaller product category.
 
-## What We Will Not Do
+## Current Non-Goals
 
 - No feature removal just to reduce audit surface.
 - No runtime/toolchain rewrites in this docs/planning phase.
@@ -95,7 +95,7 @@ smaller product category.
 - No SSR, hydration, history-router, route-loader, server-resource, or
   Player/Engine promises for the first preview.
 
-## Roadmap
+## Focused Branch Sequence
 
 ### 1. `docs/vision-preserving-preview-contract`
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -209,7 +209,7 @@ Decision:
   non-regular assets, omitted/`null`/empty assets behavior, custom and
   generated `index.html`, versioned metadata presence, and immediate package
   ownership verification;
-- package assets are planned before publication so user assets cannot collide
+- package asset planning runs before publication so user assets cannot collide
   with the generated WASM, `wasm_exec.js`, or compressed sidecars;
 - successful package/export commands verify that the published output is
   immediately recognized as a complete current GoFrame package;

--- a/docs/public-surface-audit-v.md
+++ b/docs/public-surface-audit-v.md
@@ -67,7 +67,7 @@ Updated documentation to reflect the current project surface:
 
 - current MVP 22 size and DOM pressure baseline in
   `docs/performance-baseline.md`;
-- current TinyGo example sizes and roadmap framing in `docs/architecture.md`;
+- current TinyGo example sizes and project-vision framing in `docs/architecture.md`;
 - typed component identity wording in `docs/component-identity.md`;
 - docs consistency checks in `docs/ci.md`.
 


### PR DESCRIPTION
### Summary

Polishes residual preview-facing wording so the documentation stays fact-first after the public preview release.

This replaces small roadmap-like or future-promise phrasing with current-contract language while preserving the broader GoFrame project vision.

### What Changed

* Reviewed preview-facing docs for roadmap-like wording.
* Replaced ambiguous future/promise phrasing with current preview contract wording.
* Preserved the `Scope preview != scope project` boundary.
* Left historical changelog/release-note/audit facts unchanged unless they were stale or misleading.

### Scope

Documentation-only wording polish.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No `goxc` behavior changes.
* No tests or examples changes.
* No workflow changes.
* No release tag changes.
* No GitHub Release publication.
* No preview promise expansion.

### Validation

* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`

### Notes

This PR closes the residual wording hygiene follow-up from the final preview readiness audit. It does not change GoFrame behavior or compatibility semantics.