### PR TITLE
docs(preview): document non-chrome browser evidence boundary

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -72,6 +72,12 @@ then runs:
 scripts/browser-smoke.sh
 ```
 
+The current smoke harness is Chrome/Chromium-specific. The Node scripts launch
+Chrome with a remote debugging port and use the Chrome DevTools Protocol over
+WebSocket for DOM probes, event simulation, runtime error collection, and DOM
+pressure metrics. Firefox, Safari/WebKit, and other non-Chrome engines do not
+have automated browser-smoke evidence in the current preview CI contract.
+
 The smoke script chooses dynamic ports, verifies the expected app origin before
 storage cleanup, checks WASM MIME type, and separates harness failures from app
 failures. It currently covers Todo reconciliation, duplicate-key debug
@@ -226,6 +232,7 @@ Local checks use:
 - curl for smoke server readiness checks.
 
 Set `CHROME=/path/to/chrome` when Chrome is not available as `google-chrome`.
+There is no local non-Chrome smoke command in the current preview contract.
 
 ## Size Budget Failures
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -9,8 +9,9 @@ not a production support promise.
 The current strongest evidence is Linux plus Chrome/Chromium. macOS currently
 has lightweight Intel-runner CI evidence for core Go/toolchain behavior, and
 Windows has lightweight CI evidence for the same layer. Firefox and Safari are
-not rejected platforms; they are explicitly deferred until dedicated non-Chrome
-validation is added.
+not rejected platforms, but they are outside the current preview evidence.
+The browser smoke harness is Chrome DevTools Protocol based, so non-Chrome
+behavior is not claimed by `v0.1.0-preview.*`.
 
 Labels:
 
@@ -45,9 +46,17 @@ toolchains.
 | Browser | Status | Evidence |
 |---|---|---|
 | Chrome/Chromium | CI-tested | Browser smoke and dashboard DOM pressure use Chrome/CDP. |
-| Firefox | unverified | Runtime uses standard browser APIs but has no CI coverage. |
-| Safari/WebKit | unverified | Runtime uses standard browser APIs but has no CI coverage. |
+| Firefox | unverified | Runtime uses standard browser APIs, but current CI has no Firefox smoke or package-load evidence. |
+| Safari/WebKit | unverified | Runtime uses standard browser APIs, but current CI has no Safari/WebKit smoke or package-load evidence. |
 | Non-browser WASM hosts | unsupported | Current runtime assumes browser DOM APIs. |
+
+Current non-Chrome boundary:
+
+- browser smoke scripts launch Chrome/Chromium and talk to the Chrome DevTools
+  Protocol over WebSocket;
+- the repository does not currently include a Playwright, WebDriver, Marionette,
+  or WebKit automation harness;
+- `v0.1.0-preview.*` does not claim equivalent Firefox or Safari behavior.
 
 Required browser APIs:
 


### PR DESCRIPTION
### Summary

Documents the current non-Chrome browser evidence boundary.

The current browser smoke harness remains Chrome/Chromium-based and CDP-specific. This PR records that boundary explicitly without adding flaky CI or expanding the preview support promise.

### Scope

Documentation-only evidence boundary update.

### Non-Goals

* No runtime changes.
* No GOX changes.
* No `goxc` behavior changes.
* No workflow changes.
* No example behavior changes.
* No release tag changes.
* No browser support promise expansion.

### Validation

* `git diff --check HEAD~1..HEAD`
* `node scripts/docs-check.mjs`
* `go test ./...`

### Notes

Firefox/Safari behavior remains outside the current preview promise unless later evidence explicitly expands that contract.