### PR TITLE
docs(identity): scope reusable component package evidence

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -193,8 +193,8 @@ VS Code extension:
   `gf.ComponentT` and typed identity tokens) can still have experimental
   semantics in specific lifecycle, remount, and edge-case compatibility areas.
   The exported surface is documented for preview usage, while deep behavior
-  under module/version/package-path edge cases remains experimental until
-  broader identity guarantees are proven.
+  under module/version/package-path edge cases remains experimental and outside
+  the current preview promise.
 - GOX diagnostic wording beyond the filename/line/column/source-line contract.
 - Context topology behavior and selector limitations.
 - Virtualization details such as fixed-height range buffering and table spacer
@@ -240,9 +240,8 @@ their contracts are still maturing.
 - `.gfapp` package format.
 - Broader host/runtime story beyond the browser DOM target.
 - Stronger editor tooling such as LSP/formatter behavior.
-- Future package ecosystem and reusable component distribution story.
-- Production deployment/server integration, if the project chooses that path in
-  a later phase.
+- Broader package ecosystem and reusable component distribution story.
+- Production deployment/server integration.
 
 These are not part of the first public preview promise.
 
@@ -330,15 +329,13 @@ Not stable:
 - automatic route-level Error Boundaries;
 - production deployment server behavior.
 
-## Road To Public Preview
+## Current Preview Boundaries
 
-Before public preview, GoFrame should have:
+The current preview does not claim:
 
-- a component identity decision for multi-module workspaces and reusable
-  component packages;
-- a symlink/file safety test matrix;
-- clearer package manifest compatibility policy;
-- stable migration notes for GOX syntax changes;
-- documented browser support expectations;
-- repeatable performance baseline updates;
-- explicit public/deprecated/internal API review.
+- broad multi-module workspace identity;
+- stable reusable component package identity across independently versioned
+  modules;
+- equivalent Firefox/Safari/browser engine evidence;
+- production deployment/server behavior;
+- 1.0 API compatibility.

--- a/docs/component-identity.md
+++ b/docs/component-identity.md
@@ -17,10 +17,15 @@ For the first public preview, the following behavior is considered stable enough
   `gf.ComponentT(gf.NewComponentType("importpath.Symbol", "Debug"), props, Header)`.
 - Identity defaults are derived from canonical component import/package path plus symbol name.
 - Import aliases are diagnostic labels and `gf.ComponentT` debug names, not identity keys.
-- Package-qualified GOX tags (`<layout.Shell />`, `<ui.Header />`) are stable when imports resolve to a package identity.
+- Package-qualified GOX tags (`<layout.Shell />`, `<ui.Header />`) are stable
+  inside the current app/workspace model when imports resolve to a package
+  identity.
 - Typed identity can be combined with keys (`gf.Key` / `Key`) for explicit list locality control.
 
-GoFrame examples and docs rely on these assumptions when composing multi-package trees inside one app/root.
+GoFrame examples and docs rely on these assumptions when composing
+multi-package trees inside one app/root. The `multipackage` and `cmdapp`
+examples exercise app/workspace composition; they do not claim a stable
+reusable component package ecosystem across independently versioned modules.
 
 ## Preview contract by API kind
 
@@ -59,9 +64,9 @@ For users running one module/application tree:
 
 ## Experimental frontier under preview
 
-These areas are experimental or only partially evidenced. Single-module
-multi-package composition is covered; broad multi-module or reusable package
-identity is not yet promised.
+These areas are experimental or only partially evidenced. Current preview
+evidence covers single-module app/workspace composition; broad multi-module or
+reusable package identity is outside the current preview contract.
 
 - Multi-module or module-reused component package identity.
 - Identity under `replace`, workspace aliasing, and non-trivial module path churn.
@@ -71,9 +76,9 @@ identity is not yet promised.
 
 ### Practical implication
 
-The API shape is usable and documented.
-The deeper contract under module/path edges remains experimental until later
-identity-hardening work explicitly documents and tests those edges.
+The API shape is usable and documented. The deeper contract under module/path
+edges remains experimental and requires dedicated design/test evidence before
+being claimed.
 
 ## Remount and state expectations
 
@@ -91,7 +96,7 @@ Use `gf.ComponentT` for runtime-visible typed boundaries, and keep
 `gf.Component` as a compatibility path for direct composition.
 Use direct function calls only for ordinary helper composition.
 Do not assume stable behavior across module path edits, module replacement,
-or cross-module ecosystem sharing in this preview window.
+or cross-module ecosystem sharing in the current preview contract.
 
 ## Risks and non-goals
 


### PR DESCRIPTION
### Summary

Clarifies the current preview evidence boundary for component identity.

This documents that current evidence covers generated GOX component tokens, package-qualified tags, and identity behavior inside the current app/workspace model, while broad reusable multi-module component package identity remains outside the current preview promise.

### What Changed

* Clarified the current component identity evidence boundary.
* Distinguished multipackage app/workspace support from reusable package ecosystem stability.
* Documented broad reusable multi-module component identity as outside the current preview contract.
* Preserved the existing preview scope and project vision.

### Scope

Documentation-only identity contract clarification.

### Non-Goals

* No runtime changes.
* No GOX compiler behavior changes.
* No `goxc` behavior changes.
* No example behavior changes.
* No workflow changes.
* No API additions.
* No reusable package identity implementation.
* No preview promise expansion.

### Validation

* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`
* `go test ./pkg/gox -run 'Identity|Package|Qualified|Golden|ErrorGolden'`
* `go test ./cmd/goxc -run 'Workspace|Package|Identity|CmdApp|Multipackage'`

### Notes

This PR does not change component identity behavior. It records the current evidence boundary so reusable package identity can be designed and tested separately before being claimed.