### PR TITLE
test(goxc): characterize external component package boundaries

### DIFF
--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -320,13 +320,9 @@ func App() gf.Node {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, unexpected := range []string{
-		"require example.com/ui",
-		"replace example.com/ui",
-	} {
-		if strings.Contains(string(workspaceGoMod), unexpected) {
-			t.Fatalf("workspace go.mod unexpectedly preserved external module directive %q:\n%s", unexpected, workspaceGoMod)
-		}
+	workspaceGoModText := string(workspaceGoMod)
+	if strings.Contains(workspaceGoModText, "example.com/ui") {
+		t.Fatalf("workspace go.mod unexpectedly preserved external module directive:\n%s", workspaceGoModText)
 	}
 	if _, err := os.Stat(filepath.Join(root, "ui", "card.gox.go")); !os.IsNotExist(err) {
 		t.Fatalf("external dependency GOX source was generated next to dependency source: %v", err)

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -183,6 +183,164 @@ func Layout(props LayoutProps) gf.Node {
 	}
 }
 
+func TestGenerateIntoDirectoryCharacterizesExternalModuleComponentIdentity(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeExternalCardModule(t, root, "ui", "example.com/ui", "ui")
+	writeExternalCardModule(t, root, "otherui", "example.com/otherui", "otherui")
+	writeExternalCardModule(t, root, "ui-v2", "example.com/ui/v2", "ui")
+	writeTestFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/otherui v0.0.0
+	example.com/ui v0.0.0
+	example.com/ui/v2 v2.0.0
+)
+
+replace example.com/ui => ../ui
+replace example.com/otherui => ../otherui
+replace example.com/ui/v2 => ../ui-v2
+`)
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import (
+	ui "example.com/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func App() gf.Node {
+	return <ui.Card Title="App" />
+}
+`)
+	writeTestFile(t, appDir, "alias.gox", `package main
+
+import (
+	widgets "example.com/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func AliasView() gf.Node {
+	return <widgets.Card Title="Alias" />
+}
+`)
+	writeTestFile(t, appDir, "external_cards.gox", `package main
+
+import (
+	other "example.com/otherui"
+	ui "example.com/ui"
+	uiv2 "example.com/ui/v2"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func Cards() gf.Node {
+	return (
+		<section>
+			<ui.Card Title="UI" />
+			<other.Card Title="Other" />
+			<uiv2.Card Title="V2" />
+		</section>
+	)
+}
+`)
+
+	destination := t.TempDir()
+	if err := generateIntoDirectory(appDir, destination, true); err != nil {
+		t.Fatalf("generateIntoDirectory() error: %v", err)
+	}
+
+	assertGeneratedFileContains(t, filepath.Join(destination, "app.gox.go"),
+		`gf.NewComponentType("example.com/ui.Card", "ui.Card")`,
+		`gf.ComponentT(_goxComponent_app_ui_Card, ui.CardProps{`,
+	)
+	assertGeneratedFileContains(t, filepath.Join(destination, "alias.gox.go"),
+		`gf.NewComponentType("example.com/ui.Card", "widgets.Card")`,
+		`gf.ComponentT(_goxComponent_alias_widgets_Card, widgets.CardProps{`,
+	)
+	assertGeneratedFileContains(t, filepath.Join(destination, "external_cards.gox.go"),
+		`gf.NewComponentType("example.com/ui.Card", "ui.Card")`,
+		`gf.NewComponentType("example.com/otherui.Card", "other.Card")`,
+		`gf.NewComponentType("example.com/ui/v2.Card", "uiv2.Card")`,
+	)
+	aliasContent, err := os.ReadFile(filepath.Join(destination, "alias.gox.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(aliasContent), `gf.NewComponentType("widgets.Card"`) {
+		t.Fatalf("alias-generated output used the import alias as identity:\n%s", aliasContent)
+	}
+}
+
+func TestPrepareBuildWorkspaceCharacterizesExternalModuleGOXBoundary(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeExternalCardModule(t, root, "ui", "example.com/ui", "ui")
+	writeTestFile(t, filepath.Join(root, "ui"), "card.gox", `package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func ExternalGOX() gf.Node {
+	return <Card Title="external gox" />
+}
+`)
+	writeTestFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require example.com/ui v0.0.0
+
+replace example.com/ui => ../ui
+`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import (
+	ui "example.com/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func App() gf.Node {
+	return <ui.Card Title="App" />
+}
+`)
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(t.TempDir(), "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareBuildWorkspace(layout, projectManifest{Entry: "."}); err != nil {
+		t.Fatalf("prepareBuildWorkspace() error: %v", err)
+	}
+
+	workspaceGoMod, err := os.ReadFile(filepath.Join(layout.WorkDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unexpected := range []string{
+		"require example.com/ui",
+		"replace example.com/ui",
+	} {
+		if strings.Contains(string(workspaceGoMod), unexpected) {
+			t.Fatalf("workspace go.mod unexpectedly preserved external module directive %q:\n%s", unexpected, workspaceGoMod)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "ui", "card.gox.go")); !os.IsNotExist(err) {
+		t.Fatalf("external dependency GOX source was generated next to dependency source: %v", err)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
+	if _, err := os.Stat(filepath.Join(appWorkDir, "app.gox.go")); err != nil {
+		t.Fatalf("app GOX output missing from workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(layout.WorkDir, "ui", "card.gox.go")); !os.IsNotExist(err) {
+		t.Fatalf("external dependency GOX source was materialized inside workspace: %v", err)
+	}
+}
+
 func TestGenerateIntoDirectoryReportsOriginalGOXSource(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module github.com/example/root\n\ngo 1.22\n"), 0o644); err != nil {
@@ -412,5 +570,36 @@ func writeTestFile(t *testing.T, root, relative, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func writeExternalCardModule(t *testing.T, root, directory, modulePath, packageName string) {
+	t.Helper()
+	moduleDir := filepath.Join(root, directory)
+	writeTestFile(t, moduleDir, "go.mod", "module "+modulePath+"\n\ngo 1.22\n")
+	writeTestFile(t, moduleDir, "card.go", `package `+packageName+`
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type CardProps struct {
+	Title string
+}
+
+func Card(props CardProps) gf.Node {
+	return gf.Text(props.Title)
+}
+`)
+}
+
+func assertGeneratedFileContains(t *testing.T, path string, wants ...string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated file %s: %v", path, err)
+	}
+	for _, want := range wants {
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("generated file %s missing %q:\n%s", path, want, content)
+		}
 	}
 }


### PR DESCRIPTION
### Summary

Adds executable characterization for GoFrame external component package identity boundaries.

This PR records what currently works and what remains unsupported: `goxc` generation preserves import-path-based component identity for package-qualified external imports, while the build workspace does not yet carry app external `require` / `replace` directives or generate raw `.gox` from external dependencies.

### What Changed

* Added temp-dir fixtures for an app module `example.com/app`.
* Added external component package modules:
  * `example.com/ui`
  * `example.com/otherui`
  * `example.com/ui/v2`
* Verified generated component identity for `<ui.Card />` uses `example.com/ui.Card`.
* Verified import alias changes affect debug labels, not runtime identity.
* Verified same-symbol external packages remain distinct.
* Verified versioned import paths remain distinct.
* Characterized current workspace behavior:
  * app GOX is generated into the build workspace;
  * external app `require` / `replace` directives are not preserved in workspace `go.mod`;
  * raw `.gox` files inside an external dependency are not generated into dependency source or current workspace.
* Tightened the workspace `go.mod` assertion so the test fails on any preserved `example.com/ui` directive, including future normalized or block-form formatting.

### Scope

Tests only.

### Non-Goals

* No runtime changes.
* No GOX compiler/codegen behavior changes.
* No `goxc` implementation changes.
* No build workspace dependency-handling implementation.
* No examples changes.
* No docs, README, CHANGELOG, release notes, or workflow changes.
* No reusable package ecosystem support claim.
* No build/package support claim for external component modules.

### Validation

Local validation reported:

* `go test ./pkg/gox -run 'Qualified|Identity|Package|Versioned|Collision|Alias'`
* `go test ./cmd/goxc -run 'Workspace|PackageIdentity|External|Module|Require|Replace'`
* `git diff --check`
* `go test ./cmd/goxc`
* `go test ./pkg/gox`
* `go test ./...`
* `git diff --check HEAD~1..HEAD`

Remote GitHub Actions should be checked on this PR before merge.

### Notes

This PR provides partial external-module identity evidence. It does not make reusable external component packages a supported build/package workflow yet.

The main observed gap remains workspace dependency handling: current build workspace generation does not carry app external module `require` / `replace` directives forward.