### PR TITLE
fix(goxc): preserve app module dependencies in workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,10 @@
 - Post-preview v0.2 focus documentation selecting reusable component/package
   identity as the next design/test focus without behavior changes or preview
   promise expansion.
+- `goxc` build workspace materialization now preserves app module
+  `require`/`replace` directives for external Go package resolution, rewrites
+  relative local replace targets to the original module locations, and keeps
+  external dependency `.gox` generation outside the current workspace model.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -218,6 +218,10 @@ func generateFileSafely(file, output string, options gox.GenerateOptions) error 
 
 func writeWorkspaceGoMod(workDir, appDir string) error {
 	config := workspaceModuleConfigForApp(appDir)
+	appModule, err := readWorkspaceModuleDirectives(config.ModuleRoot)
+	if err != nil {
+		return err
+	}
 	content := strings.Builder{}
 	modulePath := config.ModulePath
 	if modulePath == "" {
@@ -225,6 +229,7 @@ func writeWorkspaceGoMod(workDir, appDir string) error {
 	}
 	content.WriteString("module " + modulePath + "\n\n")
 	content.WriteString("go 1.22\n\n")
+	writeWorkspaceRequires(&content, appModule.Requires)
 	if modulePath != canonicalModulePath {
 		if repoRoot, ok := findRepositoryRootForWorkspace(appDir); ok {
 			content.WriteString("require " + canonicalModulePath + " v0.0.0\n")
@@ -240,8 +245,12 @@ func writeWorkspaceGoMod(workDir, appDir string) error {
 			content.WriteString("require " + canonicalModulePath + " " + version + "\n")
 		}
 	}
+	writeWorkspaceReplaces(&content, appModule.Replaces)
 	if err := os.WriteFile(filepath.Join(workDir, "go.mod"), []byte(content.String()), 0o644); err != nil {
 		return fmt.Errorf("write workspace go.mod: %w", err)
+	}
+	if err := copyWorkspaceGoSum(workDir, config.ModuleRoot); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/goxc/workspace_mod.go
+++ b/cmd/goxc/workspace_mod.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type workspaceModuleDirectives struct {
+	Requires []workspaceRequireDirective
+	Replaces []workspaceReplaceDirective
+}
+
+type workspaceRequireDirective struct {
+	Path     string
+	Version  string
+	Indirect bool
+}
+
+type workspaceReplaceDirective struct {
+	OldPath    string
+	OldVersion string
+	NewPath    string
+	NewVersion string
+}
+
+func readWorkspaceModuleDirectives(moduleRoot string) (workspaceModuleDirectives, error) {
+	if moduleRoot == "" {
+		return workspaceModuleDirectives{}, nil
+	}
+	path := filepath.Join(moduleRoot, "go.mod")
+	file, err := os.Open(path)
+	if err != nil {
+		return workspaceModuleDirectives{}, fmt.Errorf("read app module directives from %s: %w", path, err)
+	}
+	defer file.Close()
+
+	var directives workspaceModuleDirectives
+	block := ""
+	scanner := bufio.NewScanner(file)
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		rawLine := scanner.Text()
+		fields, err := goModFields(rawLine)
+		if err != nil {
+			return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+		}
+		if len(fields) == 0 {
+			continue
+		}
+		if block != "" {
+			if fields[0] == ")" {
+				block = ""
+				continue
+			}
+			switch block {
+			case "require":
+				require, ok, err := parseWorkspaceRequire(fields, rawLine)
+				if err != nil {
+					return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+				}
+				if ok {
+					directives.Requires = append(directives.Requires, require)
+				}
+			case "replace":
+				replace, ok, err := parseWorkspaceReplace(fields)
+				if err != nil {
+					return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+				}
+				if ok {
+					replace, err = rewriteWorkspaceReplace(moduleRoot, replace)
+					if err != nil {
+						return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+					}
+					directives.Replaces = append(directives.Replaces, replace)
+				}
+			}
+			continue
+		}
+		switch fields[0] {
+		case "require":
+			if len(fields) == 2 && fields[1] == "(" {
+				block = "require"
+				continue
+			}
+			require, ok, err := parseWorkspaceRequire(fields[1:], rawLine)
+			if err != nil {
+				return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+			}
+			if ok {
+				directives.Requires = append(directives.Requires, require)
+			}
+		case "replace":
+			if len(fields) == 2 && fields[1] == "(" {
+				block = "replace"
+				continue
+			}
+			replace, ok, err := parseWorkspaceReplace(fields[1:])
+			if err != nil {
+				return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+			}
+			if ok {
+				replace, err = rewriteWorkspaceReplace(moduleRoot, replace)
+				if err != nil {
+					return workspaceModuleDirectives{}, fmt.Errorf("parse %s:%d: %w", path, lineNumber, err)
+				}
+				directives.Replaces = append(directives.Replaces, replace)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return workspaceModuleDirectives{}, fmt.Errorf("read app module directives from %s: %w", path, err)
+	}
+	if block != "" {
+		return workspaceModuleDirectives{}, fmt.Errorf("parse %s: unterminated %s block", path, block)
+	}
+	return directives, nil
+}
+
+func parseWorkspaceRequire(fields []string, rawLine string) (workspaceRequireDirective, bool, error) {
+	if len(fields) < 2 {
+		return workspaceRequireDirective{}, false, fmt.Errorf("malformed require directive")
+	}
+	if fields[0] == canonicalModulePath {
+		return workspaceRequireDirective{}, false, nil
+	}
+	return workspaceRequireDirective{
+		Path:     fields[0],
+		Version:  fields[1],
+		Indirect: strings.Contains(rawLine, "// indirect"),
+	}, true, nil
+}
+
+func parseWorkspaceReplace(fields []string) (workspaceReplaceDirective, bool, error) {
+	arrow := -1
+	for index, field := range fields {
+		if field == "=>" {
+			arrow = index
+			break
+		}
+	}
+	if arrow <= 0 || arrow+1 >= len(fields) {
+		return workspaceReplaceDirective{}, false, fmt.Errorf("malformed replace directive")
+	}
+	if arrow > 2 || len(fields)-arrow-1 > 2 {
+		return workspaceReplaceDirective{}, false, fmt.Errorf("malformed replace directive")
+	}
+	replace := workspaceReplaceDirective{
+		OldPath: fields[0],
+		NewPath: fields[arrow+1],
+	}
+	if arrow == 2 {
+		replace.OldVersion = fields[1]
+	}
+	if len(fields)-arrow-1 == 2 {
+		replace.NewVersion = fields[arrow+2]
+	}
+	if replace.OldPath == canonicalModulePath {
+		return workspaceReplaceDirective{}, false, nil
+	}
+	return replace, true, nil
+}
+
+func rewriteWorkspaceReplace(moduleRoot string, replace workspaceReplaceDirective) (workspaceReplaceDirective, error) {
+	if replace.NewVersion != "" || !isLocalReplacePath(replace.NewPath) {
+		return replace, nil
+	}
+	target := filepath.FromSlash(replace.NewPath)
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(moduleRoot, target)
+	}
+	absolute, err := filepath.Abs(target)
+	if err != nil {
+		return workspaceReplaceDirective{}, fmt.Errorf("resolve replace target %s: %w", replace.NewPath, err)
+	}
+	replace.NewPath = filepath.ToSlash(absolute)
+	return replace, nil
+}
+
+func isLocalReplacePath(path string) bool {
+	path = filepath.ToSlash(path)
+	return path == "." || path == ".." || strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../") || strings.HasPrefix(path, "/") || goModPathHasDriveRoot(path)
+}
+
+func goModPathHasDriveRoot(path string) bool {
+	if len(path) < 3 || path[1] != ':' || path[2] != '/' {
+		return false
+	}
+	drive := path[0]
+	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+}
+
+func writeWorkspaceRequires(content *strings.Builder, requires []workspaceRequireDirective) {
+	if len(requires) == 0 {
+		return
+	}
+	content.WriteString("require (\n")
+	for _, require := range requires {
+		content.WriteString("\t")
+		content.WriteString(goModToken(require.Path))
+		content.WriteString(" ")
+		content.WriteString(goModToken(require.Version))
+		if require.Indirect {
+			content.WriteString(" // indirect")
+		}
+		content.WriteString("\n")
+	}
+	content.WriteString(")\n\n")
+}
+
+func writeWorkspaceReplaces(content *strings.Builder, replaces []workspaceReplaceDirective) {
+	if len(replaces) == 0 {
+		return
+	}
+	if content.Len() > 0 && !strings.HasSuffix(content.String(), "\n\n") {
+		content.WriteString("\n")
+	}
+	content.WriteString("replace (\n")
+	for _, replace := range replaces {
+		content.WriteString("\t")
+		content.WriteString(goModToken(replace.OldPath))
+		if replace.OldVersion != "" {
+			content.WriteString(" ")
+			content.WriteString(goModToken(replace.OldVersion))
+		}
+		content.WriteString(" => ")
+		content.WriteString(goModToken(replace.NewPath))
+		if replace.NewVersion != "" {
+			content.WriteString(" ")
+			content.WriteString(goModToken(replace.NewVersion))
+		}
+		content.WriteString("\n")
+	}
+	content.WriteString(")\n")
+}
+
+func goModFields(line string) ([]string, error) {
+	var fields []string
+	for index := 0; index < len(line); {
+		for index < len(line) && (line[index] == ' ' || line[index] == '\t' || line[index] == '\r') {
+			index++
+		}
+		if index >= len(line) || strings.HasPrefix(line[index:], "//") {
+			break
+		}
+		if line[index] == '"' || line[index] == '`' {
+			start := index
+			quote := line[index]
+			index++
+			for index < len(line) {
+				if quote == '"' && line[index] == '\\' {
+					index += 2
+					continue
+				}
+				if line[index] == quote {
+					index++
+					break
+				}
+				index++
+			}
+			if index > len(line) || line[index-1] != quote {
+				return nil, fmt.Errorf("unterminated quoted token")
+			}
+			value, err := strconv.Unquote(line[start:index])
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, value)
+			continue
+		}
+		start := index
+		for index < len(line) && line[index] != ' ' && line[index] != '\t' && line[index] != '\r' {
+			if strings.HasPrefix(line[index:], "//") {
+				break
+			}
+			index++
+		}
+		if start != index {
+			fields = append(fields, line[start:index])
+		}
+	}
+	return fields, nil
+}
+
+func goModToken(value string) string {
+	if value == "" {
+		return `""`
+	}
+	if strings.ContainsAny(value, " \t\r\n\"`") {
+		return strconv.Quote(value)
+	}
+	return value
+}
+
+func copyWorkspaceGoSum(workDir, moduleRoot string) error {
+	if moduleRoot == "" {
+		return nil
+	}
+	source := filepath.Join(moduleRoot, "go.sum")
+	info, err := os.Lstat(source)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect app module go.sum %s: %w", source, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("app module go.sum %s is a symlink; symlink paths are not supported", source)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("app module go.sum %s is not a regular file", source)
+	}
+	return copyFile(source, filepath.Join(workDir, "go.sum"))
+}

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -272,7 +273,7 @@ func Cards() gf.Node {
 	}
 }
 
-func TestPrepareBuildWorkspaceCharacterizesExternalModuleGOXBoundary(t *testing.T) {
+func TestPrepareBuildWorkspacePreservesExternalModuleDependencies(t *testing.T) {
 	root := t.TempDir()
 	appDir := filepath.Join(root, "app")
 	writeExternalCardModule(t, root, "ui", "example.com/ui", "ui")
@@ -288,9 +289,13 @@ func ExternalGOX() gf.Node {
 
 go 1.22
 
-require example.com/ui v0.0.0
+require (
+	example.com/ui v0.0.0
+)
 
-replace example.com/ui => ../ui
+replace (
+	example.com/ui => ../ui
+)
 `)
 	writeTestFile(t, appDir, "main.go", "package main\n")
 	writeTestFile(t, appDir, "app.gox", `package main
@@ -312,7 +317,8 @@ func App() gf.Node {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := prepareBuildWorkspace(layout, projectManifest{Entry: "."}); err != nil {
+	entryDir, err := prepareBuildWorkspace(layout, projectManifest{Entry: "."})
+	if err != nil {
 		t.Fatalf("prepareBuildWorkspace() error: %v", err)
 	}
 
@@ -321,19 +327,68 @@ func App() gf.Node {
 		t.Fatal(err)
 	}
 	workspaceGoModText := string(workspaceGoMod)
-	if strings.Contains(workspaceGoModText, "example.com/ui") {
-		t.Fatalf("workspace go.mod unexpectedly preserved external module directive:\n%s", workspaceGoModText)
+	replaceTarget := filepath.ToSlash(filepath.Join(root, "ui"))
+	for _, want := range []string{
+		"require (\n\texample.com/ui v0.0.0\n)",
+		"replace (\n\texample.com/ui => " + replaceTarget + "\n)",
+	} {
+		if !strings.Contains(workspaceGoModText, want) {
+			t.Fatalf("workspace go.mod missing %q:\n%s", want, workspaceGoModText)
+		}
+	}
+	if strings.Contains(workspaceGoModText, "=> ../ui") {
+		t.Fatalf("workspace go.mod preserved stale relative replace target:\n%s", workspaceGoModText)
 	}
 	if _, err := os.Stat(filepath.Join(root, "ui", "card.gox.go")); !os.IsNotExist(err) {
 		t.Fatalf("external dependency GOX source was generated next to dependency source: %v", err)
 	}
 	config := workspaceModuleConfigForApp(appDir)
 	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
-	if _, err := os.Stat(filepath.Join(appWorkDir, "app.gox.go")); err != nil {
-		t.Fatalf("app GOX output missing from workspace: %v", err)
-	}
+	assertGeneratedFileContains(t, filepath.Join(appWorkDir, "app.gox.go"),
+		`gf.NewComponentType("example.com/ui.Card", "ui.Card")`,
+	)
 	if _, err := os.Stat(filepath.Join(layout.WorkDir, "ui", "card.gox.go")); !os.IsNotExist(err) {
 		t.Fatalf("external dependency GOX source was materialized inside workspace: %v", err)
+	}
+	runGoListInWorkspace(t, entryDir)
+}
+
+func TestWriteWorkspaceGoModPreservesSingleLineExternalModuleDirectives(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require example.com/ui v0.0.0
+
+replace example.com/ui => ../ui
+`)
+	writeTestFile(t, appDir, "go.sum", "example.com/ui v0.0.0 h1:local\n")
+
+	workDir := t.TempDir()
+	if err := writeWorkspaceGoMod(workDir, appDir); err != nil {
+		t.Fatalf("writeWorkspaceGoMod() error: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(workDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"require (\n\texample.com/ui v0.0.0\n)",
+		"replace (\n\texample.com/ui => " + filepath.ToSlash(filepath.Join(root, "ui")) + "\n)",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("workspace go.mod missing %q:\n%s", want, text)
+		}
+	}
+	goSum, err := os.ReadFile(filepath.Join(workDir, "go.sum"))
+	if err != nil {
+		t.Fatalf("workspace go.sum missing: %v", err)
+	}
+	if string(goSum) != "example.com/ui v0.0.0 h1:local\n" {
+		t.Fatalf("workspace go.sum = %q", goSum)
 	}
 }
 
@@ -597,5 +652,21 @@ func assertGeneratedFileContains(t *testing.T, path string, wants ...string) {
 		if !strings.Contains(string(content), want) {
 			t.Fatalf("generated file %s missing %q:\n%s", path, want, content)
 		}
+	}
+}
+
+func runGoListInWorkspace(t *testing.T, dir string) {
+	t.Helper()
+	command := exec.Command("go", "list", "-deps", ".")
+	command.Dir = dir
+	command.Env = append(os.Environ(),
+		"GOPROXY=off",
+		"GOSUMDB=off",
+		"GOWORK=off",
+		"GOFLAGS=-mod=mod",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list in workspace failed: %v\n%s", err, output)
 	}
 }

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -90,6 +90,13 @@ The build package is `examples/cmdapp/.goframe/work/dev/examples/cmdapp/cmd/app`
 GOX discovery remains app-root-wide so imported internal packages get their
 generated files too.
 
+When an app imports ordinary Go packages from external modules, `goxc`
+preserves the nearest app module's `require` and `replace` directives in the
+materialized workspace. Relative local `replace` targets are rewritten so they
+still point at the original target after `go.mod` is written under
+`.goframe/work/<profile>`. This supports normal Go package resolution for
+external Go component packages declared by the app module.
+
 This model is intentionally used instead of a Go overlay because TinyGo
 support for overlays is not part of the current baseline.
 
@@ -245,11 +252,13 @@ goxc serve ./examples/router-dashboard --port=8080
 - No XML-style namespace tags with `:`.
 - No arbitrary selector chains beyond `packageAlias.Component`.
 - No full multi-module monorepo story.
+- No generated GOX materialization for raw `.gox` files inside external
+  dependencies. External dependencies are resolved as ordinary Go modules.
 - No file-based router or framework-level layout convention. The hash router
   uses ordinary Go route declarations and stable shell composition.
-- External module dependencies in app packages are not deeply exercised yet.
-  The current path is focused on packages below the app root plus the GoFrame
-  runtime dependency.
+- App module `require` / `replace` directives are preserved for normal Go
+  dependency resolution, but that is not a stable reusable package ecosystem or
+  full multi-module workspace claim.
 - Generated component type variable names are internal and not stable API.
 
 ## Example


### PR DESCRIPTION
### Summary

Preserves app module dependency directives when `goxc` materializes the build workspace.

PR #55 characterized the current external component package boundary: GOX/goxc generation already preserves import-path component identity for external package-qualified tags, but the build workspace dropped app external `require` / `replace` directives. This PR closes that narrow workspace dependency gap without changing GOX codegen or claiming broad reusable package ecosystem support.

### What Changed

* Added stdlib-only workspace module directive handling for app `go.mod`.
* Preserved app module `require` directives except the GoFrame runtime module, which remains handled by the existing local-repo / released-version logic.
* Preserved app module `replace` directives except GoFrame runtime replaces.
* Rewrote local relative `replace` targets to absolute slash-normalized paths so they still point to the original module targets after workspace materialization.
* Copied app `go.sum` into the workspace when present, with symlink and non-regular-file rejection.
* Added regression coverage for:
  * external Go component module resolution through `require` / `replace`;
  * generated identity for `<ui.Card />`;
  * no raw external `.gox` generation/materialization;
  * `go list -deps .` in the materialized workspace with network disabled;
  * single-line `require` / `replace` forms;
  * `go.sum` preservation.
* Updated factual docs/changelog for the new workspace behavior and remaining boundary.

### Scope

`goxc` workspace materialization, tests, and factual docs/changelog only.

### Non-Goals

* No runtime changes.
* No GOX compiler/codegen changes.
* No examples changes.
* No workflow changes.
* No release notes or release tag.
* No raw `.gox` generation inside external dependencies.
* No full multi-module monorepo support.
* No stable reusable package ecosystem claim.
* No production readiness claim.

### Validation

Local validation reported:

* `go test ./cmd/goxc -run 'Workspace|External|Module|Require|Replace|PackageIdentity'`
* `go test ./pkg/gox -run 'Qualified|Identity|Package|Versioned|Collision|Alias'`
* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./cmd/goxc`
* `go test ./pkg/gox`
* `go test ./...`
* `git diff --check HEAD~1..HEAD`

`./scripts/size-budget.sh` failed locally on an existing `examples/counter` package artifact sized like a stale standard-Go bundle. The script checks existing packaged artifacts rather than rebuilding them, so PR CI / a clean regenerated package set should be used to confirm the WASM size gate.

### Notes

This is narrow external Go package resolution support for app module dependencies. It does not support raw `.gox` files inside external dependencies and does not make broad reusable component package ecosystem promises.

Module parsing is intentionally narrow: `require` and `replace` single/block forms are handled; this is not a full Go module graph implementation.