### PR TITLE
test(goxc): cover external component package build flow

### DIFF
--- a/cmd/goxc/build_external_module_test.go
+++ b/cmd/goxc/build_external_module_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildAppSupportsExternalModuleComponentPackage(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	uiDir := filepath.Join(root, "ui")
+
+	writeExternalCardModule(t, root, "ui", "example.com/ui", "ui")
+	writeTestFile(t, uiDir, "card.gox", `package ui
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func ExternalGOX() gf.Node {
+	return <Card Title="external gox" />
+}
+`)
+	writeTestFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require example.com/ui v0.0.0
+
+replace example.com/ui => ../ui
+`)
+	writeTestFile(t, appDir, "main.go", `package main
+
+func main() {}
+`)
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import (
+	ui "example.com/ui"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func App() gf.Node {
+	return <ui.Card Title="App" />
+}
+`)
+
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "-mod=mod")
+
+	workspaceBase := filepath.Join(t.TempDir(), "workspace")
+	outputPath, err := buildApp(buildOptions{
+		appDir:    appDir,
+		compiler:  "go",
+		workspace: workspaceBase,
+	})
+	if err != nil {
+		t.Fatalf("buildApp() error: %v", err)
+	}
+	outputInfo, err := os.Stat(outputPath)
+	if err != nil {
+		t.Fatalf("build output missing: %v", err)
+	}
+	if !outputInfo.Mode().IsRegular() || outputInfo.Size() <= 0 {
+		t.Fatalf("build output is not a non-empty regular file: mode=%s size=%d", outputInfo.Mode(), outputInfo.Size())
+	}
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		compiler:  "go",
+		workspace: workspaceBase,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
+	assertGeneratedFileContains(t, filepath.Join(appWorkDir, "app.gox.go"),
+		`gf.NewComponentType("example.com/ui.Card", "ui.Card")`,
+	)
+
+	workspaceGoMod, err := os.ReadFile(filepath.Join(layout.WorkDir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceGoModText := string(workspaceGoMod)
+	replaceTarget := filepath.ToSlash(uiDir)
+	for _, want := range []string{
+		"example.com/ui v0.0.0",
+		"example.com/ui => " + replaceTarget,
+	} {
+		if !strings.Contains(workspaceGoModText, want) {
+			t.Fatalf("workspace go.mod missing %q:\n%s", want, workspaceGoModText)
+		}
+	}
+	if strings.Contains(workspaceGoModText, "=> ../ui") {
+		t.Fatalf("workspace go.mod preserved stale relative replace target:\n%s", workspaceGoModText)
+	}
+
+	if _, err := os.Stat(filepath.Join(uiDir, "card.gox.go")); !os.IsNotExist(err) {
+		t.Fatalf("external dependency GOX source was generated next to dependency source: %v", err)
+	}
+	assertWorkspaceDoesNotContainGeneratedExternalGOX(t, layout.WorkDir)
+}
+
+func assertWorkspaceDoesNotContainGeneratedExternalGOX(t *testing.T, workDir string) {
+	t.Helper()
+	err := filepath.WalkDir(workDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == "card.gox.go" {
+			t.Fatalf("external dependency GOX source was materialized inside workspace at %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk workspace for external GOX output: %v", err)
+	}
+}


### PR DESCRIPTION
### Summary

Adds executable build-flow evidence for external Go component packages.

PR #55 characterized the external component package boundary, and PR #56 preserved app module `require` / `replace` directives in the build workspace. This PR verifies the actual `goxc` Go/WASM build path for an app module that imports an external Go component package through local `require` / `replace`.

### What Changed

* Added a focused `cmd/goxc` integration test for:
  * app module `example.com/app`;
  * external module `example.com/ui`;
  * app `go.mod` with `require example.com/ui v0.0.0`;
  * local `replace example.com/ui => ../ui`;
  * app GOX using `<ui.Card />`.
* Runs `buildApp` with the standard Go compiler.
* Disables network/module workspace leakage with:
  * `GOPROXY=off`
  * `GOSUMDB=off`
  * `GOWORK=off`
  * `GOFLAGS=-mod=mod`
* Asserts the WASM output exists and is non-empty.
* Asserts generated component identity remains `example.com/ui.Card`.
* Asserts workspace `go.mod` contains rewritten external module data and does not preserve stale `=> ../ui`.
* Asserts raw `.gox` files inside the external dependency remain outside current generation/materialization.

### Scope

Tests only.

### Non-Goals

* No runtime changes.
* No GOX compiler/codegen changes.
* No `goxc` implementation changes.
* No docs, README, CHANGELOG, release notes, examples, or workflow changes.
* No raw `.gox` generation inside external dependencies.
* No remote/non-local module dependency support claim.
* No broad reusable package ecosystem claim.

### Validation

Local validation reported:

* `go test ./cmd/goxc -run 'BuildApp|External|Module|Require|Replace|PackageIdentity'`
* `go test ./cmd/goxc -run 'Workspace|External|Module|Require|Replace|PackageIdentity'`
* `go test ./pkg/gox -run 'Qualified|Identity|Package|Versioned|Collision|Alias'`
* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./cmd/goxc`
* `go test ./pkg/gox`
* `go test ./...`
* `git diff --check HEAD~1..HEAD`

Remote GitHub Actions should be checked before merge.

### Notes

This is build-flow evidence for local-replace external Go component packages only. It does not support raw `.gox` files inside external dependencies and does not make broad reusable package ecosystem promises.