### PR TITLE
docs(strategy): clarify web-first direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@
   `require`/`replace` directives for external Go package resolution, rewrites
   relative local replace targets to the original module locations, and keeps
   external dependency `.gox` generation outside the current workspace model.
+- Strategy documentation now positions GoFrame as a web-first Go application
+  framework and toolchain, marks Player/Engine and `.gfapp` as inactive
+  directions, and keeps preview promises limited to current evidence.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # goframe
 
-GoFrame is an experimental Go-first application platform for interactive
-browser apps. It combines:
+GoFrame is an experimental Go-first web application framework and toolchain for
+interactive browser/WASM apps. It combines:
 
 - the `goframe` runtime library;
 - JSX-like `.gox` markup embedded in Go files;
@@ -10,13 +10,15 @@ browser apps. It combines:
 
 GoFrame is not production-ready. Some APIs are public-candidate, but the GOX
 syntax, manifests, packaging details, and runtime internals may still change
-between MVPs. The browser/WASM target is the current implementation; the
-Player/Engine idea remains future design work, not a shipped product.
+between MVPs. The browser/WASM target is the current validated implementation;
+Player/Engine and `.gfapp` are inactive directions, not shipped products or
+preview promises.
 
 The first public preview scope is intentionally narrower than the project
-vision: it should validate the current browser/WASM application layer without
-removing or hiding working experimental surfaces such as the router, resources,
-and Error Boundaries.
+direction: it should validate the current browser/WASM application layer
+without removing or hiding working experimental surfaces such as the router,
+resources, and Error Boundaries. Staged Go backend integration is a direction
+that requires evidence before it becomes a preview feature claim.
 
 ## Status
 
@@ -38,12 +40,12 @@ Current baseline includes:
 - CI gates for Go/GOX tests, TinyGo size budgets, browser smoke, artifact
   checks, module path checks, and docs consistency.
 
-Non-goals for the current project surface include SSR, hydration,
-Player/Engine implementation, path/history-mode routing, file-based routing,
-route loaders, Suspense-style resources, global resource caching, dynamic
-virtualization, infinite loading, LSP, formatter, XML-style namespace tags,
-spread props, schema validation framework, production deployment server, and
-full multi-module monorepo support.
+Non-goals for the current project surface include SSR, hydration, fullstack
+server APIs, Player/Engine, `.gfapp`, path/history-mode routing, file-based
+routing, route loaders, Suspense-style resources, global resource caching,
+dynamic virtualization, infinite loading, LSP, formatter, XML-style namespace
+tags, spread props, schema validation framework, production deployment server,
+and full multi-module monorepo support.
 
 ## What Is GoFrame?
 
@@ -533,7 +535,7 @@ Project audits and future design:
 - [Public Surface Audit V](docs/public-surface-audit-v.md)
 - [Public Preview Hardening I](docs/public-preview-hardening-i.md)
 - [Post-preview v0.2 technical focus](docs/post-preview-v0.2-focus.md)
-- [Future GoFrame Player vision](docs/player-vision.md)
+- [Inactive GoFrame Player/Engine note](docs/player-vision.md)
 
 Examples:
 
@@ -556,7 +558,8 @@ Examples:
 - Hash router only; no SSR, hydration, path/history-mode server fallback,
   file-based routing, route loaders, hot reload, CSS-in-Go, or production
   deployment server.
-- No Player/Engine implementation or `.gfapp` package format yet.
+- Player/Engine and `.gfapp` are inactive directions outside the current
+  preview contract.
 - No XML-style namespace tags, arbitrary selector chains, spread props,
   template-block loops, formatter, or LSP.
 - No full multi-module monorepo story.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -234,16 +234,21 @@ These surfaces should be hardened, tested, and documented before wider
 promises. They should not be removed from project positioning merely because
 their contracts are still maturing.
 
-### Future Vision
+### Inactive Or Outside Current Contract
 
-- Player/Engine host and bundle model.
-- `.gfapp` package format.
-- Broader host/runtime story beyond the browser DOM target.
-- Stronger editor tooling such as LSP/formatter behavior.
-- Broader package ecosystem and reusable component distribution story.
-- Production deployment/server integration.
+- Player/Engine host and bundle model: inactive direction.
+- `.gfapp` package format: inactive direction.
+- Portable host/runtime story beyond the browser DOM target: inactive
+  direction.
+- Fullstack/backend integration: not a current feature claim.
+- Stronger editor tooling such as LSP/formatter behavior: outside the current
+  preview contract.
+- Broader package ecosystem and reusable component distribution story: outside
+  the current preview contract.
+- Production deployment/server integration: outside the current preview
+  contract.
 
-These are not part of the first public preview promise.
+These are not part of the current preview promise.
 
 ### Internal
 
@@ -318,6 +323,8 @@ Not stable:
   resource story;
 - SSR/hydration;
 - Player/Engine or `.gfapp` format;
+- portable host/runtime packaging;
+- fullstack/server APIs;
 - multi-module app support;
 - final public component package identity policy;
 - dynamic virtualization measurement;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,9 +3,10 @@
 ## Platform boundaries
 
 goframe is not intended to be a tiny replacement for React on static websites.
-goframe is an experimental Go-first application platform for interactive apps.
+goframe is an experimental Go-first web application framework and toolchain for
+interactive browser/WASM apps.
 
-The project now separates four concepts:
+The active architecture separates four concepts:
 
 ```text
 GOX language
@@ -19,14 +20,15 @@ goxc toolchain
 
 VS Code GOX extension
    syntax highlighting, snippets, language configuration, and goxc commands
-
-GoFrame Player / Engine
-   a possible future host for portable application bundles
 ```
 
 `goframe` is the library imported by applications. `goxc` is the installed
 developer tool. This distinction avoids treating the runtime package as a CLI
 product.
+
+Player/Engine, `.gfapp`, portable host/runtime packaging, and desktop/mobile
+shells are inactive directions, not active architecture layers or preview
+promises.
 
 The VS Code extension is deliberately a thin developer-experience layer over
 GOX and `goxc`. TextMate scopes provide heuristic highlighting, while terminal
@@ -315,5 +317,7 @@ See [lifecycle and effects](effects.md) for the MVP 9 side-effect model.
   of scope.
 - Size, DOM pressure, and browser smoke results are current evidence, not
   production benchmarks.
-- Path/history routing, Player/Engine, SSR/hydration, and `.gfapp` are outside
-  the current preview contract.
+- Path/history routing and SSR/hydration are outside the current preview
+  contract.
+- Player/Engine, `.gfapp`, portable host/runtime packaging, and desktop/mobile
+  shells are inactive directions.

--- a/docs/player-vision.md
+++ b/docs/player-vision.md
@@ -1,7 +1,8 @@
-# GoFrame Player vision
+# GoFrame Player/Engine inactive direction note
 
-Player/Engine is a long-term architectural direction, not a current
-implementation or first-preview promise:
+Player/Engine is inactive. It is not an active roadmap item, shipped
+implementation, current preview promise, or required path for GoFrame's
+web-first direction.
 
 ```text
 .gox source
@@ -13,19 +14,20 @@ goxc compiler/toolchain
 GoFrame Player / Engine
 ```
 
-The current separation keeps that project direction visible:
+This document is kept as historical context for older references. The sketch
+above described a possible portable host/runtime direction, but the accepted
+project direction is now web-first Go development:
 
 - GOX describes declarative application UI;
-- `goframe` provides the application runtime API;
+- `goframe` provides the browser/WASM application runtime API;
 - `goxc` owns compilation and packaging workflows;
-- Player/Engine remains outside the current preview contract.
+- browser/WASM package/export remains the validated delivery surface.
 
-A `.gfapp` bundle is not implemented in the current preview. Open design
-questions include application code, assets, permissions, runtime requirements,
-platform API versions, sandboxing, updates, native capabilities, rendering,
-debugging, bundle signing, and portability.
+Player/Engine, `.gfapp`, a portable host/runtime, desktop or mobile shells, and
+a custom application engine are not implemented and are not part of the current
+preview contract.
 
-The project should first validate the browser runtime, manifest, toolchain, and
-application model. Keeping Player/Engine visible as project vision does not mean
-the first public preview promises a custom browser, desktop shell, `.gfapp`
-runtime, or player implementation.
+GoFrame may still use lessons from this separation: authored GOX, runtime APIs,
+toolchain packaging, and deployment contracts remain distinct concerns. That
+does not make Player/Engine an active product direction, a preview feature, or
+a compatibility promise.

--- a/docs/post-preview-v0.2-focus.md
+++ b/docs/post-preview-v0.2-focus.md
@@ -50,7 +50,7 @@ The first post-preview hardening pass has recorded these boundaries:
 | Actual non-Chrome browser evidence | Deferred from this v0.2 focus. Firefox and Safari remain outside current preview evidence. |
 | Production deployment/server story | Outside the current preview contract. `goxc serve` remains development-only. |
 | Router/history/SSR/hydration | Outside this v0.2 focus. The current router is hash-based and does not claim SSR, hydration, path/history routing, or server fallback automation. |
-| Player/Engine / `.gfapp` | Visible project vision, outside the current preview contract and outside this v0.2 focus. |
+| Player/Engine / `.gfapp` | Inactive direction, outside the current preview contract and outside this v0.2 focus. |
 | Performance/DOM pressure evidence expansion | Deferred from this v0.2 focus. Existing size, browser smoke, and DOM pressure evidence remain the current baseline. |
 
 ## Selected v0.2 Focus

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -39,23 +39,27 @@ resource reload/stale-callback behavior, ErrorBoundary reset/new-incident
 behavior, and router route-key/remount policy without changing public runtime
 APIs.
 
-The first preview scope is narrower than the project vision. GoFrame remains an
-experimental Go-first application platform; the preview candidate validates the
-current browser/WASM application layer rather than reducing the long-term
-project to a small dashboard-only framework.
+The first preview scope is narrower than the project direction. GoFrame remains
+an experimental Go-first web application framework and toolchain; the preview
+candidate validates the current browser/WASM application layer rather than
+reducing the project to a small dashboard-only framework.
 
 See `docs/pre-preview-action-plan.md` for the post-audit action plan.
 
 ## Project Vision And First Preview Scope
 
-Project vision:
+Project direction:
 
-- GoFrame is an experimental Go-first application platform.
+- GoFrame is an experimental Go-first web application framework and toolchain.
 - Browser/WASM interactive applications are the first validated public layer.
 - Runtime, GOX, `goxc`, packaging, router, resources, Error Boundaries,
   examples, docs, and release policy are real project layers.
-- Player/Engine, richer host/runtime stories, stronger editor tooling, and a
-  future package ecosystem remain future vision.
+- Staged Go backend integration is a direction that requires evidence before it
+  becomes a preview feature claim.
+- Player/Engine, `.gfapp`, portable host/runtime packaging, desktop/mobile
+  shells, and custom app engines are inactive directions, not preview promises.
+- Stronger editor tooling and a broader package ecosystem remain outside the
+  current preview contract.
 
 First preview scope:
 
@@ -101,7 +105,7 @@ deployment server.
 |---|---|---|
 | Core / Public-Candidate | User-facing surfaces with real examples/tests and intended direction, still pre-1.0. | Component model, state/reducer/effects, GOX basic syntax/generation workflow, `goxc generate/build/package/export`, static browser/WASM packaging. |
 | Experimental frontier | Working surfaces that should stay visible while contracts are hardened. | Resources, Error Boundaries, router details, runtime error APIs, virtualization beyond fixed-height guarantees, advanced GOX diagnostics, package metadata details. |
-| Future vision | Strategic direction outside the first preview promise. | Player/Engine, broader host/runtime story, stronger editor tooling, future package ecosystem. |
+| Outside current contract / inactive direction | Strategic directions and inactive options outside the first preview promise. | Staged Go backend integration, stronger editor tooling, broader package ecosystem, Player/Engine, `.gfapp`, portable host/runtime packaging. |
 | Internal / implementation detail | Implementation and harness details with no compatibility promise. | Hidden `.goframe` workspace layout, mounted tree internals, debug probes, staging directories, smoke harness internals. |
 
 ## API Surface

--- a/docs/release.md
+++ b/docs/release.md
@@ -166,7 +166,7 @@ for trying the preview.
   browser platforms as explicit deferred scope when unverified;
 - reusable/multi-module component identity scope stated explicitly;
 - experimental surfaces named rather than hidden;
-- future Player/Engine direction bounded as vision, not a preview promise;
+- Player/Engine bounded as inactive and not a preview promise;
 - compatibility/deprecation notes included;
 - supply-chain/tooling evidence stated as lightweight CI/Dependabot/lockfile
   coverage, with no SBOM or scanner claim in the current preview contract;

--- a/docs/release.md
+++ b/docs/release.md
@@ -160,7 +160,8 @@ for trying the preview.
 - tag format documented;
 - install command documented;
 - maturity tiers included: public-candidate, experimental frontier,
-  compiler-facing, internal, and future vision;
+  compiler-facing, internal, and outside-current-contract / inactive-direction
+  scope;
 - platform evidence stated explicitly, including Linux/Chrome as the strongest
   current evidence, minimal macOS/Windows CI check evidence, and non-Chrome
   browser platforms as explicit deferred scope when unverified;


### PR DESCRIPTION
### Summary

Clarifies GoFrame’s active product direction after the maintainer decision to stop treating Player/Engine as an active roadmap path.

This PR aligns strategy-facing docs around GoFrame as an experimental Go-first web application framework and toolchain. The validated layer remains browser/WASM interactive applications. Staged Go backend integration is described as a direction requiring evidence before any preview claim.

### What Changed

* Marked Player/Engine, `.gfapp`, portable host/runtime packaging, desktop/mobile shells, and custom app engine direction as inactive.
* Reframed GoFrame’s active identity as a web-first Go application framework/toolchain.
* Preserved browser/WASM as the current validated implementation layer.
* Clarified that staged Go backend integration is not a shipped fullstack/server API claim.
* Updated README, architecture/API stability/readiness docs, release checklist wording, and CHANGELOG.
* Kept historical Player/Engine context as an inactive direction note rather than deleting it.

### Scope

Documentation-only strategy closeout.

### Non-Goals

* No runtime changes.
* No GOX/codegen changes.
* No `goxc` implementation changes.
* No tests or examples changes.
* No workflow changes.
* No release notes or release tag.
* No fullstack/server implementation.
* No production readiness claim.
* No SSR/hydration claim.
* No raw external `.gox` dependency support claim.

### Validation

Local validation reported:

* `git diff --check`
* `node scripts/docs-check.mjs`
* `rg -n "Player|Engine|\\.gfapp|portable|host/runtime|desktop|mobile|fullstack|SSR|hydration|production server|will support|planned|future follow-up|may be added later" README.md docs CHANGELOG.md`
* `go test ./...`
* `git diff --check HEAD~1..HEAD`

Remote GitHub Actions should be checked before merge.

### Notes

This is strategy/docs closeout only. `v0.2.0-preview.1` release notes are still required before a new tag.

Backend/fullstack evidence remains future work and is not implemented here. Player/Engine can be reopened only by explicit maintainer decision.