### PR TITLE
examples(web): cover server-backed failure recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@
   a plain Go `net/http` backend with a same-origin `/api/greeting` resource/form
   flow and browser smoke coverage, without adding a GoFrame server framework or
   production/fullstack claim.
+- Server-backed reference fixture now covers a controlled backend API failure
+  and recovery through existing resource/form state in browser smoke.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -96,7 +96,9 @@ cleanup-after-unmount behavior.
 The persistent `examples/server-backed` smoke records a narrow Go `net/http`
 backend integration boundary. A packaged GoFrame browser/WASM app is served by
 a same-origin Go backend and renders data from `/api/greeting` before and after
-a small form-driven request. This does not add a GoFrame server API.
+a small form-driven request. The same smoke covers a controlled backend failure
+state and recovery after a later valid form submission. This does not add a
+GoFrame server API.
 
 The runtime error containment fixture, Error Boundary fixture, and
 router-dashboard reference-app smoke are compiled with the Go WASM compiler

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -7,7 +7,9 @@ This example shows a narrow integration pattern:
 - static serving of the packaged standalone app;
 - a same-origin `/api/greeting` endpoint;
 - browser-side data loading through an example-local fetch bridge and
-  `gf.UseResource`.
+  `gf.UseResource`;
+- a controlled backend failure and recovery path through the same resource/form
+  state.
 
 It is a reference fixture, not a GoFrame server framework.
 
@@ -36,6 +38,8 @@ Open <http://127.0.0.1:8080>.
 - The backend can expose a same-origin API endpoint beside the packaged app.
 - The app can use existing GoFrame resource/form patterns to load backend data
   and update rendered UI after form submission.
+- The app renders the existing `gf.UseResource` failed state for a controlled
+  backend error and recovers after a later valid submission.
 - The browser fetch bridge lives in this example; it is not a runtime API.
 
 ## Project Structure
@@ -62,8 +66,9 @@ node --experimental-websocket scripts/server-backed-browser-smoke.mjs
 ```
 
 The browser smoke packages the example, starts the Go backend on a dynamic
-localhost port, opens the app through Chrome/CDP, and verifies that backend
-data renders before and after the form submits a new name.
+localhost port, opens the app through Chrome/CDP, and verifies initial backend
+data, updated backend data, controlled backend failure UI, and recovery after a
+later valid form submission.
 
 ## Non-goals
 

--- a/examples/server-backed/cmd/app/api_js.go
+++ b/examples/server-backed/cmd/app/api_js.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"strconv"
 	"syscall/js"
 
 	gf "github.com/graybuton/goframe/pkg/goframe"
@@ -62,9 +63,10 @@ func loadGreeting(key string, resolve func(string), reject func(error)) gf.Clean
 		}
 		response := args[0]
 		if !response.Get("ok").Bool() {
+			status := response.Get("status").Int()
 			active = false
 			releasePromiseFuncs()
-			reject(apiError("fetch returned a non-ok response"))
+			reject(apiError("backend returned HTTP " + strconv.Itoa(status)))
 			return nil
 		}
 		response.Call("text").Call("then", textThen).Call("catch", catchFunc)

--- a/examples/server-backed/cmd/server/main.go
+++ b/examples/server-backed/cmd/server/main.go
@@ -46,6 +46,11 @@ func greetingHandler(response http.ResponseWriter, request *http.Request) {
 	}
 	response.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	response.Header().Set("Cache-Control", "no-store")
+	if name == "fail" {
+		response.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(response, "controlled backend failure")
+		return
+	}
 	fmt.Fprintf(response, "Hello, %s, from Go backend!", name)
 }
 

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -21,6 +21,9 @@ const expectedApp = new URL(appURL);
 const initialMessage = "Hello, GoFrame, from Go backend!";
 const updatedName = "Ada";
 const updatedMessage = "Hello, Ada, from Go backend!";
+const failureName = "fail";
+const failureStatus = "failed";
+const failureMessage = "backend returned HTTP 500";
 
 let backend = null;
 let browser = null;
@@ -53,6 +56,7 @@ try {
     await waitForHTTP(`http://127.0.0.1:${backendPort}/`, () => backend.exitCode !== null, "server-backed backend");
     await assertBackendAPI("GoFrame", initialMessage);
     await assertBackendAPI(updatedName, updatedMessage);
+    await assertBackendAPIFailure(failureName, 500);
 
     browser = spawn(chrome, [
         "--headless",
@@ -107,6 +111,43 @@ try {
         input: updatedName,
     }, "server-backed form submit render");
 
+    await setGreetingName(client, failureName);
+    await waitForCondition(async () => {
+        return (await appState(client, updatedMessage)).input === failureName;
+    }, "controlled failure input update");
+    await wait(100);
+    await submitGreeting(client);
+    await waitForFailure(client, failureMessage, "controlled backend failure");
+    assertState(await appState(client, updatedMessage), {
+        app: true,
+        ready: false,
+        failed: true,
+        status: failureStatus,
+        input: failureName,
+        error: failureMessage,
+        errorNonEmpty: true,
+    }, "server-backed controlled failure render");
+
+    await setGreetingName(client, updatedName);
+    await waitForCondition(async () => {
+        return (await appState(client, updatedMessage)).input === updatedName;
+    }, "recovery input update");
+    await wait(100);
+    await submitGreeting(client);
+    await waitForGreeting(client, updatedMessage, "recovered backend greeting");
+    assertState(await appState(client, updatedMessage), {
+        app: true,
+        ready: true,
+        failed: false,
+        status: "ready",
+        message: updatedMessage,
+        messageMatches: true,
+        origin: expectedApp.origin,
+        input: updatedName,
+        error: "",
+        errorNonEmpty: false,
+    }, "server-backed recovery render");
+
     client.close();
     console.log("Server-backed browser smoke: ok");
 } finally {
@@ -125,6 +166,19 @@ async function assertBackendAPI(name, expected) {
     const text = await response.text();
     if (text !== expected) {
         throw new Error(`HARNESS FAILURE: backend API returned ${JSON.stringify(text)}, want ${JSON.stringify(expected)}`);
+    }
+}
+
+async function assertBackendAPIFailure(name, status) {
+    const url = new URL(`http://127.0.0.1:${backendPort}/api/greeting`);
+    url.searchParams.set("name", name);
+    const response = await fetch(url);
+    if (response.status !== status) {
+        throw new Error(`HARNESS FAILURE: backend API returned HTTP ${response.status}, want ${status}`);
+    }
+    const text = await response.text();
+    if (!text.trim()) {
+        throw new Error("HARNESS FAILURE: backend API failure response body was empty");
     }
 }
 
@@ -162,9 +216,17 @@ async function waitForGreeting(client, expected, label) {
     }, label);
 }
 
+async function waitForFailure(client, expectedError, label) {
+    await waitForCondition(async () => {
+        const state = await appState(client, updatedMessage);
+        return state.failed && state.status === failureStatus && state.error === expectedError;
+    }, label);
+}
+
 async function appState(client, expected) {
     return await client.callFunction(`function(expected) {
         const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() ?? "";
+        const error = document.querySelector("[data-testid='greeting-error']")?.textContent.trim() ?? "";
         return {
             app: Boolean(document.querySelector("[data-testid='server-backed-app']")),
             loading: Boolean(document.querySelector("[data-testid='greeting-loading']")),
@@ -175,6 +237,8 @@ async function appState(client, expected) {
             key: document.querySelector("[data-testid='greeting-resource-key']")?.textContent.trim() ?? "",
             message,
             messageMatches: message === expected,
+            error,
+            errorNonEmpty: error.length > 0,
             origin: window.location.origin,
         };
     }`, expected);


### PR DESCRIPTION
### Summary

Extends the persistent `examples/server-backed` reference fixture with a controlled backend failure and recovery path.

The example already demonstrates a packaged browser/WASM GoFrame app served by a plain Go `net/http` backend with a same-origin `/api/greeting` endpoint. This PR adds executable evidence that the same resource/form pattern handles a backend API failure and recovers after a later valid submission.

This remains example/smoke evidence only. It does not add a runtime fetch API, GoFrame server framework, fullstack/server API surface, SSR/hydration, route loaders, auth/session, or production server behavior.

### What Changed

* Added a controlled backend failure for `name=fail`.
* The backend returns HTTP 500 with a small text body for the controlled failure.
* Updated the example-local browser fetch bridge to report non-OK responses as `backend returned HTTP <status>`.
* Extended `scripts/server-backed-browser-smoke.mjs` to verify:
  * initial successful backend greeting;
  * successful form update;
  * controlled backend failure UI;
  * recovery to ready state after a later valid form submission.
* Updated `examples/server-backed/README.md`.
* Updated `docs/ci.md`.
* Updated `CHANGELOG.md`.

### Scope

Server-backed reference example, browser smoke, and factual docs/changelog only.

### Non-Goals

* No runtime changes.
* No GOX compiler/codegen changes.
* No `goxc` implementation changes.
* No workflow changes.
* No release notes or tag.
* No new dependencies.
* No runtime fetch API.
* No GoFrame server framework.
* No fullstack/server API surface.
* No server functions.
* No SSR or hydration.
* No route loaders.
* No auth/session framework.
* No production server behavior.

### Validation

Local validation reported:

* `go run ./cmd/goxc package ./examples/server-backed --compiler=go`
* `go run ./cmd/goxc package ./examples/server-backed --compiler=go --asset-hash --preload --compress=gzip,br`
* `go test ./examples/server-backed/...`
* `node --check scripts/server-backed-browser-smoke.mjs`
* `node --experimental-websocket scripts/server-backed-browser-smoke.mjs`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`
* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`
* `scripts/artifact-check.sh`
* `scripts/module-path-check.sh`

Remote GitHub Actions should be checked before merge.

### Notes

This is a server-backed reference example and smoke boundary only. It is not a fullstack framework, not a production server, and not a new GoFrame server API.