### PR TITLE
test(web): characterize server-backed stale cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,9 @@
   production/fullstack claim.
 - Server-backed reference fixture now covers a controlled backend API failure
   and recovery through existing resource/form state in browser smoke.
+- Server-backed browser smoke now covers delayed stale backend response
+  no-overwrite behavior through existing resource/form state and the
+  example-local fetch bridge.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -97,8 +97,8 @@ The persistent `examples/server-backed` smoke records a narrow Go `net/http`
 backend integration boundary. A packaged GoFrame browser/WASM app is served by
 a same-origin Go backend and renders data from `/api/greeting` before and after
 a small form-driven request. The same smoke covers a controlled backend failure
-state and recovery after a later valid form submission. This does not add a
-GoFrame server API.
+state, delayed stale request no-overwrite behavior, and recovery after a later
+valid form submission. This does not add a GoFrame server API.
 
 The runtime error containment fixture, Error Boundary fixture, and
 router-dashboard reference-app smoke are compiled with the Go WASM compiler

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -9,7 +9,9 @@ This example shows a narrow integration pattern:
 - browser-side data loading through an example-local fetch bridge and
   `gf.UseResource`;
 - a controlled backend failure and recovery path through the same resource/form
-  state.
+  state;
+- delayed stale backend response handling without overwriting newer rendered
+  data.
 
 It is a reference fixture, not a GoFrame server framework.
 
@@ -40,6 +42,8 @@ Open <http://127.0.0.1:8080>.
   and update rendered UI after form submission.
 - The app renders the existing `gf.UseResource` failed state for a controlled
   backend error and recovers after a later valid submission.
+- A delayed backend response can be superseded by a newer valid submission
+  without replacing the newer rendered greeting.
 - The browser fetch bridge lives in this example; it is not a runtime API.
 
 ## Project Structure
@@ -67,8 +71,8 @@ node --experimental-websocket scripts/server-backed-browser-smoke.mjs
 
 The browser smoke packages the example, starts the Go backend on a dynamic
 localhost port, opens the app through Chrome/CDP, and verifies initial backend
-data, updated backend data, controlled backend failure UI, and recovery after a
-later valid form submission.
+data, updated backend data, delayed stale response no-overwrite behavior,
+controlled backend failure UI, and recovery after a later valid form submission.
 
 ## Non-goals
 

--- a/examples/server-backed/cmd/server/main.go
+++ b/examples/server-backed/cmd/server/main.go
@@ -8,7 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const slowGreetingDelay = 750 * time.Millisecond
 
 func main() {
 	packageDir := flag.String("package", "", "packaged GoFrame standalone directory")
@@ -50,6 +53,13 @@ func greetingHandler(response http.ResponseWriter, request *http.Request) {
 		response.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(response, "controlled backend failure")
 		return
+	}
+	if name == "slow" {
+		select {
+		case <-time.After(slowGreetingDelay):
+		case <-request.Context().Done():
+			return
+		}
 	}
 	fmt.Fprintf(response, "Hello, %s, from Go backend!", name)
 }

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -21,6 +21,10 @@ const expectedApp = new URL(appURL);
 const initialMessage = "Hello, GoFrame, from Go backend!";
 const updatedName = "Ada";
 const updatedMessage = "Hello, Ada, from Go backend!";
+const slowName = "slow";
+const slowMessage = "Hello, slow, from Go backend!";
+const slowDelayMS = 750;
+const staleSettleMS = slowDelayMS + 300;
 const failureName = "fail";
 const failureStatus = "failed";
 const failureMessage = "backend returned HTTP 500";
@@ -56,6 +60,7 @@ try {
     await waitForHTTP(`http://127.0.0.1:${backendPort}/`, () => backend.exitCode !== null, "server-backed backend");
     await assertBackendAPI("GoFrame", initialMessage);
     await assertBackendAPI(updatedName, updatedMessage);
+    await assertBackendAPI(slowName, slowMessage);
     await assertBackendAPIFailure(failureName, 500);
 
     browser = spawn(chrome, [
@@ -110,6 +115,39 @@ try {
         origin: expectedApp.origin,
         input: updatedName,
     }, "server-backed form submit render");
+
+    await setGreetingName(client, slowName);
+    await waitForCondition(async () => {
+        return (await appState(client, updatedMessage, slowMessage, "name=slow")).input === slowName;
+    }, "slow input update");
+    await submitGreeting(client);
+    await waitForSlowActive(client);
+
+    await setGreetingName(client, updatedName);
+    await waitForCondition(async () => {
+        return (await appState(client, updatedMessage, slowMessage, "name=slow")).input === updatedName;
+    }, "newer Ada input update during slow request");
+    await wait(100);
+    await submitGreeting(client);
+    await waitForCondition(async () => {
+        const state = await appState(client, updatedMessage, slowMessage, "name=Ada");
+        return state.input === updatedName && state.keyContainsExpected;
+    }, "newer Ada resource key after slow request");
+    await waitForGreeting(client, updatedMessage, "newer Ada backend greeting after slow request");
+    await wait(staleSettleMS);
+    assertState(await appState(client, updatedMessage, slowMessage, "name=Ada"), {
+        app: true,
+        ready: true,
+        failed: false,
+        status: "ready",
+        message: updatedMessage,
+        messageMatches: true,
+        messageNotStale: true,
+        input: updatedName,
+        keyContainsExpected: true,
+        error: "",
+        errorNonEmpty: false,
+    }, "server-backed stale slow result ignored");
 
     await setGreetingName(client, failureName);
     await waitForCondition(async () => {
@@ -216,6 +254,18 @@ async function waitForGreeting(client, expected, label) {
     }, label);
 }
 
+async function waitForSlowActive(client) {
+    await waitForCondition(async () => {
+        const state = await appState(client, updatedMessage, slowMessage, "name=slow");
+        return state.input === slowName &&
+            state.keyContainsExpected &&
+            state.status === "loading" &&
+            state.loading &&
+            !state.ready &&
+            !state.failed;
+    }, "slow backend request active");
+}
+
 async function waitForFailure(client, expectedError, label) {
     await waitForCondition(async () => {
         const state = await appState(client, updatedMessage);
@@ -223,10 +273,11 @@ async function waitForFailure(client, expectedError, label) {
     }, label);
 }
 
-async function appState(client, expected) {
-    return await client.callFunction(`function(expected) {
+async function appState(client, expected, stale = "", keyPart = "") {
+    return await client.callFunction(`function(expected, stale, keyPart) {
         const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() ?? "";
         const error = document.querySelector("[data-testid='greeting-error']")?.textContent.trim() ?? "";
+        const key = document.querySelector("[data-testid='greeting-resource-key']")?.textContent.trim() ?? "";
         return {
             app: Boolean(document.querySelector("[data-testid='server-backed-app']")),
             loading: Boolean(document.querySelector("[data-testid='greeting-loading']")),
@@ -234,14 +285,16 @@ async function appState(client, expected) {
             failed: Boolean(document.querySelector("[data-testid='greeting-error']")),
             status: document.querySelector("[data-testid='greeting-status']")?.textContent.trim() ?? "",
             input: document.querySelector("[data-testid='greeting-name']")?.value ?? "",
-            key: document.querySelector("[data-testid='greeting-resource-key']")?.textContent.trim() ?? "",
+            key,
+            keyContainsExpected: keyPart === "" || key.includes(keyPart),
             message,
             messageMatches: message === expected,
+            messageNotStale: stale === "" || message !== stale,
             error,
             errorNonEmpty: error.length > 0,
             origin: window.location.origin,
         };
-    }`, expected);
+    }`, expected, stale, keyPart);
 }
 
 function assertState(actual, expected, label) {


### PR DESCRIPTION
### Summary

Adds executable evidence that the persistent `examples/server-backed` reference fixture does not let a delayed same-origin backend response overwrite newer rendered UI.

The server-backed example already covers success, form-driven update, controlled backend failure, and recovery. This PR adds a delayed `name=slow` backend path and extends the browser smoke to prove that a newer valid `Ada` submission wins and remains rendered after the slow response window has passed.

This remains example/smoke evidence only. It does not add a runtime fetch helper, GoFrame server framework, fullstack/server API surface, SSR/hydration, route loaders, auth/session, or production server behavior.

### What Changed

* Added a deterministic delayed backend path for `name=slow`.
* The delayed path uses `time.After` and `request.Context().Done()` so cancellation can be exercised without instrumentation.
* Extended `scripts/server-backed-browser-smoke.mjs` to verify:
  * existing initial success;
  * existing valid form update;
  * slow request becomes the active loading resource key;
  * `Ada` supersedes the slow request;
  * after the slow delay window, the UI still renders `Ada` and not the stale slow response;
  * existing controlled HTTP 500 failure;
  * recovery after a later valid submission.
* Updated `examples/server-backed/README.md`.
* Updated `docs/ci.md`.
* Updated `CHANGELOG.md`.

### Scope

Server-backed reference example smoke evidence and factual docs/changelog only.

### Non-Goals

* No runtime changes.
* No GOX compiler/codegen changes.
* No `goxc` implementation changes.
* No workflow changes.
* No release notes or tag.
* No new dependencies.
* No runtime fetch helper.
* No `gf.FetchText`.
* No `gf.FetchJSON`.
* No `gf.UseFetch`.
* No `HTTPError` public API.
* No `pkg/goframe/browser`.
* No GoFrame server framework.
* No fullstack/server API surface.
* No server functions.
* No SSR or hydration.
* No route loaders.
* No auth/session framework.
* No production server behavior.

### Validation

Local validation reported:

* `go run ./cmd/goxc package ./examples/server-backed --compiler=go`
* `go run ./cmd/goxc package ./examples/server-backed --compiler=go --asset-hash --preload --compress=gzip,br`
* `go test ./examples/server-backed/...`
* `node --check scripts/server-backed-browser-smoke.mjs`
* `node --experimental-websocket scripts/server-backed-browser-smoke.mjs`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`
* `git diff --check`
* `node scripts/docs-check.mjs`
* `go test ./...`
* `scripts/artifact-check.sh`
* `scripts/module-path-check.sh`

Remote GitHub Actions should be checked before merge.

### Notes

This strengthens the server-backed example evidence, but it still does not justify adding a public runtime/browser fetch helper by itself. It is stale request evidence only, not a fullstack framework or production server claim.