### PR TITLE
test(goxc): disable VCS stamping in workspace dependency check

### DIFF
--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -659,11 +659,12 @@ func runGoListInWorkspace(t *testing.T, dir string) {
 	t.Helper()
 	command := exec.Command("go", "list", "-deps", ".")
 	command.Dir = dir
+	goFlags := strings.TrimSpace(os.Getenv("GOFLAGS") + " -mod=mod -buildvcs=false")
 	command.Env = append(os.Environ(),
 		"GOPROXY=off",
 		"GOSUMDB=off",
 		"GOWORK=off",
-		"GOFLAGS=-mod=mod",
+		"GOFLAGS="+goFlags,
 	)
 	output, err := command.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
### Summary

Fixes a local baseline failure in `TestPrepareBuildWorkspacePreservesExternalModuleDependencies`.

The test runs an inner `go list -deps .` inside the generated workspace. That subprocess previously replaced `GOFLAGS` with `-mod=mod`, which could drop parent flags such as `-buildvcs=false` and still trigger Go VCS stamping errors in local workspaces.

This PR preserves the parent `GOFLAGS` value and appends `-mod=mod -buildvcs=false` for the inner `go list` check.

### What Changed

* Updated `runGoListInWorkspace` in `cmd/goxc/workspace_test.go`.
* Preserved any parent `GOFLAGS`.
* Added `-mod=mod -buildvcs=false` to the inner `go list -deps .` subprocess environment.
* Kept existing isolated workspace settings:
  * `GOPROXY=off`
  * `GOSUMDB=off`
  * `GOWORK=off`

### Scope

Test robustness only.

### Non-Goals

* No `goxc` implementation changes.
* No workspace generation behavior changes.
* No module handling behavior changes.
* No runtime changes.
* No GOX/codegen changes.
* No examples changes.
* No docs changes.
* No workflow changes.
* No release files.

### Validation

Local validation reported:

* `go test ./cmd/goxc -run TestPrepareBuildWorkspacePreservesExternalModuleDependencies`
* `GOFLAGS=-buildvcs=false go test ./cmd/goxc -run TestPrepareBuildWorkspacePreservesExternalModuleDependencies`
* `go test ./cmd/goxc`
* `GOFLAGS=-buildvcs=false go test ./...`
* `go test ./...`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`

### Notes

This unblocks the clean local validation baseline before the next runtime/helper work. It does not change production `goxc` behavior.