### PR TITLE
examples(resource): compose issue loader with FetchText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,9 @@
   with the server-backed reference fixture migrated to the low-level helper
   without adding JSON, cache, route-loader, server-framework, or production
   server behavior.
+- Resource example issue loading now composes `gf.FetchText` for packaged text
+  transport while keeping issue parsing, slow-delay, stale completion, and
+  cleanup-after-unmount evidence local to the example.
 - MVP 29 reference app consolidation: `examples/router-dashboard` now serves as
   the flagship integrated tutorial app with packaged data, one app-local
   resource owner, explicit loading/failed UI, manual reload, query filters,

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -234,6 +234,11 @@ fields are required.
 `examples/resource` is the focused lifecycle example. It covers reload,
 failure, stale completion, and cleanup-after-unmount scenarios.
 
+The example composes `gf.FetchText` with local issue parsing, `slow:` key
+normalization, delayed completion, and timer cleanup. Browser text transport is
+shared through the experimental helper; example-specific parsing and lifecycle
+demonstration remain local to the example.
+
 `examples/router-dashboard` shows the integration pattern for a small app:
 
 ```text

--- a/examples/resource/README.md
+++ b/examples/resource/README.md
@@ -2,9 +2,10 @@
 
 This focused example demonstrates the experimental `gf.UseResource` primitive.
 
-It loads small packaged text assets through browser `fetch`, but the runtime
-resource API itself is transport-agnostic. The fetch, parsing, delay, and abort
-logic live in the example under `internal/data`.
+It loads small packaged text assets through experimental `gf.FetchText`, while
+the runtime resource API itself remains transport-light. The example keeps
+issue parsing, `slow:` key handling, delayed completion, and lifecycle cleanup
+logic local under `internal/data`.
 
 For an integrated app that combines resources with router/query/forms/Error
 Boundary patterns, start with `examples/router-dashboard`.
@@ -26,4 +27,4 @@ goxc serve ./examples/resource --port=8080
 - Loader panic semantics are covered by runtime tests; this TinyGo browser
   smoke focuses on ordinary resource lifecycle behavior.
 - There is no cache, Suspense, route loader, retry policy, JSON helper, or
-  runtime fetch API in this MVP.
+  higher-level data framework in this example.

--- a/examples/resource/internal/data/loader_js.go
+++ b/examples/resource/internal/data/loader_js.go
@@ -11,12 +11,6 @@ import (
 
 const slowPrefix = "slow:"
 
-type LoadError string
-
-func (err LoadError) Error() string {
-	return string(err)
-}
-
 func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanup {
 	url := key
 	delay := 0
@@ -26,23 +20,11 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 	}
 
 	active := true
-	releasedPromiseFuncs := false
 	releasedTimer := false
 	var timer js.Value
 	var timerCallback js.Func
-	var responseThen js.Func
-	var textThen js.Func
-	var catchFunc js.Func
+	var fetchCleanup gf.Cleanup
 
-	releasePromiseFuncs := func() {
-		if releasedPromiseFuncs {
-			return
-		}
-		releasedPromiseFuncs = true
-		responseThen.Release()
-		textThen.Release()
-		catchFunc.Release()
-	}
 	releaseTimer := func() {
 		if releasedTimer {
 			return
@@ -53,6 +35,7 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 		}
 		timerCallback.Release()
 	}
+
 	complete := func(text string) {
 		if !active {
 			return
@@ -67,65 +50,33 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 	}
 
 	timerCallback = js.FuncOf(func(this js.Value, args []js.Value) any {
-		releaseTimer()
-		complete(args[0].String())
-		return nil
-	})
-	textThen = js.FuncOf(func(this js.Value, args []js.Value) any {
 		text := ""
 		if len(args) > 0 && args[0].Type() == js.TypeString {
 			text = args[0].String()
-		}
-		releasePromiseFuncs()
-		if !active {
-			return nil
-		}
-		if delay > 0 {
-			timer = js.Global().Call("setTimeout", timerCallback, delay, text)
-			return nil
 		}
 		releaseTimer()
 		complete(text)
 		return nil
 	})
-	catchFunc = js.FuncOf(func(this js.Value, args []js.Value) any {
-		releasePromiseFuncs()
-		releaseTimer()
-		if active {
-			active = false
-			reject(LoadError("fetch failed"))
-		}
-		return nil
-	})
-	responseThen = js.FuncOf(func(this js.Value, args []js.Value) any {
-		if !active {
-			releasePromiseFuncs()
-			releaseTimer()
-			return nil
-		}
-		if len(args) == 0 {
-			active = false
-			releasePromiseFuncs()
-			releaseTimer()
-			reject(LoadError("fetch returned no response"))
-			return nil
-		}
-		response := args[0]
-		if !response.Get("ok").Bool() {
-			active = false
-			releasePromiseFuncs()
-			releaseTimer()
-			reject(LoadError("fetch returned a non-ok response"))
-			return nil
-		}
-		response.Call("text").Call("then", textThen).Call("catch", catchFunc)
-		return nil
-	})
 
-	controller := js.Global().Get("AbortController").New()
-	options := js.Global().Get("Object").New()
-	options.Set("signal", controller.Get("signal"))
-	js.Global().Call("fetch", url, options).Call("then", responseThen).Call("catch", catchFunc)
+	fetchCleanup = gf.FetchText(url, func(text string) {
+		if !active {
+			return
+		}
+		if delay > 0 {
+			timer = js.Global().Call("setTimeout", timerCallback, delay, text)
+			return
+		}
+		releaseTimer()
+		complete(text)
+	}, func(err error) {
+		if !active {
+			return
+		}
+		active = false
+		releaseTimer()
+		reject(err)
+	})
 
 	return func() {
 		if !active {
@@ -133,6 +84,8 @@ func LoadIssues(key string, resolve func([]Issue), reject func(error)) gf.Cleanu
 		}
 		active = false
 		releaseTimer()
-		controller.Call("abort")
+		if fetchCleanup != nil {
+			fetchCleanup()
+		}
 	}
 }


### PR DESCRIPTION
### Summary

Migrates the focused `examples/resource` issue loader to compose with experimental `gf.FetchText` for browser text transport.

The example still owns its application-specific behavior locally: `slow:` key handling, delayed completion, issue parsing, timer cleanup, stale completion protection, and cleanup-after-unmount evidence.

This is the second `gf.FetchText` adoption point after `examples/server-backed`.

### What Changed

* Replaced example-local browser fetch transport plumbing in `examples/resource/internal/data/loader_js.go`.
* Kept local `LoadIssues` as the example-facing loader.
* Kept `ParseIssues` and issue parsing local.
* Preserved `slow:` key behavior and delayed completion.
* Preserved local timer cleanup and stale/unmount guards.
* Updated `examples/resource/README.md`.
* Updated `docs/resources.md`.
* Updated `CHANGELOG.md`.

### Scope

Focused resource example migration plus factual docs/changelog alignment.

### Non-Goals

* No changes to `gf.FetchText`.
* No changes to `UseResource`.
* No runtime API changes.
* No JSON helper.
* No `UseFetch`.
* No public `HTTPError`.
* No route loaders.
* No global cache.
* No retry/dedupe/polling policy.
* No server/fullstack API.
* No production server behavior.
* No GOX/codegen changes.
* No `goxc` implementation changes.
* No `examples/router-dashboard` migration.
* No workflow changes.
* No release tag or release notes.

### Validation

Local validation reported:

* `go test ./examples/resource/...`
* `go test ./pkg/goframe`
* `go run ./cmd/goxc package ./examples/resource --compiler=tinygo`
* `go run ./cmd/goxc package ./examples/resource --compiler=go`
* `node --check scripts/resource-browser-smoke.mjs`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`
* `scripts/size-budget.sh`
* `node scripts/docs-check.mjs`
* `go test ./...`
* `go vet ./...`
* `scripts/artifact-check.sh`
* `scripts/module-path-check.sh`
* `git diff --check`

### Notes

`examples/resource` is now the second `gf.FetchText` adoption point. `examples/router-dashboard` still uses its example-local loader and should only be migrated in a separate PR after this change lands and CI confirms the resource migration on `main`.