### PR TITLE
fix(goxc): report build-info version in CLI and package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,11 +193,12 @@
   panicking.
 - The resource example browser loader now releases cancelled promise/timer
   callbacks on inactive response paths.
-- `goxc version` now reports the tagged module version from Go build
-  information for module installs and `devel` for local checkout builds,
-  fixing the stale `0.1.0` CLI self-report in `v0.2.0-preview.2`. No runtime,
-  GOX, package/build/export/serve, example, or script behavior changed outside
-  the version command.
+- `goxc version` and generated `goframe-package.json` metadata now report the
+  tagged module version from Go build information for module installs and
+  `devel` for local checkout builds, fixing the stale `0.1.0` self-report in
+  `v0.2.0-preview.2`. No runtime, GOX, package workflow/layout,
+  build/export/serve, example, or script behavior changed outside toolchain
+  version self-reporting.
 
 ## v0.1.0-mvp10 - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,11 @@
   panicking.
 - The resource example browser loader now releases cancelled promise/timer
   callbacks on inactive response paths.
+- `goxc version` now reports the tagged module version from Go build
+  information for module installs and `devel` for local checkout builds,
+  fixing the stale `0.1.0` CLI self-report in `v0.2.0-preview.2`. No runtime,
+  GOX, package/build/export/serve, example, or script behavior changed outside
+  the version command.
 
 ## v0.1.0-mvp10 - 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Start here:
 - [v0.1.0-preview.2 release notes](docs/release-notes-v0.1.0-preview.2.md)
 - [v0.2.0-preview.1 release notes](docs/release-notes-v0.2.0-preview.1.md)
 - [v0.2.0-preview.2 release notes](docs/release-notes-v0.2.0-preview.2.md)
+- [v0.2.0-preview.3 release notes](docs/release-notes-v0.2.0-preview.3.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -1055,6 +1055,9 @@ func TestPackageDirectoryModePublishesAssetsRelativeToDirectory(t *testing.T) {
 	if metadata.Version != 1 || metadata.Entrypoints.HTML != indexHTMLAssetName || metadata.Entrypoints.WASM != manifest.Entrypoints.WASM || metadata.Entrypoints.Runtime != manifest.Entrypoints.Runtime {
 		t.Fatalf("package metadata = %+v, want versioned matching entrypoints", metadata)
 	}
+	if metadata.ToolchainVersion != "devel" {
+		t.Fatalf("package metadata toolchainVersion = %q, want devel", metadata.ToolchainVersion)
+	}
 	if ownership := inspectPackageOwnership(outDir); ownership.State != packageOwnedCurrent {
 		t.Fatalf("package ownership = %v (%s), want current", ownership.State, ownership.Reason)
 	}

--- a/cmd/goxc/main.go
+++ b/cmd/goxc/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 )
 
-const version = "0.1.0"
-
 func main() {
 	if len(os.Args) < 2 {
 		usage(os.Stdout)

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -317,7 +317,7 @@ func packageApp(options packageOptions) error {
 		Version:          1,
 		Name:             manifest.Name,
 		Compiler:         options.compiler,
-		ToolchainVersion: version,
+		ToolchainVersion: goxcVersion(),
 		AssetsDir:        assetDirectoryName,
 		HashAssets:       options.assetHash,
 		Preload:          options.preload,

--- a/cmd/goxc/version.go
+++ b/cmd/goxc/version.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
@@ -12,7 +13,7 @@ func versionCommand(args []string) error {
 	if len(args) != 0 {
 		return errors.New("usage: goxc version")
 	}
-	fmt.Printf("goxc version %s\n", version)
+	fmt.Printf("goxc version %s\n", goxcVersion())
 	if path, err := exec.LookPath("go"); err == nil {
 		output, versionErr := exec.Command(path, "version").CombinedOutput()
 		if versionErr == nil {
@@ -36,4 +37,32 @@ func versionCommand(args []string) error {
 	}
 	fmt.Println(strings.TrimSpace(string(output)))
 	return nil
+}
+
+func goxcVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "devel"
+	}
+	return versionFromBuildInfo(info)
+}
+
+func versionFromBuildInfo(info *debug.BuildInfo) string {
+	if info == nil {
+		return "devel"
+	}
+	version := strings.TrimSpace(info.Main.Version)
+	if version == "" || version == "(devel)" || buildInfoHasVCSSettings(info) {
+		return "devel"
+	}
+	return version
+}
+
+func buildInfoHasVCSSettings(info *debug.BuildInfo) bool {
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs" || strings.HasPrefix(setting.Key, "vcs.") {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/goxc/version_test.go
+++ b/cmd/goxc/version_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestVersionFromBuildInfoTaggedModule(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Version: "v0.2.0-preview.3",
+		},
+	}
+
+	if got := versionFromBuildInfo(info); got != "v0.2.0-preview.3" {
+		t.Fatalf("versionFromBuildInfo() = %q, want v0.2.0-preview.3", got)
+	}
+}
+
+func TestVersionFromBuildInfoLocalVCSBuild(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Version: "v0.2.0-preview.3",
+		},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs", Value: "git"},
+			{Key: "vcs.revision", Value: "53b2a15e2255e586ad5ba550a514da141aa74514"},
+			{Key: "vcs.modified", Value: "false"},
+		},
+	}
+
+	if got := versionFromBuildInfo(info); got != "devel" {
+		t.Fatalf("versionFromBuildInfo(local VCS build) = %q, want devel", got)
+	}
+}
+
+func TestVersionFromBuildInfoDevelopmentBuild(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{
+			Version: "(devel)",
+		},
+	}
+
+	if got := versionFromBuildInfo(info); got != "devel" {
+		t.Fatalf("versionFromBuildInfo() = %q, want devel", got)
+	}
+}
+
+func TestVersionFromBuildInfoEmptyVersion(t *testing.T) {
+	info := &debug.BuildInfo{}
+
+	if got := versionFromBuildInfo(info); got != "devel" {
+		t.Fatalf("versionFromBuildInfo() = %q, want devel", got)
+	}
+}
+
+func TestVersionFromBuildInfoUnavailable(t *testing.T) {
+	if got := versionFromBuildInfo(nil); got != "devel" {
+		t.Fatalf("versionFromBuildInfo(nil) = %q, want devel", got)
+	}
+}

--- a/docs/release-notes-v0.2.0-preview.3.md
+++ b/docs/release-notes-v0.2.0-preview.3.md
@@ -1,0 +1,95 @@
+# GoFrame v0.2.0-preview.3 Release Notes
+
+## Summary
+
+`v0.2.0-preview.3` is a hotfix preview after `v0.2.0-preview.2`.
+
+It fixes stale `goxc version` output. `v0.2.0-preview.2` installed from the
+correct Go module tag, but the CLI self-reported:
+
+```text
+goxc version 0.1.0
+```
+
+`goxc version` now reports the module version recorded in Go build information
+for tagged module installs. Local checkout builds report:
+
+```text
+goxc version devel
+```
+
+## What Changed
+
+- `goxc version` no longer uses the hardcoded release constant for CLI
+  self-reporting.
+- Tagged module installs such as `@v0.2.0-preview.3` report
+  `v0.2.0-preview.3`.
+- Local checkout builds such as `go run ./cmd/goxc version` and
+  `go install ./cmd/goxc` report `devel`.
+
+## Compatibility
+
+- No GoFrame runtime behavior changed.
+- No GOX parser, codegen, or language behavior changed.
+- No `goxc` package, build, export, serve, clean, doctor, workspace, or
+  manifest behavior changed.
+- No examples changed.
+- No migration is required.
+
+## Validation
+
+Release-gate validation for this hotfix should include:
+
+- `go test ./cmd/goxc`;
+- `go test ./...`;
+- `go vet ./...`;
+- `node scripts/docs-check.mjs`;
+- `scripts/artifact-check.sh`;
+- `scripts/module-path-check.sh`;
+- `scripts/size-budget.sh`;
+- `scripts/browser-smoke.sh`.
+
+The release readiness check should also verify local checkout behavior:
+
+```bash
+go run ./cmd/goxc version
+tmpbin="$(mktemp -d)"
+GOBIN="$tmpbin" go install ./cmd/goxc
+"$tmpbin/goxc" version
+```
+
+Both local commands should print `goxc version devel` on the first line.
+
+## Install
+
+After the tag is published, install the exact hotfix preview with:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.3
+```
+
+## Verification
+
+Run:
+
+```bash
+goxc version
+```
+
+Expected first line:
+
+```text
+goxc version v0.2.0-preview.3
+```
+
+## Non-Goals
+
+This hotfix does not include:
+
+- runtime changes;
+- GOX parser, codegen, or language changes;
+- `goxc` package/build/export/serve behavior changes;
+- server/fullstack API changes;
+- production readiness claims;
+- route loader, JSON/data framework, or global cache changes;
+- release tag creation in the release-notes PR.

--- a/docs/release-notes-v0.2.0-preview.3.md
+++ b/docs/release-notes-v0.2.0-preview.3.md
@@ -4,35 +4,46 @@
 
 `v0.2.0-preview.3` is a hotfix preview after `v0.2.0-preview.2`.
 
-It fixes stale `goxc version` output. `v0.2.0-preview.2` installed from the
+It fixes stale toolchain self-reporting. `v0.2.0-preview.2` installed from the
 correct Go module tag, but the CLI self-reported:
 
 ```text
 goxc version 0.1.0
 ```
 
-`goxc version` now reports the module version recorded in Go build information
-for tagged module installs. Local checkout builds report:
+and `goxc package` wrote generated package metadata with:
+
+```json
+"toolchainVersion": "0.1.0"
+```
+
+`goxc version` and generated `goframe-package.json` metadata now use the module
+version recorded in Go build information for tagged module installs. Local
+checkout builds report and write:
 
 ```text
-goxc version devel
+devel
 ```
 
 ## What Changed
 
 - `goxc version` no longer uses the hardcoded release constant for CLI
   self-reporting.
-- Tagged module installs such as `@v0.2.0-preview.3` report
+- `goxc package` writes `toolchainVersion` from the same build-info-derived
+  value in generated `goframe-package.json` metadata.
+- Tagged module installs such as `@v0.2.0-preview.3` report and write
   `v0.2.0-preview.3`.
 - Local checkout builds such as `go run ./cmd/goxc version` and
-  `go install ./cmd/goxc` report `devel`.
+  `go install ./cmd/goxc` report `devel`, and local package metadata writes
+  `"toolchainVersion": "devel"`.
 
 ## Compatibility
 
 - No GoFrame runtime behavior changed.
 - No GOX parser, codegen, or language behavior changed.
-- No `goxc` package, build, export, serve, clean, doctor, workspace, or
-  manifest behavior changed.
+- No package workflow, layout, build, export, serve, clean, doctor, workspace,
+  or manifest behavior changed.
+- Package metadata now reports the build-info-derived toolchain version.
 - No examples changed.
 - No migration is required.
 
@@ -60,6 +71,19 @@ GOBIN="$tmpbin" go install ./cmd/goxc
 
 Both local commands should print `goxc version devel` on the first line.
 
+It should also verify local package metadata:
+
+```bash
+go run ./cmd/goxc package ./examples/counter --compiler=go
+```
+
+The generated `examples/counter/.goframe/package/standalone/goframe-package.json`
+should contain:
+
+```json
+"toolchainVersion": "devel"
+```
+
 ## Install
 
 After the tag is published, install the exact hotfix preview with:
@@ -82,13 +106,20 @@ Expected first line:
 goxc version v0.2.0-preview.3
 ```
 
+Generated `goframe-package.json` metadata should include:
+
+```json
+"toolchainVersion": "v0.2.0-preview.3"
+```
+
 ## Non-Goals
 
 This hotfix does not include:
 
 - runtime changes;
 - GOX parser, codegen, or language changes;
-- `goxc` package/build/export/serve behavior changes;
+- package workflow or layout changes beyond the reported metadata value;
+- `goxc` build/export/serve behavior changes;
 - server/fullstack API changes;
 - production readiness claims;
 - route loader, JSON/data framework, or global cache changes;

--- a/docs/release.md
+++ b/docs/release.md
@@ -83,6 +83,7 @@ Current preview release note documents:
 - `docs/release-notes-v0.1.0-preview.2.md`
 - `docs/release-notes-v0.2.0-preview.1.md`
 - `docs/release-notes-v0.2.0-preview.2.md`
+- `docs/release-notes-v0.2.0-preview.3.md`
 
 `CHANGELOG.md` remains the factual change log; release notes should summarize
 preview scope, maturity tiers, validation evidence, compatibility notes, and


### PR DESCRIPTION
### Summary

Fixes stale GoFrame toolchain self-reporting after `v0.2.0-preview.2`.

`v0.2.0-preview.2` installed from the correct Go module tag, but `goxc version` still printed `0.1.0`, and generated `goframe-package.json` metadata still wrote `"toolchainVersion": "0.1.0"`.

This PR makes both surfaces use the Go build-info-derived module version:

* tagged module installs report/write the tag version, for example `v0.2.0-preview.3`;
* local checkout builds report/write `devel`.

### What Changed

* Updated `goxc version` to resolve the toolchain version from Go build info.
* Removed the stale hardcoded `0.1.0` version constant.
* Updated package metadata generation so `goframe-package.json` writes the same build-info-derived toolchain version.
* Added focused tests for tagged, local VCS, `(devel)`, empty, and unavailable build-info paths.
* Extended package metadata coverage to assert local package output writes `"toolchainVersion": "devel"`.
* Added `v0.2.0-preview.3` hotfix release notes.
* Updated `CHANGELOG.md`, `README.md`, and `docs/release.md` release-note references.

### Scope

Hotfix for toolchain version self-reporting only.

### Non-Goals

* No runtime changes.
* No GOX/codegen changes.
* No package workflow or layout changes.
* No `goxc` build/export/serve/clean/doctor behavior changes.
* No example source changes.
* No script changes.
* No workflow changes.
* No tag creation.
* No GitHub Release creation.
* No fullstack/server API claim.
* No production readiness claim.

### Validation

Local validation reported:

* `go test ./cmd/goxc`
* `go test ./...`
* `go vet ./...`
* `go test -tags=goframe_debug ./...`
* `go test -race ./pkg/... ./cmd/...`
* `node scripts/docs-check.mjs`
* `scripts/artifact-check.sh`
* `scripts/module-path-check.sh`
* `scripts/size-budget.sh`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`
* `go run ./cmd/goxc version`
* local `GOBIN` install smoke for `./cmd/goxc`
* `go run ./cmd/goxc package ./examples/counter --compiler=go`
* decoded metadata check confirming `"toolchainVersion": "devel"`
* `git diff --check`

### Notes

This PR prepares the `v0.2.0-preview.3` hotfix but does not create the tag.

After merge, a separate read-only release readiness check should verify `main`, CI, tag state, and external install behavior before publishing `v0.2.0-preview.3`.

After `v0.2.0-preview.3` is published, `v0.2.0-preview.2` should get a known-issue note explaining the stale `0.1.0` self-reporting in `goxc version` and package metadata.