### PR TITLE
docs(deployment): update package metadata version example

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -200,7 +200,7 @@ metadata compatibility policy.
   "version": 1,
   "name": "todo",
   "compiler": "tinygo",
-  "toolchainVersion": "0.1.0",
+  "toolchainVersion": "devel",
   "assetsDir": "assets",
   "hashAssets": true,
   "preload": true,
@@ -212,6 +212,9 @@ metadata compatibility policy.
   "generatedAt": "2026-06-17T00:00:00Z"
 }
 ```
+
+Local checkout builds write `devel`; tagged module installs write the module
+version recorded in Go build information, such as `v0.2.0-preview.3`.
 
 `goframe-package.json` is the authoritative current package completion marker.
 `goxc` publishes it last and removes it first during destructive package


### PR DESCRIPTION
### Summary

Updates deployment documentation after the preview.3 toolchain-version hotfix.

The `goframe-package.json` example in `docs/deployment.md` still showed `"toolchainVersion": "0.1.0"`, even though current `main` now writes build-info-derived toolchain versions:

* local checkout builds write `devel`;
* tagged module installs write the module version, such as `v0.2.0-preview.3`.

### What Changed

* Replaced the stale `"toolchainVersion": "0.1.0"` package metadata example with `"toolchainVersion": "devel"`.
* Added a short note explaining local checkout behavior.
* Added a short note explaining tagged module install behavior.

### Scope

Docs-only deployment documentation alignment before the `v0.2.0-preview.3` release readiness rerun.

### Non-Goals

* No code changes.
* No runtime changes.
* No GOX/codegen changes.
* No `goxc` implementation changes.
* No example source changes.
* No script changes.
* No workflow changes.
* No release tag.
* No GitHub Release.
* No production readiness claim.
* No fullstack/server API claim.

### Validation

Local validation reported:

* `node scripts/docs-check.mjs`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `rg -n '"toolchainVersion": "0\.1\.0"' docs README.md CHANGELOG.md`
* `rg -n 'toolchainVersion' docs/deployment.md docs/release-notes-v0.2.0-preview.3.md`
* `go test ./cmd/goxc`
* `go test ./...`

### Notes

This PR fixes stale deployment documentation only. It does not create `v0.2.0-preview.3`.

After merge, `v0.2.0-preview.3` still needs a fresh read-only release readiness check.

The previous readiness `NO-GO` came from a stale ignored `examples/counter` package artifact. Before rerunning `scripts/size-budget.sh`, regenerate the counter package through the TinyGo packaging path.