### PR TITLE
test(perf): characterize splitProps allocations

### DIFF
--- a/pkg/goframe/props_test.go
+++ b/pkg/goframe/props_test.go
@@ -1,0 +1,182 @@
+package goframe
+
+import "testing"
+
+var benchmarkSplitPropsDOM map[string]domProp
+var benchmarkSplitPropsEvents map[string]any
+
+func TestSplitPropsContract(t *testing.T) {
+	clickHandler := &struct{ name string }{"click"}
+	inputHandler := &struct{ name string }{"input"}
+
+	dom, events := splitProps(Props{
+		"id":                "issue-1",
+		"value":             "open",
+		"name":              "status",
+		"href":              "/issues/1",
+		"data-custom":       "kept",
+		"className":         "issue-row",
+		"htmlFor":           "status-input",
+		"OnClick":           clickHandler,
+		"onInput":           inputHandler,
+		"OnChange":          false,
+		"disabled":          true,
+		"checked":           false,
+		"data-nil":          nil,
+		"data-count":        42,
+		"data-ratio":        3.5,
+		"aria-expanded":     true,
+		"data-unsupported":  struct{ label string }{"unsupported"},
+		"data-bool-skipped": false,
+	})
+
+	wantDOM := map[string]domProp{
+		"id":               {value: "issue-1"},
+		"value":            {value: "open"},
+		"name":             {value: "status"},
+		"href":             {value: "/issues/1"},
+		"data-custom":      {value: "kept"},
+		"class":            {value: "issue-row"},
+		"for":              {value: "status-input"},
+		"disabled":         {boolean: true},
+		"data-count":       {value: "42"},
+		"data-ratio":       {value: "3.5"},
+		"aria-expanded":    {boolean: true},
+		"data-unsupported": {},
+	}
+	if len(dom) != len(wantDOM) {
+		t.Fatalf("dom length = %d, want %d: %#v", len(dom), len(wantDOM), dom)
+	}
+	for name, want := range wantDOM {
+		if got, ok := dom[name]; !ok || got != want {
+			t.Fatalf("dom[%q] = %#v, %v; want %#v, true", name, got, ok, want)
+		}
+	}
+	for _, name := range []string{"checked", "data-nil", "data-bool-skipped"} {
+		if _, exists := dom[name]; exists {
+			t.Fatalf("dom[%q] should be absent", name)
+		}
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("events length = %d, want 2: %#v", len(events), events)
+	}
+	if got := events["click"]; got != clickHandler {
+		t.Fatalf("events[click] = %#v, want original click handler", got)
+	}
+	if got := events["input"]; got != inputHandler {
+		t.Fatalf("events[input] = %#v, want original input handler", got)
+	}
+	if _, exists := events["change"]; exists {
+		t.Fatalf("events[change] should be absent")
+	}
+}
+
+func TestSplitPropsEmptyProps(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		props Props
+	}{
+		{name: "empty", props: Props{}},
+		{name: "nil", props: nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dom, events := splitProps(test.props)
+			if len(dom) != 0 {
+				t.Fatalf("dom = %#v, want empty", dom)
+			}
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+		})
+	}
+}
+
+func BenchmarkSplitPropsAllocations(b *testing.B) {
+	tests := []struct {
+		name       string
+		props      Props
+		wantDOM    int
+		wantEvents int
+	}{
+		{
+			name:       "empty_props",
+			props:      Props{},
+			wantDOM:    0,
+			wantEvents: 0,
+		},
+		{
+			name:       "nil_props",
+			props:      nil,
+			wantDOM:    0,
+			wantEvents: 0,
+		},
+		{
+			name: "small_static_element",
+			props: Props{
+				"id":        "summary",
+				"className": "card",
+				"title":     "Summary",
+				"role":      "region",
+			},
+			wantDOM:    4,
+			wantEvents: 0,
+		},
+		{
+			name: "input_like_props",
+			props: Props{
+				"id":          "issue-filter",
+				"name":        "filter",
+				"value":       "open",
+				"placeholder": "Filter issues",
+				"disabled":    false,
+				"OnInput":     func(InputEvent) {},
+				"OnChange":    func(InputEvent) {},
+			},
+			wantDOM:    4,
+			wantEvents: 2,
+		},
+		{
+			name: "button_like_props",
+			props: Props{
+				"className": "button primary",
+				"type":      "button",
+				"disabled":  true,
+				"OnClick":   func(Event) {},
+			},
+			wantDOM:    3,
+			wantEvents: 1,
+		},
+		{
+			name: "mixed_dashboard_row_props",
+			props: Props{
+				"id":            "issue-row-42",
+				"className":     "issue-row selected",
+				"data-testid":   "issue-row-42",
+				"style":         "height:32px",
+				"aria-rowindex": 42,
+				"hidden":        false,
+				"selected":      true,
+				"OnClick":       func(Event) {},
+				"OnMouseEnter":  func(Event) {},
+			},
+			wantDOM:    6,
+			wantEvents: 2,
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			dom, events := splitProps(test.props)
+			if len(dom) != test.wantDOM || len(events) != test.wantEvents {
+				b.Fatalf("sanity splitProps() dom=%d events=%d, want dom=%d events=%d", len(dom), len(events), test.wantDOM, test.wantEvents)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchmarkSplitPropsDOM, benchmarkSplitPropsEvents = splitProps(test.props)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

Adds focused behavior coverage and allocation benchmarks for the current `splitProps` implementation.

This PR is an evidence pass for #69. It records the existing `splitProps` contract and benchmark baseline before any optimization work.

### What Changed

* Added semantic regression coverage for `splitProps`.
* Covered DOM attribute splitting, event prop splitting, boolean attributes, skipped false/nil values, attribute normalization, primitive conversion, unsupported values, and empty/nil props.
* Added focused `BenchmarkSplitPropsAllocations` cases for representative prop shapes:
  * empty props;
  * nil props;
  * small static element;
  * input-like props;
  * button-like props;
  * mixed dashboard/list row props.
* Captured allocation evidence with `b.ReportAllocs()` while preserving the existing broader `BenchmarkSplitProps`.

### Scope

Test and benchmark characterization only.

This PR does not optimize `splitProps` yet. It establishes the baseline needed to evaluate a later optimization PR.

### Non-Goals

* No runtime behavior changes.
* No changes to `pkg/goframe/props.go`.
* No GOX/codegen changes.
* No `goxc` changes.
* No example changes.
* No docs changes.
* No script or workflow changes.
* No public API changes.
* Leaves #69 open for a follow-up optimization PR.

### Validation

Local validation reported:

* `go test ./pkg/goframe -run 'TestSplitProps|TestToString|TestEventName|TestNormalize'`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkSplitProps' -benchmem -count=5`
* `go test ./pkg/goframe`
* `go test ./...`
* `go vet ./...`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `bash -n scripts/browser-smoke.sh`

### Benchmark Notes

The benchmark baseline shows stable allocation counts:

* empty/nil props still allocate 2 times;
* representative interactive props allocate 6-7 times;
* the existing broader `BenchmarkSplitProps` path allocates 15 times.

This makes the current map allocation cost visible enough to justify a careful follow-up experiment, but this PR intentionally does not implement that optimization.

### Notes

Follow-up optimization work should stay evidence-driven.

Possible approaches such as slices, pooling, or another internal representation should be evaluated in a separate PR against this baseline, with size-budget and browser-smoke validation before merge.