### PR TITLE
perf(goframe): reduce splitProps empty and event-free allocations

### DIFF
--- a/pkg/goframe/props.go
+++ b/pkg/goframe/props.go
@@ -73,8 +73,12 @@ func normalizeAttributeName(name string) string {
 }
 
 func splitProps(props Props) (map[string]domProp, map[string]any) {
-	dom := make(map[string]domProp)
-	events := make(map[string]any)
+	if len(props) == 0 {
+		return nil, nil
+	}
+
+	var dom map[string]domProp
+	var events map[string]any
 	for name, value := range props {
 		if value == nil {
 			continue
@@ -83,15 +87,24 @@ func splitProps(props Props) (map[string]domProp, map[string]any) {
 			continue
 		}
 		if eventName, ok := eventNameForProp(name); ok {
+			if events == nil {
+				events = make(map[string]any)
+			}
 			events[eventName] = value
 			continue
 		}
 		name = normalizeAttributeName(name)
 		if boolean, ok := value.(bool); ok {
 			if boolean {
+				if dom == nil {
+					dom = make(map[string]domProp)
+				}
 				dom[name] = domProp{boolean: true}
 			}
 			continue
+		}
+		if dom == nil {
+			dom = make(map[string]domProp)
 		}
 		dom[name] = domProp{value: ToString(value)}
 	}


### PR DESCRIPTION
### Summary

Reduces avoidable `splitProps` map allocations while preserving the behavior characterized in the previous evidence PR.

Related to #69.

This is the first narrow optimization pass after the `splitProps` allocation benchmark baseline. It does not switch to pooling or a slice-based representation.

### What Changed

* Added an empty/nil props fast path that returns empty-equivalent nil maps.
* Changed `splitProps` to allocate the DOM props map lazily, only when the first DOM prop is emitted.
* Changed `splitProps` to allocate the events map lazily, only when the first event prop is emitted.
* Preserved the existing `splitProps` contract:
  * nil values are skipped;
  * false boolean values are skipped;
  * event names are normalized through the existing event prop path;
  * attribute names still use the existing normalization behavior;
  * true boolean DOM attributes still produce boolean DOM props;
  * primitive values still go through `ToString`;
  * unsupported non-nil values still become empty-string DOM props.

### Scope

Narrow runtime allocation optimization for `splitProps` only.

### Non-Goals

* No public API changes.
* No GOX/codegen changes.
* No `goxc` changes.
* No example changes.
* No docs changes.
* No script or workflow changes.
* No pooling.
* No slice-based props representation.
* No changes to DOM patching semantics.
* No changes to event handling semantics.
* Does not complete the broader optimization work tracked in #69.

### Validation

Local validation reported:

* `go test ./pkg/goframe -run 'TestSplitProps|TestToString|TestEventName|TestNormalize'`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkSplitProps' -benchmem -count=10`
* `go test ./pkg/goframe`
* `go test ./...`
* `go vet ./...`
* `go test -tags=goframe_debug ./...`
* `go test -race ./pkg/... ./cmd/...`
* `scripts/size-budget.sh`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`

### Benchmark Notes

Reported before/after allocation results:

* `empty_props`: 2 allocs/op, 96 B/op -> 0 allocs/op, 0 B/op
* `nil_props`: 2 allocs/op, 96 B/op -> 0 allocs/op, 0 B/op
* `small_static_element`: 4 allocs/op, 464 B/op -> 3 allocs/op, 416 B/op
* `input_like_props`: 6 allocs/op, 752 B/op -> 6 allocs/op, 752 B/op
* `button_like_props`: 6 allocs/op, 760 B/op -> 6 allocs/op, 760 B/op
* `mixed_dashboard_row_props`: 7 allocs/op, 776 B/op -> 7 allocs/op, 776 B/op
* existing broader `BenchmarkSplitProps`: 15 allocs/op, 848 B/op -> 15 allocs/op, 848 B/op

Timing was locally noisy, but allocation counts and B/op improved for empty/nil and event-free cases, while representative interactive cases stayed neutral.

### Notes

This PR intentionally keeps #69 open for further follow-up.

Larger approaches such as pooling or a slice-based internal representation should be evaluated separately against this benchmark baseline, with size-budget and browser-smoke validation before merge.