### PR TITLE
perf(goframe): use slice-backed splitProps output

### DIFF
--- a/pkg/goframe/props.go
+++ b/pkg/goframe/props.go
@@ -13,6 +13,63 @@ type domProp struct {
 	boolean bool
 }
 
+type splitDOMProp struct {
+	name string
+	prop domProp
+}
+
+type splitEventProp struct {
+	name     string
+	callback any
+}
+
+type splitDOMProps []splitDOMProp
+
+type splitEventProps []splitEventProp
+
+func (props splitDOMProps) get(name string) (domProp, bool) {
+	for _, prop := range props {
+		if prop.name == name {
+			return prop.prop, true
+		}
+	}
+	return domProp{}, false
+}
+
+func (props splitDOMProps) has(name string) bool {
+	_, ok := props.get(name)
+	return ok
+}
+
+func (props *splitDOMProps) set(name string, prop domProp) {
+	for index := range *props {
+		if (*props)[index].name == name {
+			(*props)[index].prop = prop
+			return
+		}
+	}
+	*props = append(*props, splitDOMProp{name: name, prop: prop})
+}
+
+func (events splitEventProps) get(name string) (any, bool) {
+	for _, event := range events {
+		if event.name == name {
+			return event.callback, true
+		}
+	}
+	return nil, false
+}
+
+func (events *splitEventProps) set(name string, callback any) {
+	for index := range *events {
+		if (*events)[index].name == name {
+			(*events)[index].callback = callback
+			return
+		}
+	}
+	*events = append(*events, splitEventProp{name: name, callback: callback})
+}
+
 // ToString converts supported primitive values into text suitable for a Text
 // node. Unsupported values become an empty string to keep the WASM runtime
 // independent from fmt and reflection-heavy formatting.
@@ -72,13 +129,13 @@ func normalizeAttributeName(name string) string {
 	}
 }
 
-func splitProps(props Props) (map[string]domProp, map[string]any) {
+func splitProps(props Props) (splitDOMProps, splitEventProps) {
 	if len(props) == 0 {
 		return nil, nil
 	}
 
-	var dom map[string]domProp
-	var events map[string]any
+	var dom splitDOMProps
+	var events splitEventProps
 	for name, value := range props {
 		if value == nil {
 			continue
@@ -88,25 +145,25 @@ func splitProps(props Props) (map[string]domProp, map[string]any) {
 		}
 		if eventName, ok := eventNameForProp(name); ok {
 			if events == nil {
-				events = make(map[string]any)
+				events = make(splitEventProps, 0, len(props))
 			}
-			events[eventName] = value
+			events.set(eventName, value)
 			continue
 		}
 		name = normalizeAttributeName(name)
 		if boolean, ok := value.(bool); ok {
 			if boolean {
 				if dom == nil {
-					dom = make(map[string]domProp)
+					dom = make(splitDOMProps, 0, len(props))
 				}
-				dom[name] = domProp{boolean: true}
+				dom.set(name, domProp{boolean: true})
 			}
 			continue
 		}
 		if dom == nil {
-			dom = make(map[string]domProp)
+			dom = make(splitDOMProps, 0, len(props))
 		}
-		dom[name] = domProp{value: ToString(value)}
+		dom.set(name, domProp{value: ToString(value)})
 	}
 	return dom, events
 }

--- a/pkg/goframe/props_test.go
+++ b/pkg/goframe/props_test.go
@@ -2,8 +2,8 @@ package goframe
 
 import "testing"
 
-var benchmarkSplitPropsDOM map[string]domProp
-var benchmarkSplitPropsEvents map[string]any
+var benchmarkSplitPropsDOM splitDOMProps
+var benchmarkSplitPropsEvents splitEventProps
 
 func TestSplitPropsContract(t *testing.T) {
 	clickHandler := &struct{ name string }{"click"}
@@ -48,12 +48,12 @@ func TestSplitPropsContract(t *testing.T) {
 		t.Fatalf("dom length = %d, want %d: %#v", len(dom), len(wantDOM), dom)
 	}
 	for name, want := range wantDOM {
-		if got, ok := dom[name]; !ok || got != want {
+		if got, ok := dom.get(name); !ok || got != want {
 			t.Fatalf("dom[%q] = %#v, %v; want %#v, true", name, got, ok, want)
 		}
 	}
 	for _, name := range []string{"checked", "data-nil", "data-bool-skipped"} {
-		if _, exists := dom[name]; exists {
+		if dom.has(name) {
 			t.Fatalf("dom[%q] should be absent", name)
 		}
 	}
@@ -61,13 +61,13 @@ func TestSplitPropsContract(t *testing.T) {
 	if len(events) != 2 {
 		t.Fatalf("events length = %d, want 2: %#v", len(events), events)
 	}
-	if got := events["click"]; got != clickHandler {
+	if got, ok := events.get("click"); !ok || got != clickHandler {
 		t.Fatalf("events[click] = %#v, want original click handler", got)
 	}
-	if got := events["input"]; got != inputHandler {
+	if got, ok := events.get("input"); !ok || got != inputHandler {
 		t.Fatalf("events[input] = %#v, want original input handler", got)
 	}
-	if _, exists := events["change"]; exists {
+	if _, exists := events.get("change"); exists {
 		t.Fatalf("events[change] should be absent")
 	}
 }
@@ -89,6 +89,32 @@ func TestSplitPropsEmptyProps(t *testing.T) {
 				t.Fatalf("events = %#v, want empty", events)
 			}
 		})
+	}
+}
+
+func TestSplitPropsDeduplicatesNormalizedNames(t *testing.T) {
+	clickHandler := &struct{ name string }{"click"}
+	lowerClickHandler := &struct{ name string }{"lower-click"}
+
+	dom, events := splitProps(Props{
+		"class":     "base",
+		"className": "primary",
+		"OnClick":   clickHandler,
+		"onclick":   lowerClickHandler,
+	})
+
+	if len(dom) != 1 {
+		t.Fatalf("dom length = %d, want 1: %#v", len(dom), dom)
+	}
+	if got, ok := dom.get("class"); !ok || (got != (domProp{value: "base"}) && got != (domProp{value: "primary"})) {
+		t.Fatalf("dom[class] = %#v, %v; want one normalized class prop", got, ok)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("events length = %d, want 1: %#v", len(events), events)
+	}
+	if got, ok := events.get("click"); !ok || (got != any(clickHandler) && got != any(lowerClickHandler)) {
+		t.Fatalf("events[click] = %#v, %v; want one normalized click callback", got, ok)
 	}
 }
 

--- a/pkg/goframe/reconcile_test.go
+++ b/pkg/goframe/reconcile_test.go
@@ -135,19 +135,21 @@ func TestSplitPropsNormalizesDOMAndEvents(t *testing.T) {
 		"onInput":     func(InputEvent) {},
 	})
 
-	if got := dom["class"]; got != (domProp{value: "primary"}) {
-		t.Fatalf("class = %#v", got)
+	if got, ok := dom.get("class"); !ok || got != (domProp{value: "primary"}) {
+		t.Fatalf("class = %#v, %v", got, ok)
 	}
-	if got := dom["value"]; got != (domProp{value: "task"}) {
-		t.Fatalf("value = %#v", got)
+	if got, ok := dom.get("value"); !ok || got != (domProp{value: "task"}) {
+		t.Fatalf("value = %#v, %v", got, ok)
 	}
-	if got := dom["disabled"]; got != (domProp{boolean: true}) {
-		t.Fatalf("disabled = %#v", got)
+	if got, ok := dom.get("disabled"); !ok || got != (domProp{boolean: true}) {
+		t.Fatalf("disabled = %#v, %v", got, ok)
 	}
-	if _, exists := dom["placeholder"]; exists {
+	if dom.has("placeholder") {
 		t.Fatal("false placeholder should be absent")
 	}
-	if len(events) != 2 || events["click"] == nil || events["input"] == nil {
+	click, clickExists := events.get("click")
+	input, inputExists := events.get("input")
+	if len(events) != 2 || !clickExists || click == nil || !inputExists || input == nil {
 		t.Fatalf("events = %#v", events)
 	}
 }
@@ -162,13 +164,13 @@ func TestSplitPropsHandlesUncomparableValues(t *testing.T) {
 	if len(events) != 0 {
 		t.Fatalf("events = %#v, want none", events)
 	}
-	if got := dom["data-slice"]; got != (domProp{}) {
-		t.Fatalf("data-slice = %#v, want empty string prop", got)
+	if got, ok := dom.get("data-slice"); !ok || got != (domProp{}) {
+		t.Fatalf("data-slice = %#v, %v; want empty string prop", got, ok)
 	}
-	if got := dom["data-map"]; got != (domProp{}) {
-		t.Fatalf("data-map = %#v, want empty string prop", got)
+	if got, ok := dom.get("data-map"); !ok || got != (domProp{}) {
+		t.Fatalf("data-map = %#v, %v; want empty string prop", got, ok)
 	}
-	if _, exists := dom["hidden"]; exists {
+	if dom.has("hidden") {
 		t.Fatal("false prop should be absent")
 	}
 }

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -76,7 +76,7 @@ func applyPostMountProps(element js.Value, node VNode) {
 		return
 	}
 	props, _ := splitProps(node.Props)
-	if prop, ok := props["value"]; ok {
+	if prop, ok := props.get("value"); ok {
 		setDOMProp(element, "value", prop)
 	}
 }
@@ -259,16 +259,16 @@ func patchProps(element js.Value, mounted *mountedNode, oldProps, newProps Props
 	oldDOM, _ := splitProps(oldProps)
 	newDOM, newEvents := splitProps(newProps)
 
-	for name, oldProp := range oldDOM {
-		if _, exists := newDOM[name]; !exists {
-			removeDOMProp(element, name, oldProp)
+	for _, oldProp := range oldDOM {
+		if !newDOM.has(oldProp.name) {
+			removeDOMProp(element, oldProp.name, oldProp.prop)
 		}
 	}
-	for name, newProp := range newDOM {
-		if oldProp, exists := oldDOM[name]; exists && oldProp == newProp {
+	for _, newProp := range newDOM {
+		if oldProp, exists := oldDOM.get(newProp.name); exists && oldProp == newProp.prop {
 			continue
 		}
-		setDOMProp(element, name, newProp)
+		setDOMProp(element, newProp.name, newProp.prop)
 	}
 	patchEvents(element, mounted, newEvents, owner)
 }
@@ -301,9 +301,9 @@ func setDOMProp(element js.Value, name string, prop domProp) {
 	element.Call("setAttribute", name, prop.value)
 }
 
-func patchEvents(element js.Value, mounted *mountedNode, callbacks map[string]any, owner *componentInstance) {
+func patchEvents(element js.Value, mounted *mountedNode, callbacks splitEventProps, owner *componentInstance) {
 	for eventName, event := range mounted.events {
-		if _, exists := callbacks[eventName]; exists {
+		if _, exists := callbacks.get(eventName); exists {
 			continue
 		}
 		element.Call("removeEventListener", eventName, event.handler)
@@ -318,15 +318,16 @@ func patchEvents(element js.Value, mounted *mountedNode, callbacks map[string]an
 	if mounted.events == nil {
 		mounted.events = make(map[string]*mountedEvent, len(callbacks))
 	}
-	for eventName, callback := range callbacks {
+	for _, callback := range callbacks {
+		eventName := callback.name
 		if event, exists := mounted.events[eventName]; exists {
-			event.callback = callback
+			event.callback = callback.callback
 			event.component = runtimeComponentName(owner)
 			event.eventName = eventName
 			continue
 		}
 		event := &mountedEvent{
-			callback:  callback,
+			callback:  callback.callback,
 			component: runtimeComponentName(owner),
 			eventName: eventName,
 		}


### PR DESCRIPTION
### Summary

Replaces the transient `splitProps` map output with small internal slice-backed structures.

Related to #69.

This is the second focused `splitProps` allocation step after the benchmark characterization and lazy-map allocation pass. It keeps the public `Props` API unchanged while reducing allocation cost in representative prop paths.

### What Changed

* Added internal slice-backed `splitDOMProps` and `splitEventProps` output types.
* Added internal lookup/upsert helpers for split DOM props and event props.
* Updated `splitProps` to emit slice-backed transient output instead of map output.
* Updated `applyPostMountProps`, `patchProps`, and `patchEvents` to use the new internal split output.
* Kept `mounted.events` map-based so stable mounted event handler behavior remains unchanged.
* Updated existing `splitProps` tests to use the new internal lookup helpers.
* Updated `reconcile_test.go` direct `splitProps` assertions without weakening behavior coverage.
* Added duplicate normalized-name coverage for `class` / `className` and `OnClick` / `onclick`.

### Scope

Narrow internal runtime allocation optimization for `splitProps` output only.

### Non-Goals

* No public API changes.
* No changes to exported `Props`.
* No GOX/codegen changes.
* No `goxc` changes.
* No example changes.
* No docs changes.
* No script or workflow changes.
* No pooling.
* No `sync.Pool`.
* No unsafe or reflection.
* No mutation batching.
* No keyed reconciliation changes.
* No changes to DOM patching semantics.
* No changes to event handling semantics.
* No changes to focus handling or effect ordering.
* Does not complete all possible follow-up work for #69.

### Validation

Local validation reported:

* `go test ./pkg/goframe -run 'TestSplitProps|TestToString|TestEventName|TestNormalize'`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkSplitProps' -benchmem -count=10`
* `go test ./pkg/goframe`
* `go test ./...`
* `go vet ./...`
* `go test -tags=goframe_debug ./...`
* `go test -race ./pkg/... ./cmd/...`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `scripts/size-budget.sh`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`

### Benchmark Notes

Reported before/after allocation results:

* existing `BenchmarkSplitProps`: 15 allocs/op, 848 B/op -> 13 allocs/op, 784 B/op
* `empty_props`: 0 allocs/op, 0 B/op -> 0 allocs/op, 0 B/op
* `nil_props`: 0 allocs/op, 0 B/op -> 0 allocs/op, 0 B/op
* `small_static_element`: 3 allocs/op, 416 B/op -> 2 allocs/op, 176 B/op
* `input_like_props`: 6 allocs/op, 752 B/op -> 4 allocs/op, 528 B/op
* `button_like_props`: 6 allocs/op, 760 B/op -> 4 allocs/op, 312 B/op
* `mixed_dashboard_row_props`: 7 allocs/op, 776 B/op -> 5 allocs/op, 712 B/op

Timing was locally noisy, but allocation counts and B/op improved across the representative cases while keeping empty/nil props at zero allocations.

### Notes

This PR keeps #69 open for further follow-up.

Pooling or other larger internal representations should only be evaluated later if another benchmark target shows enough remaining allocation pressure to justify the extra complexity.