### PR TITLE
test(goframe): characterize keyed child reorders

### DIFF
--- a/pkg/goframe/bench_test.go
+++ b/pkg/goframe/bench_test.go
@@ -2,6 +2,8 @@ package goframe
 
 import "testing"
 
+var benchmarkChildMatches []int
+
 func BenchmarkDirtyQueuePruning(b *testing.B) {
 	root := dirtyTestInstance("Root", nil)
 	parent := dirtyTestInstance("Parent", root)
@@ -47,6 +49,150 @@ func BenchmarkMatchChildIndicesUnkeyed(b *testing.B) {
 			b.Fatalf("last match = %d", matches[127])
 		}
 	}
+}
+
+func BenchmarkMatchChildIndicesReorders(b *testing.B) {
+	const size = 128
+
+	tests := []struct {
+		name   string
+		old    []string
+		new    []string
+		checks map[int]int
+	}{
+		{
+			name: "stable_keyed_order",
+			old:  sequentialBenchmarkKeys(size),
+			new:  sequentialBenchmarkKeys(size),
+			checks: map[int]int{
+				0:        0,
+				size - 1: size - 1,
+			},
+		},
+		{
+			name: "reverse_keyed_order",
+			old:  sequentialBenchmarkKeys(size),
+			new:  reverseBenchmarkKeys(size),
+			checks: map[int]int{
+				0:        size - 1,
+				size - 1: 0,
+			},
+		},
+		{
+			name: "rotate_left_keyed_order",
+			old:  sequentialBenchmarkKeys(size),
+			new:  rotateLeftBenchmarkKeys(size),
+			checks: map[int]int{
+				0:        1,
+				size - 1: 0,
+			},
+		},
+		{
+			name: "rotate_right_keyed_order",
+			old:  sequentialBenchmarkKeys(size),
+			new:  rotateRightBenchmarkKeys(size),
+			checks: map[int]int{
+				0:        size - 1,
+				size - 1: size - 2,
+			},
+		},
+		{
+			name: "insert_remove_keyed_order",
+			old:  sequentialBenchmarkKeys(size),
+			new:  insertRemoveBenchmarkKeys(size),
+			checks: map[int]int{
+				0:        noChildMatch,
+				1:        1,
+				size - 1: size - 1,
+			},
+		},
+		{
+			name: "mixed_keyed_unkeyed_order",
+			old:  mixedBenchmarkKeys(size),
+			new:  mixedReorderedBenchmarkKeys(size),
+			checks: map[int]int{
+				0: size - 2,
+				1: 1,
+				2: 0,
+				3: 3,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			matches := matchChildIndices(test.old, test.new)
+			for index, want := range test.checks {
+				if matches[index] != want {
+					b.Fatalf("sanity match[%d] = %d, want %d", index, matches[index], want)
+				}
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchmarkChildMatches = matchChildIndices(test.old, test.new)
+			}
+		})
+	}
+}
+
+func sequentialBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		keys[index] = "item-" + ToString(index)
+	}
+	return keys
+}
+
+func reverseBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		keys[index] = "item-" + ToString(size-1-index)
+	}
+	return keys
+}
+
+func rotateLeftBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		keys[index] = "item-" + ToString((index+1)%size)
+	}
+	return keys
+}
+
+func rotateRightBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		keys[index] = "item-" + ToString((index+size-1)%size)
+	}
+	return keys
+}
+
+func insertRemoveBenchmarkKeys(size int) []string {
+	keys := sequentialBenchmarkKeys(size)
+	keys[0] = "new-item"
+	return keys
+}
+
+func mixedBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		if index%2 == 0 {
+			keys[index] = "item-" + ToString(index)
+		}
+	}
+	return keys
+}
+
+func mixedReorderedBenchmarkKeys(size int) []string {
+	keys := make([]string, size)
+	for index := range keys {
+		if index%2 == 0 {
+			keys[index] = "item-" + ToString((index+size-2)%size)
+		}
+	}
+	return keys
 }
 
 func BenchmarkSplitProps(b *testing.B) {

--- a/pkg/goframe/reconcile_reorder_test.go
+++ b/pkg/goframe/reconcile_reorder_test.go
@@ -1,0 +1,187 @@
+package goframe
+
+import (
+	"reflect"
+	"testing"
+)
+
+type currentPlacementChild struct {
+	id      string
+	pending bool
+}
+
+type currentPlacementStats struct {
+	final    []string
+	mounts   int
+	removals int
+	moves    int
+}
+
+func TestCurrentKeyedReorderPlacement(t *testing.T) {
+	// These counts characterize current right-to-left placement behavior. They
+	// are not asserted to be optimal; LIS work may intentionally update them.
+	tests := []struct {
+		name string
+		old  []string
+		new  []string
+		want currentPlacementStats
+	}{
+		{
+			name: "stable keyed order",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"a", "b", "c", "d"},
+			want: currentPlacementStats{
+				final: []string{"a", "b", "c", "d"},
+			},
+		},
+		{
+			name: "rotate left",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"b", "c", "d", "a"},
+			want: currentPlacementStats{
+				final: []string{"b", "c", "d", "a"},
+				moves: 1,
+			},
+		},
+		{
+			name: "rotate right",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"d", "a", "b", "c"},
+			want: currentPlacementStats{
+				final: []string{"d", "a", "b", "c"},
+				moves: 3,
+			},
+		},
+		{
+			name: "reverse",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"d", "c", "b", "a"},
+			want: currentPlacementStats{
+				final: []string{"d", "c", "b", "a"},
+				moves: 3,
+			},
+		},
+		{
+			name: "insert beginning and end",
+			old:  []string{"a", "b", "c"},
+			new:  []string{"x", "a", "b", "c", "y"},
+			want: currentPlacementStats{
+				final:  []string{"x", "a", "b", "c", "y"},
+				mounts: 2,
+			},
+		},
+		{
+			name: "remove middle",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"a", "c", "d"},
+			want: currentPlacementStats{
+				final:    []string{"a", "c", "d"},
+				removals: 1,
+			},
+		},
+		{
+			name: "mixed insert remove reorder",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"c", "x", "a"},
+			want: currentPlacementStats{
+				final:    []string{"c", "x", "a"},
+				mounts:   1,
+				removals: 2,
+				moves:    1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := simulateCurrentPatchChildrenPlacement(t, test.old, test.new)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("placement stats = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []string) currentPlacementStats {
+	t.Helper()
+
+	matches := matchChildIndices(oldKeys, newKeys)
+	used := make([]bool, len(oldKeys))
+	children := make([]currentPlacementChild, len(newKeys))
+	for index, key := range newKeys {
+		oldIndex := matches[index]
+		if oldIndex == noChildMatch {
+			children[index] = currentPlacementChild{id: key, pending: true}
+			continue
+		}
+		used[oldIndex] = true
+		children[index] = currentPlacementChild{id: oldKeys[oldIndex]}
+	}
+
+	stats := currentPlacementStats{
+		final: make([]string, 0, len(newKeys)),
+	}
+	for index, key := range oldKeys {
+		if used[index] {
+			stats.final = append(stats.final, key)
+			continue
+		}
+		stats.removals++
+	}
+
+	var reference string
+	hasReference := false
+	for index := len(children) - 1; index >= 0; index-- {
+		child := children[index]
+		if child.pending {
+			stats.mounts++
+			stats.final = insertBeforeCurrentPlacement(t, stats.final, child.id, reference, hasReference)
+			reference = child.id
+			hasReference = true
+			continue
+		}
+
+		childIndex := indexOfCurrentPlacement(t, stats.final, child.id)
+		hasNext := childIndex+1 < len(stats.final)
+		nextIsReference := !hasNext && !hasReference
+		if hasNext && hasReference && stats.final[childIndex+1] == reference {
+			nextIsReference = true
+		}
+		if nextIsReference {
+			reference = child.id
+			hasReference = true
+			continue
+		}
+
+		stats.moves++
+		stats.final = append(stats.final[:childIndex], stats.final[childIndex+1:]...)
+		stats.final = insertBeforeCurrentPlacement(t, stats.final, child.id, reference, hasReference)
+		reference = child.id
+		hasReference = true
+	}
+
+	return stats
+}
+
+func insertBeforeCurrentPlacement(t *testing.T, order []string, id, reference string, hasReference bool) []string {
+	t.Helper()
+	if !hasReference {
+		return append(order, id)
+	}
+	index := indexOfCurrentPlacement(t, order, reference)
+	order = append(order, "")
+	copy(order[index+1:], order[index:])
+	order[index] = id
+	return order
+}
+
+func indexOfCurrentPlacement(t *testing.T, order []string, id string) int {
+	t.Helper()
+	for index, value := range order {
+		if value == id {
+			return index
+		}
+	}
+	t.Fatalf("placement id %q missing from %v", id, order)
+	return -1
+}

--- a/pkg/goframe/reconcile_test.go
+++ b/pkg/goframe/reconcile_test.go
@@ -56,16 +56,52 @@ func TestMatchChildIndices(t *testing.T) {
 			want: []int{0, 1, noChildMatch},
 		},
 		{
+			name: "stable keyed order",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"a", "b", "c", "d"},
+			want: []int{0, 1, 2, 3},
+		},
+		{
+			name: "reverse keyed order",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"d", "c", "b", "a"},
+			want: []int{3, 2, 1, 0},
+		},
+		{
+			name: "rotate keyed order left",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"b", "c", "d", "a"},
+			want: []int{1, 2, 3, 0},
+		},
+		{
+			name: "rotate keyed order right",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"d", "a", "b", "c"},
+			want: []int{3, 0, 1, 2},
+		},
+		{
 			name: "keyed reorder and insert",
 			old:  []string{"a", "b", "c"},
 			new:  []string{"c", "b", "d", "a"},
 			want: []int{2, 1, noChildMatch, 0},
 		},
 		{
+			name: "insert around stable keyed children",
+			old:  []string{"a", "b", "c"},
+			new:  []string{"x", "a", "b", "c", "y"},
+			want: []int{noChildMatch, 0, 1, 2, noChildMatch},
+		},
+		{
 			name: "keyed removal keeps surviving identity",
 			old:  []string{"todo-1", "todo-2"},
 			new:  []string{"todo-2"},
 			want: []int{1},
+		},
+		{
+			name: "remove keyed children",
+			old:  []string{"a", "b", "c", "d"},
+			new:  []string{"a", "c"},
+			want: []int{0, 2},
 		},
 		{
 			name: "mixed children keep unkeyed order",
@@ -76,6 +112,18 @@ func TestMatchChildIndices(t *testing.T) {
 		{
 			name: "duplicate new key mounts duplicate",
 			old:  []string{"a"},
+			new:  []string{"a", "a"},
+			want: []int{0, noChildMatch},
+		},
+		{
+			name: "duplicate old key single new key",
+			old:  []string{"a", "a", "b"},
+			new:  []string{"a", "b"},
+			want: []int{0, 2},
+		},
+		{
+			name: "duplicate old key duplicate new key",
+			old:  []string{"a", "a"},
 			new:  []string{"a", "a"},
 			want: []int{0, noChildMatch},
 		},


### PR DESCRIPTION
### Summary

Adds test and benchmark characterization for current keyed child reorder behavior before any LIS work.

Related to #71.

This PR records how `matchChildIndices` and the current right-to-left placement flow behave today. It intentionally does not optimize reconciliation or implement LIS.

### What Changed

* Extended `TestMatchChildIndices` with explicit keyed reorder scenarios:
  * stable keyed order;
  * reverse keyed order;
  * rotate-left;
  * rotate-right;
  * insert around stable keyed children;
  * keyed removals;
  * mixed keyed/unkeyed children;
  * duplicate new keys;
  * duplicate old keys.
* Added test-only current placement characterization via `TestCurrentKeyedReorderPlacement`.
* Added a test-only simulator for the current `patchChildren` placement model:
  * uses `matchChildIndices`;
  * removes unused old children;
  * walks children from right to left;
  * counts pending mounts;
  * counts removals;
  * counts existing-node moves;
  * preserves current no-op behavior when an existing node is already before the requested reference.
* Added reorder benchmarks for `matchChildIndices` across stable, reverse, rotate-left, rotate-right, insert/remove, and mixed keyed/unkeyed cases.

### Scope

Test and benchmark characterization only.

No production code changed.

### Non-Goals

* No runtime behavior changes.
* No public API changes.
* No reconciliation optimization.
* No LIS implementation.
* No LIS helper.
* No DOM mutation batching.
* No `syscall/js` test harness.
* No GOX/codegen changes.
* No `goxc` changes.
* No example changes.
* No docs changes.
* No script or workflow changes.
* Leaves #71 for a follow-up optimization PR.

### Validation

Local validation reported:

* `go test ./pkg/goframe -run 'TestMatchChildIndices|TestCurrentKeyedReorderPlacement|TestSameNodeIdentity|TestConditionalSibling'`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkMatchChildIndices|Benchmark.*Reorder' -benchmem -count=10`
* `go test ./pkg/goframe`
* `go test ./...`
* `go vet ./...`
* `go test -tags=goframe_debug ./...`
* `go test -race ./pkg/... ./cmd/...`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `bash -n scripts/browser-smoke.sh`

`scripts/size-budget.sh` and full `scripts/browser-smoke.sh` were skipped locally because this PR changes only tests and benchmarks.

### Characterization Notes

Current placement counts recorded by the test-only simulator:

* stable `[a b c d] -> [a b c d]`: `0` moves, `0` mounts, `0` removals
* rotate-left `[a b c d] -> [b c d a]`: `1` move, `0` mounts, `0` removals
* rotate-right `[a b c d] -> [d a b c]`: `3` moves, `0` mounts, `0` removals
* reverse `[a b c d] -> [d c b a]`: `3` moves, `0` mounts, `0` removals
* insert beginning/end `[a b c] -> [x a b c y]`: `0` moves, `2` mounts, `0` removals
* remove middle `[a b c d] -> [a c d]`: `0` moves, `0` mounts, `1` removal
* mixed `[a b c d] -> [c x a]`: `1` move, `1` mount, `2` removals

These counts characterize current right-to-left placement behavior. They are not asserted to be optimal.

### Benchmark Notes

Reported benchmark summary for size `128`:

* `stable_keyed_order`: `6 allocs/op`, `8744 B/op`, median `15633.5 ns/op`
* `reverse_keyed_order`: `6 allocs/op`, `8744 B/op`, median `14779.5 ns/op`
* `rotate_left_keyed_order`: `6 allocs/op`, `8744 B/op`, median `14778.5 ns/op`
* `rotate_right_keyed_order`: `6 allocs/op`, `8744 B/op`, median `14301 ns/op`
* `insert_remove_keyed_order`: `6 allocs/op`, `8744 B/op`, median `15857.5 ns/op`
* `mixed_keyed_unkeyed_order`: `6 allocs/op`, `8744 B/op`, median `8769 ns/op`

Existing baselines reported:

* keyed baseline: `6 allocs/op`, `8744 B/op`, median `15006 ns/op`
* unkeyed baseline: `6 allocs/op`, `8744 B/op`, median `3057 ns/op`

### Notes

This PR intentionally freezes current behavior as evidence.

A future LIS PR should update the move-count expectations deliberately, with benchmark evidence and an explanation of which current behavior changed.