### PR TITLE
perf(wasm): reduce virtual table runtime size

### DIFF
--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -69,14 +69,14 @@ type VirtualRange struct {
 }
 
 const (
-	virtualTableTopSpacerKey    = "goframe:virtual-table:spacer:top"
-	virtualTableBottomSpacerKey = "goframe:virtual-table:spacer:bottom"
-	virtualTableEmptyKey        = "goframe:virtual-table:empty"
-	virtualTableRowKeyPrefix    = "goframe:virtual-table:row:"
+	virtualTableTopSpacerKey    = "\x00vt"
+	virtualTableBottomSpacerKey = "\x00vb"
+	virtualTableEmptyKey        = "\x00ve"
+	virtualTableRowKeyPrefix    = "\x00vr:"
 )
 
 func renderVirtualList[T any](props VirtualListProps[T]) Node {
-	validateVirtualDimensions("VirtualList", props.Height, props.ItemHeight, "ItemHeight")
+	validateVirtualListDimensions(props.Height, props.ItemHeight)
 	if props.RenderItem == nil {
 		panic("goframe: VirtualList requires RenderItem")
 	}
@@ -123,7 +123,7 @@ func renderVirtualList[T any](props VirtualListProps[T]) Node {
 }
 
 func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
-	validateVirtualDimensions("VirtualTable", props.Height, props.RowHeight, "RowHeight")
+	validateVirtualTableDimensions(props.Height, props.RowHeight)
 	if props.RenderRow == nil {
 		panic("goframe: VirtualTable requires RenderRow")
 	}
@@ -239,20 +239,32 @@ func renderVirtualTableEmpty(render func() Node) (node Node) {
 	return render()
 }
 
-func validateVirtualDimensions(name string, height int, itemHeight int, itemHeightName string) {
+func validateVirtualListDimensions(height int, itemHeight int) {
 	if height <= 0 || itemHeight <= 0 {
-		panic("goframe: " + name + " requires positive Height and " + itemHeightName)
+		panic("goframe: VirtualList requires positive Height and ItemHeight")
+	}
+}
+
+func validateVirtualTableDimensions(height int, rowHeight int) {
+	if height <= 0 || rowHeight <= 0 {
+		panic("goframe: VirtualTable requires positive Height and RowHeight")
+	}
+}
+
+func validateVirtualRangeDimensions(height int, itemHeight int) {
+	if height <= 0 || itemHeight <= 0 {
+		panic("goframe: virtual range requires positive Height and ItemHeight")
 	}
 }
 
 func calculateVirtualRange(length int, height int, itemHeight int, overscan int, scrollTop int) VirtualRange {
+	validateVirtualRangeDimensions(height, itemHeight)
 	visibleStart := virtualVisibleStart(length, itemHeight, scrollTop)
 	rangeStart := virtualRangeStartForVisibleStart(length, height, itemHeight, overscan, visibleStart)
 	return calculateVirtualRangeFromStart(length, height, itemHeight, overscan, rangeStart)
 }
 
 func calculateVirtualRangeFromStart(length int, height int, itemHeight int, overscan int, rangeStart int) VirtualRange {
-	validateVirtualDimensions("virtual range", height, itemHeight, "ItemHeight")
 	if length <= 0 {
 		return VirtualRange{}
 	}
@@ -351,29 +363,28 @@ func virtualViewportStyle(height int) string {
 }
 
 func virtualTableSpacerRow(name string, height int, columnCount int) Node {
+	heightValue := ToString(height)
 	return El("tr", Props{
 		"class":       "gf-virtual-table-spacer gf-virtual-table-spacer-" + name,
 		"aria-hidden": "true",
-		"style":       "height:" + ToString(height) + "px;overflow-anchor:none;",
+		"style":       "height:" + heightValue + "px;overflow-anchor:none;",
 	}, El("td", Props{
 		"colspan": virtualTableColumnCount(columnCount),
-		"style":   "height:" + ToString(height) + "px;padding:0;border:0;line-height:0;font-size:0;overflow-anchor:none;",
+		"style":   "height:" + heightValue + "px;padding:0;border:0;line-height:0;font-size:0;overflow-anchor:none;",
 	}))
 }
 
 func virtualTableContentRow(content Node, columnCount int) Node {
-	return El("tr", Props{
-		"class": "gf-virtual-table-content",
-	}, El("td", Props{
+	return El("tr", Props{}, El("td", Props{
 		"colspan": virtualTableColumnCount(columnCount),
 	}, content))
 }
 
-func virtualTableColumnCount(value int) string {
+func virtualTableColumnCount(value int) int {
 	if value <= 0 {
-		value = 1
+		return 1
 	}
-	return ToString(value)
+	return value
 }
 
 func joinVirtualClass(base string, extra string) string {

--- a/pkg/goframe/virtual_test.go
+++ b/pkg/goframe/virtual_test.go
@@ -183,15 +183,15 @@ func TestVirtualTableCreatesComponentBoundary(t *testing.T) {
 func TestVirtualTableColumnCount(t *testing.T) {
 	tests := []struct {
 		value int
-		want  string
+		want  int
 	}{
-		{value: 0, want: "1"},
-		{value: -1, want: "1"},
-		{value: 7, want: "7"},
+		{value: 0, want: 1},
+		{value: -1, want: 1},
+		{value: 7, want: 7},
 	}
 	for _, test := range tests {
 		if got := virtualTableColumnCount(test.value); got != test.want {
-			t.Fatalf("column count %d = %q, want %q", test.value, got, test.want)
+			t.Fatalf("column count %d = %d, want %d", test.value, got, test.want)
 		}
 	}
 }
@@ -199,7 +199,7 @@ func TestVirtualTableColumnCount(t *testing.T) {
 func TestVirtualTableSpacerRowUsesColumnCount(t *testing.T) {
 	row := virtualTableSpacerRow("top", 48, 7).(VNode)
 	cell := row.Children[0].(VNode)
-	if got := cell.Props["colspan"]; got != "7" {
+	if got := cell.Props["colspan"]; got != 7 {
 		t.Fatalf("spacer colspan = %#v, want 7", got)
 	}
 }
@@ -207,7 +207,7 @@ func TestVirtualTableSpacerRowUsesColumnCount(t *testing.T) {
 func TestVirtualTableContentRowUsesColumnCount(t *testing.T) {
 	row := virtualTableContentRow(Text("empty"), 7).(VNode)
 	cell := row.Children[0].(VNode)
-	if got := cell.Props["colspan"]; got != "7" {
+	if got := cell.Props["colspan"]; got != 7 {
 		t.Fatalf("content colspan = %#v, want 7", got)
 	}
 }
@@ -312,7 +312,7 @@ func TestVirtualTableKeysEmptyState(t *testing.T) {
 	}
 	row := requireVNode(t, empty.Node)
 	cell := requireVNode(t, row.Children[0])
-	if got := cell.Props["colspan"]; got != "7" {
+	if got := cell.Props["colspan"]; got != 7 {
 		t.Fatalf("empty colspan = %#v, want 7", got)
 	}
 }


### PR DESCRIPTION
### Summary

Reduces `VirtualTable` runtime WASM size with small behavior-preserving cleanups.

Related to #71.

This PR recovers dashboard raw-size headroom before retrying LIS work. It does not change the `VirtualTable` public API, fixed-row semantics, scroll behavior, or reconciliation behavior.

### What Changed

* Reused spacer height text inside `VirtualTable` spacer row rendering.
* Kept `colspan` as an integer and let normal prop stringification handle DOM output.
* Shortened unexported internal virtual table keys.
* Removed an unused fallback content row class from the internal fallback/empty content row.
* Preserved spacer class names used by smoke checks.
* Preserved public row keys, windowing behavior, and fixed-row rendering semantics.

### Scope

Narrow WASM runtime-size cleanup for `VirtualTable`.

### Non-Goals

* No public API changes.
* No `VirtualTable` API changes.
* No `VirtualList` API changes.
* No fixed-row behavior changes.
* No scroll/windowing behavior changes.
* No public key semantics changes.
* No error recovery changes.
* No event wrapper changes.
* No focus handling changes.
* No DOM batching.
* No reconciliation or LIS changes.
* No GOX/codegen changes.
* No `goxc` changes.
* No examples changes.
* No docs changes.
* No script or workflow changes.
* No size budget changes.
* No generated artifact commits.

### Size Results

Reported dashboard raw-size improvement:

* local Go 1.24.4 + TinyGo 0.41.1:
  * before: `169789 B / 168960 B`
  * after: `168934 B / 168960 B`
  * delta: `-855 B`
  * result: pass, `26 B` under budget

* CI-like Go 1.22.12 + TinyGo 0.41.1:
  * before: `168907 B / 168960 B`
  * after: `168052 B / 168960 B`
  * delta: `-855 B`
  * result: pass, `908 B` under budget

Other observed app impact:

* dashboard raw size decreased by `855 B`
* virtualized raw size decreased by about `843-844 B`
* no checked app raw-size increase observed
* gzip, brotli, and zstd budget checks passed

### Candidate Notes

Tried and reverted:

* hoisting row style string: no measured size win
* simplifying spacer class names: reverted because smoke scripts rely on top/bottom spacer class selectors

Kept:

* reused spacer height string: small behavior-neutral win
* kept `colspan` as int internally: measurable size win
* shortened internal virtual table keys: reduced linked string data
* removed unused fallback content row class: final size win

### Validation

Local validation reported:

* `go test ./pkg/goframe -run 'TestVirtual|Test.*Virtual'`
* `go test ./pkg/goframe`
* `go test ./...`
* `go vet ./...`
* `go test -tags=goframe_debug ./...`
* `go test -race ./pkg/... ./cmd/...`
* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `scripts/size-budget.sh`
* `bash -n scripts/browser-smoke.sh`
* `scripts/browser-smoke.sh`

Browser smoke passed for dashboard and virtualized examples.

### Notes

This restores some dashboard WASM headroom, but the budget remains tight.

LIS should still be retried only as a very small measured variant with strict size-budget validation.