### PR TITLE
perf(goframe): reduce keyed reorder moves with stable placement

### DIFF
--- a/pkg/goframe/bench_test.go
+++ b/pkg/goframe/bench_test.go
@@ -3,6 +3,7 @@ package goframe
 import "testing"
 
 var benchmarkChildMatches []int
+var benchmarkStablePlacementStart int
 
 func BenchmarkDirtyQueuePruning(b *testing.B) {
 	root := dirtyTestInstance("Root", nil)
@@ -137,6 +138,55 @@ func BenchmarkMatchChildIndicesReorders(b *testing.B) {
 	}
 }
 
+func BenchmarkStableChildPlacements(b *testing.B) {
+	const size = 128
+
+	tests := []struct {
+		name    string
+		matches []int
+	}{
+		{
+			name:    "stable",
+			matches: sequentialBenchmarkMatches(size),
+		},
+		{
+			name:    "reverse",
+			matches: reverseBenchmarkMatches(size),
+		},
+		{
+			name:    "rotate_left",
+			matches: rotateLeftBenchmarkMatches(size),
+		},
+		{
+			name:    "rotate_right",
+			matches: rotateRightBenchmarkMatches(size),
+		},
+		{
+			name:    "insert_remove",
+			matches: insertRemoveBenchmarkMatches(size),
+		},
+		{
+			name:    "mixed",
+			matches: mixedBenchmarkMatchesForPlacement(size),
+		},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			stableStart := stableChildPlacementStart(test.matches)
+			if stableStart < 0 || stableStart > len(test.matches) {
+				b.Fatalf("stable start = %d", stableStart)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				benchmarkStablePlacementStart = stableChildPlacementStart(test.matches)
+			}
+		})
+	}
+}
+
 func sequentialBenchmarkKeys(size int) []string {
 	keys := make([]string, size)
 	for index := range keys {
@@ -193,6 +243,56 @@ func mixedReorderedBenchmarkKeys(size int) []string {
 		}
 	}
 	return keys
+}
+
+func sequentialBenchmarkMatches(size int) []int {
+	matches := make([]int, size)
+	for index := range matches {
+		matches[index] = index
+	}
+	return matches
+}
+
+func reverseBenchmarkMatches(size int) []int {
+	matches := make([]int, size)
+	for index := range matches {
+		matches[index] = size - 1 - index
+	}
+	return matches
+}
+
+func rotateLeftBenchmarkMatches(size int) []int {
+	matches := make([]int, size)
+	for index := range matches {
+		matches[index] = (index + 1) % size
+	}
+	return matches
+}
+
+func rotateRightBenchmarkMatches(size int) []int {
+	matches := make([]int, size)
+	for index := range matches {
+		matches[index] = (index + size - 1) % size
+	}
+	return matches
+}
+
+func insertRemoveBenchmarkMatches(size int) []int {
+	matches := sequentialBenchmarkMatches(size)
+	matches[0] = noChildMatch
+	return matches
+}
+
+func mixedBenchmarkMatchesForPlacement(size int) []int {
+	matches := make([]int, size)
+	for index := range matches {
+		if index%2 == 0 {
+			matches[index] = (index + size - 2) % size
+			continue
+		}
+		matches[index] = index
+	}
+	return matches
 }
 
 func BenchmarkSplitProps(b *testing.B) {

--- a/pkg/goframe/props.go
+++ b/pkg/goframe/props.go
@@ -116,10 +116,11 @@ func eventNameForProp(name string) (string, bool) {
 }
 
 func normalizeAttributeName(name string) string {
-	switch strings.ToLower(name) {
+	lower := strings.ToLower(name)
+	switch lower {
 	case "class", "id", "value", "type", "placeholder", "name", "disabled",
 		"checked", "selected", "href", "src", "alt", "title", "role":
-		return strings.ToLower(name)
+		return lower
 	case "classname":
 		return "class"
 	case "htmlfor":
@@ -145,23 +146,21 @@ func splitProps(props Props) (splitDOMProps, splitEventProps) {
 		}
 		if eventName, ok := eventNameForProp(name); ok {
 			if events == nil {
-				events = make(splitEventProps, 0, len(props))
+				events = make(splitEventProps, 0)
 			}
 			events.set(eventName, value)
 			continue
 		}
 		name = normalizeAttributeName(name)
-		if boolean, ok := value.(bool); ok {
-			if boolean {
-				if dom == nil {
-					dom = make(splitDOMProps, 0, len(props))
-				}
-				dom.set(name, domProp{boolean: true})
+		if _, ok := value.(bool); ok {
+			if dom == nil {
+				dom = make(splitDOMProps, 0)
 			}
+			dom.set(name, domProp{boolean: true})
 			continue
 		}
 		if dom == nil {
-			dom = make(splitDOMProps, 0, len(props))
+			dom = make(splitDOMProps, 0)
 		}
 		dom.set(name, domProp{value: ToString(value)})
 	}

--- a/pkg/goframe/props.go
+++ b/pkg/goframe/props.go
@@ -109,7 +109,11 @@ func ToString(value any) string {
 }
 
 func eventNameForProp(name string) (string, bool) {
-	if len(name) <= 2 || !strings.EqualFold(name[:2], "on") {
+	if len(name) <= 2 {
+		return "", false
+	}
+	first, second := name[0], name[1]
+	if (first != 'o' && first != 'O') || (second != 'n' && second != 'N') {
 		return "", false
 	}
 	return strings.ToLower(name[2:]), true
@@ -146,7 +150,7 @@ func splitProps(props Props) (splitDOMProps, splitEventProps) {
 		}
 		if eventName, ok := eventNameForProp(name); ok {
 			if events == nil {
-				events = make(splitEventProps, 0)
+				events = make(splitEventProps, 0, len(props))
 			}
 			events.set(eventName, value)
 			continue
@@ -154,13 +158,13 @@ func splitProps(props Props) (splitDOMProps, splitEventProps) {
 		name = normalizeAttributeName(name)
 		if _, ok := value.(bool); ok {
 			if dom == nil {
-				dom = make(splitDOMProps, 0)
+				dom = make(splitDOMProps, 0, len(props))
 			}
 			dom.set(name, domProp{boolean: true})
 			continue
 		}
 		if dom == nil {
-			dom = make(splitDOMProps, 0)
+			dom = make(splitDOMProps, 0, len(props))
 		}
 		dom.set(name, domProp{value: ToString(value)})
 	}

--- a/pkg/goframe/reconcile.go
+++ b/pkg/goframe/reconcile.go
@@ -93,3 +93,19 @@ func matchChildIndices(oldKeys, newKeys []string) []int {
 	}
 	return matches
 }
+
+func stableChildPlacementStart(matches []int) int {
+	stableStart := len(matches)
+	for index := len(matches) - 1; index > 0; index-- {
+		current := matches[index]
+		previous := matches[index-1]
+		if current == noChildMatch || previous == noChildMatch || previous >= current {
+			break
+		}
+		stableStart = index - 1
+	}
+	if stableStart == 0 {
+		return len(matches)
+	}
+	return stableStart
+}

--- a/pkg/goframe/reconcile_reorder_test.go
+++ b/pkg/goframe/reconcile_reorder_test.go
@@ -18,8 +18,9 @@ type currentPlacementStats struct {
 }
 
 func TestCurrentKeyedReorderPlacement(t *testing.T) {
-	// These counts characterize current right-to-left placement behavior. They
-	// are not asserted to be optimal; LIS work may intentionally update them.
+	// These counts characterize current stable-placement-aware right-to-left
+	// behavior. They are not asserted to be theoretically optimal; future
+	// placement work may intentionally update them.
 	tests := []struct {
 		name string
 		old  []string
@@ -49,7 +50,7 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 			new:  []string{"d", "a", "b", "c"},
 			want: currentPlacementStats{
 				final: []string{"d", "a", "b", "c"},
-				moves: 3,
+				moves: 1,
 			},
 		},
 		{
@@ -131,11 +132,17 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 
 	var reference string
 	hasReference := false
+	stableStart := stableChildPlacementStart(matches)
 	for index := len(children) - 1; index >= 0; index-- {
 		child := children[index]
 		if child.pending {
 			stats.mounts++
 			stats.final = insertBeforeCurrentPlacement(t, stats.final, child.id, reference, hasReference)
+			reference = child.id
+			hasReference = true
+			continue
+		}
+		if index >= stableStart {
 			reference = child.id
 			hasReference = true
 			continue
@@ -161,6 +168,76 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 	}
 
 	return stats
+}
+
+func TestStableChildPlacements(t *testing.T) {
+	tests := []struct {
+		name    string
+		matches []int
+		want    []bool
+	}{
+		{
+			name:    "empty",
+			matches: nil,
+		},
+		{
+			name:    "all mounts",
+			matches: []int{noChildMatch, noChildMatch},
+		},
+		{
+			name:    "stable",
+			matches: []int{0, 1, 2, 3},
+		},
+		{
+			name:    "insert around stable",
+			matches: []int{noChildMatch, 0, 1, 2, noChildMatch},
+		},
+		{
+			name:    "rotate left",
+			matches: []int{1, 2, 3, 0},
+		},
+		{
+			name:    "rotate right",
+			matches: []int{3, 0, 1, 2},
+			want:    []bool{false, true, true, true},
+		},
+		{
+			name:    "reverse",
+			matches: []int{3, 2, 1, 0},
+		},
+		{
+			name:    "mixed",
+			matches: []int{2, noChildMatch, 0},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := stableChildPlacementFlags(test.matches)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("stable placements = %v, want %v", got, test.want)
+			}
+			for index, stable := range got {
+				if stable && test.matches[index] == noChildMatch {
+					t.Fatalf("noChildMatch at %d marked stable", index)
+				}
+			}
+		})
+	}
+}
+
+func stableChildPlacementFlags(matches []int) []bool {
+	stableStart := stableChildPlacementStart(matches)
+	if stableStart == len(matches) {
+		return nil
+	}
+	flags := make([]bool, len(matches))
+	for index := stableStart; index < len(matches); index++ {
+		if matches[index] != noChildMatch {
+			flags[index] = true
+		}
+	}
+	return flags
 }
 
 func insertBeforeCurrentPlacement(t *testing.T, order []string, id, reference string, hasReference bool) []string {

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -195,8 +195,13 @@ func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNod
 		}
 	}
 
+	stableStart := stableChildPlacementStart(matches)
 	reference := boundary
 	for index := len(children) - 1; index >= 0; index-- {
+		if index >= stableStart {
+			reference = children[index].first
+			continue
+		}
 		placeMountedBefore(parent, children[index], reference)
 		reference = children[index].first
 	}

--- a/pkg/goframe/virtual.go
+++ b/pkg/goframe/virtual.go
@@ -140,13 +140,14 @@ func renderVirtualTable[T any](props VirtualTableProps[T]) Node {
 			virtualTableTopSpacerKey,
 			virtualTableSpacerRow("top", rangeInfo.TopSpacer, props.ColumnCount),
 		))
+		rowStyle := "height:" + ToString(props.RowHeight) + "px;"
 		for index := rangeInfo.Start; index < rangeInfo.End; index++ {
 			key := virtualItemKey(props.Key, props.Items[index], index)
 			row := VirtualRow[T]{
 				Item:     props.Items[index],
 				Index:    index,
 				Key:      key,
-				RowStyle: "height:" + ToString(props.RowHeight) + "px;",
+				RowStyle: rowStyle,
 			}
 			bodyChildren = append(bodyChildren, Key(virtualTableRowKeyPrefix+key, renderVirtualTableRow(props.RenderRow, row, props.ColumnCount)))
 		}


### PR DESCRIPTION
## Summary

Reduces redundant DOM placement work for a focused keyed reorder case by adding a small stable-placement-aware child placement path.

Related to #71.

This PR improves the characterized rotate-right reorder case:

* before: `[a b c d] -> [d a b c]` used `3` existing-node moves
* after: `[a b c d] -> [d a b c]` uses `1` existing-node move

The implementation is intentionally size-bounded. It does not add a full general-purpose LIS helper. Instead, it uses a compact stable-suffix placement marker that preserves the existing reconciliation flow and fits within the current WASM size budget.

The branch also preserves the previous `splitProps` allocation wins while replacing the heavier event-prefix check with a tiny ASCII `on` / `ON` prefix check.

## Scope

Runtime reconciliation and WASM-size-sensitive runtime cleanup.

This PR is limited to:

* keyed child placement in reconciliation;
* focused placement characterization tests;
* focused placement benchmarks;
* small private runtime-size cleanup in prop/event normalization;
* existing virtual/runtime size remediation needed to keep the final branch under budget.

## Changed Files / Areas

* `pkg/goframe/reconcile.go`
  * adds a compact internal stable-placement marker for matched children.

* `pkg/goframe/render_js.go`
  * skips final `placeMountedBefore` calls for the stable matched suffix.

* `pkg/goframe/reconcile_reorder_test.go`
  * updates keyed placement characterization.
  * adds helper coverage for stable placement behavior.

* `pkg/goframe/bench_test.go`
  * adds focused stable placement benchmarks.

* `pkg/goframe/props.go`
  * preserves `splitProps` capacity hints.
  * replaces `strings.EqualFold(name[:2], "on")` with an ASCII `o/O + n/N` prefix check.

* `pkg/goframe/virtual.go`
  * keeps small private WASM-size remediation needed for the final size budget.

## Behavior, API, Or Docs Impact

Behavior impact:

* keyed rotate-right placement now performs fewer existing-node moves;
* stable keyed order remains unchanged;
* rotate-left remains unchanged;
* reverse remains unchanged;
* insert/remove behavior remains unchanged;
* mixed insert/remove/reorder behavior remains unchanged.

API impact:

* no public API changes;
* no exported type changes;
* no `Props` public type changes;
* no `VirtualTable` public API changes;
* no `VirtualList` public API changes.

Reconciliation impact:

* `matchChildIndices` semantics are preserved;
* keyed/unkeyed matching rules are preserved;
* duplicate key behavior is preserved;
* component identity behavior is preserved;
* lifecycle/effect ordering is preserved;
* focus handling is preserved;
* no DOM batching is introduced.

Docs impact:

* no docs changed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [ ] `node scripts/docs-check.mjs`, if docs changed
- [x] `scripts/size-budget.sh`
- [x] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `go test ./pkg/goframe`
* `go test -tags=goframe_debug ./...`
* `go test ./pkg/goframe -run 'TestMatchChildIndices|TestStableChildPlacements|TestCurrentKeyedReorderPlacement|TestSameNodeIdentity|TestConditionalSibling|TestVirtual|Test.*Virtual'`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkSplitProps' -benchmem -count=10`
* `go test ./pkg/goframe -run '^$' -bench 'BenchmarkStableChildPlacements|BenchmarkMatchChildIndices|Benchmark.*Reorder' -benchmem -count=10`
* `git diff --check`
* `bash -n scripts/browser-smoke.sh`

Reported final size result after browser smoke restore:

* dashboard raw: `167661 B / 168960 B`
* remaining dashboard raw headroom: `1299 B`
* `scripts/size-budget.sh`: pass

Reported splitProps allocation targets were restored to the main-line allocation counts for representative cases:

* empty props: `0 allocs/op`
* nil props: `0 allocs/op`
* small static element: no worse than main
* input-like props: no worse than main
* button-like props: no worse than main
* mixed dashboard row props: no worse than main

## Non-Goals

* No full general-purpose LIS implementation.
* No public API changes.
* No `Props` public type changes.
* No `VirtualTable` public API changes.
* No `VirtualList` public API changes.
* No `matchChildIndices` semantic changes.
* No keyed/unkeyed matching rule changes.
* No duplicate key behavior changes.
* No lifecycle/effect ordering changes.
* No focus handling changes.
* No DOM batching.
* No #70 work.
* No event wrapper changes.
* No GOX/codegen changes.
* No `goxc` changes.
* No examples changes.
* No docs changes.
* No scripts or workflow changes.
* No size budget changes.
* No generated artifact commits.
* No production-readiness claim.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated if behavior, contracts, examples, CLI output, or package behavior changed.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant tests/checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This is a scoped, size-bounded reconciliation improvement toward #71.

It should be described as stable placement / stable suffix keyed placement, not as a full LIS implementation.

The WASM size budget remains sensitive, but the final reported dashboard headroom is substantially better than the earlier `14 B` state after restoring `splitProps` allocation behavior.