### PR TITLE
fix(goframe): invalidate stale scheduled updates after batch reset

### DIFF
--- a/pkg/goframe/state.go
+++ b/pkg/goframe/state.go
@@ -13,6 +13,7 @@ type stateHandle[T any] struct {
 
 type updateBatch struct {
 	pending bool
+	epoch   int
 }
 
 func (batch *updateBatch) request(enqueue func(func()), update func()) {
@@ -20,7 +21,11 @@ func (batch *updateBatch) request(enqueue func(func()), update func()) {
 		return
 	}
 	batch.pending = true
+	epoch := batch.epoch
 	enqueue(func() {
+		if epoch != batch.epoch {
+			return
+		}
 		batch.pending = false
 		update()
 	})
@@ -28,6 +33,7 @@ func (batch *updateBatch) request(enqueue func(func()), update func()) {
 
 func (batch *updateBatch) reset() {
 	batch.pending = false
+	batch.epoch++
 }
 
 // UseState returns the state value at the current component render position

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -449,7 +449,7 @@ func TestUseReducerDispatchSamePrimitiveValueDoesNotSchedule(t *testing.T) {
 	}
 }
 
-func TestUpdateBatchCoalescesRequests(t *testing.T) {
+func TestUpdateBatchCoalescesPendingRequests(t *testing.T) {
 	var batch updateBatch
 	var queued []func()
 	enqueue := func(update func()) {
@@ -464,14 +464,49 @@ func TestUpdateBatchCoalescesRequests(t *testing.T) {
 	if len(queued) != 1 {
 		t.Fatalf("queued updates = %d, want 1", len(queued))
 	}
+	if updates != 0 {
+		t.Fatalf("updates before queued callback = %d, want 0", updates)
+	}
 	queued[0]()
 	if updates != 1 {
 		t.Fatalf("updates = %d, want 1", updates)
 	}
+}
+
+func TestUpdateBatchAllowsRequestAfterFlush(t *testing.T) {
+	var batch updateBatch
+	var queued []func()
+	enqueue := func(update func()) {
+		queued = append(queued, update)
+	}
+	updates := 0
+
+	batch.request(enqueue, func() { updates++ })
+	queued[0]()
 
 	batch.request(enqueue, func() { updates++ })
 	if len(queued) != 2 {
 		t.Fatalf("queued updates after flush = %d, want 2", len(queued))
+	}
+	queued[1]()
+	if updates != 2 {
+		t.Fatalf("updates = %d, want 2", updates)
+	}
+}
+
+func TestUpdateBatchResetClearsPendingRequest(t *testing.T) {
+	var batch updateBatch
+	var queued []func()
+	enqueue := func(update func()) {
+		queued = append(queued, update)
+	}
+
+	batch.request(enqueue, func() {})
+	batch.reset()
+	batch.request(enqueue, func() {})
+
+	if len(queued) != 2 {
+		t.Fatalf("queued updates after reset = %d, want 2", len(queued))
 	}
 }
 

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -510,6 +510,46 @@ func TestUpdateBatchResetClearsPendingRequest(t *testing.T) {
 	}
 }
 
+func TestUpdateBatchResetInvalidatesQueuedRequest(t *testing.T) {
+	var batch updateBatch
+	var queued []func()
+	enqueue := func(update func()) {
+		queued = append(queued, update)
+	}
+	updateA := 0
+	updateB := 0
+
+	batch.request(enqueue, func() { updateA++ })
+	if len(queued) != 1 {
+		t.Fatalf("queued updates = %d, want 1", len(queued))
+	}
+	if updateA != 0 {
+		t.Fatalf("updateA before queued callback = %d, want 0", updateA)
+	}
+
+	batch.reset()
+	batch.request(enqueue, func() { updateB++ })
+	if len(queued) != 2 {
+		t.Fatalf("queued updates after reset = %d, want 2", len(queued))
+	}
+
+	queued[0]()
+	if updateA != 0 {
+		t.Fatalf("stale updateA ran %d time(s), want 0", updateA)
+	}
+	if updateB != 0 {
+		t.Fatalf("updateB before current callback = %d, want 0", updateB)
+	}
+
+	queued[1]()
+	if updateB != 1 {
+		t.Fatalf("updateB = %d, want 1", updateB)
+	}
+	if len(queued) != 2 {
+		t.Fatalf("queued updates after callbacks = %d, want 2", len(queued))
+	}
+}
+
 func testComponentInstance(name string, render func() Node, schedule func(*componentInstance)) *componentInstance {
 	node := Component(name, struct{}{}, func(struct{}) Node {
 		return render()

--- a/scripts/todo-browser-smoke.mjs
+++ b/scripts/todo-browser-smoke.mjs
@@ -84,6 +84,8 @@ try {
                 listSame: window.__list === document.querySelector("#todo-list"),
                 active: document.activeElement.id,
                 value: document.querySelector("#todo-input").value,
+                selectionStart: document.querySelector("#todo-input").selectionStart,
+                selectionEnd: document.querySelector("#todo-input").selectionEnd,
                 appRenderDelta: (window.goframeComponentRenderCounts.App || 0) - baseline.appRenders,
                 headerRenderDelta: (window.goframeComponentRenderCounts.Header || 0) - baseline.headerRenders,
                 formRenderDelta: (window.goframeComponentRenderCounts.TodoForm || 0) - baseline.formRenders,
@@ -105,6 +107,8 @@ try {
             listSame: true,
             active: "todo-input",
             value: "B",
+            selectionStart: 1,
+            selectionEnd: 1,
             appRenderDelta: 0,
             headerRenderDelta: 0,
             formRenderDelta: 1,
@@ -282,6 +286,7 @@ async function typeTodo(client, text) {
         const input = document.querySelector("#todo-input");
         input.focus();
         input.value = ${JSON.stringify(text)};
+        input.setSelectionRange(input.value.length, input.value.length);
         if (window.__GOFRAME_DEBUG__) {
             for (const key of Object.keys(window.__GOFRAME_DEBUG__.operations)) {
                 window.__GOFRAME_DEBUG__.operations[key] = 0;


### PR DESCRIPTION
## Summary

Fixes a scheduler correctness edge case in `updateBatch`.

Related to #70.

Before this change, a callback queued before `updateBatch.reset()` could still run later and execute stale update work. This could also interfere with a newer pending scheduled update.

This PR adds a private batch epoch so queued callbacks are invalidated when the batch is reset.

The branch also keeps the scheduler/focus evidence added while investigating #70:

* `updateBatch` coalesces pending requests;
* `updateBatch` allows scheduling again after a valid flush;
* `reset()` clears pending scheduling state;
* stale callbacks queued before reset are ignored;
* the todo browser smoke now verifies focused input selection preservation during dirty updates.

This is a narrow scheduler correctness fix. It does not implement a full commit buffer or DOM mutation queue.

## Scope

Runtime scheduler correctness and focused browser evidence.

This PR is limited to:

* `updateBatch` reset invalidation;
* focused unit tests for `updateBatch`;
* strengthened todo browser smoke coverage for input selection preservation.

## Changed Files / Areas

* `pkg/goframe/state.go`
  * adds a private `epoch` field to `updateBatch`;
  * queued callbacks capture the epoch;
  * callbacks whose epoch was invalidated by `reset()` return without running stale update work.

* `pkg/goframe/state_test.go`
  * covers request coalescing;
  * covers scheduling after a valid flush;
  * covers reset allowing a new request;
  * covers reset invalidating stale queued callbacks.

* `scripts/todo-browser-smoke.mjs`
  * asserts `selectionStart` / `selectionEnd` are preserved after the dirty update path;
  * keeps existing active input, DOM identity, render count, patch count, and mutation assertions.

## Behavior, API, Or Docs Impact

Behavior impact:

* stale scheduled callbacks created before `updateBatch.reset()` are now ignored;
* stale callbacks cannot clear a newer pending request;
* valid scheduled callbacks still clear `pending` before running their update;
* request coalescing behavior is preserved;
* request-after-flush behavior is preserved;
* focus and selection preservation behavior is covered by browser smoke.

API impact:

* no public API changes;
* no scheduler API added;
* no hook API changes.

Docs impact:

* no docs changed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [x] `scripts/size-budget.sh`
- [x] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `go test ./pkg/goframe -run 'TestUpdateBatch'`
* `go test ./pkg/goframe -run 'TestUpdateBatch|TestState|TestUseReducer|TestDirty|TestSameNodeIdentity|TestConditionalSibling'`
* `node --check scripts/todo-browser-smoke.mjs`
* `go test ./pkg/goframe`
* `go test -tags=goframe_debug ./...`
* `git diff --check`
* `bash -n scripts/browser-smoke.sh`

Reported size result:

* dashboard raw before browser smoke: `167661 B / 168960 B`
* dashboard raw after browser smoke: `167783 B / 168960 B`
* remaining dashboard raw headroom: `1177 B`
* `scripts/size-budget.sh`: pass

## Non-Goals

* No full commit-buffer implementation.
* No DOM mutation queue.
* No reconciliation rewrite.
* No public scheduler API.
* No public API changes.
* No focus behavior rewrite.
* No event wrapper changes.
* No GOX/codegen changes.
* No `goxc` changes.
* No examples changes.
* No docs changes.
* No workflow changes.
* No size budget changes.
* No generated artifact commits.
* No production-readiness claim.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated if behavior, contracts, examples, CLI output, or package behavior changed.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant tests/checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This PR partially addresses the scheduler/focus direction from #70 by fixing a concrete reset invalidation bug in the existing batching layer.

The broader commit-buffer / DOM mutation queue architecture remains a separate future decision.