### PR TITLE
fix(gox): reject keyword component prop names

### DIFF
--- a/pkg/gox/codegen.go
+++ b/pkg/gox/codegen.go
@@ -3,6 +3,7 @@ package gox
 import (
 	"bytes"
 	"fmt"
+	gotoken "go/token"
 	"html"
 	"path/filepath"
 	"strconv"
@@ -204,7 +205,7 @@ func (ctx *codegenContext) writeComponent(output *bytes.Buffer, component *Eleme
 	fmt.Fprintf(&body, "gf.ComponentT(%s, %s{\n", ctx.componentTypeExpression(componentInfo), componentInfo.propsType)
 	for _, attribute := range attributes {
 		if !validGoIdentifier(attribute.Name) {
-			return fmt.Errorf("gox: component prop %q must be a Go field name", attribute.Name)
+			return fmt.Errorf("gox: component prop %q is not a valid Go field name", attribute.Name)
 		}
 		writeIndent(&body, depth+1)
 		fmt.Fprintf(&body, "%s: ", attribute.Name)
@@ -485,6 +486,9 @@ func isComponent(tag string) bool {
 }
 
 func validGoIdentifier(value string) bool {
+	if gotoken.IsKeyword(value) {
+		return false
+	}
 	characters := []rune(value)
 	if len(characters) == 0 || !unicode.IsLetter(characters[0]) && characters[0] != '_' {
 		return false

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -76,6 +76,76 @@ func App() gf.Node {
 	}
 }
 
+func TestGenerateRejectsKeywordComponentProps(t *testing.T) {
+	keywords := []string{
+		"break", "default", "func", "interface", "select",
+		"case", "defer", "go", "map", "struct",
+		"chan", "else", "goto", "package", "switch",
+		"const", "fallthrough", "if", "range", "type",
+		"continue", "for", "import", "return", "var",
+	}
+	for _, keyword := range keywords {
+		t.Run(keyword, func(t *testing.T) {
+			source := []byte(`package main
+
+func View() any {
+	return <Button ` + keyword + `="x" />
+}
+`)
+			_, err := GenerateNamed("keyword_component_prop.gox", source)
+			if err == nil {
+				t.Fatal("GenerateNamed() returned nil error")
+			}
+			want := `component prop "` + keyword + `" is not a valid Go field name`
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %q, want %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestGenerateAllowsDOMTypeAttributeAndComponentPseudoProps(t *testing.T) {
+	source := []byte(`package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type ButtonProps struct {
+	Label string
+}
+
+func Button(props ButtonProps) gf.Node {
+	return <button type="button">{props.Label}</button>
+}
+
+func View() gf.Node {
+	return (
+		<form>
+			<input type="text" />
+			<Button Key="save" Label="Save" />
+		</form>
+	)
+}
+`)
+	generated, err := Generate(source)
+	if err != nil {
+		t.Fatalf("Generate() error: %v", err)
+	}
+	if _, err := parser.ParseFile(gotoken.NewFileSet(), "valid_props.gox.go", generated, parser.AllErrors); err != nil {
+		t.Fatalf("generated Go does not parse: %v\n%s", err, generated)
+	}
+	text := string(generated)
+	for _, want := range []string{
+		`"type": "text"`,
+		`"type": "button"`,
+		`Label: "Save"`,
+		`gf.Key("save"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("generated source does not contain %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestGenerateFileToWithOptionsWritesExplicitOutput(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "src", "view.gox")

--- a/pkg/gox/parser.go
+++ b/pkg/gox/parser.go
@@ -107,7 +107,7 @@ func (parser *Parser) parseOpenedNode() (Node, error) {
 			return element, nil
 		case tokenIdentifier:
 			if component && next.value != "Key" && !validGoIdentifier(next.value) {
-				return nil, parser.lexer.errorAt(next.offset, "component prop %q must be a Go field name", next.value)
+				return nil, parser.lexer.errorAt(next.offset, "component prop %q is not a valid Go field name", next.value)
 			}
 			if next.value == "Key" {
 				if seenKey {

--- a/pkg/gox/testdata/errors/invalid_component_prop.golden.txt
+++ b/pkg/gox/testdata/errors/invalid_component_prop.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/invalid_component_prop.gox:4:17: component prop "bad-prop" must be a Go field name
+testdata/errors/invalid_component_prop.gox:4:17: component prop "bad-prop" is not a valid Go field name
   <Button bad-prop="x" />

--- a/pkg/gox/testdata/errors/keyword_component_prop_func.golden.txt
+++ b/pkg/gox/testdata/errors/keyword_component_prop_func.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/keyword_component_prop_func.gox:4:17: component prop "func" is not a valid Go field name
+  <Button func="x" />

--- a/pkg/gox/testdata/errors/keyword_component_prop_func.gox
+++ b/pkg/gox/testdata/errors/keyword_component_prop_func.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <Button func="x" />
+}

--- a/pkg/gox/testdata/errors/keyword_component_prop_type.golden.txt
+++ b/pkg/gox/testdata/errors/keyword_component_prop_type.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/keyword_component_prop_type.gox:4:17: component prop "type" is not a valid Go field name
+  <Button type="x" />

--- a/pkg/gox/testdata/errors/keyword_component_prop_type.gox
+++ b/pkg/gox/testdata/errors/keyword_component_prop_type.gox
@@ -1,0 +1,5 @@
+package demo
+
+func View() any {
+	return <Button type="x" />
+}


### PR DESCRIPTION
## Summary

Reject Go keyword component prop names before GOX codegen emits invalid Go.

Addresses GOX audit finding GF-GOX-001.

During the compiler audit, fuzzing found that a capitalized component tag could accept a prop named like a Go keyword, such as `type`, and then generate invalid Go:

`type: "..."`

This PR turns that failure into a focused source-level GOX diagnostic instead of allowing the invalid generated Go path.

## Scope

This PR is limited to GOX component prop identifier validation and regression coverage.

It does not expand the GOX grammar and does not change runtime behavior.

## Changed Files / Areas

* `pkg/gox/codegen.go`
  * imports `go/token`;
  * updates `validGoIdentifier` so Go keywords are rejected;
  * aligns the codegen fallback diagnostic wording for invalid component prop names.

* `pkg/gox/parser.go`
  * returns the focused component prop diagnostic before codegen for invalid component field names.

* `pkg/gox/generate_test.go`
  * adds coverage for all Go keywords as rejected component prop names;
  * verifies DOM `type` attributes still generate quoted `gf.Props` entries;
  * verifies valid component props still work;
  * verifies `Key` pseudo-prop behavior is preserved.

* `pkg/gox/testdata/errors/*`
  * adds keyword component prop error goldens for `type` and `func`;
  * updates the existing invalid component prop golden to the new diagnostic wording.

## Behavior, API, Or Docs Impact

Behavior impact:

* component prop names that are Go keywords are now rejected with a source-level GOX diagnostic;
* GOX no longer reaches the raw generated-Go parser failure for this case;
* DOM/lowercase element attributes such as `<input type="text" />` are unchanged;
* valid component prop fields are unchanged;
* `Key` pseudo-prop behavior is unchanged.

API impact:

* no public API changes.

Docs impact:

* no docs changed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [ ] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `go test ./pkg/gox`
* `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
* `go test ./pkg/gox -run 'TestGenerateRejectsKeywordComponentProps|TestGenerateAllowsDOMTypeAttributeAndComponentPseudoProps'`
* `go test ./pkg/gox -run=FuzzParseElement -fuzz=FuzzParseElement -fuzztime=10s`
* `go test ./pkg/gox -run=FuzzGenerate -fuzz=FuzzGenerate -fuzztime=10s`
* `go test ./cmd/goxc -run 'Test.*GOX|Test.*Gox|Test.*Generate|Test.*Workspace|Test.*Component'`

## Non-Goals

* No GOX grammar expansion.
* No formatter work.
* No LSP work.
* No broad parser rewrite.
* No broad codegen rewrite.
* No `cmd/goxc` package/export/workspace cleanup.
* No runtime changes.
* No examples changes.
* No docs changes.
* No workflow changes.
* No generated `.gox.go` files.
* No committed fuzz corpus.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated if behavior, contracts, examples, CLI output, or package behavior changed.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant tests/checks are listed above.
- [x] This branch is based on current `main`.

## Notes

The fuzz-generated seed was not committed because the repository does not currently use committed fuzz corpus files for this package.

The behavior is covered by deterministic tests and error goldens instead.

The GOX audit should resume after this fix is merged and CI is green.