### PR TITLE
fix(goxc): return nonzero for failed doctor checks

### DIFF
--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -595,6 +595,25 @@ func TestDoctorDoesNotFail(t *testing.T) {
 	}
 }
 
+func TestDoctorReturnsErrorWhenRequiredChecksFail(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	var err error
+	output := captureStdout(t, func() {
+		err = doctorCommand(nil)
+	})
+	if err == nil {
+		t.Fatal("doctorCommand() returned nil error for required check failure")
+	}
+	for _, want := range []string{
+		"Go:           not found",
+		"Status: errors found",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestStaticHandlerServesWASMContentType(t *testing.T) {
 	directory := t.TempDir()
 	if err := os.Mkdir(filepath.Join(directory, "assets"), 0o755); err != nil {
@@ -710,6 +729,33 @@ func captureStderr(t *testing.T, fn func()) string {
 	os.Stderr = writer
 	defer func() {
 		os.Stderr = old
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = old
 	}()
 
 	fn()

--- a/cmd/goxc/doctor.go
+++ b/cmd/goxc/doctor.go
@@ -82,6 +82,7 @@ func doctorCommand(args []string) error {
 	switch {
 	case failures > 0:
 		fmt.Println("Status: errors found")
+		return errors.New("doctor: required checks failed")
 	case warnings > 0:
 		fmt.Println("Status: ok with warnings")
 	default:


### PR DESCRIPTION
## Summary

Makes `goxc doctor` return a nonzero error when required checks fail.

Addresses toolchain audit finding GF-GOXC-001.

Before this change, `goxc doctor` could print:

`Status: errors found`

but still return success. That made the command unreliable as a local diagnostic gate for users, scripts, or release checks.

This PR preserves the existing doctor output and required/optional check split, but returns an error when required checks fail.

## Scope

This PR is limited to `goxc doctor` exit behavior and focused test coverage.

It does not add new doctor probes and does not change build, package, export, serve, clean, runtime, or GOX compiler behavior.

## Changed Files / Areas

* `cmd/goxc/doctor.go`
  * returns `doctor: required checks failed` when required doctor checks fail;
  * preserves `Status: errors found`;
  * keeps warning-only doctor runs successful.

* `cmd/goxc/cli_test.go`
  * adds deterministic coverage for failed required doctor checks;
  * simulates a missing required `go` tool with an empty `PATH`;
  * verifies the command returns an error while still printing the expected diagnostic output;
  * adds a small stdout capture helper for the doctor test.

## Behavior, API, Or Docs Impact

Behavior impact:

* `goxc doctor` now exits nonzero when required checks fail;
* `goxc doctor` still exits zero when required checks pass;
* warning-only doctor output remains non-fatal;
* existing user-readable diagnostic output is preserved.

API impact:

* no public Go API changes.

Docs impact:

* no docs changed;
* no documented command output text changed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [ ] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `go test ./cmd/goxc`
* `go test ./cmd/goxc -run 'Test.*Doctor'`
* `go test ./cmd/goxc -run 'Test.*Doctor|Test.*CLI|Test.*Command|Test.*Version'`
* `go test ./pkg/gox`
* `go run ./cmd/goxc doctor`
* `git diff --check HEAD~1..HEAD`
* `git status --short --untracked-files=all`

## Non-Goals

* No release prep.
* No release notes.
* No new doctor probes.
* No broad CLI framework rewrite.
* No runtime changes.
* No `pkg/gox` changes.
* No package/build/export workflow changes.
* No serve behavior changes.
* No clean behavior changes.
* No workspace/module changes.
* No docs changes.
* No examples changes.
* No scripts or workflow changes.
* No generated artifacts.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated if behavior, contracts, examples, CLI output, or package behavior changed.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant tests/checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This is the only focused toolchain cleanup from the `cmd/goxc` audit that is worth landing before release prep.

After this PR is merged and CI is green, release prep for `v0.2.0-preview.4` can start.