### PR TITLE
docs(release): prepare v0.2.0 preview 4 notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -56,7 +56,7 @@ body:
     attributes:
       label: Checklist
       options:
-        - label: I understand v0.1.0-preview.1 is experimental and this request is not a preview promise.
+        - label: I understand the current preview is experimental and this request is not a preview promise.
           required: true
         - label: I described the smallest useful scope rather than a broad rewrite.
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- `v0.2.0-preview.4` release notes documenting runtime hot-path work, WASM
+  size headroom recovery, keyed placement behavior, scheduler reset
+  correctness, GOX diagnostics, `goxc doctor` exit behavior, community docs,
+  branding assets, audit outcomes, compatibility notes, and remaining preview
+  limits.
+- Newcomer-first README structure with Quick Start near the top, a branded hero
+  header, and links to the current preview notes.
+- Lightweight GoFrame brand assets under `assets/brand/`, including the project
+  mark, 128px PNG export, brand README, and no-affiliation disclaimer.
+- Real repository CODEOWNERS coverage, clarified NOTICE ownership, and polished
+  CONTRIBUTING, SECURITY, and code-of-conduct wording for the current
+  browser/WASM preview.
+- Runtime, GOX, and `cmd/goxc` audit passes completed with no blocker or
+  high-severity findings after focused follow-up fixes.
 - Hashed asset packaging for `goxc package`, including `assets/`,
   `asset-manifest.json`, `goframe-package.json`, preload hints, and
   `bundle.wasm` naming.
@@ -155,6 +169,18 @@
 
 ### Fixed
 
+- `splitProps` allocation behavior was characterized and reduced for common
+  runtime prop paths while preserving nil and empty zero-allocation behavior.
+- `VirtualTable` runtime code was reduced to recover dashboard WASM size
+  headroom.
+- Keyed child placement now avoids redundant moves for the stable suffix
+  pattern, reducing the characterized rotate-right existing-node move count
+  from three to one without implementing a full LIS reconciler.
+- Scheduler reset now invalidates stale queued update callbacks so pre-reset
+  work cannot run after a newer request is queued.
+- GOX now rejects Go keyword component prop names before codegen with
+  source-level diagnostics, while preserving DOM attributes such as `type`.
+- `goxc doctor` now returns nonzero when required checks fail.
 - The router-dashboard route Error Boundary fallback now distinguishes retrying
   the current crashing route from safely navigating back to the issues list, and
   browser smoke covers recovery from `?panic=render` without reloading the

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ it does not write generated `.gox.go` files next to authored source by default.
 - [API stability](docs/api-stability.md) and
   [platform support](docs/platform-support.md) - maturity and support
   boundaries.
-- Current published preview notes:
-  [v0.2.0-preview.3](docs/release-notes-v0.2.0-preview.3.md).
+- Preview notes prepared for:
+  [v0.2.0-preview.4](docs/release-notes-v0.2.0-preview.4.md).
 
 For the fastest tour, start with `examples/counter`, then
 `examples/components`, then `examples/router-dashboard`.
@@ -510,7 +510,7 @@ Start here:
 
 - [GoFrame Tutorial](docs/tutorial.md)
 - [Evaluator guide](docs/evaluator-guide.md)
-- [Release notes through v0.2.0-preview.3](docs/release-notes-v0.2.0-preview.3.md)
+- [Release notes through v0.2.0-preview.4](docs/release-notes-v0.2.0-preview.4.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -214,7 +214,7 @@ metadata compatibility policy.
 ```
 
 Local checkout builds write `devel`; tagged module installs write the module
-version recorded in Go build information, such as `v0.2.0-preview.3`.
+version recorded in Go build information, such as `v0.2.0-preview.4`.
 
 `goframe-package.json` is the authoritative current package completion marker.
 `goxc` publishes it last and removes it first during destructive package

--- a/docs/evaluator-guide.md
+++ b/docs/evaluator-guide.md
@@ -1,6 +1,6 @@
 # Evaluator Guide
 
-This guide is for evaluating the `v0.1.0-preview.1` browser/WASM layer. It is
+This guide is for evaluating the `v0.2.0-preview.4` browser/WASM layer. It is
 not a production deployment guide.
 
 ## Prerequisites
@@ -156,4 +156,4 @@ app. It is not a cross-browser certification suite.
 
 For the guided walkthrough, read the [tutorial](tutorial.md). For release scope
 and limitations, read the
-[v0.1.0-preview.1 release notes](release-notes-v0.1.0-preview.1.md).
+[v0.2.0-preview.4 release notes](release-notes-v0.2.0-preview.4.md).

--- a/docs/release-notes-v0.2.0-preview.4.md
+++ b/docs/release-notes-v0.2.0-preview.4.md
@@ -1,0 +1,138 @@
+# GoFrame v0.2.0-preview.4 Release Notes
+
+## Summary
+
+`v0.2.0-preview.4` is a maintenance, correctness, performance,
+release-readiness, and public-surface preview for GoFrame's current
+browser/WASM layer.
+
+This preview improves runtime hot paths, recovers WASM size headroom, reduces a
+common keyed placement move pattern, fixes scheduler reset correctness, improves
+GOX diagnostics, tightens `goxc doctor` command behavior, and refreshes the
+repository public presentation.
+
+GoFrame remains experimental. The validated surface is interactive
+browser/WASM applications built with the GoFrame runtime, GOX, `goxc`, and
+standard Go or TinyGo WebAssembly output. This preview does not claim
+production readiness, stable 1.0 APIs, fullstack/server APIs, SSR/hydration,
+Player/Engine, `.gfapp`, formatter, or LSP support.
+
+## Highlights
+
+### Runtime And Performance
+
+- `splitProps` hot paths were characterized and reduced, while preserving
+  zero-allocation behavior for nil and empty props.
+- `splitProps` now uses a smaller slice-backed internal shape for DOM and event
+  prop output.
+- `VirtualTable` runtime code was reduced to recover dashboard WASM size
+  headroom.
+- Keyed child placement now skips redundant moves for a stable suffix pattern.
+  The characterized rotate-right case `[a b c d] -> [d a b c]` improves from
+  three existing-node moves to one.
+- This is not a full LIS reconciliation implementation. Broader keyed reorder
+  optimization remains future work.
+
+### Runtime Correctness
+
+- The update scheduler reset path now invalidates stale queued callbacks. A
+  callback scheduled before `reset()` can no longer run stale update work after
+  a newer request is queued.
+- Browser smoke coverage now includes focused input value and selection
+  preservation during dirty updates.
+- A full batching mutation queue or commit-buffer architecture remains future
+  architecture work. Related issue: #70.
+
+### GOX
+
+- Component prop names that are Go keywords are rejected before codegen with a
+  source-level diagnostic.
+- DOM attributes such as `type` remain valid where they are DOM props rather
+  than generated Go struct field names.
+- GOX no longer emits invalid generated Go for keyword component prop names.
+
+### goxc
+
+- `goxc doctor` now returns a nonzero command result when required checks fail.
+- Existing user-readable doctor diagnostics remain the primary explanation for
+  failed checks.
+
+### Public And Community Surface
+
+- The README was rewritten into a newcomer-first landing page with Quick Start
+  near the top.
+- The README now includes a branded hero header and the GoFrame mark.
+- Lightweight project branding assets were added under `assets/brand/`.
+- `CODEOWNERS`, `NOTICE`, `SECURITY`, `CONTRIBUTING`, and other
+  community-facing metadata were clarified.
+- No GitHub social preview image is committed in the repository.
+
+### Audits
+
+- Runtime audit completed with no blocker or high-severity findings after the
+  focused runtime fixes.
+- GOX audit completed with no blocker or high-severity findings after the
+  keyword component prop diagnostic fix.
+- `cmd/goxc` audit completed with no blocker or high-severity findings after
+  the doctor exit-status fix.
+
+## Compatibility
+
+- Browser/WASM remains the validated preview surface.
+- Standard Go and TinyGo workflows remain supported as documented.
+- No stable API guarantee is introduced.
+- No production hosting or production runtime claim is introduced.
+- Normal preview users do not need a migration.
+- Users who relied on invalid GOX component props named with Go keywords must
+  rename those props to valid exported Go field names.
+- Documentation, community metadata, and branding changes do not affect runtime,
+  GOX, or `goxc` code behavior.
+
+## Known Limitations And Follow-Ups
+
+- `splitProps` allocation work improved hot paths, but broader allocation
+  elimination can continue.
+- A batching mutation queue or commit-buffer architecture remains future work.
+  Related issue: #70.
+- Keyed placement improved a common stable-suffix case, but full LIS
+  reconciliation remains future work. Tracked separately in #71.
+- Retained focused-input selection restoration still has a focused follow-up.
+  Follow-up area: #69.
+- Malformed embedded GOX expression diagnostics can be improved.
+- Workspace module directive fidelity is intentionally limited and can be
+  refined later.
+- Production readiness, SSR/hydration, fullstack/server APIs, Player/Engine,
+  `.gfapp`, formatter, and LSP remain non-goals for this preview.
+
+## Install
+
+After the tag is published, install the exact preview with:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.4
+```
+
+## Verification
+
+Run:
+
+```bash
+goxc version
+goxc doctor
+```
+
+Expected first line after an exact tagged install:
+
+```text
+goxc version v0.2.0-preview.4
+```
+
+For a quick browser/WASM check:
+
+```bash
+goxc package ./examples/counter --compiler=tinygo
+goxc serve ./examples/counter --port=8080
+```
+
+Use `--compiler=go` when TinyGo is unavailable or when standard Go/WASM output
+is preferred for local inspection.

--- a/docs/release-notes-v0.2.0-preview.4.md
+++ b/docs/release-notes-v0.2.0-preview.4.md
@@ -91,13 +91,12 @@ Player/Engine, `.gfapp`, formatter, or LSP support.
 ## Known Limitations And Follow-Ups
 
 - `splitProps` allocation work improved hot paths, but broader allocation
-  elimination can continue.
+  elimination can continue. Follow-up area: #69.
 - A batching mutation queue or commit-buffer architecture remains future work.
   Related issue: #70.
 - Keyed placement improved a common stable-suffix case, but full LIS
   reconciliation remains future work. Tracked separately in #71.
 - Retained focused-input selection restoration still has a focused follow-up.
-  Follow-up area: #69.
 - Malformed embedded GOX expression diagnostics can be improved.
 - Workspace module directive fidelity is intentionally limited and can be
   refined later.

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,16 +11,16 @@ Current milestone tag:
 v0.1.0-mvp10
 ```
 
-Recommended first public preview tag:
+Current preview tag under preparation:
 
 ```text
-v0.1.0-preview.1
+v0.2.0-preview.4
 ```
 
 Subsequent previews should increment the pre-release number:
 
 ```text
-v0.1.0-preview.2
+v0.2.0-preview.5
 ```
 
 The current MVP tags remain historical milestone tags. They are not public API
@@ -29,8 +29,8 @@ release tags.
 Use annotated, signed tags when possible:
 
 ```bash
-git tag -s v0.1.0-preview.1 -m "GoFrame public preview 1"
-git push origin v0.1.0-preview.1
+git tag -s v0.2.0-preview.4 -m "GoFrame v0.2.0-preview.4"
+git push origin v0.2.0-preview.4
 ```
 
 ## Pre-Release Checklist
@@ -84,6 +84,7 @@ Current preview release note documents:
 - `docs/release-notes-v0.2.0-preview.1.md`
 - `docs/release-notes-v0.2.0-preview.2.md`
 - `docs/release-notes-v0.2.0-preview.3.md`
+- `docs/release-notes-v0.2.0-preview.4.md`
 
 `CHANGELOG.md` remains the factual change log; release notes should summarize
 preview scope, maturity tiers, validation evidence, compatibility notes, and
@@ -179,9 +180,9 @@ for trying the preview.
 
 ## Versioning Decision
 
-The recommended first public-preview tag is `v0.1.0-preview.1`. It is a Go
-module pre-release tag. Later previews increment the numeric suffix.
+Preview tags are Go module pre-release tags. Later previews increment the
+numeric suffix.
 
-`v0.1.0` final should wait until public-preview blockers in
+The eventual non-preview release should wait until public-preview blockers in
 `docs/public-preview-readiness.md` are closed or consciously accepted in release
 notes.


### PR DESCRIPTION
## Summary

Prepares repository documentation for `v0.2.0-preview.4`.

This PR adds the preview.4 release notes and aligns current-preview references across the README, evaluator guide, release hygiene docs, deployment docs, changelog, and feature-request template.

It does not create a tag, publish a GitHub release, or change runtime, GOX, `goxc`, examples, scripts, workflows, or assets.

## Scope

Release-prep documentation and community metadata only.

This PR updates:

* `docs/release-notes-v0.2.0-preview.4.md`
* `docs/release.md`
* `docs/evaluator-guide.md`
* `docs/deployment.md`
* `README.md`
* `CHANGELOG.md`
* `.github/ISSUE_TEMPLATE/feature_request.yml`

## Changed Files / Areas

* `docs/release-notes-v0.2.0-preview.4.md`
  * adds release notes for `v0.2.0-preview.4`;
  * summarizes runtime hot-path work, WASM size headroom recovery, keyed placement behavior, scheduler reset correctness, GOX diagnostics, `goxc doctor` exit behavior, public/community docs, branding, and audit outcomes;
  * documents compatibility boundaries and known limitations;
  * keeps production readiness, stable APIs, fullstack/server APIs, SSR/hydration, Player/Engine, `.gfapp`, formatter, and LSP out of scope.

* `docs/release.md`
  * lists preview.4 release notes;
  * updates the tag-under-preparation examples to `v0.2.0-preview.4`;
  * keeps tag creation and publishing as separate release steps.

* `docs/evaluator-guide.md`
  * updates current preview references from stale preview wording to `v0.2.0-preview.4`;
  * points evaluator-facing release scope and limitations to the new preview.4 notes.

* `docs/deployment.md`
  * updates the tagged module version example to `v0.2.0-preview.4`.

* `README.md`
  * updates current release-note links from preview.3 to prepared preview.4 notes;
  * preserves the branded hero header and newcomer-first README structure.

* `CHANGELOG.md`
  * adds factual preview.4 release-prep entries under `Unreleased`.

* `.github/ISSUE_TEMPLATE/feature_request.yml`
  * replaces stale hard-coded preview.1 wording with versionless current-preview wording.

## Behavior, API, Or Docs Impact

Docs impact:

* preview.4 release notes are now present;
* current-preview references are aligned with `v0.2.0-preview.4 release notes are now present;
* current-preview references are aligned with `v0.2.0-preview.4`;
* release docs, evaluator guide, README, deployment docs, and changelog are consistent for the next preview;
* the feature request template no longer hard-codes an old preview version.

API/runtime/toolchain impact:

* no runtime changes;
* no `pkg/goframe` changes;
* no `pkg/gox` changes;
* no `cmd/goxc` changes;
* no example code changes;
* no scripts or workflow changes.

Release impact:

* release-prep docs only;
* no tag created;
* no GitHub release published;
* tag/release publishing remains a separate step after merge.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [ ] `go test ./...`
- [ ] `go test -race ./pkg/... ./cmd/...`
- [ ] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `git diff --check HEAD~1..HEAD`
* `git status --short --untracked-files=all`
* stale preview-reference audit for README, CHANGELOG, docs, and `.github`
* auto-closing issue keyword audit for `Fixes #`, `Closes #`, and `Resolves #`

## Non-Goals

* No runtime changes.
* No GOX compiler changes.
* No `goxc` toolchain changes.
* No example changes.
* No script changes.
* No workflow changes.
* No asset or branding image changes.
* No generated artifacts.
* No social preview image.
* No tag creation.
* No GitHub release publishing.
* No production-readiness claim.
* No stable 1.0 API claim.
* No fullstack/server framework claim.
* No SSR/hydration claim.
* No Player/Engine or `.gfapp` promise.
* No auto-closing issue keywords.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated for release-prep scope.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

The release notes use neutral issue references only.

Related to #69, #70, and #71.

Tag creation and GitHub release publishing remain separate after this PR lands.