### PR TITLE
docs(release): close out v0.2.0 preview 4 publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ it does not write generated `.gox.go` files next to authored source by default.
 - [API stability](docs/api-stability.md) and
   [platform support](docs/platform-support.md) - maturity and support
   boundaries.
-- Preview notes prepared for:
+- Current published preview notes:
   [v0.2.0-preview.4](docs/release-notes-v0.2.0-preview.4.md).
 
 For the fastest tour, start with `examples/counter`, then

--- a/docs/release-notes-v0.2.0-preview.4.md
+++ b/docs/release-notes-v0.2.0-preview.4.md
@@ -105,7 +105,7 @@ Player/Engine, `.gfapp`, formatter, or LSP support.
 
 ## Install
 
-After the tag is published, install the exact preview with:
+Install the exact preview with:
 
 ```bash
 go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.4

--- a/docs/release.md
+++ b/docs/release.md
@@ -91,6 +91,65 @@ preview scope, maturity tiers, validation evidence, compatibility notes, and
 known limitations. `docs/evaluator-guide.md` is the evaluator-facing quick path
 for trying the preview.
 
+## GitHub Release Body Style
+
+Preview release titles should stay short and version-first:
+
+```text
+GoFrame vX.Y.Z-preview.N
+```
+
+Stable release titles should use the same shape without the preview suffix:
+
+```text
+GoFrame vX.Y.Z
+```
+
+Put scope and caveats in the body, not in a long title.
+
+Preview GitHub Release bodies should be concise publish-facing contracts, not
+marketing announcements. They should answer what was released, what surface is
+safe to evaluate, what was validated, what the release does not promise, how to
+install it, and how to verify it.
+
+Preferred preview body order:
+
+- `Status / Scope`;
+- `Highlights`;
+- `Compatibility`;
+- `Validation`;
+- `Known limitations and follow-ups`;
+- `Install`;
+- `Verification`;
+- `Links`;
+- `Non-goals`, when useful.
+
+Use calm, factual, scope-bounding language. Prefer terms such as `preview`,
+`experimental`, `pre-release`, `validated surface`, `current browser/WASM
+layer`, `not production-ready`, `no stable API guarantee`, `known limitations`,
+and `tracked separately` when they apply. Avoid stable or production wording
+unless the release is actually stable and production-ready, and keep limitations
+explicit rather than scattered.
+
+Use neutral issue references, for example `Related issue: #70`, `Tracked
+separately in #71`, or `See also #69`. Avoid the auto-closing verbs `Fixes`,
+`Closes`, and `Resolves` unless the release body intentionally wants GitHub
+auto-closing behavior.
+
+For preview releases in the GitHub UI:
+
+- mark the release as a pre-release;
+- use manual notes rather than generated notes;
+- do not upload binaries or assets unless GoFrame starts supporting an official
+  binary distribution surface;
+- do not mark preview releases as stable/latest when the UI supports avoiding
+  that.
+
+The GitHub Release body is the concise publication entrypoint.
+`docs/release-notes-*.md` is the durable detailed release record in the
+repository. `CHANGELOG.md` is factual cumulative history, not a narrative
+announcement.
+
 ## Public Preview Checklist
 
 ### Repository

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,7 @@ Current milestone tag:
 v0.1.0-mvp10
 ```
 
-Current preview tag under preparation:
+Latest published preview tag:
 
 ```text
 v0.2.0-preview.4
@@ -26,11 +26,11 @@ v0.2.0-preview.5
 The current MVP tags remain historical milestone tags. They are not public API
 release tags.
 
-Use annotated, signed tags when possible:
+Use annotated, signed tags when possible for future previews:
 
 ```bash
-git tag -s v0.2.0-preview.4 -m "GoFrame v0.2.0-preview.4"
-git push origin v0.2.0-preview.4
+git tag -s vX.Y.Z-preview.N -m "GoFrame vX.Y.Z-preview.N"
+git push origin vX.Y.Z-preview.N
 ```
 
 ## Pre-Release Checklist


### PR DESCRIPTION
## Summary

Closes out the `v0.2.0-preview.4` publishing cycle in repository docs.

This PR updates post-publish wording now that `v0.2.0-preview.4` is the current published preview, and adds a compact GitHub Release body style guide so future preview releases are written consistently.

It does not change runtime, GOX, `goxc`, examples, scripts, workflows, assets, tags, or GitHub Release state.

## Scope

Release documentation cleanup only.

This PR updates:

* `README.md`
* `docs/release.md`
* `docs/release-notes-v0.2.0-preview.4.md`

## Changed Files / Areas

* `README.md`
  * changes the preview.4 release-note link wording from pre-publication language to current published-preview language.

* `docs/release-notes-v0.2.0-preview.4.md`
  * updates the install section now that the tag is published.

* `docs/release.md`
  * marks `v0.2.0-preview.4` as the latest published preview tag;
  * changes tag commands to generic future-preview examples instead of repeating the already-published tag;
  * adds a compact `GitHub Release Body Style` section;
  * documents short version-first release titles;
  * documents preview release bodies as concise publish-facing contracts, not marketing announcements;
  * records the preferred preview body order: status/scope, highlights, compatibility, validation, known limitations, install, verification, links, and non-goals when useful;
  * documents neutral issue-reference wording and avoids auto-closing release-body language;
  * clarifies the split between GitHub Release body, durable release notes, and `CHANGELOG.md`.

## Behavior, API, Or Docs Impact

Docs impact:

* repository docs now describe `v0.2.0-preview.4` as published, not merely prepared;
* future GitHub Release bodies have an explicit style guide;
* release-process docs now better distinguish:
  * GitHub Release body as the concise publication entrypoint;
  * `docs/release-notes-*.md` as the durable detailed release record;
  * `CHANGELOG.md` as factual cumulative history.

API/runtime/toolchain impact:

* no runtime changes;
* no `pkg/goframe` changes;
* no `pkg/gox` changes;
* no `cmd/goxc` changes;
* no example changes;
* no script or workflow changes.

Release impact:

* no tag changes;
* no GitHub Release edits;
* no release assets uploaded;
* no generated artifacts committed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [ ] `go test ./...`
- [ ] `go test -race ./pkg/... ./cmd/...`
- [ ] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `git status --short --untracked-files=all`
* release-style section search in `docs/release.md`
* post-publish wording search
* auto-closing keyword search for `Fixes #`, `Closes #`, and `Resolves #`

## Non-Goals

* No runtime changes.
* No GOX compiler changes.
* No `goxc` toolchain changes.
* No example changes.
* No script changes.
* No workflow changes.
* No asset or branding image changes.
* No generated artifacts.
* No tag changes.
* No GitHub Release edits.
* No issue comments.
* No issue closing.
* No new release notes.
* No CHANGELOG convention change.
* No social preview changes.
* No runtime correctness follow-ups.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Docs were updated for release-closeout scope.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This PR intentionally combines the small post-publish wording cleanup with the release-body style guardrail so the change is useful as a single release-closeout PR.

Runtime correctness follow-ups remain separate.