### PR TITLE
fix(goframe): restore selection on retained focused inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,8 @@
   from three to one without implementing a full LIS reconciler.
 - Scheduler reset now invalidates stale queued update callbacks so pre-reset
   work cannot run after a newer request is queued.
+- Retained focused inputs now restore their selection range after dirty
+  component updates.
 - GOX now rejects Go keyword component prop names before codegen with
   source-level diagnostics, while preserving DOM attributes such as `type`.
 - `goxc doctor` now returns nonzero when required checks fail.

--- a/pkg/goframe/mount_js.go
+++ b/pkg/goframe/mount_js.go
@@ -181,10 +181,10 @@ func restoreFocus(document js.Value, snapshot focusSnapshot) {
 		return
 	}
 	active := document.Get("activeElement")
-	if !active.IsUndefined() && !active.IsNull() && active.Equal(element) {
-		return
+	alreadyActive := !active.IsUndefined() && !active.IsNull() && active.Equal(element)
+	if !alreadyActive {
+		element.Call("focus")
 	}
-	element.Call("focus")
 	if snapshot.hasSelection && element.Get("setSelectionRange").Type() == js.TypeFunction {
 		element.Call("setSelectionRange", snapshot.selectionStart, snapshot.selectionEnd)
 	}

--- a/scripts/todo-browser-smoke.mjs
+++ b/scripts/todo-browser-smoke.mjs
@@ -69,7 +69,7 @@ try {
         "typing audit installed",
     );
 
-    await typeTodo(client, "B");
+    await typeTodoWithRetainedSelection(client, "BC", "BXC", 1, 1);
     assertDeepEqual(
         await client.evaluate(`(() => {
             const debug = window.__GOFRAME_DEBUG__;
@@ -106,7 +106,7 @@ try {
             formSame: true,
             listSame: true,
             active: "todo-input",
-            value: "B",
+            value: "BC",
             selectionStart: 1,
             selectionEnd: 1,
             appRenderDelta: 0,
@@ -123,7 +123,7 @@ try {
                 formChildList: 0,
                 list: 0,
             },
-            operations: emptyOperations(),
+            operations: { ...emptyOperations(), setProperty: 1 },
         },
         "typing preserves unrelated DOM and performs no structural operations",
     );
@@ -217,7 +217,7 @@ try {
     );
 
     const persisted = await client.evaluate(`localStorage.getItem("goframe.todo.items")`);
-    if (typeof persisted !== "string" || !persisted.includes("B")) {
+    if (typeof persisted !== "string" || !persisted.includes("BC")) {
         throw new Error(`APP FAILURE: todo persistence: got ${JSON.stringify(persisted)}, want stored todo text`);
     }
     console.log("todo persistence write: ok");
@@ -230,7 +230,7 @@ try {
             text: document.querySelector("#todo-2 .todo-text")?.textContent,
             headerRenders: window.goframeComponentRenderCounts.Header,
         })`),
-        { order: ["todo-2"], text: "B", headerRenders: 1 },
+        { order: ["todo-2"], text: "BC", headerRenders: 1 },
         "todo persistence reload",
     );
 
@@ -293,6 +293,33 @@ async function typeTodo(client, text) {
             }
         }
         input.dispatchEvent(new Event("input", { bubbles: true }));
+        return true;
+    })()`);
+    await wait(100);
+}
+
+async function typeTodoWithRetainedSelection(client, text, transientText, selectionStart, selectionEnd) {
+    await client.evaluate(`(() => {
+        const input = document.querySelector("#todo-input");
+        input.focus();
+        input.value = ${JSON.stringify(text)};
+        input.setSelectionRange(${selectionStart}, ${selectionEnd});
+        if (window.__GOFRAME_DEBUG__) {
+            for (const key of Object.keys(window.__GOFRAME_DEBUG__.operations)) {
+                window.__GOFRAME_DEBUG__.operations[key] = 0;
+            }
+        }
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+
+        // Force the dirty patch to restore the controlled value while retaining
+        // the active input node, so selection restoration is observable.
+        input.value = ${JSON.stringify(transientText)};
+        input.setSelectionRange(${selectionStart}, ${selectionEnd});
+        if (window.__GOFRAME_DEBUG__) {
+            for (const key of Object.keys(window.__GOFRAME_DEBUG__.operations)) {
+                window.__GOFRAME_DEBUG__.operations[key] = 0;
+            }
+        }
         return true;
     })()`);
     await wait(100);


### PR DESCRIPTION
## Summary

Restores selection range for retained focused inputs after dirty component updates.

Previously, `restoreFocus` returned early when the captured element was already `document.activeElement`. That preserved focus, but skipped `setSelectionRange`, so retained controlled inputs could lose the captured cursor/selection position during an update.

This PR keeps the existing focus behavior, but still restores selection when the focused element is retained.

## Scope

Runtime correctness and nearest browser-smoke coverage only.

This PR updates:

* `pkg/goframe/mount_js.go`
* `scripts/todo-browser-smoke.mjs`
* `CHANGELOG.md`

## Changed Files / Areas

* `pkg/goframe/mount_js.go`
  * changes `restoreFocus` so it skips only the unnecessary `focus()` call when the captured element is already active;
  * still calls `setSelectionRange` when a captured selection snapshot exists and the element supports selection restoration.

* `scripts/todo-browser-smoke.mjs`
  * adds retained-selection coverage for `#todo-input`;
  * verifies the same input node is retained;
  * verifies focus remains on the input;
  * verifies the controlled value is restored;
  * verifies `selectionStart` / `selectionEnd` are restored to a non-end cursor position.

* `CHANGELOG.md`
  * records the runtime correctness fix under `Unreleased`.

## Behavior, API, Or Docs Impact

Runtime behavior:

* retained focused inputs now restore their selection range after dirty component updates;
* existing focus restoration behavior is preserved;
* `focus()` is not called again when the captured element is already active.

API impact:

* no public API changes;
* no new runtime API;
* no GOX changes;
* no `goxc` changes.

Docs impact:

* changelog only.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [x] `scripts/size-budget.sh`
- [x] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `go test ./pkg/goframe`
* `node --check scripts/todo-browser-smoke.mjs`
* `git status --short --untracked-files=all`

Browser-smoke evidence:

* retained `#todo-input` node remains the same;
* active element remains `todo-input`;
* controlled value restores to `BC`;
* selection restores to `1..1`;
* the expected single controlled-value property write is accounted for.

WASM size evidence reported:

* dashboard raw size: `167794 B / 168960 B`
* headroom: `1166 B`

## Non-Goals

* No public API changes.
* No batching mutation queue.
* No commit buffer.
* No scheduler architecture rewrite.
* No broad focus manager.
* No focus capture expansion for id-less elements.
* No GOX compiler changes.
* No `goxc` changes.
* No example changes.
* No workflow changes.
* No asset changes.
* No release docs changes.
* No generated artifacts.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Browser behavior change is covered by browser smoke.
- [x] Changelog was updated.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

The commit-buffer / batching architecture remains separate.

Broader focus-capture behavior for elements without IDs remains separate.

Full runtime scheduler work remains separate.