### PR TITLE
fix(gox): report malformed embedded expressions at source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@
   component updates.
 - GOX now rejects Go keyword component prop names before codegen with
   source-level diagnostics, while preserving DOM attributes such as `type`.
+- GOX now reports malformed embedded expressions as source-level diagnostics
+  before generated Go parsing.
 - `goxc doctor` now returns nonzero when required checks fail.
 - The router-dashboard route Error Boundary fallback now distinguishes retrying
   the current crashing route from safely navigating back to the issues list, and

--- a/pkg/gox/codegen.go
+++ b/pkg/gox/codegen.go
@@ -323,6 +323,9 @@ func (ctx *codegenContext) writeChildExpression(output *bytes.Buffer, code strin
 	if err != nil {
 		return err
 	}
+	if err := validateEmbeddedExpression(rewritten); err != nil {
+		return err
+	}
 	fmt.Fprintf(output, "gf.Child(%s)", rewritten)
 	return nil
 }
@@ -342,6 +345,9 @@ func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string
 		if !thenOK || !elseOK {
 			return "", false, fmt.Errorf("gox: ternary render branches must be GOX nodes")
 		}
+		if err := validateEmbeddedExpression(condition); err != nil {
+			return "", false, err
+		}
 		return "gf.IfElse(" + strings.TrimSpace(condition) + ", " + thenNode + ", " + elseNode + ")", true, nil
 	}
 
@@ -351,6 +357,9 @@ func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string
 			return "", false, err
 		}
 		if nodeOK {
+			if err := validateEmbeddedExpression(condition); err != nil {
+				return "", false, err
+			}
 			return "gf.If(" + strings.TrimSpace(condition) + ", " + node + ")", true, nil
 		}
 	}

--- a/pkg/gox/codegen.go
+++ b/pkg/gox/codegen.go
@@ -184,7 +184,7 @@ func (ctx *codegenContext) writeNode(output *bytes.Buffer, node Node, depth int)
 		if code == "" {
 			return fmt.Errorf("gox: empty child expression")
 		}
-		return ctx.errorAtNode(node, ctx.writeChildExpression(output, code, depth))
+		return ctx.errorAtNode(node, ctx.writeChildExpression(output, code, ctx.expressionCodeOffset(node, code), depth))
 	default:
 		return fmt.Errorf("gox: unsupported AST node %T", node)
 	}
@@ -311,15 +311,15 @@ func writeAttributeValue(output *bytes.Buffer, attribute Attribute) error {
 	return nil
 }
 
-func (ctx *codegenContext) writeChildExpression(output *bytes.Buffer, code string, depth int) error {
-	if rendered, ok, err := ctx.lowerRenderExpression(code, depth); err != nil {
+func (ctx *codegenContext) writeChildExpression(output *bytes.Buffer, code string, codeOffset int, depth int) error {
+	if rendered, ok, err := ctx.lowerRenderExpression(code, codeOffset, depth); err != nil {
 		return err
 	} else if ok {
 		output.WriteString(rendered)
 		return nil
 	}
 
-	rewritten, err := ctx.rewriteMarkupInGo(code)
+	rewritten, err := ctx.rewriteMarkupInGo(code, codeOffset)
 	if err != nil {
 		return err
 	}
@@ -330,15 +330,15 @@ func (ctx *codegenContext) writeChildExpression(output *bytes.Buffer, code strin
 	return nil
 }
 
-func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string, bool, error) {
+func (ctx *codegenContext) lowerRenderExpression(code string, codeOffset int, depth int) (string, bool, error) {
 	if condition, thenCode, elseCode, ok, err := splitTernaryExpression(code); err != nil {
 		return "", false, err
 	} else if ok {
-		thenNode, thenOK, err := ctx.codegenNodeExpression(thenCode, depth)
+		thenNode, thenOK, err := ctx.codegenNodeExpression(thenCode, subexpressionOffset(code, codeOffset, thenCode), depth)
 		if err != nil {
 			return "", false, err
 		}
-		elseNode, elseOK, err := ctx.codegenNodeExpression(elseCode, depth)
+		elseNode, elseOK, err := ctx.codegenNodeExpression(elseCode, subexpressionOffset(code, codeOffset, elseCode), depth)
 		if err != nil {
 			return "", false, err
 		}
@@ -352,7 +352,7 @@ func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string
 	}
 
 	if condition, nodeCode, ok := splitRenderAndExpression(code); ok {
-		node, nodeOK, err := ctx.codegenNodeExpression(nodeCode, depth)
+		node, nodeOK, err := ctx.codegenNodeExpression(nodeCode, subexpressionOffset(code, codeOffset, nodeCode), depth)
 		if err != nil {
 			return "", false, err
 		}
@@ -366,19 +366,19 @@ func (ctx *codegenContext) lowerRenderExpression(code string, depth int) (string
 	return "", false, nil
 }
 
-func (ctx *codegenContext) codegenNodeExpression(code string, depth int) (string, bool, error) {
+func (ctx *codegenContext) codegenNodeExpression(code string, codeOffset int, depth int) (string, bool, error) {
 	code = strings.TrimSpace(code)
 	if code == "" {
 		return "", false, nil
 	}
 	if inner, ok := unwrapOuterParens(code); ok {
-		return ctx.codegenNodeExpression(inner, depth)
+		return ctx.codegenNodeExpression(inner, subexpressionOffset(code, codeOffset, inner), depth)
 	}
 	if code[0] != '<' {
 		return "", false, nil
 	}
 
-	node, consumed, err := ParseElement(code)
+	node, consumed, err := ctx.parseNestedElement(code, codeOffset)
 	if err != nil {
 		return "", false, err
 	}
@@ -392,7 +392,7 @@ func (ctx *codegenContext) codegenNodeExpression(code string, depth int) (string
 	return output.String(), true, nil
 }
 
-func (ctx *codegenContext) rewriteMarkupInGo(code string) (string, error) {
+func (ctx *codegenContext) rewriteMarkupInGo(code string, codeOffset int) (string, error) {
 	var output bytes.Buffer
 	cursor := 0
 	searchFrom := 0
@@ -402,7 +402,7 @@ func (ctx *codegenContext) rewriteMarkupInGo(code string) (string, error) {
 		if start < 0 {
 			break
 		}
-		node, consumed, err := ParseElement(code[start:])
+		node, consumed, err := ctx.parseNestedElement(code[start:], offsetFromBase(codeOffset, start))
 		if err != nil {
 			return "", err
 		}
@@ -422,6 +422,69 @@ func (ctx *codegenContext) rewriteMarkupInGo(code string) (string, error) {
 	}
 	output.WriteString(code[cursor:])
 	return output.String(), nil
+}
+
+func (ctx *codegenContext) parseNestedElement(input string, offset int) (Node, int, error) {
+	if ctx.diagnosticFilename == "" || ctx.diagnosticSource == "" || offset < 0 {
+		return ParseElement(input)
+	}
+	line, column := lineColumn(ctx.diagnosticSource, offset)
+	if line == 1 {
+		column += ctx.diagnosticColumn - 1
+	}
+	line += ctx.diagnosticLine - 1
+	node, consumed, positions, err := parseElementAtWithPositions(input, ctx.diagnosticFilename, line, column)
+	if err != nil {
+		return nil, 0, err
+	}
+	ctx.mergePositions(positions, offset)
+	return node, consumed, nil
+}
+
+func (ctx *codegenContext) mergePositions(positions map[Node]int, offset int) {
+	if ctx.positions == nil || offset < 0 {
+		return
+	}
+	for node, position := range positions {
+		ctx.positions[node] = offset + position
+	}
+}
+
+func (ctx *codegenContext) expressionCodeOffset(node Node, code string) int {
+	if ctx.positions == nil || ctx.diagnosticSource == "" {
+		return -1
+	}
+	offset, ok := ctx.positions[node]
+	if !ok {
+		return -1
+	}
+	start := offset + 1
+	if start > len(ctx.diagnosticSource) {
+		return -1
+	}
+	index := strings.Index(ctx.diagnosticSource[start:], code)
+	if index < 0 {
+		return -1
+	}
+	return start + index
+}
+
+func subexpressionOffset(parent string, parentOffset int, child string) int {
+	if parentOffset < 0 {
+		return -1
+	}
+	index := strings.Index(parent, child)
+	if index < 0 {
+		return -1
+	}
+	return parentOffset + index
+}
+
+func offsetFromBase(base, offset int) int {
+	if base < 0 {
+		return -1
+	}
+	return base + offset
 }
 
 func splitKeyAttribute(attributes []Attribute) (string, []Attribute, error) {

--- a/pkg/gox/expression.go
+++ b/pkg/gox/expression.go
@@ -1,6 +1,10 @@
 package gox
 
-import "strings"
+import (
+	"fmt"
+	"go/parser"
+	"strings"
+)
 
 func splitRenderAndExpression(code string) (string, string, bool) {
 	positions := topLevelOperatorPositions(code, "&&")
@@ -39,6 +43,13 @@ func splitTernaryExpression(code string) (string, string, string, bool, error) {
 
 func expressionError(message string) error {
 	return simpleError(message)
+}
+
+func validateEmbeddedExpression(code string) error {
+	if _, err := parser.ParseExpr(strings.TrimSpace(code)); err != nil {
+		return fmt.Errorf("gox: invalid embedded expression: %v", err)
+	}
+	return nil
 }
 
 func unwrapOuterParens(code string) (string, bool) {

--- a/pkg/gox/parser.go
+++ b/pkg/gox/parser.go
@@ -157,6 +157,9 @@ func (parser *Parser) parseAttribute(name token) (Attribute, error) {
 			}
 			return Attribute{}, parser.lexer.errorAt(value.offset, "gox: empty expression for attribute %q", name.value)
 		}
+		if err := validateEmbeddedExpression(value.value); err != nil {
+			return Attribute{}, parser.lexer.errorAt(value.offset, "%s", err)
+		}
 		return Attribute{Name: name.value, Value: ExpressionValue{Code: value.value}}, nil
 	default:
 		return Attribute{}, parser.unexpected(value, "quoted string or Go expression")

--- a/pkg/gox/testdata/errors/malformed_attr_expression.golden.txt
+++ b/pkg/gox/testdata/errors/malformed_attr_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/malformed_attr_expression.gox:4:22: gox: invalid embedded expression: 1:7: expected operand, found 'EOF'
+  <input value={name +} />

--- a/pkg/gox/testdata/errors/malformed_attr_expression.gox
+++ b/pkg/gox/testdata/errors/malformed_attr_expression.gox
@@ -1,0 +1,5 @@
+package main
+
+func App() any {
+	return <input value={name +} />
+}

--- a/pkg/gox/testdata/errors/malformed_child_expression.golden.txt
+++ b/pkg/gox/testdata/errors/malformed_child_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/malformed_child_expression.gox:4:15: gox: invalid embedded expression: 1:8: expected operand, found 'EOF'
+  <main>{count +}</main>

--- a/pkg/gox/testdata/errors/malformed_child_expression.gox
+++ b/pkg/gox/testdata/errors/malformed_child_expression.gox
@@ -1,0 +1,5 @@
+package main
+
+func App() any {
+	return <main>{count +}</main>
+}

--- a/pkg/gox/testdata/errors/malformed_nested_child_expression.golden.txt
+++ b/pkg/gox/testdata/errors/malformed_nested_child_expression.golden.txt
@@ -1,0 +1,2 @@
+testdata/errors/malformed_nested_child_expression.gox:5:67: gox: invalid embedded expression: 1:7: expected operand, found 'EOF'
+  <main>{gf.Map(items, func(item string) any { return <Item>{item +}</Item> })}</main>

--- a/pkg/gox/testdata/errors/malformed_nested_child_expression.gox
+++ b/pkg/gox/testdata/errors/malformed_nested_child_expression.gox
@@ -1,0 +1,6 @@
+package main
+
+func App() any {
+	items := []string{"a"}
+	return <main>{gf.Map(items, func(item string) any { return <Item>{item +}</Item> })}</main>
+}

--- a/pkg/gox/testdata/errors/nested_markup_callback_error.golden.txt
+++ b/pkg/gox/testdata/errors/nested_markup_callback_error.golden.txt
@@ -1,2 +1,2 @@
-testdata/errors/nested_markup_callback_error.gox:6:15: expected closing tag </Item>, got </Wrong>
-  <main>{gf.Map(items, func(item string) gf.Node {
+testdata/errors/nested_markup_callback_error.gox:7:31: expected closing tag </Item>, got </Wrong>
+  <Item Label={item}></Wrong>


### PR DESCRIPTION
## Summary

Reports malformed embedded GOX expressions as source-level diagnostics before generated Go parsing.

Previously, malformed embedded expressions could pass through GOX parsing/codegen and fail later as generated-Go parse errors. That made the error harder to understand because the user saw a Go parser failure instead of a diagnostic tied to the authored `.gox` source.

This PR validates embedded expressions earlier, preserves source locations for nested GOX markup inside embedded Go expressions, and reports diagnostics with GOX context, filename, line, column, and source snippet.

## Scope

GOX diagnostics and nearest error-golden coverage only.

This PR updates:

* `pkg/gox/expression.go`
* `pkg/gox/parser.go`
* `pkg/gox/codegen.go`
* `pkg/gox/testdata/errors/*`
* `CHANGELOG.md`

## Changed Files / Areas

* `pkg/gox/expression.go`
  * adds embedded expression validation using Go expression parsing;
  * wraps parser failures as `gox: invalid embedded expression`.

* `pkg/gox/parser.go`
  * validates attribute expression values at the authored source-token location;
  * reports malformed attribute expressions before codegen.

* `pkg/gox/codegen.go`
  * validates child expressions after GOX-specific nested markup rewrites;
  * validates render-expression conditions for ternary and `&&` lowering paths;
  * preserves diagnostic positions for nested GOX markup parsed inside embedded Go expressions;
  * carries expression-body offsets through nested rewrite/codegen paths;
  * maps nested node errors back to the authored `.gox` source instead of the outer expression.

* `pkg/gox/testdata/errors/`
  * adds malformed child expression coverage;
  * adds malformed attribute expression coverage;
  * adds malformed nested child expression coverage;
  * updates nested callback markup diagnostics to point at the inner malformed markup location;
  * asserts source-level `.gox` diagnostics instead of generated-Go parse leakage.

* `CHANGELOG.md`
  * records the user-visible GOX diagnostic improvement under `Unreleased`.

## Behavior, API, Or Docs Impact

GOX behavior:

* malformed embedded child expressions now produce GOX/source-level diagnostics;
* malformed embedded attribute expressions now produce GOX/source-level diagnostics;
* malformed nested expressions inside embedded GOX markup now preserve the inner source location;
* nested callback markup diagnostics now point at the nested markup line when possible;
* valid embedded expressions continue to compile;
* generated Go parse errors are no longer the primary diagnostic for the covered malformed expression cases.

API impact:

* no public API changes;
* no runtime changes;
* no `goxc` command behavior changes;
* no GOX grammar expansion.

Docs impact:

* changelog only.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `go test ./pkg/gox`
* `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
* `go test ./pkg/gox -run TestErrorGolden` characterization before the nested-location fix
* `git status --short --untracked-files=all`

Characterization evidence:

* malformed attribute expression previously leaked as generated-Go parse error;
* malformed child expression previously leaked as generated-Go parse error;
* malformed nested child expression previously pointed at the outer embedded expression;
* covered malformed expression cases now produce `gox: invalid embedded expression` diagnostics tied to `.gox` source;
* nested malformed expression coverage now points at the inner `{item +}` location.

## Non-Goals

* No GOX grammar expansion.
* No formatter work.
* No LSP work.
* No semantic/type-checking diagnostics.
* No runtime changes.
* No `goxc` changes.
* No examples changes.
* No scripts changes.
* No workflows changes.
* No release docs changes.
* No generated artifacts.

## Checklist

- [x] This PR has no unrelated changes.
- [x] GOX diagnostic behavior is covered by error-golden tests.
- [x] Nested GOX markup diagnostics preserve source locations.
- [x] Changelog was updated.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

Broader GOX parser/tooling strategy remains separate.

Formatter and LSP work remain separate.

Semantic/type-checking diagnostics remain separate.