### PR TITLE
perf(goframe): reduce keyed reorder moves with O(n log n) LIS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,9 +173,10 @@
   runtime prop paths while preserving nil and empty zero-allocation behavior.
 - `VirtualTable` runtime code was reduced to recover dashboard WASM size
   headroom.
-- Keyed child placement now avoids redundant moves for the stable suffix
-  pattern, reducing the characterized rotate-right existing-node move count
-  from three to one without implementing a full LIS reconciler.
+- Keyed child placement now avoids additional redundant moves by keeping the
+  longest increasing keyed subsequence stable during placement, preserving the
+  characterized rotate-right one-move behavior and reducing a middle-backward
+  keyed reorder from two existing-node moves to one.
 - Scheduler reset now invalidates stale queued update callbacks so pre-reset
   work cannot run after a newer request is queued.
 - Retained focused inputs now restore their selection range after dirty

--- a/pkg/goframe/bench_test.go
+++ b/pkg/goframe/bench_test.go
@@ -176,6 +176,11 @@ func BenchmarkStableChildPlacements(b *testing.B) {
 			keys:    mixedReorderedBenchmarkKeys(size),
 			matches: mixedBenchmarkMatchesForPlacement(size),
 		},
+		{
+			name:    "long_move_backward",
+			keys:    moveEarlyBackwardBenchmarkKeys(2048),
+			matches: moveEarlyBackwardBenchmarkMatches(2048),
+		},
 	}
 
 	for _, test := range tests {
@@ -299,6 +304,24 @@ func mixedBenchmarkMatchesForPlacement(size int) []int {
 		}
 		matches[index] = index
 	}
+	return matches
+}
+
+func moveEarlyBackwardBenchmarkKeys(size int) []string {
+	keys := sequentialBenchmarkKeys(size)
+	insert := size / 2
+	moved := keys[1]
+	copy(keys[1:insert], keys[2:insert+1])
+	keys[insert] = moved
+	return keys
+}
+
+func moveEarlyBackwardBenchmarkMatches(size int) []int {
+	matches := sequentialBenchmarkMatches(size)
+	insert := size / 2
+	moved := matches[1]
+	copy(matches[1:insert], matches[2:insert+1])
+	matches[insert] = moved
 	return matches
 }
 

--- a/pkg/goframe/bench_test.go
+++ b/pkg/goframe/bench_test.go
@@ -3,7 +3,7 @@ package goframe
 import "testing"
 
 var benchmarkChildMatches []int
-var benchmarkStablePlacementStart int
+var benchmarkStablePlacements []bool
 
 func BenchmarkDirtyQueuePruning(b *testing.B) {
 	root := dirtyTestInstance("Root", nil)
@@ -143,45 +143,52 @@ func BenchmarkStableChildPlacements(b *testing.B) {
 
 	tests := []struct {
 		name    string
+		keys    []string
 		matches []int
 	}{
 		{
 			name:    "stable",
+			keys:    sequentialBenchmarkKeys(size),
 			matches: sequentialBenchmarkMatches(size),
 		},
 		{
 			name:    "reverse",
+			keys:    reverseBenchmarkKeys(size),
 			matches: reverseBenchmarkMatches(size),
 		},
 		{
 			name:    "rotate_left",
+			keys:    rotateLeftBenchmarkKeys(size),
 			matches: rotateLeftBenchmarkMatches(size),
 		},
 		{
 			name:    "rotate_right",
+			keys:    rotateRightBenchmarkKeys(size),
 			matches: rotateRightBenchmarkMatches(size),
 		},
 		{
 			name:    "insert_remove",
+			keys:    insertRemoveBenchmarkKeys(size),
 			matches: insertRemoveBenchmarkMatches(size),
 		},
 		{
 			name:    "mixed",
+			keys:    mixedReorderedBenchmarkKeys(size),
 			matches: mixedBenchmarkMatchesForPlacement(size),
 		},
 	}
 
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			stableStart := stableChildPlacementStart(test.matches)
-			if stableStart < 0 || stableStart > len(test.matches) {
-				b.Fatalf("stable start = %d", stableStart)
+			placements := stableChildPlacements(test.matches, test.keys)
+			if len(placements) > len(test.matches) {
+				b.Fatalf("stable placements length = %d", len(placements))
 			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for range b.N {
-				benchmarkStablePlacementStart = stableChildPlacementStart(test.matches)
+				benchmarkStablePlacements = stableChildPlacements(test.matches, test.keys)
 			}
 		})
 	}

--- a/pkg/goframe/reconcile.go
+++ b/pkg/goframe/reconcile.go
@@ -111,26 +111,38 @@ func stableChildPlacementStart(matches []int) int {
 }
 
 func stableChildPlacements(matches []int, keys []string) []bool {
-	lengths := make([]int, len(matches))
+	ends := make([]int, len(matches))
+	previous := make([]int, len(matches))
 	bestIndex := noChildMatch
 	bestLength := 0
+	length := 0
 
 	for index, match := range matches {
 		if match == noChildMatch || keys[index] == "" {
 			continue
 		}
-		lengths[index] = 1
-		for previousIndex := 0; previousIndex < index; previousIndex++ {
-			if lengths[previousIndex] == 0 || matches[previousIndex] >= match {
+		low := 0
+		high := length
+		for low < high {
+			mid := (low + high) / 2
+			if matches[ends[mid]] < match {
+				low = mid + 1
 				continue
 			}
-			length := lengths[previousIndex] + 1
-			if length > lengths[index] {
-				lengths[index] = length
-			}
+			high = mid
 		}
-		if lengths[index] > bestLength {
-			bestLength = lengths[index]
+
+		previous[index] = noChildMatch
+		if low > 0 {
+			previous[index] = ends[low-1]
+		}
+		ends[low] = index
+		if low == length {
+			length++
+		}
+		currentLength := low + 1
+		if currentLength > bestLength {
+			bestLength = currentLength
 			bestIndex = index
 		}
 	}
@@ -141,16 +153,7 @@ func stableChildPlacements(matches []int, keys []string) []bool {
 	stable := make([]bool, len(matches))
 	for bestIndex != noChildMatch {
 		stable[bestIndex] = true
-		nextIndex := noChildMatch
-		nextLength := lengths[bestIndex] - 1
-		currentMatch := matches[bestIndex]
-		for index := bestIndex - 1; index >= 0; index-- {
-			if lengths[index] != 0 && lengths[index] == nextLength && matches[index] < currentMatch {
-				nextIndex = index
-				break
-			}
-		}
-		bestIndex = nextIndex
+		bestIndex = previous[bestIndex]
 	}
 	return stable
 }

--- a/pkg/goframe/reconcile.go
+++ b/pkg/goframe/reconcile.go
@@ -109,3 +109,48 @@ func stableChildPlacementStart(matches []int) int {
 	}
 	return stableStart
 }
+
+func stableChildPlacements(matches []int, keys []string) []bool {
+	lengths := make([]int, len(matches))
+	bestIndex := noChildMatch
+	bestLength := 0
+
+	for index, match := range matches {
+		if match == noChildMatch || keys[index] == "" {
+			continue
+		}
+		lengths[index] = 1
+		for previousIndex := 0; previousIndex < index; previousIndex++ {
+			if lengths[previousIndex] == 0 || matches[previousIndex] >= match {
+				continue
+			}
+			length := lengths[previousIndex] + 1
+			if length > lengths[index] {
+				lengths[index] = length
+			}
+		}
+		if lengths[index] > bestLength {
+			bestLength = lengths[index]
+			bestIndex = index
+		}
+	}
+	if bestIndex == noChildMatch {
+		return nil
+	}
+
+	stable := make([]bool, len(matches))
+	for bestIndex != noChildMatch {
+		stable[bestIndex] = true
+		nextIndex := noChildMatch
+		nextLength := lengths[bestIndex] - 1
+		currentMatch := matches[bestIndex]
+		for index := bestIndex - 1; index >= 0; index-- {
+			if lengths[index] != 0 && lengths[index] == nextLength && matches[index] < currentMatch {
+				nextIndex = index
+				break
+			}
+		}
+		bestIndex = nextIndex
+	}
+	return stable
+}

--- a/pkg/goframe/reconcile_reorder_test.go
+++ b/pkg/goframe/reconcile_reorder_test.go
@@ -345,6 +345,38 @@ func TestStableChildPlacements(t *testing.T) {
 	}
 }
 
+func TestStableChildPlacementsLongKeyedList(t *testing.T) {
+	const size = 1024
+
+	matches := sequentialBenchmarkMatches(size)
+	keys := sequentialBenchmarkKeys(size)
+	// Move one early item backward while the rest of the keyed children remain
+	// in order. The stable set should keep every other keyed child in place.
+	moved := matches[1]
+	copy(matches[1:], matches[2:32])
+	matches[31] = moved
+	movedKey := keys[1]
+	copy(keys[1:], keys[2:32])
+	keys[31] = movedKey
+
+	stable := stableChildPlacements(matches, keys)
+	if len(stable) != size {
+		t.Fatalf("stable placements length = %d, want %d", len(stable), size)
+	}
+	stableCount := 0
+	for index, value := range stable {
+		if index == 31 && value {
+			t.Fatal("moved key should not be marked stable")
+		}
+		if value {
+			stableCount++
+		}
+	}
+	if stableCount != size-1 {
+		t.Fatalf("stable placements = %d, want %d", stableCount, size-1)
+	}
+}
+
 func stableSuffixChildPlacementFlags(matches []int, keys []string) []bool {
 	stableStart := stableChildPlacementStart(matches)
 	if stableStart == len(matches) {

--- a/pkg/goframe/reconcile_reorder_test.go
+++ b/pkg/goframe/reconcile_reorder_test.go
@@ -17,21 +17,24 @@ type currentPlacementStats struct {
 	moves    int
 }
 
-func TestCurrentKeyedReorderPlacement(t *testing.T) {
-	// These counts characterize current stable-placement-aware right-to-left
-	// behavior. They are not asserted to be theoretically optimal; future
-	// placement work may intentionally update them.
+func TestKeyedReorderPlacement(t *testing.T) {
+	// Before counts characterize the previous stable-suffix placement behavior.
+	// After counts assert the current LIS-aware keyed placement behavior.
 	tests := []struct {
-		name string
-		old  []string
-		new  []string
-		want currentPlacementStats
+		name   string
+		old    []string
+		new    []string
+		before currentPlacementStats
+		after  currentPlacementStats
 	}{
 		{
 			name: "stable keyed order",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"a", "b", "c", "d"},
-			want: currentPlacementStats{
+			before: currentPlacementStats{
+				final: []string{"a", "b", "c", "d"},
+			},
+			after: currentPlacementStats{
 				final: []string{"a", "b", "c", "d"},
 			},
 		},
@@ -39,7 +42,11 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 			name: "rotate left",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"b", "c", "d", "a"},
-			want: currentPlacementStats{
+			before: currentPlacementStats{
+				final: []string{"b", "c", "d", "a"},
+				moves: 1,
+			},
+			after: currentPlacementStats{
 				final: []string{"b", "c", "d", "a"},
 				moves: 1,
 			},
@@ -48,7 +55,11 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 			name: "rotate right",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"d", "a", "b", "c"},
-			want: currentPlacementStats{
+			before: currentPlacementStats{
+				final: []string{"d", "a", "b", "c"},
+				moves: 1,
+			},
+			after: currentPlacementStats{
 				final: []string{"d", "a", "b", "c"},
 				moves: 1,
 			},
@@ -57,17 +68,51 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 			name: "reverse",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"d", "c", "b", "a"},
-			want: currentPlacementStats{
+			before: currentPlacementStats{
 				final: []string{"d", "c", "b", "a"},
 				moves: 3,
+			},
+			after: currentPlacementStats{
+				final: []string{"d", "c", "b", "a"},
+				moves: 3,
+			},
+		},
+		{
+			name: "move middle item forward",
+			old:  []string{"a", "b", "c", "d", "e"},
+			new:  []string{"a", "d", "b", "c", "e"},
+			before: currentPlacementStats{
+				final: []string{"a", "d", "b", "c", "e"},
+				moves: 1,
+			},
+			after: currentPlacementStats{
+				final: []string{"a", "d", "b", "c", "e"},
+				moves: 1,
+			},
+		},
+		{
+			name: "move middle item backward",
+			old:  []string{"a", "b", "c", "d", "e"},
+			new:  []string{"a", "c", "d", "b", "e"},
+			before: currentPlacementStats{
+				final: []string{"a", "c", "d", "b", "e"},
+				moves: 2,
+			},
+			after: currentPlacementStats{
+				final: []string{"a", "c", "d", "b", "e"},
+				moves: 1,
 			},
 		},
 		{
 			name: "insert beginning and end",
 			old:  []string{"a", "b", "c"},
 			new:  []string{"x", "a", "b", "c", "y"},
-			want: currentPlacementStats{
-				final:  []string{"x", "a", "b", "c", "y"},
+			before: currentPlacementStats{
+				final:  []string{"new-0:x", "a", "b", "c", "new-4:y"},
+				mounts: 2,
+			},
+			after: currentPlacementStats{
+				final:  []string{"new-0:x", "a", "b", "c", "new-4:y"},
 				mounts: 2,
 			},
 		},
@@ -75,17 +120,53 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 			name: "remove middle",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"a", "c", "d"},
-			want: currentPlacementStats{
+			before: currentPlacementStats{
 				final:    []string{"a", "c", "d"},
 				removals: 1,
+			},
+			after: currentPlacementStats{
+				final:    []string{"a", "c", "d"},
+				removals: 1,
+			},
+		},
+		{
+			name: "mixed keyed and unkeyed reorder",
+			old:  []string{"a", "", "b", ""},
+			new:  []string{"b", "", "a", ""},
+			before: currentPlacementStats{
+				final: []string{"b", "old-1", "a", "old-3"},
+				moves: 2,
+			},
+			after: currentPlacementStats{
+				final: []string{"b", "old-1", "a", "old-3"},
+				moves: 2,
+			},
+		},
+		{
+			name: "duplicate new key mounts duplicate",
+			old:  []string{"a", "b"},
+			new:  []string{"a", "a", "b"},
+			before: currentPlacementStats{
+				final:  []string{"a", "new-1:a", "b"},
+				mounts: 1,
+			},
+			after: currentPlacementStats{
+				final:  []string{"a", "new-1:a", "b"},
+				mounts: 1,
 			},
 		},
 		{
 			name: "mixed insert remove reorder",
 			old:  []string{"a", "b", "c", "d"},
 			new:  []string{"c", "x", "a"},
-			want: currentPlacementStats{
-				final:    []string{"c", "x", "a"},
+			before: currentPlacementStats{
+				final:    []string{"c", "new-1:x", "a"},
+				mounts:   1,
+				removals: 2,
+				moves:    1,
+			},
+			after: currentPlacementStats{
+				final:    []string{"c", "new-1:x", "a"},
 				mounts:   1,
 				removals: 2,
 				moves:    1,
@@ -95,16 +176,25 @@ func TestCurrentKeyedReorderPlacement(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := simulateCurrentPatchChildrenPlacement(t, test.old, test.new)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Fatalf("placement stats = %#v, want %#v", got, test.want)
+			before := simulateCurrentPatchChildrenPlacement(t, test.old, test.new, stableSuffixChildPlacementFlags)
+			if !reflect.DeepEqual(before, test.before) {
+				t.Fatalf("previous placement stats = %#v, want %#v", before, test.before)
+			}
+			after := simulateCurrentPatchChildrenPlacement(t, test.old, test.new, stableChildPlacements)
+			if !reflect.DeepEqual(after, test.after) {
+				t.Fatalf("placement stats = %#v, want %#v", after, test.after)
 			}
 		})
 	}
 }
 
-func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []string) currentPlacementStats {
+func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []string, stable func([]int, []string) []bool) currentPlacementStats {
 	t.Helper()
+
+	oldIDs := make([]string, len(oldKeys))
+	for index, key := range oldKeys {
+		oldIDs[index] = currentPlacementID("old", index, key)
+	}
 
 	matches := matchChildIndices(oldKeys, newKeys)
 	used := make([]bool, len(oldKeys))
@@ -112,19 +202,19 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 	for index, key := range newKeys {
 		oldIndex := matches[index]
 		if oldIndex == noChildMatch {
-			children[index] = currentPlacementChild{id: key, pending: true}
+			children[index] = currentPlacementChild{id: currentPlacementID("new", index, key), pending: true}
 			continue
 		}
 		used[oldIndex] = true
-		children[index] = currentPlacementChild{id: oldKeys[oldIndex]}
+		children[index] = currentPlacementChild{id: oldIDs[oldIndex]}
 	}
 
 	stats := currentPlacementStats{
 		final: make([]string, 0, len(newKeys)),
 	}
-	for index, key := range oldKeys {
+	for index := range oldKeys {
 		if used[index] {
-			stats.final = append(stats.final, key)
+			stats.final = append(stats.final, oldIDs[index])
 			continue
 		}
 		stats.removals++
@@ -132,7 +222,7 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 
 	var reference string
 	hasReference := false
-	stableStart := stableChildPlacementStart(matches)
+	stablePlacements := stable(matches, newKeys)
 	for index := len(children) - 1; index >= 0; index-- {
 		child := children[index]
 		if child.pending {
@@ -142,7 +232,7 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 			hasReference = true
 			continue
 		}
-		if index >= stableStart {
+		if stablePlacements != nil && stablePlacements[index] {
 			reference = child.id
 			hasReference = true
 			continue
@@ -170,9 +260,20 @@ func simulateCurrentPatchChildrenPlacement(t *testing.T, oldKeys, newKeys []stri
 	return stats
 }
 
+func currentPlacementID(prefix string, index int, key string) string {
+	if key == "" {
+		return prefix + "-" + ToString(index)
+	}
+	if prefix == "old" {
+		return key
+	}
+	return prefix + "-" + ToString(index) + ":" + key
+}
+
 func TestStableChildPlacements(t *testing.T) {
 	tests := []struct {
 		name    string
+		keys    []string
 		matches []int
 		want    []bool
 	}{
@@ -182,38 +283,56 @@ func TestStableChildPlacements(t *testing.T) {
 		},
 		{
 			name:    "all mounts",
+			keys:    []string{"a", "b"},
 			matches: []int{noChildMatch, noChildMatch},
 		},
 		{
 			name:    "stable",
+			keys:    []string{"a", "b", "c", "d"},
 			matches: []int{0, 1, 2, 3},
+			want:    []bool{true, true, true, true},
 		},
 		{
 			name:    "insert around stable",
+			keys:    []string{"x", "a", "b", "c", "y"},
 			matches: []int{noChildMatch, 0, 1, 2, noChildMatch},
+			want:    []bool{false, true, true, true, false},
 		},
 		{
 			name:    "rotate left",
+			keys:    []string{"b", "c", "d", "a"},
 			matches: []int{1, 2, 3, 0},
+			want:    []bool{true, true, true, false},
 		},
 		{
 			name:    "rotate right",
+			keys:    []string{"d", "a", "b", "c"},
 			matches: []int{3, 0, 1, 2},
 			want:    []bool{false, true, true, true},
 		},
 		{
 			name:    "reverse",
+			keys:    []string{"d", "c", "b", "a"},
 			matches: []int{3, 2, 1, 0},
+			want:    []bool{true, false, false, false},
 		},
 		{
 			name:    "mixed",
+			keys:    []string{"c", "x", "a"},
 			matches: []int{2, noChildMatch, 0},
+			want:    []bool{true, false, false},
+		},
+		{
+			name:    "unkeyed ignored",
+			keys:    []string{"b", "", "a", ""},
+			matches: []int{2, 1, 0, 3},
+			want:    []bool{true, false, false, false},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := stableChildPlacementFlags(test.matches)
+			got := stableChildPlacements(test.matches, test.keys)
 			if !reflect.DeepEqual(got, test.want) {
 				t.Fatalf("stable placements = %v, want %v", got, test.want)
 			}
@@ -226,7 +345,7 @@ func TestStableChildPlacements(t *testing.T) {
 	}
 }
 
-func stableChildPlacementFlags(matches []int) []bool {
+func stableSuffixChildPlacementFlags(matches []int, keys []string) []bool {
 	stableStart := stableChildPlacementStart(matches)
 	if stableStart == len(matches) {
 		return nil

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -195,10 +195,10 @@ func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNod
 		}
 	}
 
-	stableStart := stableChildPlacementStart(matches)
+	stablePlacements := stableChildPlacements(matches, newKeys)
 	reference := boundary
 	for index := len(children) - 1; index >= 0; index-- {
-		if index >= stableStart {
+		if stablePlacements != nil && stablePlacements[index] {
 			reference = children[index].first
 			continue
 		}


### PR DESCRIPTION
## Summary

Adds an exact `O(n log n)` LIS-aware keyed child placement optimization for GoFrame reconciliation.

This PR keeps the existing keyed matching, mounting, removal, duplicate-key handling, keyed/unkeyed behavior, and component identity semantics, but changes placement so matched keyed children in the longest increasing old-index subsequence are kept stable instead of being moved again.

The implementation was updated after review to avoid the earlier unbounded `O(n²)` LIS scan on long keyed lists.

Related to #71.

## Scope

Runtime reconciliation performance and nearest executable evidence only.

This PR updates:

* `pkg/goframe/reconcile.go`
* `pkg/goframe/render_js.go`
* `pkg/goframe/reconcile_reorder_test.go`
* `pkg/goframe/bench_test.go`
* `CHANGELOG.md`

## Changed Files / Areas

* `pkg/goframe/reconcile.go`
  * adds exact LIS-aware stable placement marking for matched keyed children;
  * uses an `O(n log n)` marker based on keyed old-index tails and predecessor links;
  * ignores mounts and unkeyed children for LIS stability;
  * preserves existing child matching behavior.

* `pkg/goframe/render_js.go`
  * uses LIS stable placement markers during right-to-left child placement;
  * skips redundant DOM moves for keyed children that belong to the stable subsequence.

* `pkg/goframe/reconcile_reorder_test.go`
  * expands keyed reorder placement characterization;
  * records before/after move counts;
  * covers stable, rotate-left, rotate-right, reverse, middle-forward, middle-backward, insert/remove, mixed keyed/unkeyed, duplicate keys, and mixed insert/remove reorder cases;
  * adds long keyed-list coverage for the bounded LIS path.

* `pkg/goframe/bench_test.go`
  * updates keyed placement benchmarks for the `O(n log n)` LIS marker;
  * adds a 2048-child long-list benchmark case.

* `CHANGELOG.md`
  * records the scoped keyed placement optimization under `Unreleased`.

## Behavior, API, Or Docs Impact

Runtime behavior:

* keyed child placement now keeps the longest increasing keyed subsequence stable during placement;
* redundant moves are reduced for LIS-benefiting keyed reorder cases;
* characterized middle-backward keyed reorder improves from the old stable-suffix baseline of `2` existing-node moves to `1`;
* previously improved rotate-right behavior remains at `1` move;
* mounting, removal, keyed matching, duplicate-key behavior, keyed/unkeyed behavior, and component state preservation semantics are unchanged.

API impact:

* no public API changes;
* no GOX changes;
* no `goxc` changes;
* no scheduler changes;
* no commit-buffer or mutation-queue work.

Docs impact:

* changelog only.

## Move-Count Evidence

Before → after:

* stable: `0 -> 0`
* rotate-left: `1 -> 1`
* rotate-right: `1 -> 1`
* reverse: `3 -> 3`
* move middle forward: `1 -> 1`
* move middle backward: `2 -> 1`
* insert beginning/end: `2 mounts -> 2 mounts`, `0 moves -> 0 moves`
* remove middle: `1 removal -> 1 removal`, `0 moves -> 0 moves`
* mixed keyed/unkeyed: `2 -> 2`
* duplicate new key: `1 mount -> 1 mount`

## Performance / Size Evidence

WASM size budget reported after the bounded LIS follow-up:

* dashboard raw before the follow-up: `168324 B / 168960 B`
* dashboard raw after the follow-up: `168231 B / 168960 B`
* follow-up raw delta: `-93 B`
* remaining dashboard headroom: `729 B`
* full size budget: passed

Benchmark evidence reported:

* keyed matching benchmark stayed at `8744 B/op`, `6 allocs/op`;
* 128-child placement cases improved from roughly `6.5-14.6 µs/op` to roughly `1.5-3.1 µs/op`;
* 128-child placement allocations changed from `1152 B/op`, `2 allocs/op` to `2176 B/op`, `3 allocs/op`;
* 2048-child `long_move_backward` placement case runs in `77490 ns/op`, `34816 B/op`, `3 allocs/op`.

The LIS marker is now exact `O(n log n)`, so the optimization avoids the previous unbounded `O(n²)` scan while still spending a small allocation budget for stable-placement marking.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [x] `go test ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [x] `scripts/size-budget.sh`
- [x] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `go test ./pkg/goframe -run 'Test.*Reconcile|Test.*Key|Test.*Placement|Test.*Reorder'`
* `go test ./pkg/goframe`
* `go test -tags=goframe_debug ./...`
* post-browser `scripts/size-budget.sh`
* before/after keyed placement benchmarks
* long-list keyed placement benchmark

## Non-Goals

* No public API changes.
* No keyed matching behavior changes.
* No duplicate-key behavior changes.
* No keyed/unkeyed matching behavior changes.
* No component identity or state preservation changes.
* No broad reconciler rewrite.
* No scheduler changes.
* No commit buffer.
* No mutation queue.
* No GOX changes.
* No `goxc` changes.
* No examples changes.
* No scripts changes.
* No workflows changes.
* No release docs changes.
* No generated artifacts.
* No issue closing.

## Checklist

- [x] This PR has no unrelated changes.
- [x] Keyed reorder behavior is covered by executable tests.
- [x] Before/after move-count evidence is included.
- [x] Long keyed-list placement work is covered by test and benchmark evidence.
- [x] WASM size budget passes.
- [x] Browser smoke passes.
- [x] Changelog was updated.
- [x] This PR does not add a production-readiness claim.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This is a scoped LIS-aware placement optimization for matched keyed children, not a broader reconciliation rewrite.

#71 may be considered addressed for this scoped keyed-placement implementation after review, but this PR intentionally uses `Related to #71` and does not auto-close it.

#70 commit-buffer architecture remains separate.

Further runtime optimization work should account for the reduced dashboard raw-size headroom.