### PR TITLE
docs(release): mark v0.2.0 preview 5 as published

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,8 @@ it does not write generated `.gox.go` files next to authored source by default.
 - [API stability](docs/api-stability.md) and
   [platform support](docs/platform-support.md) - maturity and support
   boundaries.
-- Preview notes prepared for:
-  [v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md).
 - Current published preview notes:
-  [v0.2.0-preview.4](docs/release-notes-v0.2.0-preview.4.md).
+  [v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md).
 
 For the fastest tour, start with `examples/counter`, then
 `examples/components`, then `examples/router-dashboard`.
@@ -512,7 +510,7 @@ Start here:
 
 - [GoFrame Tutorial](docs/tutorial.md)
 - [Evaluator guide](docs/evaluator-guide.md)
-- [Preview notes prepared through v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md)
+- [Release notes through v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -214,7 +214,7 @@ metadata compatibility policy.
 ```
 
 Local checkout builds write `devel`; tagged module installs write the module
-version recorded in Go build information, such as `v0.2.0-preview.4`.
+version recorded in Go build information, such as `v0.2.0-preview.5`.
 
 `goframe-package.json` is the authoritative current package completion marker.
 `goxc` publishes it last and removes it first during destructive package

--- a/docs/evaluator-guide.md
+++ b/docs/evaluator-guide.md
@@ -1,6 +1,6 @@
 # Evaluator Guide
 
-This guide is for evaluating the `v0.2.0-preview.4` browser/WASM layer. It is
+This guide is for evaluating the `v0.2.0-preview.5` browser/WASM layer. It is
 not a production deployment guide.
 
 ## Prerequisites
@@ -156,4 +156,4 @@ app. It is not a cross-browser certification suite.
 
 For the guided walkthrough, read the [tutorial](tutorial.md). For release scope
 and limitations, read the
-[v0.2.0-preview.4 release notes](release-notes-v0.2.0-preview.4.md).
+[v0.2.0-preview.5 release notes](release-notes-v0.2.0-preview.5.md).

--- a/docs/release-notes-v0.2.0-preview.5.md
+++ b/docs/release-notes-v0.2.0-preview.5.md
@@ -52,7 +52,8 @@ LSP support.
 
 ### Release And Docs Process
 
-- Repository docs now mark `v0.2.0-preview.4` as the latest published preview.
+- Repository docs distinguish published-preview state from prepared-preview
+  state across the release cycle.
 - Release documentation includes GitHub Release title/body style guidance for
   future preview releases.
 - These were process/docs cleanups, not runtime behavior changes.
@@ -111,7 +112,7 @@ Release-gate validation for this preview should include:
 
 ## Install
 
-After the tag is published, install the exact preview with:
+Install the exact preview with:
 
 ```bash
 go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.5

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,12 +14,6 @@ v0.1.0-mvp10
 Latest published preview tag:
 
 ```text
-v0.2.0-preview.4
-```
-
-Current preview tag under preparation:
-
-```text
 v0.2.0-preview.5
 ```
 


### PR DESCRIPTION
## Summary

Marks `v0.2.0-preview.5` as the latest published preview in repository documentation.

The tag and GitHub Pre-Release were published manually before this PR. This PR only updates post-publish wording on `main` so docs no longer describe preview.5 as prepared or pending publication.

It does not create a tag, publish or edit a GitHub Release, or change runtime/compiler/toolchain code.

## Scope

Post-publish documentation cleanup only.

This PR updates:

* `README.md`
* `docs/release.md`
* `docs/release-notes-v0.2.0-preview.5.md`
* `docs/evaluator-guide.md`
* `docs/deployment.md`

## Changed Files / Areas

* `README.md`
  * removes preview.5 prepared wording;
  * marks `v0.2.0-preview.5` as the current published preview notes;
  * updates the documentation map wording to release notes through preview.5.

* `docs/release.md`
  * marks `v0.2.0-preview.5` as the latest published preview tag;
  * removes the preview.5 under-preparation block;
  * keeps release hygiene policy unchanged.

* `docs/release-notes-v0.2.0-preview.5.md`
  * updates install wording now that the tag is published;
  * removes stale pre-publication wording;
  * keeps release scope, validation, compatibility, links, and limitations unchanged.

* `docs/evaluator-guide.md`
  * moves the evaluator target from preview.4 to published preview.5;
  * updates the release-note link to preview.5.

* `docs/deployment.md`
  * updates the tagged module version example to `v0.2.0-preview.5`.

## Behavior, API, Or Docs Impact

Docs impact:

* `v0.2.0-preview.5` is now documented as the current published preview;
* preview.5 install and verification wording now matches the published tag state;
* evaluator and deployment docs now align with the published preview.5 module version;
* preview.4 remains only as historical/previous-preview context.

API/runtime/toolchain impact:

* no runtime changes;
* no `pkg/goframe` changes;
* no `pkg/gox` changes;
* no `cmd/goxc` changes;
* no example changes;
* no script or workflow changes.

Release impact:

* no tag created by this PR;
* no GitHub Release created by this PR;
* no GitHub Release edited by this PR;
* no release assets uploaded;
* no generated artifacts committed.

## Validation

Local validation reported:

- [ ] `scripts/check.sh`
- [ ] `go test ./...`
- [ ] `go test -race ./pkg/... ./cmd/...`
- [ ] `go vet ./...`
- [x] `node scripts/docs-check.mjs`, if docs changed
- [ ] `scripts/size-budget.sh`
- [ ] `scripts/browser-smoke.sh`, if runtime/browser behavior changed
- [ ] VS Code extension compile, if `extensions/vscode-gox` changed

Additional focused validation reported:

* `git diff --check`
* `git status --short --untracked-files=all`
* local and remote `v0.2.0-preview.5` tag both resolve to `2d5cab1b20cc7bff2dacbcf83f54fbee6205eb9b`
* published install verification through default `GOPROXY`
* `goxc version v0.2.0-preview.5`
* `goxc doctor` status: `ok`
* stale pre-publication wording search
* auto-closing issue keyword search

## Non-Goals

* No runtime changes.
* No GOX compiler changes.
* No `goxc` toolchain changes.
* No example changes.
* No script changes.
* No workflow changes.
* No asset changes.
* No generated artifacts.
* No tag creation.
* No GitHub Release publishing.
* No GitHub Release edits.
* No issue comments.
* No issue closing.
* No social preview changes.
* No preview.6 preparation.

## Checklist

- [x] This PR has no unrelated changes.
- [x] `v0.2.0-preview.5` is documented as published.
- [x] Pre-publication wording for preview.5 was removed from affected docs.
- [x] Evaluator and deployment docs now align with published preview.5.
- [x] This PR does not add a production-readiness claim.
- [x] This PR avoids auto-closing issue keywords.
- [x] Relevant checks are listed above.
- [x] This branch is based on current `main`.

## Notes

This closes the preview.5 documentation loop after manual tag and GitHub Pre-Release publication.

Runtime architecture follow-ups, including #70, remain separate.