### PR TITLE
feat(goxc): add structured GOX check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Read-only `goxc check` validation for authored GOX files and directory trees,
+  with text output, a versioned JSON diagnostics contract, nonzero diagnostic
+  exit status, and no generated output or workspace materialization.
 - `v0.2.0-preview.5` release notes documenting retained input selection
   restoration, GOX embedded-expression source diagnostics, nested diagnostic
   source-location preservation, exact O(n log n) LIS-aware keyed placement, and

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ LSP support.
 ## Quick Start
 
 Install `goxc`, add its install directory to `PATH`, check your local
-toolchain, package the counter example, and serve it locally:
+toolchain and GOX source, package the counter example, and serve it locally:
 
 ```bash
 go install github.com/graybuton/goframe/cmd/goxc@latest
@@ -50,6 +50,7 @@ fi
 export PATH="$goxc_bin:$PATH"
 
 goxc doctor
+goxc check ./examples/counter
 goxc package ./examples/counter --compiler=tinygo
 goxc serve ./examples/counter --port=8080
 ```
@@ -86,6 +87,7 @@ func App(props AppProps) gf.Node {
 }
 ```
 
+`goxc check` validates authored `.gox` files without writing generated output.
 `goxc generate` turns `.gox` files into Go compiler output under `.goframe`;
 it does not write generated `.gox.go` files next to authored source by default.
 
@@ -95,8 +97,8 @@ it does not write generated `.gox.go` files next to authored source by default.
   context, events, reconciliation, resources, routing, and fixed-height
   virtualization.
 - `pkg/gox`: GOX lexer/parser/codegen with source-oriented diagnostics.
-- `cmd/goxc`: generate, build, package, export, serve, size, clean, doctor,
-  and version commands.
+- `cmd/goxc`: check, generate, build, package, export, serve, size, clean,
+  doctor, and version commands.
 - Examples and scripts that exercise the runtime, compiler, package workflow,
   browser smoke paths, and WASM size budgets.
 - A lightweight VS Code GOX extension in `extensions/vscode-gox`.
@@ -396,6 +398,7 @@ Common commands:
 
 | Command | Responsibility |
 |---|---|
+| `goxc check <file-or-directory>` | Validate authored `.gox` source without writing generated files. |
 | `goxc generate <app>` | Generate `.gox.go` compiler output under `.goframe/gen`. |
 | `goxc build <app>` | Compile raw WASM under `.goframe/build/<compiler>/dev`. |
 | `goxc package <app>` | Build a runnable `.goframe/package/standalone` bundle. |

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ LSP support.
 ## Quick Start
 
 Install `goxc`, add its install directory to `PATH`, check your local
-toolchain and GOX source, package the counter example, and serve it locally:
+toolchain, package the counter example, and serve it locally:
 
 ```bash
 go install github.com/graybuton/goframe/cmd/goxc@latest
@@ -50,7 +50,6 @@ fi
 export PATH="$goxc_bin:$PATH"
 
 goxc doctor
-goxc check ./examples/counter
 goxc package ./examples/counter --compiler=tinygo
 goxc serve ./examples/counter --port=8080
 ```
@@ -116,8 +115,10 @@ it does not write generated `.gox.go` files next to authored source by default.
 - [API stability](docs/api-stability.md) and
   [platform support](docs/platform-support.md) - maturity and support
   boundaries.
-- Current published preview notes:
-  [v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md).
+- [Releases](https://github.com/graybuton/goframe/releases) - published
+  previews and release notes.
+- [Release process](docs/release.md) - versioning, validation, and publishing
+  policy.
 
 For the fastest tour, start with `examples/counter`, then
 `examples/components`, then `examples/router-dashboard`.
@@ -513,7 +514,8 @@ Start here:
 
 - [GoFrame Tutorial](docs/tutorial.md)
 - [Evaluator guide](docs/evaluator-guide.md)
-- [Release notes through v0.2.0-preview.5](docs/release-notes-v0.2.0-preview.5.md)
+- [Published releases and release notes](https://github.com/graybuton/goframe/releases)
+- [Release process](docs/release.md)
 - [Architecture and toolchain boundaries](docs/architecture.md)
 - [Runtime model](docs/runtime-model.md)
 - [GOX language and diagnostics](docs/gox-language.md)

--- a/cmd/goxc/check.go
+++ b/cmd/goxc/check.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/graybuton/goframe/pkg/gox"
+)
+
+const checkSchemaVersion = 1
+
+var errCheckDiagnostics = errors.New("GOX diagnostics found")
+
+type checkFormat string
+
+const (
+	checkFormatText checkFormat = "text"
+	checkFormatJSON checkFormat = "json"
+)
+
+type checkOptions struct {
+	path   string
+	format checkFormat
+}
+
+type checkDiagnostic struct {
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+	Source   string `json:"source"`
+}
+
+type checkReport struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	OK            bool              `json:"ok"`
+	FilesChecked  int               `json:"filesChecked"`
+	Diagnostics   []checkDiagnostic `json:"diagnostics"`
+}
+
+type checkSource struct {
+	path    string
+	content []byte
+}
+
+func checkCommand(args []string) error {
+	return runCheckCommand(args, os.Stdout, os.Stderr)
+}
+
+func runCheckCommand(args []string, stdout, stderr io.Writer) error {
+	options, err := parseCheckOptions(args)
+	if err != nil {
+		return err
+	}
+	report, err := checkPath(options.path)
+	if err != nil {
+		return err
+	}
+
+	switch options.format {
+	case checkFormatJSON:
+		err = writeCheckJSON(stdout, report)
+	case checkFormatText:
+		err = writeCheckText(stdout, stderr, report)
+	default:
+		return fmt.Errorf("unsupported check format %q", options.format)
+	}
+	if err != nil {
+		return fmt.Errorf("write check report: %w", err)
+	}
+	if !report.OK {
+		return errCheckDiagnostics
+	}
+	return nil
+}
+
+func parseCheckOptions(args []string) (checkOptions, error) {
+	options := checkOptions{format: checkFormatText}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case strings.HasPrefix(arg, "--format="):
+			format, err := parseCheckFormat(strings.TrimPrefix(arg, "--format="))
+			if err != nil {
+				return checkOptions{}, err
+			}
+			options.format = format
+		case arg == "--format":
+			index++
+			if index >= len(args) {
+				return checkOptions{}, errors.New("--format requires a value")
+			}
+			format, err := parseCheckFormat(args[index])
+			if err != nil {
+				return checkOptions{}, err
+			}
+			options.format = format
+		case strings.HasPrefix(arg, "-"):
+			return checkOptions{}, fmt.Errorf("unknown check flag %q", arg)
+		case options.path == "":
+			options.path = arg
+		default:
+			return checkOptions{}, fmt.Errorf("unexpected check argument %q", arg)
+		}
+	}
+	if options.path == "" {
+		return checkOptions{}, errors.New("usage: goxc check <file-or-directory> [--format=text|json]")
+	}
+	return options, nil
+}
+
+func parseCheckFormat(value string) (checkFormat, error) {
+	switch checkFormat(value) {
+	case checkFormatText:
+		return checkFormatText, nil
+	case checkFormatJSON:
+		return checkFormatJSON, nil
+	default:
+		return "", fmt.Errorf("unsupported check format %q; expected text or json", value)
+	}
+}
+
+func checkPath(path string) (checkReport, error) {
+	files, err := findGOXFiles(path)
+	if err != nil {
+		return checkReport{}, err
+	}
+	if len(files) == 0 {
+		return checkReport{}, fmt.Errorf("no .gox files found below %s", path)
+	}
+	appDir, err := generationAppDir(path)
+	if err != nil {
+		return checkReport{}, err
+	}
+	appDir, err = filepath.Abs(appDir)
+	if err != nil {
+		return checkReport{}, fmt.Errorf("resolve GOX application directory %s: %w", appDir, err)
+	}
+
+	sources := make([]checkSource, 0, len(files))
+	for _, file := range files {
+		absolute, err := filepath.Abs(file)
+		if err != nil {
+			return checkReport{}, fmt.Errorf("resolve GOX source %s: %w", file, err)
+		}
+		absolute = filepath.Clean(absolute)
+		info, err := regularFileNoFollow(absolute, "GOX source file")
+		if err != nil {
+			return checkReport{}, err
+		}
+		if info.Size() < 0 {
+			return checkReport{}, fmt.Errorf("inspect %s: invalid source size", absolute)
+		}
+		content, err := os.ReadFile(absolute)
+		if err != nil {
+			return checkReport{}, fmt.Errorf("read %s: %w", absolute, err)
+		}
+		sources = append(sources, checkSource{path: absolute, content: content})
+	}
+	sort.Slice(sources, func(left, right int) bool {
+		return sources[left].path < sources[right].path
+	})
+
+	diagnostics := make([]checkDiagnostic, 0)
+	for _, source := range sources {
+		_, err := gox.GenerateWithOptions(source.content, gox.GenerateOptions{
+			Filename:        source.path,
+			PackageIdentity: packageIdentityForFile(appDir, source.path),
+		})
+		if err != nil {
+			diagnostics = append(diagnostics, checkDiagnosticFromError(source.path, err))
+		}
+	}
+	sort.Slice(diagnostics, func(left, right int) bool {
+		first := diagnostics[left]
+		second := diagnostics[right]
+		if first.File != second.File {
+			return first.File < second.File
+		}
+		if first.Line != second.Line {
+			return first.Line < second.Line
+		}
+		if first.Column != second.Column {
+			return first.Column < second.Column
+		}
+		return first.Message < second.Message
+	})
+
+	return checkReport{
+		SchemaVersion: checkSchemaVersion,
+		OK:            len(diagnostics) == 0,
+		FilesChecked:  len(sources),
+		Diagnostics:   diagnostics,
+	}, nil
+}
+
+func checkDiagnosticFromError(filename string, err error) checkDiagnostic {
+	var diagnosticError gox.DiagnosticError
+	if errors.As(err, &diagnosticError) {
+		diagnostic := diagnosticError.Diagnostic
+		return checkDiagnostic{
+			File:     filepath.Clean(diagnostic.Filename),
+			Line:     diagnostic.Line,
+			Column:   diagnostic.Column,
+			Severity: "error",
+			Message:  diagnostic.Message,
+			Source:   diagnostic.Source,
+		}
+	}
+
+	message := err.Error()
+	prefix := filename + ":"
+	if strings.HasPrefix(message, prefix) {
+		message = strings.TrimSpace(strings.TrimPrefix(message, prefix))
+	}
+	return checkDiagnostic{
+		File:     filename,
+		Severity: "error",
+		Message:  message,
+		Source:   "",
+	}
+}
+
+func writeCheckText(stdout, stderr io.Writer, report checkReport) error {
+	if report.OK {
+		_, err := fmt.Fprintf(stdout, "checked %d GOX files: no diagnostics\n", report.FilesChecked)
+		return err
+	}
+	for _, diagnostic := range report.Diagnostics {
+		if diagnostic.Line > 0 && diagnostic.Column > 0 {
+			if _, err := fmt.Fprintf(stderr, "%s:%d:%d: %s\n", diagnostic.File, diagnostic.Line, diagnostic.Column, diagnostic.Message); err != nil {
+				return err
+			}
+		} else if _, err := fmt.Fprintf(stderr, "%s: %s\n", diagnostic.File, diagnostic.Message); err != nil {
+			return err
+		}
+		if diagnostic.Source != "" {
+			if _, err := fmt.Fprintf(stderr, "  %s\n", diagnostic.Source); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintf(stderr, "checked %d GOX files: %s\n", report.FilesChecked, checkDiagnosticCount(len(report.Diagnostics)))
+	return err
+}
+
+func checkDiagnosticCount(count int) string {
+	if count == 1 {
+		return "1 diagnostic"
+	}
+	return fmt.Sprintf("%d diagnostics", count)
+}
+
+func writeCheckJSON(output io.Writer, report checkReport) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(report)
+}

--- a/cmd/goxc/check_test.go
+++ b/cmd/goxc/check_test.go
@@ -1,0 +1,392 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const validCheckSource = `package main
+
+func App() any {
+	return <main>Hello</main>
+}
+`
+
+const invalidCheckSource = `package main
+
+func App() any {
+	return <main>{}</main>
+}
+`
+
+func TestParseCheckOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantPath   string
+		wantFormat checkFormat
+		wantError  string
+	}{
+		{name: "default text", args: []string{"app.gox"}, wantPath: "app.gox", wantFormat: checkFormatText},
+		{name: "explicit text equals", args: []string{"app.gox", "--format=text"}, wantPath: "app.gox", wantFormat: checkFormatText},
+		{name: "explicit text separate", args: []string{"--format", "text", "app.gox"}, wantPath: "app.gox", wantFormat: checkFormatText},
+		{name: "json equals", args: []string{"app.gox", "--format=json"}, wantPath: "app.gox", wantFormat: checkFormatJSON},
+		{name: "json separate", args: []string{"--format", "json", "app.gox"}, wantPath: "app.gox", wantFormat: checkFormatJSON},
+		{name: "missing path", wantError: "usage: goxc check"},
+		{name: "format without path", args: []string{"--format=json"}, wantError: "usage: goxc check"},
+		{name: "extra positional", args: []string{"one.gox", "two.gox"}, wantError: "unexpected check argument"},
+		{name: "unknown flag", args: []string{"app.gox", "--watch"}, wantError: "unknown check flag"},
+		{name: "no json alias", args: []string{"app.gox", "--json"}, wantError: "unknown check flag"},
+		{name: "no short format", args: []string{"app.gox", "-f", "json"}, wantError: "unknown check flag"},
+		{name: "missing format value", args: []string{"app.gox", "--format"}, wantError: "--format requires a value"},
+		{name: "unsupported format", args: []string{"app.gox", "--format=yaml"}, wantError: "unsupported check format"},
+		{name: "no out", args: []string{"app.gox", "--out=gen"}, wantError: "unknown check flag"},
+		{name: "no workspace", args: []string{"app.gox", "--workspace=work"}, wantError: "unknown check flag"},
+		{name: "no in place", args: []string{"app.gox", "--in-place"}, wantError: "unknown check flag"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options, err := parseCheckOptions(test.args)
+			if test.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("parseCheckOptions() error = %v, want %q", err, test.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCheckOptions() error: %v", err)
+			}
+			if options.path != test.wantPath || options.format != test.wantFormat {
+				t.Fatalf("parseCheckOptions() = %+v, want path %q format %q", options, test.wantPath, test.wantFormat)
+			}
+		})
+	}
+}
+
+func TestCheckValidSingleFileText(t *testing.T) {
+	root := t.TempDir()
+	path := writeCheckSource(t, root, "app.gox", validCheckSource)
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{path})
+	if err != nil {
+		t.Fatalf("runCheckCommand() error: %v", err)
+	}
+	if stdout != "checked 1 GOX files: no diagnostics\n" {
+		t.Fatalf("stdout = %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckValidSingleFileJSON(t *testing.T) {
+	root := t.TempDir()
+	path := writeCheckSource(t, root, "app.gox", validCheckSource)
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{path, "--format=json"})
+	if err != nil {
+		t.Fatalf("runCheckCommand() error: %v", err)
+	}
+	report := decodeCheckReport(t, stdout)
+	if report.SchemaVersion != 1 || !report.OK || report.FilesChecked != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Diagnostics == nil || len(report.Diagnostics) != 0 {
+		t.Fatalf("diagnostics = %#v, want non-nil empty slice", report.Diagnostics)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckInvalidSourceText(t *testing.T) {
+	root := t.TempDir()
+	path := writeCheckSource(t, root, "app.gox", invalidCheckSource)
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{path})
+	if !errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("runCheckCommand() error = %v, want errCheckDiagnostics", err)
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty", stdout)
+	}
+	want := path + ":4:15: gox: empty child expression\n  <main>{}</main>\nchecked 1 GOX files: 1 diagnostic\n"
+	if stderr != want {
+		t.Fatalf("stderr = %q, want %q", stderr, want)
+	}
+	if strings.Contains(stderr, ".goframe") {
+		t.Fatalf("stderr contains generated workspace path: %q", stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckInvalidSourceJSON(t *testing.T) {
+	root := t.TempDir()
+	path := writeCheckSource(t, root, "app.gox", invalidCheckSource)
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{path, "--format", "json"})
+	if !errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("runCheckCommand() error = %v, want errCheckDiagnostics", err)
+	}
+	report := decodeCheckReport(t, stdout)
+	if report.SchemaVersion != 1 || report.OK || report.FilesChecked != 1 || len(report.Diagnostics) != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+	diagnostic := report.Diagnostics[0]
+	want := checkDiagnostic{
+		File:     path,
+		Line:     4,
+		Column:   15,
+		Severity: "error",
+		Message:  "gox: empty child expression",
+		Source:   "<main>{}</main>",
+	}
+	if diagnostic != want {
+		t.Fatalf("diagnostic = %+v, want %+v", diagnostic, want)
+	}
+	if !filepath.IsAbs(diagnostic.File) {
+		t.Fatalf("diagnostic file = %q, want absolute path", diagnostic.File)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	if strings.Contains(stdout, `\u003c`) || strings.Contains(stdout, `\u003e`) {
+		t.Fatalf("JSON escaped GOX markup as HTML: %q", stdout)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckCollectsDiagnosticsFromMultipleFiles(t *testing.T) {
+	root := t.TempDir()
+	writeCheckSource(t, root, "valid.gox", validCheckSource)
+	firstPath := writeCheckSource(t, root, "a/first.gox", invalidCheckSource)
+	secondPath := writeCheckSource(t, root, "z/second.gox", invalidCheckSource)
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{root, "--format=json"})
+	if !errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("runCheckCommand() error = %v, want errCheckDiagnostics", err)
+	}
+	report := decodeCheckReport(t, stdout)
+	if report.FilesChecked != 3 || len(report.Diagnostics) != 2 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Diagnostics[0].File != firstPath || report.Diagnostics[1].File != secondPath {
+		t.Fatalf("diagnostic order = %#v", report.Diagnostics)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckNestedPackageTreeWithoutWorkspace(t *testing.T) {
+	root := t.TempDir()
+	writeCheckSource(t, root, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeCheckSource(t, root, "app.gox", validCheckSource)
+	writeCheckSource(t, root, "internal/ui/view.gox", strings.Replace(validCheckSource, "package main", "package ui", 1))
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{root, "--format=json"})
+	if err != nil {
+		t.Fatalf("runCheckCommand() error: %v", err)
+	}
+	report := decodeCheckReport(t, stdout)
+	if !report.OK || report.FilesChecked != 2 {
+		t.Fatalf("report = %+v", report)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckGenericCompilerErrorUsesSourceFile(t *testing.T) {
+	root := t.TempDir()
+	path := writeCheckSource(t, root, "plain.gox", "package main\n\nfunc App() any { return nil }\n")
+
+	stdout, stderr, err := runCheckForTest([]string{path, "--format=json"})
+	if !errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("runCheckCommand() error = %v, want errCheckDiagnostics", err)
+	}
+	report := decodeCheckReport(t, stdout)
+	if len(report.Diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v", report.Diagnostics)
+	}
+	diagnostic := report.Diagnostics[0]
+	if diagnostic.File != path || diagnostic.Line != 0 || diagnostic.Column != 0 || diagnostic.Source != "" || diagnostic.Severity != "error" {
+		t.Fatalf("diagnostic = %+v", diagnostic)
+	}
+	if diagnostic.Message != "no GOX markup elements found" || strings.Contains(diagnostic.Message, path) {
+		t.Fatalf("diagnostic message = %q", diagnostic.Message)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty", stderr)
+	}
+
+	stdout, stderr, err = runCheckForTest([]string{path})
+	if !errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("text runCheckCommand() error = %v, want errCheckDiagnostics", err)
+	}
+	if stdout != "" {
+		t.Fatalf("text stdout = %q, want empty", stdout)
+	}
+	wantText := path + ": no GOX markup elements found\nchecked 1 GOX files: 1 diagnostic\n"
+	if stderr != wantText || strings.Contains(stderr, ":0:0") {
+		t.Fatalf("text stderr = %q, want %q without zero location", stderr, wantText)
+	}
+}
+
+func TestCheckDirectoryWithNoGOXFilesIsOperationalError(t *testing.T) {
+	root := t.TempDir()
+	writeCheckSource(t, root, "main.go", "package main\n")
+	before := snapshotCheckTree(t, root)
+
+	stdout, stderr, err := runCheckForTest([]string{root, "--format=json"})
+	if err == nil || errors.Is(err, errCheckDiagnostics) || !strings.Contains(err.Error(), "no .gox files found") {
+		t.Fatalf("runCheckCommand() error = %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("operational error output: stdout=%q stderr=%q", stdout, stderr)
+	}
+	assertCheckTreeUnchanged(t, root, before)
+}
+
+func TestCheckMissingPathIsOperationalError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.gox")
+	stdout, stderr, err := runCheckForTest([]string{path, "--format=json"})
+	if err == nil || errors.Is(err, errCheckDiagnostics) {
+		t.Fatalf("runCheckCommand() error = %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("missing path output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCheckRejectsSymlinkedGOXSource(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	target := writeCheckSource(t, t.TempDir(), "target.gox", validCheckSource)
+	link := filepath.Join(root, "app.gox")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := runCheckForTest([]string{link, "--format=json"})
+	if err == nil || errors.Is(err, errCheckDiagnostics) || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("runCheckCommand() error = %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("symlink error output: stdout=%q stderr=%q", stdout, stderr)
+	}
+}
+
+func TestCheckUsageIsListed(t *testing.T) {
+	var output bytes.Buffer
+	usage(&output)
+	if !strings.Contains(output.String(), "check <path>") {
+		t.Fatalf("usage() does not list check: %q", output.String())
+	}
+}
+
+func runCheckForTest(args []string) (string, string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := runCheckCommand(args, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func decodeCheckReport(t *testing.T, output string) checkReport {
+	t.Helper()
+	if !strings.HasSuffix(output, "\n") || strings.Count(output, "\n") != 1 {
+		t.Fatalf("JSON output must have exactly one trailing newline: %q", output)
+	}
+	decoder := json.NewDecoder(strings.NewReader(output))
+	var report checkReport
+	if err := decoder.Decode(&report); err != nil {
+		t.Fatalf("decode check report: %v\n%s", err, output)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		t.Fatalf("JSON output contains extra content: %v\n%s", err, output)
+	}
+	return report
+}
+
+func writeCheckSource(t *testing.T, root, relative, content string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Clean(absolute)
+}
+
+type checkTreeEntry struct {
+	Mode    os.FileMode
+	Content string
+}
+
+func snapshotCheckTree(t *testing.T, root string) map[string]checkTreeEntry {
+	t.Helper()
+	snapshot := map[string]checkTreeEntry{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entry := checkTreeEntry{Mode: info.Mode()}
+		if info.Mode().IsRegular() {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			entry.Content = string(content)
+		}
+		snapshot[filepath.ToSlash(relative)] = entry
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot check tree: %v", err)
+	}
+	return snapshot
+}
+
+func assertCheckTreeUnchanged(t *testing.T, root string, before map[string]checkTreeEntry) {
+	t.Helper()
+	after := snapshotCheckTree(t, root)
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("checked tree changed\nbefore: %#v\nafter:  %#v", before, after)
+	}
+	if _, err := os.Lstat(filepath.Join(root, defaultWorkspaceName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("check created %s: %v", defaultWorkspaceName, err)
+	}
+	for path := range after {
+		if strings.HasSuffix(path, ".gox.go") {
+			t.Fatalf("check created generated file %s", path)
+		}
+	}
+}

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCommandUsage(t *testing.T) {
-	for _, command := range []string{"generate", "build", "package", "export", "serve", "size", "doctor", "clean", "version"} {
+	for _, command := range []string{"check", "generate", "build", "package", "export", "serve", "size", "doctor", "clean", "version"} {
 		t.Run(command, func(t *testing.T) {
 			var output bytes.Buffer
 			commandUsage(&output, command)

--- a/cmd/goxc/main.go
+++ b/cmd/goxc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +35,12 @@ func main() {
 			return
 		}
 		err = generateCommand(os.Args[2:])
+	case "check":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "check")
+			return
+		}
+		err = checkCommand(os.Args[2:])
 	case "build":
 		if commandHelpRequested(os.Args[2:]) {
 			commandUsage(os.Stdout, "build")
@@ -77,6 +84,9 @@ func main() {
 	}
 
 	if err != nil {
+		if errors.Is(err, errCheckDiagnostics) {
+			os.Exit(1)
+		}
 		fmt.Fprintln(os.Stderr, "goxc:", err)
 		os.Exit(1)
 	}
@@ -88,6 +98,7 @@ func usage(output io.Writer) {
 	fmt.Fprintln(output, "usage: goxc <command> [arguments]")
 	fmt.Fprintln(output, "")
 	fmt.Fprintln(output, "commands:")
+	fmt.Fprintln(output, "  check <path>          validate .gox source without writing generated files")
 	fmt.Fprintln(output, "  generate <path>       generate .go files from .gox files into .goframe/gen/")
 	fmt.Fprintln(output, "  build <app>           compile raw WASM into .goframe/build/")
 	fmt.Fprintln(output, "  package <app>         create a runnable bundle in .goframe/package/")
@@ -114,6 +125,9 @@ func commandHelpRequested(args []string) bool {
 
 func commandUsage(output io.Writer, command string) {
 	switch command {
+	case "check":
+		fmt.Fprintln(output, "usage: goxc check <file-or-directory> [--format=text|json]")
+		fmt.Fprintln(output, "validate GOX source without writing generated files or running Go type checking")
 	case "generate":
 		fmt.Fprintln(output, "usage: goxc generate <file-or-directory> [--out=directory] [--workspace=directory] [--in-place]")
 		fmt.Fprintln(output, "generate .go compiler output from .gox files; default output is .goframe/gen/")

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -103,6 +103,7 @@ Runtime:
 
 Tooling:
 
+- `goxc check`
 - `goxc generate`
 - `goxc build`
 - `goxc package`
@@ -115,6 +116,12 @@ Tooling:
 
 These are public-candidate because examples and docs rely on them, but their
 exact shapes can still change before public preview.
+
+The `goxc check --format=json` schema version 1 transport is a versioned
+tooling process contract. Consumers should reject unsupported schema versions,
+and incompatible field or semantic changes require a schema version increment.
+Exact diagnostic wording remains experimental. This transport contract is not
+an LSP stability promise and does not imply inline editor diagnostics.
 
 ### Exported Compiler-Facing / Low-Level
 

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -433,6 +433,60 @@ examples/app.gox:12:18: expected closing tag </div>, got </main>
   <div>Broken</main>
 ```
 
+Run a read-only source check for one authored file or a directory tree:
+
+```bash
+goxc check ./examples/counter
+goxc check ./examples/counter --format=json
+```
+
+Directory checks recursively validate authored `.gox` files in nested packages
+using the same discovery and package-identity rules as generation. Files are
+processed in deterministic lexical order. Symlinked source paths are rejected,
+and the existing top-level skipped directories such as `.goframe`, `build`,
+`dist`, `node_modules`, and `.git` are not scanned.
+
+`goxc check` calls the GOX generator in memory and discards successful output.
+It does not create `.goframe`, generated `.gox.go` files, build/package files,
+or a generated workspace. A completed check exits `0` when no diagnostics are
+found and `1` when source diagnostics exist. Argument, path, discovery, safety,
+and source-read failures also exit `1` through the normal `goxc` operational
+error path.
+
+Text is the default format. Source diagnostics and the failed summary go to
+stderr; a successful summary goes to stdout. JSON mode writes one compact JSON
+document and a trailing newline to stdout. Completed JSON diagnostic reports do
+not add human-readable output to stderr. GOX markup remains readable because
+the encoder does not apply JSON HTML escaping.
+
+The current machine-readable transport uses schema version 1:
+
+```json
+{"schemaVersion":1,"ok":false,"filesChecked":1,"diagnostics":[{"file":"/absolute/path/app.gox","line":4,"column":15,"severity":"error","message":"gox: empty child expression","source":"<main>{}</main>"}]}
+```
+
+The schema has these contracts:
+
+- `schemaVersion` is the integer `1`; consumers should reject unsupported
+  versions, and incompatible field or semantic changes require an increment;
+- `ok` is true only when `diagnostics` is empty;
+- `filesChecked` includes every processed `.gox` file, including files with a
+  diagnostic;
+- `diagnostics` is always an array and is ordered by file, line, column, then
+  message;
+- `file` is a cleaned absolute native filesystem path;
+- `line` and `column` are one-based when available and `0` when unavailable;
+- `severity` is currently always `"error"`;
+- `source` is the relevant authored source line when available and an empty
+  string otherwise.
+
+The versioned schema is a process contract for tooling and future editor
+consumers, not an LSP or inline VS Code diagnostics implementation. Exact
+diagnostic wording remains experimental. The existing generator currently
+returns at most one compiler diagnostic per file, but a directory check
+continues through all later files instead of stopping at the first failing
+file. Operational failures do not produce a completed or partial JSON report.
+
 GOX also reports focused diagnostics for unclosed tags, invalid component
 names, invalid component prop names, empty child/attribute expressions,
 duplicate or valueless `Key` pseudo-props, spread props, XML-style namespace
@@ -463,7 +517,10 @@ examples/app.gox:8:15: spread props are not supported; pass explicit props inste
   <Button {...props} />
 ```
 
-Go type errors, such as a missing props struct or invalid field type, are
+`goxc check` validates GOX parsing and code generation only. It does not run Go
+or TinyGo type checking, scan remote modules, or process external dependency
+`.gox` files outside the requested authored tree. Go type errors, such as an
+unknown component prop, a missing props struct, or an invalid field type, are
 reported by the selected Go or TinyGo compiler after generation. Those errors
 may still mention the hidden `.goframe/work/<profile>` workspace because they
 come from the Go toolchain, but `goxc` generation failures prefer the original

--- a/docs/release.md
+++ b/docs/release.md
@@ -70,6 +70,21 @@ The recommended install path for the CLI is:
 go install github.com/graybuton/goframe/cmd/goxc@latest
 ```
 
+### README release references
+
+README is a version-agnostic project entry point. It links to GitHub Releases
+and this release process instead of hard-coding the latest preview tag or a
+current release-note filename. Version-specific scope and history belong in
+GitHub Releases, `docs/release-notes-*.md`, `CHANGELOG.md`, and intentionally
+versioned release or evaluator documents. Release-prep and post-publish work
+should not modify README solely to advance a current-preview pointer.
+
+Because the Quick Start installs `goxc` with `@latest`, every command in that
+sequence must exist in the latest published module tag. Commands merged on
+`main` may appear in current-main reference sections before their next release,
+but should enter the `@latest` Quick Start only after a release containing them
+is published.
+
 ## After Tagging
 
 Use the dedicated release notes document for the preview tag being released.


### PR DESCRIPTION
## Summary

Adds a read-only `goxc check` command for validating authored GOX source without generating files or materializing a build workspace.

The command accepts one `.gox` file or a directory tree, validates every discovered source through the existing in-memory GOX generation boundary, and reports deterministic source diagnostics in either human-readable text or a versioned JSON format.

```bash
goxc check <file-or-directory>
goxc check <file-or-directory> --format=json
```

This PR also documents the structured diagnostics contract and makes the README release-version agnostic while keeping its `@latest` Quick Start compatible with the currently published toolchain.

## Scope

This PR is limited to:

* the new `goxc check` command;
* focused CLI and no-write regression coverage;
* the schema-version-1 JSON diagnostics contract;
* command and API-stability documentation;
* README release-reference and Quick Start hygiene.

The three commits form one engineering chain:

* add the structured read-only check command and its tests;
* document the command and diagnostics transport contract;
* decouple README onboarding from unreleased commands and preview-version churn.

## Changed Files / Areas

### `cmd/goxc/check.go`

Adds:

* `goxc check <file-or-directory>`;
* text and JSON output modes;
* recursive authored-source discovery;
* deterministic file and diagnostic ordering;
* source diagnostic aggregation across multiple files;
* explicit completed-diagnostics exit handling;
* no-write validation through `gox.GenerateWithOptions`.

### `cmd/goxc/main.go`

Adds:

* top-level `check` dispatch;
* command help and usage text;
* sentinel handling that exits nonzero without printing a duplicate `goxc:` error after a completed diagnostic report.

### `cmd/goxc/check_test.go`

Covers:

* option parsing;
* text and JSON success output;
* text and JSON diagnostic output;
* multi-file diagnostic collection;
* nested authored package trees;
* generic compiler errors without source locations;
* missing paths and directories without GOX files;
* symlink rejection;
* deterministic ordering;
* no generated files or workspace materialization;
* clean stdout/stderr behavior.

### Documentation

Updates:

* `README.md`;
* `docs/gox-language.md`;
* `docs/api-stability.md`;
* `docs/release.md`;
* `CHANGELOG.md`.

The README remains a version-agnostic project entry point:

* its Quick Start continues to install `goxc` through `@latest`;
* only commands available in the latest published module tag appear in that sequence;
* current-main commands may still appear in reference sections;
* release discovery uses stable GitHub Releases and release-process links rather than a hard-coded preview number.

## CLI Contract

Usage:

```text
goxc check <file-or-directory> [--format=text|json]
```

Supported forms:

```bash
goxc check ./app.gox
goxc check ./app
goxc check ./app --format=text
goxc check ./app --format=json
goxc check ./app --format json
```

Behavior:

* text is the default format;
* one authored `.gox` file or a directory tree is accepted;
* nested authored package directories are checked recursively;
* files are processed in deterministic lexical order;
* existing source-discovery, skipped-directory, package-identity, and symlink policies are reused;
* checking continues after an earlier file produces a compiler diagnostic;
* successful generated Go is discarded in memory.

Exit behavior:

* valid completed check: exit `0`;
* completed check with source diagnostics: exit `1`;
* argument, path, discovery, safety, or I/O failure: exit `1` through the normal CLI error path.

## Structured Diagnostics Contract

JSON mode emits exactly one compact JSON document followed by one newline.

Schema version:

```json
{
  "schemaVersion": 1,
  "ok": false,
  "filesChecked": 1,
  "diagnostics": [
    {
      "file": "/absolute/path/app.gox",
      "line": 4,
      "column": 15,
      "severity": "error",
      "message": "gox: empty child expression",
      "source": "<main>{}</main>"
    }
  ]
}
```

Top-level fields:

* `schemaVersion`;
* `ok`;
* `filesChecked`;
* `diagnostics`.

Diagnostic fields:

* `file`;
* `line`;
* `column`;
* `severity`;
* `message`;
* `source`.

Contract details:

* `schemaVersion` is currently `1`;
* incompatible transport changes require a schema-version increment;
* `diagnostics` is always an array, including successful reports;
* file paths are cleaned absolute native filesystem paths;
* line and column values are one-based when known and `0` when unavailable;
* severity is currently always `"error"`;
* diagnostics are ordered by file, line, column, and message;
* source-oriented `gox.DiagnosticError` fields are preserved;
* generic compiler errors use the authored file path, zero location, and an empty source line;
* JSON output disables HTML escaping so GOX markup remains readable;
* completed JSON diagnostic reports do not emit additional human-readable stderr text;
* operational failures do not emit partial completed reports.

The transport shape is versioned, but exact diagnostic wording remains experimental.

## Text Output

Text mode preserves source-oriented diagnostic formatting:

```text
/path/app.gox:4:15: gox: empty child expression
  <main>{}</main>
checked 1 GOX files: 1 diagnostic
```

Successful checks print a concise stdout summary:

```text
checked 3 GOX files: no diagnostics
```

Diagnostics and failed summaries are written to stderr.

Generic diagnostics without a known source location do not print a misleading `:0:0` suffix.

## No-Write And Safety Guarantees

`goxc check` does not create or modify:

* `.goframe`;
* generated `.gox.go` files;
* authored `.gox` files;
* generated workspaces;
* `go.mod` or `go.sum`;
* build, package, or export output;
* temporary files inside the checked source tree.

The command:

* reads all discovered sources before producing a completed report;
* rejects symlinked source paths through the existing safety policy;
* skips existing tool-owned and dependency directories;
* does not invoke Go or TinyGo compilation;
* does not perform semantic or type checking.

## Behavior, API, Or Docs Impact

Tooling impact:

* adds the public-candidate `goxc check` command;
* adds the schema-version-1 diagnostics process contract;
* enables external tooling to consume stable structured source locations without parsing human output.

Compiler impact:

* no `pkg/gox` production changes;
* no new exported compiler API;
* no GOX grammar changes;
* no diagnostic generation behavior changes.

Runtime and packaging impact:

* no runtime changes;
* no browser/WASM behavior changes;
* no build behavior changes;
* no package or export behavior changes;
* no workspace behavior changes;
* no manifest changes.

Documentation impact:

* documents the new command and its limits;
* records the JSON transport contract;
* keeps inline editor diagnostics explicitly out of scope;
* removes hard-coded current-preview references from README;
* keeps the `@latest` Quick Start aligned with the published CLI.

## Validation

Implementation validation reported:

- [x] `go test ./cmd/goxc -run 'Test.*Check|TestCommandUsage'`
- [x] `go test ./cmd/goxc`
- [x] `go test ./pkg/gox`
- [x] `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go test -tags=goframe_debug ./...`
- [x] `go test -race ./pkg/... ./cmd/...`
- [x] `node scripts/docs-check.mjs`
- [x] `git diff --check`
- [x] installed-binary text and JSON checks
- [x] authored-tree no-write verification
- [x] `scripts/size-budget.sh`
- [x] `bash -n scripts/browser-smoke.sh`
- [x] `scripts/browser-smoke.sh`

Reported local size evidence:

* dashboard raw size: `168231 B / 168960 B`;
* remaining raw headroom: `729 B`;
* TinyGo: `0.41.1`, matching CI;
* local Go: `1.24.4`, not matching CI `1.22.x`.

The local size result is informational because the Go version differs from CI. The PR's WASM Size workflow remains authoritative.

The final follow-up changed Markdown only and reran:

- [x] focused `goxc check` tests;
- [x] docs consistency checks;
- [x] README Quick Start compatibility audit;
- [x] README preview-version audit;
- [x] release-policy audit.

GitHub Actions on the final PR head:

- [ ] Core
- [ ] Browser Smoke
- [ ] WASM Size
- [ ] VS Code Extension

## Non-Goals

* No inline VS Code diagnostics.
* No VS Code extension changes.
* No LSP.
* No formatter.
* No completion or semantic highlighting.
* No watch mode.
* No Go or TinyGo type checking.
* No multi-diagnostic compiler redesign.
* No remote module scanning.
* No external dependency `.gox` processing outside the requested tree.
* No stdin input mode.
* No GOX grammar expansion.
* No public Go API changes.
* No runtime changes.
* No build, package, export, or workspace changes.
* No examples changes.
* No scripts or workflow changes.
* No release preparation.
* No generated artifacts.

## Checklist

- [x] `goxc check` validates files and directory trees.
- [x] Validation is read-only.
- [x] Multiple authored files are checked after an earlier diagnostic.
- [x] Text diagnostics preserve source-oriented locations.
- [x] JSON output is one parseable schema-version-1 document.
- [x] JSON diagnostic runs do not pollute stderr.
- [x] Operational failures remain distinct from completed reports.
- [x] Diagnostic ordering is deterministic.
- [x] Symlink and skipped-directory policies are preserved.
- [x] No compiler or runtime API was expanded.
- [x] No Go/TinyGo type-checking claim is made.
- [x] Exact diagnostic wording remains experimental.
- [x] README Quick Start remains compatible with published `@latest`.
- [x] README no longer requires preview-version pointer updates.
- [x] Current-main `goxc check` documentation remains available.
- [x] No inline editor integration is claimed.

## Notes

The current GOX generator returns at most one compiler diagnostic per file. `goxc check` aggregates those diagnostics across all files in the requested authored tree.

This PR establishes a structured process boundary for CLI and tooling consumers. It does not implement an editor integration or language server.