### PR TITLE
feat(vscode): surface GOX source diagnostics

### DIFF
--- a/.github/workflows/ci-vscode.yml
+++ b/.github/workflows/ci-vscode.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Compile
-        run: npm run compile
+      - name: Compile and test
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- VS Code inline GOX source diagnostics backed by the schema-v1 `goxc check`
+  transport, with manual and saved-file workspace checks, stale-run protection,
+  and multi-root isolation.
 - Read-only `goxc check` validation for authored GOX files and directory trees,
   with text output, a versioned JSON diagnostics contract, nonzero diagnostic
   exit status, and no generated output or workspace materialization.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -120,8 +120,9 @@ exact shapes can still change before public preview.
 The `goxc check --format=json` schema version 1 transport is a versioned
 tooling process contract. Consumers should reject unsupported schema versions,
 and incompatible field or semantic changes require a schema version increment.
-Exact diagnostic wording remains experimental. This transport contract is not
-an LSP stability promise and does not imply inline editor diagnostics.
+The official lightweight VS Code extension consumes this contract for
+CLI-backed source diagnostics. Exact diagnostic wording remains experimental,
+and this editor integration does not create an LSP compatibility promise.
 
 ### Exported Compiler-Facing / Low-Level
 
@@ -188,8 +189,10 @@ Tooling contracts:
 
 VS Code extension:
 
-- syntax highlighting, snippets, and command wrappers over `goxc` are
-  experimental tooling contracts, not language-server stability promises.
+- syntax highlighting, snippets, command wrappers over `goxc`, and CLI-backed
+  schema-v1 source diagnostics are experimental editor tooling contracts, not
+  language-server stability promises. LSP and formatter behavior remain
+  outside the current contract.
 
 ### Experimental Frontier
 
@@ -238,7 +241,7 @@ VS Code extension:
   intentionally does not add a runtime form framework.
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
-- VS Code extension commands and snippets.
+- VS Code extension commands, snippets, and CLI-backed diagnostics behavior.
 - `pkg/gox` AST/lexer/parser structures.
 
 These surfaces should be hardened, tested, and documented before wider

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -115,11 +115,12 @@ surface remains experimental.
 
 `.github/workflows/ci-vscode.yml` runs on pull requests and pushes to `main`.
 
-It validates extension JSON files, installs dependencies with `npm ci`, and
-runs:
+It validates extension JSON files, installs dependencies with `npm ci`,
+compiles the TypeScript extension, and runs pure Node tests for the diagnostics
+transport helpers through:
 
 ```bash
-npm run compile
+npm test
 ```
 
 ## Dependabot
@@ -221,8 +222,11 @@ VS Code extension:
 ```bash
 cd extensions/vscode-gox
 npm ci
-npm run compile
+npm test
 ```
+
+Use `npm run compile` separately during extension development when the pure
+test run is not needed.
 
 ## Required Tools
 

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -475,7 +475,10 @@ The schema has these contracts:
 - `diagnostics` is always an array and is ordered by file, line, column, then
   message;
 - `file` is a cleaned absolute native filesystem path;
-- `line` and `column` are one-based when available and `0` when unavailable;
+- `line` is one-based when available and `0` when unavailable;
+- `column` is a one-based UTF-8 byte column when available and `0` when
+  unavailable; editor consumers must translate it into their editor's position
+  encoding;
 - `severity` is currently always `"error"`;
 - `source` is the relevant authored source line when available and an empty
   string otherwise.

--- a/docs/gox-language.md
+++ b/docs/gox-language.md
@@ -480,8 +480,10 @@ The schema has these contracts:
 - `source` is the relevant authored source line when available and an empty
   string otherwise.
 
-The versioned schema is a process contract for tooling and future editor
-consumers, not an LSP or inline VS Code diagnostics implementation. Exact
+The official lightweight VS Code extension consumes schema version 1 for
+CLI-backed inline source diagnostics. This remains process-based editor
+tooling, not an LSP. It checks saved authored source and does not diagnose
+unsaved buffer content or run Go/TinyGo semantic type checking. Exact
 diagnostic wording remains experimental. The existing generator currently
 returns at most one compiler diagnostic per file, but a directory check
 continues through all later files instead of stopping at the first failing

--- a/extensions/vscode-gox/README.md
+++ b/extensions/vscode-gox/README.md
@@ -11,11 +11,15 @@ This extension provides the first editor experience for GoFrame `.gox` files.
 - snippets for applications, components, state, buttons, cards, and fragments;
 - lightweight highlighting for GOX render expressions such as
   `{condition && <Node />}` and `{condition ? <A /> : <B />}`;
-- command-palette actions that run the installed `goxc` toolchain in an
-  integrated terminal.
+- inline GOX source diagnostics backed by `goxc check --format=json` when a
+  saved `.gox` file or its workspace is checked;
+- terminal-backed command-palette actions for `generate`, `package`, `serve`,
+  and `doctor`.
 
 ## Commands
 
+- `GOX: Check Current Project` checks the selected workspace folder and updates
+  inline source diagnostics
 - `GOX: Generate Current Project` runs `goxc generate .`
 - `GOX: Package Current Project` runs `goxc package .`
 - `GOX: Serve Current Project` runs `goxc serve .`
@@ -25,6 +29,27 @@ Project commands use the workspace containing the active editor, falling back
 to the first workspace folder. Set `gox.goxcPath` when `goxc` is not available
 directly from the integrated terminal's `PATH`.
 
+## Diagnostics
+
+The extension runs `goxc check <workspace-folder> --format=json` without a
+shell and consumes the versioned schema-v1 report. This requires a current
+`goxc` executable that includes the `check` command. Set `gox.goxcPath` to an
+executable path or command name available through `PATH`; the setting is not a
+shell command and must not include arguments.
+
+Saving an authored `.gox` file checks its owning workspace folder. The manual
+`GOX: Check Current Project` command checks the workspace containing the active
+editor, falling back to the first workspace folder. Multi-root workspaces keep
+diagnostics and active checks isolated by folder. A newer check supersedes an
+older in-flight check for the same folder, while checks in different folders
+can run independently.
+
+Diagnostics use saved source only. The extension does not check every edit or
+inspect unsaved buffer content, and `goxc check` does not perform Go or TinyGo
+semantic type checking. Operational launch, process, and schema failures leave
+the previous diagnostics intact and are recorded in the `GOX Diagnostics`
+Output Channel. Compiler diagnostics are normal completed check results.
+
 ## Development
 
 Requirements: Node.js 20+, npm, and VS Code.
@@ -32,7 +57,7 @@ Requirements: Node.js 20+, npm, and VS Code.
 ```bash
 cd extensions/vscode-gox
 npm install
-npm run compile
+npm test
 ```
 
 `pnpm install` and `pnpm run compile` are also supported.
@@ -80,9 +105,10 @@ theme work.
 ## Limitations
 
 This MVP does not include an LSP, semantic highlighting, type-aware completion,
-inline `goxc` diagnostics, formatting, watch mode, debugger integration, or
-marketplace publishing. TextMate highlighting is intentionally heuristic and
-does not replace the GOX compiler.
+formatting, unsaved-buffer diagnostics, Go/TinyGo semantic type checking,
+diagnostic watch mode, debugger integration, or marketplace publishing.
+TextMate highlighting is intentionally heuristic, and the CLI-backed source
+diagnostics do not replace the Go compiler.
 
 ## License
 

--- a/extensions/vscode-gox/README.md
+++ b/extensions/vscode-gox/README.md
@@ -48,6 +48,12 @@ diagnostics and active checks isolated by folder. A newer check supersedes an
 older in-flight check for the same folder, while checks in different folders
 can run independently.
 
+Deleting an authored `.gox` file through VS Code removes diagnostics for its
+old URI. Renaming or moving a `.gox` file through VS Code removes old-path
+diagnostics and rechecks the destination workspace, while keeping file
+operations isolated by workspace folder. These hooks cover VS Code file
+operations; they are not general filesystem watch mode.
+
 Diagnostics use saved source only. The extension does not check every edit or
 inspect unsaved buffer content, and `goxc check` does not perform Go or TinyGo
 semantic type checking. Operational launch, process, and schema failures leave

--- a/extensions/vscode-gox/README.md
+++ b/extensions/vscode-gox/README.md
@@ -37,6 +37,10 @@ shell and consumes the versioned schema-v1 report. This requires a current
 executable path or command name available through `PATH`; the setting is not a
 shell command and must not include arguments.
 
+The extension executes the configured `goxc` executable and is disabled in VS
+Code Restricted Mode and untrusted workspaces. Automatic saved-file diagnostics
+require a trusted workspace.
+
 Saving an authored `.gox` file checks its owning workspace folder. The manual
 `GOX: Check Current Project` command checks the workspace containing the active
 editor, falling back to the first workspace folder. Multi-root workspaces keep

--- a/extensions/vscode-gox/package.json
+++ b/extensions/vscode-gox/package.json
@@ -8,6 +8,12 @@
   "engines": {
     "vscode": "^1.85.0"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "GOX diagnostics and toolchain commands execute the configured goxc executable."
+    }
+  },
   "categories": [
     "Programming Languages",
     "Snippets",

--- a/extensions/vscode-gox/package.json
+++ b/extensions/vscode-gox/package.json
@@ -29,6 +29,7 @@
   "main": "./out/extension.js",
   "scripts": {
     "compile": "tsc -p ./",
+    "test": "npm run compile && node --test out/check.test.js",
     "watch": "tsc -watch -p ./",
     "vscode:prepublish": "npm run compile"
   },

--- a/extensions/vscode-gox/package.json
+++ b/extensions/vscode-gox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gox",
   "displayName": "GOX Language Support",
-  "description": "Syntax highlighting, snippets, icons, and goxc commands for GoFrame GOX files.",
+  "description": "Syntax highlighting, snippets, diagnostics, icons, and goxc commands for GoFrame GOX files.",
   "version": "0.1.0",
   "publisher": "goframe",
   "license": "Apache-2.0",
@@ -21,6 +21,8 @@
     "jsx"
   ],
   "activationEvents": [
+    "onLanguage:gox",
+    "onCommand:gox.check",
     "onCommand:gox.generate",
     "onCommand:gox.package",
     "onCommand:gox.serve",
@@ -70,6 +72,10 @@
     ],
     "commands": [
       {
+        "command": "gox.check",
+        "title": "GOX: Check Current Project"
+      },
+      {
         "command": "gox.generate",
         "title": "GOX: Generate Current Project"
       },
@@ -92,7 +98,7 @@
         "gox.goxcPath": {
           "type": "string",
           "default": "goxc",
-          "description": "Path or command name used to run the goxc toolchain."
+          "description": "Executable path or command name used to run goxc; this is not a shell command and must not include arguments."
         }
       }
     }

--- a/extensions/vscode-gox/package.json
+++ b/extensions/vscode-gox/package.json
@@ -97,6 +97,7 @@
       "properties": {
         "gox.goxcPath": {
           "type": "string",
+          "scope": "resource",
           "default": "goxc",
           "description": "Executable path or command name used to run goxc; this is not a shell command and must not include arguments."
         }

--- a/extensions/vscode-gox/src/check.test.ts
+++ b/extensions/vscode-gox/src/check.test.ts
@@ -1,0 +1,273 @@
+import assert = require("node:assert/strict");
+import * as path from "node:path";
+import test = require("node:test");
+
+import {
+  CheckDiagnostic,
+  RunGenerationCoordinator,
+  buildCheckInvocation,
+  diagnosticRange,
+  groupDiagnosticsByFile,
+  interpretCheckProcessResult,
+  parseCheckReport,
+  planWorkspaceDiagnosticUpdate,
+} from "./check";
+
+const workspacePath = path.resolve("workspace with spaces");
+const firstFile = path.join(workspacePath, "first.gox");
+const secondFile = path.join(workspacePath, "nested", "second.gox");
+
+function diagnostic(file = firstFile): CheckDiagnostic {
+  return {
+    file,
+    line: 4,
+    column: 15,
+    severity: "error",
+    message: "gox: source diagnostic",
+    source: "<main>{}</main>",
+  };
+}
+
+function cleanJSON(): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    ok: true,
+    filesChecked: 2,
+    diagnostics: [],
+  });
+}
+
+function diagnosticJSON(): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    ok: false,
+    filesChecked: 2,
+    diagnostics: [diagnostic()],
+  });
+}
+
+test("parses a clean schema-v1 report", () => {
+  const report = parseCheckReport(`\n${cleanJSON()}\n`);
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.ok, true);
+  assert.equal(report.filesChecked, 2);
+  assert.deepEqual(report.diagnostics, []);
+});
+
+test("parses a diagnostic schema-v1 report and permits unknown fields", () => {
+  const value = JSON.parse(diagnosticJSON());
+  value.transportNote = "compatible";
+  value.diagnostics[0].futureField = 1;
+  const report = parseCheckReport(JSON.stringify(value));
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.diagnostics, [diagnostic()]);
+});
+
+test("rejects an unsupported schema version", () => {
+  const value = JSON.parse(cleanJSON());
+  value.schemaVersion = 2;
+  assert.throws(() => parseCheckReport(JSON.stringify(value)), /unsupported schemaVersion 2/);
+});
+
+test("rejects malformed JSON and extra output", () => {
+  assert.throws(() => parseCheckReport(""), /invalid JSON report/);
+  assert.throws(() => parseCheckReport("notice\n{}"), /invalid JSON report/);
+  assert.throws(() => parseCheckReport(`${cleanJSON()}\nnotice`), /invalid JSON report/);
+});
+
+test("rejects missing and wrong-type required fields", () => {
+  const cases: Array<[string, (value: Record<string, unknown>) => void, RegExp]> = [
+    ["schemaVersion", (value) => delete value.schemaVersion, /schemaVersion must be an integer/],
+    ["ok", (value) => { value.ok = "true"; }, /ok must be a boolean/],
+    [
+      "filesChecked",
+      (value) => { value.filesChecked = -1; },
+      /filesChecked must be a non-negative integer/,
+    ],
+    ["diagnostics", (value) => { value.diagnostics = {}; }, /diagnostics must be an array/],
+  ];
+  for (const [name, mutate, expected] of cases) {
+    const value = JSON.parse(cleanJSON()) as Record<string, unknown>;
+    mutate(value);
+    assert.throws(() => parseCheckReport(JSON.stringify(value)), expected, name);
+  }
+});
+
+test("validates every diagnostic field", () => {
+  const cases: Array<[string, unknown, RegExp]> = [
+    ["file", "relative.gox", /file must be a non-empty absolute path/],
+    ["line", -1, /line must be a non-negative integer/],
+    ["column", 1.5, /column must be a non-negative integer/],
+    ["severity", "warning", /severity must be "error"/],
+    ["message", "", /message must be a non-empty string/],
+    ["source", 1, /source must be a string/],
+  ];
+  for (const [field, invalid, expected] of cases) {
+    const value = JSON.parse(diagnosticJSON());
+    value.diagnostics[0][field] = invalid;
+    assert.throws(() => parseCheckReport(JSON.stringify(value)), expected, field);
+  }
+});
+
+test("rejects reports with inconsistent ok and diagnostics", () => {
+  const clean = JSON.parse(cleanJSON());
+  clean.ok = false;
+  assert.throws(() => parseCheckReport(JSON.stringify(clean)), /ok must be true/);
+
+  const failed = JSON.parse(diagnosticJSON());
+  failed.ok = true;
+  assert.throws(() => parseCheckReport(JSON.stringify(failed)), /ok must be true/);
+});
+
+test("interprets exit 0 with a clean report as completed", () => {
+  const result = interpretCheckProcessResult({
+    exitCode: 0,
+    signal: null,
+    stdout: cleanJSON(),
+    stderr: "",
+  });
+  assert.equal(result.kind, "completed");
+  if (result.kind === "completed") {
+    assert.equal(result.report.ok, true);
+  }
+});
+
+test("interprets exit 1 with diagnostics as completed", () => {
+  const result = interpretCheckProcessResult({
+    exitCode: 1,
+    signal: null,
+    stdout: diagnosticJSON(),
+    stderr: "  \n",
+  });
+  assert.equal(result.kind, "completed");
+  if (result.kind === "completed") {
+    assert.equal(result.report.diagnostics.length, 1);
+  }
+});
+
+test("treats exit 1 without a valid report as a tooling error", () => {
+  const result = interpretCheckProcessResult({
+    exitCode: 1,
+    signal: null,
+    stdout: "",
+    stderr: "goxc: no .gox files found",
+  });
+  assert.equal(result.kind, "toolingError");
+});
+
+test("rejects process/report mismatches and other exit codes", () => {
+  for (const [exitCode, stdout] of [[0, diagnosticJSON()], [1, cleanJSON()], [2, cleanJSON()]] as const) {
+    const result = interpretCheckProcessResult({
+      exitCode,
+      signal: null,
+      stdout,
+      stderr: "",
+    });
+    assert.equal(result.kind, "toolingError");
+  }
+});
+
+test("rejects stderr pollution for a completed JSON result", () => {
+  const result = interpretCheckProcessResult({
+    exitCode: 0,
+    signal: null,
+    stdout: cleanJSON(),
+    stderr: "warning",
+  });
+  assert.deepEqual(result, {
+    kind: "toolingError",
+    error: "completed JSON report included non-empty stderr",
+  });
+});
+
+test("classifies launch and signal failures as tooling errors", () => {
+  const launch = interpretCheckProcessResult({
+    exitCode: null,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    launchError: new Error("ENOENT"),
+  });
+  assert.equal(launch.kind, "toolingError");
+  const signal = interpretCheckProcessResult({
+    exitCode: null,
+    signal: "SIGTERM",
+    stdout: cleanJSON(),
+    stderr: "",
+  });
+  assert.equal(signal.kind, "toolingError");
+});
+
+test("groups diagnostics by absolute file path", () => {
+  const grouped = groupDiagnosticsByFile([
+    diagnostic(firstFile),
+    diagnostic(secondFile),
+    { ...diagnostic(firstFile), line: 8 },
+  ]);
+  assert.deepEqual([...grouped.keys()], [firstFile, secondFile]);
+  assert.equal(grouped.get(firstFile)?.length, 2);
+  assert.equal(grouped.get(secondFile)?.length, 1);
+});
+
+test("maps one-based locations to zero-based one-character ranges", () => {
+  assert.deepEqual(diagnosticRange(4, 15), {
+    startLine: 3,
+    startCharacter: 14,
+    endLine: 3,
+    endCharacter: 15,
+  });
+});
+
+test("maps unknown or partial locations to a file-level range", () => {
+  const fileRange = {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 0,
+  };
+  assert.deepEqual(diagnosticRange(0, 0), fileRange);
+  assert.deepEqual(diagnosticRange(4, 0), fileRange);
+});
+
+test("later runs invalidate earlier generations", () => {
+  const coordinator = new RunGenerationCoordinator();
+  const first = coordinator.begin("workspace-a");
+  const second = coordinator.begin("workspace-a");
+  assert.equal(coordinator.isCurrent("workspace-a", first), false);
+  assert.equal(coordinator.isCurrent("workspace-a", second), true);
+});
+
+test("stale completion is rejected after explicit invalidation", () => {
+  const coordinator = new RunGenerationCoordinator();
+  const run = coordinator.begin("workspace-a");
+  coordinator.invalidate("workspace-a");
+  assert.equal(coordinator.isCurrent("workspace-a", run), false);
+});
+
+test("plans stale-key removal for one workspace", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a", "stale-a"])],
+  ]);
+  const plan = planWorkspaceDiagnosticUpdate(ownership, "workspace-a", ["file-a", "new-a"]);
+  assert.deepEqual(plan.staleKeys, ["stale-a"]);
+  assert.deepEqual(plan.nextKeys, ["file-a", "new-a"]);
+  assert.deepEqual([...plan.ownership.get("workspace-a") ?? []].sort(), ["file-a", "new-a"]);
+});
+
+test("workspace update leaves another workspace ownership untouched", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a"])],
+    ["workspace-b", new Set(["file-b"])],
+  ]);
+  const plan = planWorkspaceDiagnosticUpdate(ownership, "workspace-a", []);
+  assert.deepEqual([...plan.ownership.get("workspace-b") ?? []], ["file-b"]);
+  assert.deepEqual([...ownership.get("workspace-a") ?? []], ["file-a"]);
+});
+
+test("builds a non-shell invocation with the workspace path as one argument", () => {
+  assert.deepEqual(buildCheckInvocation("/tools/goxc binary", workspacePath), {
+    executable: "/tools/goxc binary",
+    args: ["check", workspacePath, "--format=json"],
+    cwd: workspacePath,
+  });
+});

--- a/extensions/vscode-gox/src/check.test.ts
+++ b/extensions/vscode-gox/src/check.test.ts
@@ -17,6 +17,10 @@ const workspacePath = path.resolve("workspace with spaces");
 const firstFile = path.join(workspacePath, "first.gox");
 const secondFile = path.join(workspacePath, "nested", "second.gox");
 
+function sourceBytes(source: string): Uint8Array {
+  return Buffer.from(source, "utf8");
+}
+
 function diagnostic(file = firstFile): CheckDiagnostic {
   return {
     file,
@@ -209,12 +213,85 @@ test("groups diagnostics by absolute file path", () => {
   assert.equal(grouped.get(secondFile)?.length, 1);
 });
 
-test("maps one-based locations to zero-based one-character ranges", () => {
-  assert.deepEqual(diagnosticRange(4, 15), {
-    startLine: 3,
+test("maps an ASCII byte column to a UTF-16 editor range", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("first\nabcdefghijklmnop"), 2, 15), {
+    startLine: 1,
     startCharacter: 14,
-    endLine: 3,
+    endLine: 1,
     endCharacter: 15,
+  });
+});
+
+test("maps a byte column after a two-byte UTF-8 character", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("<p>é{}</p>"), 1, 6), {
+    startLine: 0,
+    startCharacter: 4,
+    endLine: 0,
+    endCharacter: 5,
+  });
+});
+
+test("maps a byte column after a four-byte UTF-8 character", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("<p>🙂{}</p>"), 1, 8), {
+    startLine: 0,
+    startCharacter: 5,
+    endLine: 0,
+    endCharacter: 6,
+  });
+});
+
+test("maps indentation and mixed non-ASCII prefixes", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("header\n    é🙂{}"), 2, 11), {
+    startLine: 1,
+    startCharacter: 7,
+    endLine: 1,
+    endCharacter: 8,
+  });
+});
+
+test("maps CRLF source without treating carriage return as editor text", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("first\r\n<p>é{}</p>\r\n"), 2, 6), {
+    startLine: 1,
+    startCharacter: 4,
+    endLine: 1,
+    endCharacter: 5,
+  });
+});
+
+test("uses a zero-width range at the end of a source line", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("é"), 1, 3), {
+    startLine: 0,
+    startCharacter: 1,
+    endLine: 0,
+    endCharacter: 1,
+  });
+});
+
+test("clamps a byte column beyond the source line to its end", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("éx"), 1, 99), {
+    startLine: 0,
+    startCharacter: 2,
+    endLine: 0,
+    endCharacter: 2,
+  });
+});
+
+test("maps a byte column inside a UTF-8 sequence to a file-level range", () => {
+  const fileRange = {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 0,
+  };
+  assert.deepEqual(diagnosticRange(sourceBytes("éx"), 1, 2), fileRange);
+});
+
+test("maps a missing source line to a file-level range", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("one line"), 2, 1), {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 0,
   });
 });
 
@@ -225,8 +302,35 @@ test("maps unknown or partial locations to a file-level range", () => {
     endLine: 0,
     endCharacter: 0,
   };
-  assert.deepEqual(diagnosticRange(0, 0), fileRange);
-  assert.deepEqual(diagnosticRange(4, 0), fileRange);
+  const source = sourceBytes("<main />");
+  assert.deepEqual(diagnosticRange(source, 0, 0), fileRange);
+  assert.deepEqual(diagnosticRange(source, 4, 0), fileRange);
+  assert.deepEqual(diagnosticRange(undefined, 1, 1), fileRange);
+});
+
+test("covers one complete supplementary code point at the diagnostic start", () => {
+  assert.deepEqual(diagnosticRange(sourceBytes("🙂x"), 1, 1), {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 2,
+  });
+});
+
+test("maps multiple diagnostics from the same saved source bytes", () => {
+  const source = sourceBytes("éx\n🙂y");
+  assert.deepEqual(diagnosticRange(source, 1, 3), {
+    startLine: 0,
+    startCharacter: 1,
+    endLine: 0,
+    endCharacter: 2,
+  });
+  assert.deepEqual(diagnosticRange(source, 2, 5), {
+    startLine: 1,
+    startCharacter: 2,
+    endLine: 1,
+    endCharacter: 3,
+  });
 });
 
 test("later runs invalidate earlier generations", () => {

--- a/extensions/vscode-gox/src/check.test.ts
+++ b/extensions/vscode-gox/src/check.test.ts
@@ -10,7 +10,9 @@ import {
   groupDiagnosticsByFile,
   interpretCheckProcessResult,
   parseCheckReport,
+  planWorkspaceDiagnosticRemoval,
   planWorkspaceDiagnosticUpdate,
+  resourcePathRelation,
 } from "./check";
 
 const workspacePath = path.resolve("workspace with spaces");
@@ -366,6 +368,153 @@ test("workspace update leaves another workspace ownership untouched", () => {
   const plan = planWorkspaceDiagnosticUpdate(ownership, "workspace-a", []);
   assert.deepEqual([...plan.ownership.get("workspace-b") ?? []], ["file-b"]);
   assert.deepEqual([...ownership.get("workspace-a") ?? []], ["file-a"]);
+});
+
+test("plans exact owned URI removal", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a", "file-b"])],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", ["file-a"]);
+  assert.deepEqual(plan.removedKeys, ["file-a"]);
+  assert.deepEqual(plan.nextKeys, ["file-b"]);
+});
+
+test("unknown URI removal is a no-op", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a"])],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", ["unknown"]);
+  assert.deepEqual(plan.removedKeys, []);
+  assert.deepEqual(plan.nextKeys, ["file-a"]);
+  assert.deepEqual([...plan.ownership.get("workspace-a") ?? []], ["file-a"]);
+});
+
+test("plans multiple owned URI removals", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a", "file-b", "file-c"])],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(
+    ownership,
+    "workspace-a",
+    ["file-c", "file-a"],
+  );
+  assert.deepEqual(plan.removedKeys, ["file-a", "file-c"]);
+  assert.deepEqual(plan.nextKeys, ["file-b"]);
+});
+
+test("removing the last owned URI leaves an empty set", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a"])],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", ["file-a"]);
+  assert.deepEqual(plan.nextKeys, []);
+  assert.deepEqual([...plan.ownership.get("workspace-a") ?? []], []);
+});
+
+test("workspace removal planning leaves another workspace untouched", () => {
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(["file-a"])],
+    ["workspace-b", new Set(["file-b"])],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", ["file-a"]);
+  assert.deepEqual([...plan.ownership.get("workspace-b") ?? []], ["file-b"]);
+});
+
+test("resource path relation recognizes directory descendants", () => {
+  assert.equal(
+    resourcePathRelation(
+      { scheme: "file", fsPath: path.join(workspacePath, "removed") },
+      { scheme: "file", fsPath: path.join(workspacePath, "removed", "nested", "app.gox") },
+    ),
+    "descendant",
+  );
+});
+
+test("resource path relation rejects a prefix sibling", () => {
+  assert.equal(
+    resourcePathRelation(
+      { scheme: "file", fsPath: path.join(workspacePath, "app") },
+      { scheme: "file", fsPath: path.join(workspacePath, "application", "app.gox") },
+    ),
+    "outside",
+  );
+});
+
+test("resource path relation recognizes exact file paths", () => {
+  assert.equal(
+    resourcePathRelation(
+      { scheme: "file", fsPath: firstFile },
+      { scheme: "file", fsPath: firstFile },
+    ),
+    "exact",
+  );
+});
+
+test("resource path relation rejects outside paths and mismatched schemes", () => {
+  const parent = { scheme: "file", fsPath: path.join(workspacePath, "app") };
+  assert.equal(
+    resourcePathRelation(parent, {
+      scheme: "file",
+      fsPath: path.join(workspacePath, "other", "app.gox"),
+    }),
+    "outside",
+  );
+  assert.equal(
+    resourcePathRelation(parent, {
+      scheme: "untitled",
+      fsPath: path.join(workspacePath, "app", "app.gox"),
+    }),
+    "outside",
+  );
+});
+
+test("workspace removal planning does not mutate its ownership input", () => {
+  const workspaceA = new Set(["file-a", "file-b"]);
+  const workspaceB = new Set(["file-c"]);
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", workspaceA],
+    ["workspace-b", workspaceB],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", ["file-a"]);
+  assert.deepEqual([...workspaceA], ["file-a", "file-b"]);
+  assert.deepEqual([...workspaceB], ["file-c"]);
+  assert.notEqual(plan.ownership.get("workspace-a"), workspaceA);
+  assert.notEqual(plan.ownership.get("workspace-b"), workspaceB);
+});
+
+test("a renamed directory identifies multiple descendant diagnostic keys", () => {
+  const removedDirectory = {
+    scheme: "file",
+    fsPath: path.join(workspacePath, "old"),
+  };
+  const resources = new Map([
+    ["first", { scheme: "file", fsPath: path.join(workspacePath, "old", "first.gox") }],
+    [
+      "second",
+      { scheme: "file", fsPath: path.join(workspacePath, "old", "nested", "second.gox") },
+    ],
+    ["other", { scheme: "file", fsPath: path.join(workspacePath, "other.gox") }],
+  ]);
+  const removedKeys = [...resources]
+    .filter(([, candidate]) => resourcePathRelation(removedDirectory, candidate) === "descendant")
+    .map(([key]) => key);
+  const ownership = new Map<string, ReadonlySet<string>>([
+    ["workspace-a", new Set(resources.keys())],
+  ]);
+  const plan = planWorkspaceDiagnosticRemoval(ownership, "workspace-a", removedKeys);
+  assert.deepEqual(plan.removedKeys, ["first", "second"]);
+  assert.deepEqual(plan.nextKeys, ["other"]);
+});
+
+test("resource path relation supports normalized Windows paths", () => {
+  assert.equal(
+    resourcePathRelation(
+      { scheme: "file", fsPath: "C:/Work/App/." },
+      { scheme: "file", fsPath: "c:/work/app/nested/../file.gox" },
+      path.win32,
+    ),
+    "descendant",
+  );
 });
 
 test("builds a non-shell invocation with the workspace path as one argument", () => {

--- a/extensions/vscode-gox/src/check.ts
+++ b/extensions/vscode-gox/src/check.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import * as path from "node:path";
+import { TextDecoder } from "node:util";
 
 export const checkSchemaVersion = 1;
 
@@ -155,23 +156,37 @@ export function groupDiagnosticsByFile(
   return grouped;
 }
 
-export function diagnosticRange(line: number, column: number): DiagnosticRange {
-  if (line <= 0 || column <= 0) {
-    return {
-      startLine: 0,
-      startCharacter: 0,
-      endLine: 0,
-      endCharacter: 0,
-    };
+export function diagnosticRange(
+  source: Uint8Array | undefined,
+  line: number,
+  column: number,
+): DiagnosticRange {
+  if (!source || line <= 0 || column <= 0) {
+    return fileLevelDiagnosticRange();
   }
-  const startLine = line - 1;
-  const startCharacter = column - 1;
-  return {
-    startLine,
-    startCharacter,
-    endLine: startLine,
-    endCharacter: startCharacter + 1,
-  };
+
+  const rawLine = sourceLineBytes(source, line);
+  if (!rawLine) {
+    return fileLevelDiagnosticRange();
+  }
+
+  const byteOffset = Math.min(column - 1, rawLine.length);
+  try {
+    const lineText = utf8Decoder.decode(rawLine);
+    const startCharacter = utf8Decoder.decode(rawLine.subarray(0, byteOffset)).length;
+    const codePoint = lineText.codePointAt(startCharacter);
+    const width = byteOffset < rawLine.length && codePoint !== undefined
+      ? codePoint > 0xffff ? 2 : 1
+      : 0;
+    return {
+      startLine: line - 1,
+      startCharacter,
+      endLine: line - 1,
+      endCharacter: startCharacter + width,
+    };
+  } catch {
+    return fileLevelDiagnosticRange();
+  }
 }
 
 export function buildCheckInvocation(executable: string, workspacePath: string): CheckInvocation {
@@ -261,6 +276,34 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isNonNegativeInteger(value: unknown): value is number {
   return Number.isInteger(value) && typeof value === "number" && value >= 0;
+}
+
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function sourceLineBytes(source: Uint8Array, line: number): Uint8Array | undefined {
+  let currentLine = 1;
+  let lineStart = 0;
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] !== 0x0a) {
+      continue;
+    }
+    if (currentLine === line) {
+      const lineEnd = index > lineStart && source[index - 1] === 0x0d ? index - 1 : index;
+      return source.subarray(lineStart, lineEnd);
+    }
+    currentLine++;
+    lineStart = index + 1;
+  }
+  return currentLine === line ? source.subarray(lineStart) : undefined;
+}
+
+function fileLevelDiagnosticRange(): DiagnosticRange {
+  return {
+    startLine: 0,
+    startCharacter: 0,
+    endLine: 0,
+    endCharacter: 0,
+  };
 }
 
 function errorMessage(error: unknown): string {

--- a/extensions/vscode-gox/src/check.ts
+++ b/extensions/vscode-gox/src/check.ts
@@ -1,0 +1,268 @@
+/// <reference types="node" />
+
+import * as path from "node:path";
+
+export const checkSchemaVersion = 1;
+
+export interface CheckDiagnostic {
+  file: string;
+  line: number;
+  column: number;
+  severity: "error";
+  message: string;
+  source: string;
+}
+
+export interface CheckReport {
+  schemaVersion: 1;
+  ok: boolean;
+  filesChecked: number;
+  diagnostics: CheckDiagnostic[];
+}
+
+export interface CheckProcessResult {
+  exitCode: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  launchError?: Error;
+}
+
+export type CheckProcessInterpretation =
+  | { kind: "completed"; report: CheckReport }
+  | { kind: "toolingError"; error: string };
+
+export interface DiagnosticRange {
+  startLine: number;
+  startCharacter: number;
+  endLine: number;
+  endCharacter: number;
+}
+
+export interface CheckInvocation {
+  executable: string;
+  args: string[];
+  cwd: string;
+}
+
+export interface WorkspaceDiagnosticUpdatePlan {
+  staleKeys: string[];
+  nextKeys: string[];
+  ownership: Map<string, Set<string>>;
+}
+
+export function parseCheckReport(stdout: string): CheckReport {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`invalid JSON report: ${errorMessage(error)}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error("check report must be a JSON object");
+  }
+
+  const schemaVersion = parsed.schemaVersion;
+  if (!Number.isInteger(schemaVersion)) {
+    throw new Error("schemaVersion must be an integer");
+  }
+  if (schemaVersion !== checkSchemaVersion) {
+    throw new Error(`unsupported schemaVersion ${String(schemaVersion)}`);
+  }
+  if (typeof parsed.ok !== "boolean") {
+    throw new Error("ok must be a boolean");
+  }
+  if (!isNonNegativeInteger(parsed.filesChecked)) {
+    throw new Error("filesChecked must be a non-negative integer");
+  }
+  if (!Array.isArray(parsed.diagnostics)) {
+    throw new Error("diagnostics must be an array");
+  }
+
+  const diagnostics = parsed.diagnostics.map(parseDiagnostic);
+  if (parsed.ok !== (diagnostics.length === 0)) {
+    throw new Error("ok must be true only when diagnostics is empty");
+  }
+
+  return {
+    schemaVersion: checkSchemaVersion,
+    ok: parsed.ok,
+    filesChecked: parsed.filesChecked,
+    diagnostics,
+  };
+}
+
+export function interpretCheckProcessResult(
+  result: CheckProcessResult,
+): CheckProcessInterpretation {
+  if (result.launchError) {
+    return {
+      kind: "toolingError",
+      error: `process launch failed: ${result.launchError.message}`,
+    };
+  }
+  if (result.signal) {
+    return {
+      kind: "toolingError",
+      error: `process terminated by signal ${result.signal}`,
+    };
+  }
+
+  let report: CheckReport;
+  try {
+    report = parseCheckReport(result.stdout);
+  } catch (error) {
+    return { kind: "toolingError", error: errorMessage(error) };
+  }
+
+  if (result.stderr.trim() !== "") {
+    return {
+      kind: "toolingError",
+      error: "completed JSON report included non-empty stderr",
+    };
+  }
+  if (result.exitCode === 0 && report.ok && report.diagnostics.length === 0) {
+    return { kind: "completed", report };
+  }
+  if (result.exitCode === 1 && !report.ok && report.diagnostics.length > 0) {
+    return { kind: "completed", report };
+  }
+  if (result.exitCode !== 0 && result.exitCode !== 1) {
+    return {
+      kind: "toolingError",
+      error: `unexpected process exit code ${String(result.exitCode)}`,
+    };
+  }
+  return {
+    kind: "toolingError",
+    error: `exit code ${String(result.exitCode)} is inconsistent with the JSON report`,
+  };
+}
+
+export function groupDiagnosticsByFile(
+  diagnostics: readonly CheckDiagnostic[],
+): Map<string, CheckDiagnostic[]> {
+  const grouped = new Map<string, CheckDiagnostic[]>();
+  for (const diagnostic of diagnostics) {
+    const current = grouped.get(diagnostic.file);
+    if (current) {
+      current.push(diagnostic);
+    } else {
+      grouped.set(diagnostic.file, [diagnostic]);
+    }
+  }
+  return grouped;
+}
+
+export function diagnosticRange(line: number, column: number): DiagnosticRange {
+  if (line <= 0 || column <= 0) {
+    return {
+      startLine: 0,
+      startCharacter: 0,
+      endLine: 0,
+      endCharacter: 0,
+    };
+  }
+  const startLine = line - 1;
+  const startCharacter = column - 1;
+  return {
+    startLine,
+    startCharacter,
+    endLine: startLine,
+    endCharacter: startCharacter + 1,
+  };
+}
+
+export function buildCheckInvocation(executable: string, workspacePath: string): CheckInvocation {
+  if (executable.length === 0) {
+    throw new Error("goxc executable must not be empty");
+  }
+  return {
+    executable,
+    args: ["check", workspacePath, "--format=json"],
+    cwd: workspacePath,
+  };
+}
+
+export class RunGenerationCoordinator {
+  private readonly generations = new Map<string, number>();
+
+  begin(workspaceKey: string): number {
+    const generation = (this.generations.get(workspaceKey) ?? 0) + 1;
+    this.generations.set(workspaceKey, generation);
+    return generation;
+  }
+
+  invalidate(workspaceKey: string): number {
+    return this.begin(workspaceKey);
+  }
+
+  isCurrent(workspaceKey: string, generation: number): boolean {
+    return this.generations.get(workspaceKey) === generation;
+  }
+}
+
+export function planWorkspaceDiagnosticUpdate(
+  currentOwnership: ReadonlyMap<string, ReadonlySet<string>>,
+  workspaceKey: string,
+  nextKeyValues: Iterable<string>,
+): WorkspaceDiagnosticUpdatePlan {
+  const nextKeys = new Set(nextKeyValues);
+  const previousKeys = currentOwnership.get(workspaceKey) ?? new Set<string>();
+  const staleKeys = [...previousKeys].filter((key) => !nextKeys.has(key)).sort();
+  const ownership = new Map<string, Set<string>>();
+  for (const [key, values] of currentOwnership) {
+    ownership.set(key, new Set(values));
+  }
+  ownership.set(workspaceKey, nextKeys);
+  return {
+    staleKeys,
+    nextKeys: [...nextKeys].sort(),
+    ownership,
+  };
+}
+
+function parseDiagnostic(value: unknown, index: number): CheckDiagnostic {
+  if (!isRecord(value)) {
+    throw new Error(`diagnostics[${index}] must be an object`);
+  }
+  if (typeof value.file !== "string" || value.file.length === 0 || !path.isAbsolute(value.file)) {
+    throw new Error(`diagnostics[${index}].file must be a non-empty absolute path`);
+  }
+  if (!isNonNegativeInteger(value.line)) {
+    throw new Error(`diagnostics[${index}].line must be a non-negative integer`);
+  }
+  if (!isNonNegativeInteger(value.column)) {
+    throw new Error(`diagnostics[${index}].column must be a non-negative integer`);
+  }
+  if (value.severity !== "error") {
+    throw new Error(`diagnostics[${index}].severity must be "error"`);
+  }
+  if (typeof value.message !== "string" || value.message.trim() === "") {
+    throw new Error(`diagnostics[${index}].message must be a non-empty string`);
+  }
+  if (typeof value.source !== "string") {
+    throw new Error(`diagnostics[${index}].source must be a string`);
+  }
+  return {
+    file: value.file,
+    line: value.line,
+    column: value.column,
+    severity: value.severity,
+    message: value.message,
+    source: value.source,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && typeof value === "number" && value >= 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/vscode-gox/src/check.ts
+++ b/extensions/vscode-gox/src/check.ts
@@ -52,6 +52,24 @@ export interface WorkspaceDiagnosticUpdatePlan {
   ownership: Map<string, Set<string>>;
 }
 
+export interface WorkspaceDiagnosticRemovalPlan {
+  removedKeys: string[];
+  nextKeys: string[];
+  ownership: Map<string, Set<string>>;
+}
+
+export interface ResourcePath {
+  scheme: string;
+  fsPath: string;
+}
+
+export type ResourcePathRelation = "exact" | "descendant" | "outside";
+
+type PathOperations = Pick<
+  typeof path,
+  "isAbsolute" | "relative" | "resolve" | "sep"
+>;
+
 export function parseCheckReport(stdout: string): CheckReport {
   let parsed: unknown;
   try {
@@ -226,16 +244,57 @@ export function planWorkspaceDiagnosticUpdate(
   const nextKeys = new Set(nextKeyValues);
   const previousKeys = currentOwnership.get(workspaceKey) ?? new Set<string>();
   const staleKeys = [...previousKeys].filter((key) => !nextKeys.has(key)).sort();
-  const ownership = new Map<string, Set<string>>();
-  for (const [key, values] of currentOwnership) {
-    ownership.set(key, new Set(values));
-  }
+  const ownership = cloneOwnership(currentOwnership);
   ownership.set(workspaceKey, nextKeys);
   return {
     staleKeys,
     nextKeys: [...nextKeys].sort(),
     ownership,
   };
+}
+
+export function resourcePathRelation(
+  parent: ResourcePath,
+  candidate: ResourcePath,
+  pathOperations: PathOperations = path,
+): ResourcePathRelation {
+  if (parent.scheme !== candidate.scheme) {
+    return "outside";
+  }
+
+  const relative = pathOperations.relative(
+    pathOperations.resolve(parent.fsPath),
+    pathOperations.resolve(candidate.fsPath),
+  );
+  if (relative === "") {
+    return "exact";
+  }
+  if (
+    relative === ".." ||
+    relative.startsWith(`..${pathOperations.sep}`) ||
+    pathOperations.isAbsolute(relative)
+  ) {
+    return "outside";
+  }
+  return "descendant";
+}
+
+export function planWorkspaceDiagnosticRemoval(
+  currentOwnership: ReadonlyMap<string, ReadonlySet<string>>,
+  workspaceKey: string,
+  removedKeyValues: Iterable<string>,
+): WorkspaceDiagnosticRemovalPlan {
+  const removedKeySet = new Set(removedKeyValues);
+  const previousKeys = currentOwnership.get(workspaceKey);
+  const ownership = cloneOwnership(currentOwnership);
+  if (!previousKeys) {
+    return { removedKeys: [], nextKeys: [], ownership };
+  }
+
+  const removedKeys = [...previousKeys].filter((key) => removedKeySet.has(key)).sort();
+  const nextKeys = [...previousKeys].filter((key) => !removedKeySet.has(key)).sort();
+  ownership.set(workspaceKey, new Set(nextKeys));
+  return { removedKeys, nextKeys, ownership };
 }
 
 function parseDiagnostic(value: unknown, index: number): CheckDiagnostic {
@@ -304,6 +363,16 @@ function fileLevelDiagnosticRange(): DiagnosticRange {
     endLine: 0,
     endCharacter: 0,
   };
+}
+
+function cloneOwnership(
+  ownership: ReadonlyMap<string, ReadonlySet<string>>,
+): Map<string, Set<string>> {
+  const cloned = new Map<string, Set<string>>();
+  for (const [key, values] of ownership) {
+    cloned.set(key, new Set(values));
+  }
+  return cloned;
 }
 
 function errorMessage(error: unknown): string {

--- a/extensions/vscode-gox/src/extension.ts
+++ b/extensions/vscode-gox/src/extension.ts
@@ -1,17 +1,301 @@
+import { ChildProcess, spawn } from "node:child_process";
+
 import * as vscode from "vscode";
 
+import {
+  CheckInvocation,
+  CheckProcessResult,
+  CheckReport,
+  RunGenerationCoordinator,
+  buildCheckInvocation,
+  diagnosticRange,
+  groupDiagnosticsByFile,
+  interpretCheckProcessResult,
+  planWorkspaceDiagnosticUpdate,
+} from "./check";
+
 type ProjectCommand = "generate" | "package" | "serve";
+type CheckSource = "manual" | "save";
+
+interface WorkspaceRunState {
+  child?: ChildProcess;
+  ownedUris: Set<string>;
+}
 
 export function activate(context: vscode.ExtensionContext): void {
+  const diagnostics = vscode.languages.createDiagnosticCollection("gox");
+  const output = vscode.window.createOutputChannel("GOX Diagnostics");
+  const checks = new CheckController(diagnostics, output);
+
   context.subscriptions.push(
+    diagnostics,
+    output,
+    checks,
     vscode.commands.registerCommand("gox.generate", () => runProjectCommand("generate")),
     vscode.commands.registerCommand("gox.package", () => runProjectCommand("package")),
     vscode.commands.registerCommand("gox.serve", () => runProjectCommand("serve")),
     vscode.commands.registerCommand("gox.doctor", runDoctor),
+    vscode.commands.registerCommand("gox.check", async () => {
+      const workspace = currentWorkspace();
+      if (!workspace) {
+        await vscode.window.showWarningMessage(
+          "GOX: Open a workspace folder before checking the current project.",
+        );
+        return;
+      }
+      await checks.run(workspace, "manual");
+    }),
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      if (!isAuthoredGOXDocument(document)) {
+        return;
+      }
+      const workspace = vscode.workspace.getWorkspaceFolder(document.uri);
+      if (workspace) {
+        void checks.run(workspace, "save");
+      }
+    }),
+    vscode.workspace.onDidChangeWorkspaceFolders((event) => {
+      for (const workspace of event.removed) {
+        checks.removeWorkspace(workspace);
+      }
+    }),
   );
 }
 
 export function deactivate(): void {}
+
+class CheckController implements vscode.Disposable {
+  private readonly states = new Map<string, WorkspaceRunState>();
+  private readonly generations = new RunGenerationCoordinator();
+
+  constructor(
+    private readonly diagnostics: vscode.DiagnosticCollection,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
+  run(workspace: vscode.WorkspaceFolder, source: CheckSource): Promise<void> {
+    const workspaceKey = workspace.uri.toString();
+    const state = this.workspaceState(workspaceKey);
+    const generation = this.generations.begin(workspaceKey);
+    this.cancelChild(state);
+
+    const executable = configuredGoxcExecutable(workspace);
+    const fallbackInvocation: CheckInvocation = {
+      executable,
+      args: ["check", workspace.uri.fsPath, "--format=json"],
+      cwd: workspace.uri.fsPath,
+    };
+    let invocation: CheckInvocation;
+    try {
+      invocation = buildCheckInvocation(executable, workspace.uri.fsPath);
+    } catch (error) {
+      const launchError = asError(error);
+      const result: CheckProcessResult = {
+        exitCode: null,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        launchError,
+      };
+      this.handleToolingError(workspace, source, fallbackInvocation, result, launchError.message);
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      let child: ChildProcess;
+      try {
+        child = spawn(invocation.executable, invocation.args, {
+          cwd: invocation.cwd,
+          shell: false,
+          windowsHide: true,
+        });
+      } catch (error) {
+        const launchError = asError(error);
+        const result: CheckProcessResult = {
+          exitCode: null,
+          signal: null,
+          stdout: "",
+          stderr: "",
+          launchError,
+        };
+        this.handleToolingError(
+          workspace,
+          source,
+          invocation,
+          result,
+          `process launch failed: ${launchError.message}`,
+        );
+        resolve();
+        return;
+      }
+
+      state.child = child;
+      let stdout = "";
+      let stderr = "";
+      let settled = false;
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
+      child.stderr?.on("data", (chunk: string) => { stderr += chunk; });
+
+      const finish = (result: CheckProcessResult): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (!this.generations.isCurrent(workspaceKey, generation)) {
+          resolve();
+          return;
+        }
+        if (state.child === child) {
+          state.child = undefined;
+        }
+
+        const interpretation = interpretCheckProcessResult(result);
+        if (interpretation.kind === "toolingError") {
+          this.handleToolingError(
+            workspace,
+            source,
+            invocation,
+            result,
+            interpretation.error,
+          );
+        } else {
+          this.applyReport(workspace, state, interpretation.report);
+        }
+        resolve();
+      };
+
+      child.once("error", (error) => {
+        finish({
+          exitCode: null,
+          signal: null,
+          stdout,
+          stderr,
+          launchError: error,
+        });
+      });
+      child.once("close", (exitCode, signal) => {
+        finish({ exitCode, signal, stdout, stderr });
+      });
+    });
+  }
+
+  removeWorkspace(workspace: vscode.WorkspaceFolder): void {
+    const workspaceKey = workspace.uri.toString();
+    const state = this.states.get(workspaceKey);
+    this.generations.invalidate(workspaceKey);
+    if (!state) {
+      return;
+    }
+    this.cancelChild(state);
+    for (const uriKey of state.ownedUris) {
+      this.diagnostics.delete(vscode.Uri.parse(uriKey));
+    }
+    this.states.delete(workspaceKey);
+  }
+
+  dispose(): void {
+    for (const [workspaceKey, state] of this.states) {
+      this.generations.invalidate(workspaceKey);
+      this.cancelChild(state);
+    }
+    this.states.clear();
+  }
+
+  private workspaceState(workspaceKey: string): WorkspaceRunState {
+    let state = this.states.get(workspaceKey);
+    if (!state) {
+      state = { ownedUris: new Set<string>() };
+      this.states.set(workspaceKey, state);
+    }
+    return state;
+  }
+
+  private cancelChild(state: WorkspaceRunState): void {
+    const child = state.child;
+    state.child = undefined;
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill();
+    }
+  }
+
+  private applyReport(
+    workspace: vscode.WorkspaceFolder,
+    state: WorkspaceRunState,
+    report: CheckReport,
+  ): void {
+    const workspaceKey = workspace.uri.toString();
+    const grouped = new Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>();
+    for (const [file, fileDiagnostics] of groupDiagnosticsByFile(report.diagnostics)) {
+      const uri = vscode.Uri.file(file);
+      const owner = vscode.workspace.getWorkspaceFolder(uri);
+      if (!owner || owner.uri.toString() !== workspaceKey) {
+        continue;
+      }
+      grouped.set(uri.toString(), {
+        uri,
+        diagnostics: fileDiagnostics.map((item) => {
+          const location = diagnosticRange(item.line, item.column);
+          const diagnostic = new vscode.Diagnostic(
+            new vscode.Range(
+              location.startLine,
+              location.startCharacter,
+              location.endLine,
+              location.endCharacter,
+            ),
+            item.message,
+            vscode.DiagnosticSeverity.Error,
+          );
+          diagnostic.source = "goxc";
+          return diagnostic;
+        }),
+      });
+    }
+
+    const ownership = new Map<string, ReadonlySet<string>>();
+    for (const [key, current] of this.states) {
+      ownership.set(key, current.ownedUris);
+    }
+    const plan = planWorkspaceDiagnosticUpdate(ownership, workspaceKey, grouped.keys());
+    for (const uriKey of plan.staleKeys) {
+      this.diagnostics.delete(vscode.Uri.parse(uriKey));
+    }
+    for (const uriKey of plan.nextKeys) {
+      const current = grouped.get(uriKey);
+      if (current) {
+        this.diagnostics.set(current.uri, current.diagnostics);
+      }
+    }
+    state.ownedUris = new Set(plan.nextKeys);
+  }
+
+  private handleToolingError(
+    workspace: vscode.WorkspaceFolder,
+    source: CheckSource,
+    invocation: CheckInvocation,
+    result: CheckProcessResult,
+    error: string,
+  ): void {
+    this.output.appendLine(`[${new Date().toISOString()}] goxc check tooling error`);
+    this.output.appendLine(`workspace: ${workspace.uri.fsPath}`);
+    this.output.appendLine(`executable: ${JSON.stringify(invocation.executable)}`);
+    this.output.appendLine(`arguments: ${JSON.stringify(invocation.args)}`);
+    this.output.appendLine(`cwd: ${invocation.cwd}`);
+    this.output.appendLine(`exit code: ${String(result.exitCode)}`);
+    this.output.appendLine(`signal: ${String(result.signal)}`);
+    this.output.appendLine(`launch error: ${result.launchError?.message ?? ""}`);
+    this.output.appendLine(`transport error: ${error}`);
+    this.output.appendLine(`stdout:\n${result.stdout}`);
+    this.output.appendLine(`stderr:\n${result.stderr}`);
+    this.output.appendLine("");
+    if (source === "manual") {
+      void vscode.window.showErrorMessage(
+        'GOX check failed. Open the "GOX Diagnostics" output channel for details.',
+      );
+    }
+  }
+}
 
 async function runProjectCommand(command: ProjectCommand): Promise<void> {
   const workspace = currentWorkspace();
@@ -27,7 +311,7 @@ async function runProjectCommand(command: ProjectCommand): Promise<void> {
     cwd: workspace.uri,
   });
   terminal.show();
-  terminal.sendText(`${goxcPath()} ${command} .`);
+  terminal.sendText(`${terminalGoxcPath(workspace)} ${command} .`);
 }
 
 function runDoctor(): void {
@@ -37,7 +321,7 @@ function runDoctor(): void {
     cwd: workspace?.uri,
   });
   terminal.show();
-  terminal.sendText(`${goxcPath()} doctor`);
+  terminal.sendText(`${terminalGoxcPath(workspace)} doctor`);
 }
 
 function currentWorkspace(): vscode.WorkspaceFolder | undefined {
@@ -51,9 +335,18 @@ function currentWorkspace(): vscode.WorkspaceFolder | undefined {
   return vscode.workspace.workspaceFolders?.[0];
 }
 
-function goxcPath(): string {
-  const configured = vscode.workspace.getConfiguration("gox").get<string>("goxcPath", "goxc");
-  return shellQuote(configured);
+function isAuthoredGOXDocument(document: vscode.TextDocument): boolean {
+  return document.uri.scheme === "file" && document.uri.fsPath.toLowerCase().endsWith(".gox");
+}
+
+function configuredGoxcExecutable(workspace?: vscode.WorkspaceFolder): string {
+  return vscode.workspace
+    .getConfiguration("gox", workspace?.uri)
+    .get<string>("goxcPath", "goxc");
+}
+
+function terminalGoxcPath(workspace?: vscode.WorkspaceFolder): string {
+  return shellQuote(configuredGoxcExecutable(workspace));
 }
 
 function shellQuote(value: string): string {
@@ -61,4 +354,8 @@ function shellQuote(value: string): string {
     return value;
   }
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/extensions/vscode-gox/src/extension.ts
+++ b/extensions/vscode-gox/src/extension.ts
@@ -11,15 +11,21 @@ import {
   diagnosticRange,
   groupDiagnosticsByFile,
   interpretCheckProcessResult,
+  planWorkspaceDiagnosticRemoval,
   planWorkspaceDiagnosticUpdate,
+  resourcePathRelation,
 } from "./check";
 
 type ProjectCommand = "generate" | "package" | "serve";
-type CheckSource = "manual" | "save";
+type CheckSource = "manual" | "save" | "rename";
 
 interface WorkspaceRunState {
   child?: ChildProcess;
   ownedUris: Set<string>;
+}
+
+interface PathRemovalResult {
+  matchedDescendant: boolean;
 }
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -53,6 +59,12 @@ export function activate(context: vscode.ExtensionContext): void {
       if (workspace) {
         void checks.run(workspace, "save");
       }
+    }),
+    vscode.workspace.onDidDeleteFiles((event) => {
+      checks.handleDeletedFiles(event.files);
+    }),
+    vscode.workspace.onDidRenameFiles((event) => {
+      checks.handleRenamedFiles(event.files);
     }),
     vscode.workspace.onDidChangeWorkspaceFolders((event) => {
       for (const workspace of event.removed) {
@@ -210,6 +222,27 @@ class CheckController implements vscode.Disposable {
     this.states.delete(workspaceKey);
   }
 
+  handleDeletedFiles(files: readonly vscode.Uri[]): void {
+    this.removePaths(files);
+  }
+
+  handleRenamedFiles(files: vscode.FileRenameEvent["files"]): void {
+    const removals = this.removePaths(files.map((file) => file.oldUri));
+    const destinationWorkspaces = new Map<string, vscode.WorkspaceFolder>();
+    files.forEach((file, index) => {
+      const destination = vscode.workspace.getWorkspaceFolder(file.newUri);
+      if (!destination) {
+        return;
+      }
+      if (isAuthoredGOXUri(file.newUri) || removals[index].matchedDescendant) {
+        destinationWorkspaces.set(destination.uri.toString(), destination);
+      }
+    });
+    for (const workspace of destinationWorkspaces.values()) {
+      void this.run(workspace, "rename");
+    }
+  }
+
   dispose(): void {
     for (const [workspaceKey, state] of this.states) {
       this.generations.invalidate(workspaceKey);
@@ -233,6 +266,63 @@ class CheckController implements vscode.Disposable {
     if (child && child.exitCode === null && child.signalCode === null) {
       child.kill();
     }
+  }
+
+  private removePaths(paths: readonly vscode.Uri[]): PathRemovalResult[] {
+    const results = paths.map(() => ({ matchedDescendant: false }));
+    const workspaceGroups = new Map<string, Array<{ index: number; uri: vscode.Uri }>>();
+    paths.forEach((uri, index) => {
+      const workspace = vscode.workspace.getWorkspaceFolder(uri);
+      if (!workspace) {
+        return;
+      }
+      const workspaceKey = workspace.uri.toString();
+      const current = workspaceGroups.get(workspaceKey);
+      if (current) {
+        current.push({ index, uri });
+      } else {
+        workspaceGroups.set(workspaceKey, [{ index, uri }]);
+      }
+    });
+
+    for (const [workspaceKey, removedPaths] of workspaceGroups) {
+      this.generations.invalidate(workspaceKey);
+      const state = this.states.get(workspaceKey);
+      if (!state) {
+        continue;
+      }
+      this.cancelChild(state);
+
+      const removedKeys = new Set<string>();
+      for (const uriKey of state.ownedUris) {
+        const candidate = vscode.Uri.parse(uriKey);
+        for (const removedPath of removedPaths) {
+          const relation = resourcePathRelation(
+            { scheme: removedPath.uri.scheme, fsPath: removedPath.uri.fsPath },
+            { scheme: candidate.scheme, fsPath: candidate.fsPath },
+          );
+          if (relation === "outside") {
+            continue;
+          }
+          removedKeys.add(uriKey);
+          if (relation === "descendant") {
+            results[removedPath.index].matchedDescendant = true;
+          }
+        }
+      }
+
+      const ownership = new Map<string, ReadonlySet<string>>();
+      for (const [key, current] of this.states) {
+        ownership.set(key, current.ownedUris);
+      }
+      const plan = planWorkspaceDiagnosticRemoval(ownership, workspaceKey, removedKeys);
+      for (const uriKey of plan.removedKeys) {
+        this.diagnostics.delete(vscode.Uri.parse(uriKey));
+      }
+      state.ownedUris = new Set(plan.nextKeys);
+    }
+
+    return results;
   }
 
   private async applyReport(
@@ -378,7 +468,11 @@ function currentWorkspace(): vscode.WorkspaceFolder | undefined {
 }
 
 function isAuthoredGOXDocument(document: vscode.TextDocument): boolean {
-  return document.uri.scheme === "file" && document.uri.fsPath.toLowerCase().endsWith(".gox");
+  return isAuthoredGOXUri(document.uri);
+}
+
+function isAuthoredGOXUri(uri: vscode.Uri): boolean {
+  return uri.scheme === "file" && uri.fsPath.toLowerCase().endsWith(".gox");
 }
 
 function configuredGoxcExecutable(workspace?: vscode.WorkspaceFolder): string {

--- a/extensions/vscode-gox/src/extension.ts
+++ b/extensions/vscode-gox/src/extension.ts
@@ -74,6 +74,15 @@ class CheckController implements vscode.Disposable {
   ) {}
 
   run(workspace: vscode.WorkspaceFolder, source: CheckSource): Promise<void> {
+    if (!vscode.workspace.isTrusted) {
+      if (source === "manual") {
+        void vscode.window.showWarningMessage(
+          "GOX checks require a trusted workspace because they execute the configured goxc executable.",
+        );
+      }
+      return Promise.resolve();
+    }
+
     const workspaceKey = workspace.uri.toString();
     const state = this.workspaceState(workspaceKey);
     const generation = this.generations.begin(workspaceKey);

--- a/extensions/vscode-gox/src/extension.ts
+++ b/extensions/vscode-gox/src/extension.ts
@@ -161,7 +161,13 @@ class CheckController implements vscode.Disposable {
             interpretation.error,
           );
         } else {
-          this.applyReport(workspace, state, interpretation.report);
+          void this.applyReport(
+            workspace,
+            state,
+            interpretation.report,
+            generation,
+          ).then(resolve);
+          return;
         }
         resolve();
       };
@@ -220,38 +226,65 @@ class CheckController implements vscode.Disposable {
     }
   }
 
-  private applyReport(
+  private async applyReport(
     workspace: vscode.WorkspaceFolder,
     state: WorkspaceRunState,
     report: CheckReport,
-  ): void {
+    generation: number,
+  ): Promise<void> {
     const workspaceKey = workspace.uri.toString();
-    const grouped = new Map<string, { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }>();
+    const sourceGroups = new Map<string, { uri: vscode.Uri; items: CheckReport["diagnostics"] }>();
     for (const [file, fileDiagnostics] of groupDiagnosticsByFile(report.diagnostics)) {
       const uri = vscode.Uri.file(file);
       const owner = vscode.workspace.getWorkspaceFolder(uri);
       if (!owner || owner.uri.toString() !== workspaceKey) {
         continue;
       }
-      grouped.set(uri.toString(), {
-        uri,
-        diagnostics: fileDiagnostics.map((item) => {
-          const location = diagnosticRange(item.line, item.column);
-          const diagnostic = new vscode.Diagnostic(
-            new vscode.Range(
-              location.startLine,
-              location.startCharacter,
-              location.endLine,
-              location.endCharacter,
-            ),
-            item.message,
-            vscode.DiagnosticSeverity.Error,
-          );
-          diagnostic.source = "goxc";
-          return diagnostic;
-        }),
-      });
+      const uriKey = uri.toString();
+      const current = sourceGroups.get(uriKey);
+      if (current) {
+        current.items.push(...fileDiagnostics);
+      } else {
+        sourceGroups.set(uriKey, { uri, items: [...fileDiagnostics] });
+      }
     }
+
+    const mappedGroups = await Promise.all(
+      [...sourceGroups.entries()].map(async ([uriKey, current]) => {
+        let source: Uint8Array | undefined;
+        try {
+          source = await vscode.workspace.fs.readFile(current.uri);
+        } catch {
+          source = undefined;
+        }
+        return [
+          uriKey,
+          {
+            uri: current.uri,
+            diagnostics: current.items.map((item) => {
+              const location = diagnosticRange(source, item.line, item.column);
+              const diagnostic = new vscode.Diagnostic(
+                new vscode.Range(
+                  location.startLine,
+                  location.startCharacter,
+                  location.endLine,
+                  location.endCharacter,
+                ),
+                item.message,
+                vscode.DiagnosticSeverity.Error,
+              );
+              diagnostic.source = "goxc";
+              return diagnostic;
+            }),
+          },
+        ] as const;
+      }),
+    );
+    if (!this.generations.isCurrent(workspaceKey, generation)) {
+      return;
+    }
+
+    const grouped = new Map(mappedGroups);
 
     const ownership = new Map<string, ReadonlySet<string>>();
     for (const [key, current] of this.states) {


### PR DESCRIPTION
## Summary

Adds CLI-backed inline GOX source diagnostics to the lightweight VS Code extension.

The extension now consumes the schema-version-1 output of:

```text
goxc check <workspace-folder> --format=json
```

Diagnostics run:

- manually through `GOX: Check Current Project`;
- automatically when an authored `.gox` file is saved;
- after supported `.gox` rename or move operations performed through VS Code.

The implementation uses a non-shell child process, keeps diagnostics isolated between multi-root workspace folders, prevents stale process completions from overwriting newer results, translates GOX byte columns into correct VS Code positions, and removes diagnostics for deleted or renamed source files.

## Scope

This PR is limited to the existing VS Code extension and its integration with the established `goxc check --format=json` contract.

It adds:

- inline diagnostics for saved authored `.gox` files;
- a manual project-check command;
- strict schema-v1 parsing and process-result validation;
- diagnostic exit-code handling;
- UTF-8 byte-column to UTF-16 editor-position conversion;
- per-workspace process cancellation and stale-run protection;
- multi-root diagnostic ownership;
- cleanup for deleted and renamed GOX files;
- an explicit Workspace Trust boundary;
- focused pure Node tests;
- extension CI coverage for compilation and tests;
- factual documentation and changelog updates.

No runtime, GOX grammar, compiler, or `goxc` behavior is changed.

## Commit Structure

The seven commits form one reviewable engineering chain:

1. `feat(vscode): add GOX diagnostics report helpers`
   - adds pure schema, process, range, generation, and ownership helpers;
   - adds the initial focused Node test suite;
   - updates extension CI to run tests.

2. `feat(vscode): surface GOX source diagnostics`
   - adds the diagnostic collection and output channel;
   - connects manual and saved-file checks;
   - adds non-shell process execution;
   - adds per-workspace cancellation and multi-root isolation.

3. `docs(vscode): document GOX diagnostics workflow`
   - documents behavior, limitations, stability, and CI expectations.

4. `fix(vscode): scope goxc path per workspace folder`
   - makes `gox.goxcPath` resource-scoped for multi-root workspaces.

5. `fix(vscode): map GOX byte columns to editor offsets`
   - converts one-based UTF-8 byte columns to UTF-16 VS Code positions;
   - reads the same saved filesystem source checked by `goxc`;
   - preserves stale-run safety during asynchronous source reads.

6. `fix(vscode): gate tool execution on workspace trust`
   - declares the extension unsupported in untrusted workspaces;
   - prevents diagnostics processes from running without Workspace Trust.

7. `fix(vscode): clear diagnostics for removed GOX files`
   - removes diagnostics for deleted or renamed paths;
   - handles directory descendants safely;
   - prevents in-flight checks from restoring removed diagnostics;
   - rechecks destination workspaces after relevant moves.

## Diagnostics Behavior

### Manual checks

`GOX: Check Current Project` checks:

1. the workspace folder containing the active editor;
2. otherwise the first workspace folder.

If no workspace folder is open, the command displays a concise warning.

### Saved-file checks

Saving an authored filesystem `.gox` document checks its owning workspace folder.

The extension does not:

- check on every edit;
- inspect unsaved buffer contents;
- check standalone files outside a workspace folder.

### Delete and rename handling

VS Code file-operation events are used to prevent stale Problems entries:

- deleting a `.gox` file removes diagnostics for its old URI;
- deleting a directory removes owned diagnostics below that path;
- renaming or moving a `.gox` file removes old-path diagnostics;
- relevant destination workspaces are checked once after a move;
- moves between workspace roots remain isolated;
- existing checks are invalidated before diagnostics are removed.

This is not general filesystem watch mode. File operations performed entirely outside VS Code are not continuously monitored.

## Process Contract

Diagnostics run without a shell:

```text
goxc check <workspace-folder> --format=json
```

`gox.goxcPath` is an executable path or command name. It is not interpreted as a shell command and must not contain arguments.

The extension interprets process results as follows:

- exit `0` with a valid clean schema-v1 report: completed check;
- exit `1` with a valid schema-v1 diagnostic report: completed check;
- launch failure, malformed output, unsupported schema, non-empty stderr, signal termination, or inconsistent exit/report state: tooling error.

Diagnostic exit `1` is a normal compiler result, not a tooling failure.

## Diagnostic Mapping

Schema-v1 locations are mapped using:

- absolute authored file paths;
- one-based source lines;
- one-based UTF-8 byte columns;
- saved source bytes from the filesystem;
- UTF-16 code-unit positions expected by VS Code;
- safe `0:0` fallback ranges when the source location cannot be mapped;
- `DiagnosticSeverity.Error`;
- diagnostic source `goxc`.

The mapper handles:

- ASCII;
- multi-byte UTF-8 characters;
- supplementary Unicode characters;
- indentation;
- LF and CRLF line endings;
- end-of-line positions;
- oversized byte columns;
- invalid mid-sequence byte offsets;
- missing or unreadable source.

Exact diagnostic wording remains experimental.

## Stale Runs And Multi-Root Workspaces

Each workspace folder independently owns:

- its active child process;
- its generation counter;
- its current diagnostic URI set.

Starting a newer check for one folder invalidates and attempts to terminate its previous process.

A stale process completion or asynchronous source-read phase cannot:

- replace newer diagnostics;
- restore diagnostics for a deleted path;
- clear diagnostics owned by another workspace folder.

Checks in separate workspace folders may run independently.

`gox.goxcPath` is resource-scoped, so each folder in a multi-root workspace may use its own executable configuration.

## Workspace Trust

The extension executes the configured `goxc` executable and is disabled in VS Code Restricted Mode and untrusted workspaces.

A defensive runtime guard also prevents a diagnostics process from starting when the workspace is not trusted:

- automatic checks are skipped silently;
- manual checks show one concise trust warning;
- no fallback executable is run.

Trusted workspaces retain resource-scoped `gox.goxcPath` behavior.

## Operational Failures

Operational failures:

- preserve the previous diagnostics;
- write invocation, exit, signal, stdout, stderr, and transport details to the `GOX Diagnostics` Output Channel;
- remain silent for automatic save and rename checks;
- show one concise error message for a failed manual check.

Source-reading failures during range mapping are not treated as process failures. The diagnostic remains available with a safe fallback range.

## Tests

The extension includes 43 pure Node tests without a third-party test framework or new dependency.

Coverage includes:

- valid clean and diagnostic schema-v1 reports;
- malformed and unsupported reports;
- required field validation;
- report and exit-code consistency;
- launch, signal, stderr, and transport failures;
- diagnostic grouping;
- ASCII and Unicode position conversion;
- LF and CRLF handling;
- end-of-line and oversized-column clamping;
- invalid UTF-8 boundaries;
- stale-run generation invalidation;
- workspace-isolated diagnostic updates;
- exact and descendant path matching;
- prefix-sibling rejection;
- immutable ownership-removal planning;
- multi-root removal isolation;
- normalized Windows path behavior;
- non-shell argument-vector construction.

## CI And Documentation

The VS Code workflow now runs:

```bash
npm test
```

which compiles the extension and executes the pure Node test suite.

Updated documentation:

- `extensions/vscode-gox/README.md`;
- `docs/gox-language.md`;
- `docs/api-stability.md`;
- `docs/ci.md`;
- `CHANGELOG.md`.

The documentation records:

- current saved-source diagnostics behavior;
- the schema-v1 column encoding;
- multi-root and stale-run semantics;
- Workspace Trust requirements;
- delete and rename cleanup;
- the distinction between CLI-backed diagnostics and an LSP.

## Validation

Local validation:

- [x] `npm ci --prefix extensions/vscode-gox`
- [x] `npm test --prefix extensions/vscode-gox`
- [x] 43 pure Node tests passed
- [x] extension JSON parsing
- [x] `go test ./cmd/goxc -run 'Test.*Check|TestCommandUsage'`
- [x] `node scripts/docs-check.mjs`
- [x] `git diff --check`
- [x] resource-scoped `gox.goxcPath` assertion
- [x] Workspace Trust capability assertion
- [x] clean final working tree

GitHub Actions on the current PR head:

- [x] Core
- [x] Browser Smoke
- [x] WASM Size
- [x] VS Code Extension

## Behavior, API, And Compatibility Impact

Editor tooling impact:

- adds saved-source inline GOX diagnostics;
- adds one manual project-check command;
- adds automatic cleanup for supported delete and rename operations;
- adds multi-root-aware process and diagnostic ownership;
- requires Workspace Trust before executing `goxc`.

Toolchain impact:

- consumes the existing `goxc check --format=json` schema-v1 process contract;
- documents the existing UTF-8 byte-column unit;
- does not change the schema or exit behavior.

Compiler and runtime impact:

- no `pkg/gox` implementation changes;
- no GOX syntax changes;
- no diagnostic generation changes;
- no `pkg/goframe` changes;
- no browser/WASM runtime changes.

Compatibility:

- no new npm dependencies;
- no extension version change;
- no migration is required for the existing command wrappers;
- workspace-specific `gox.goxcPath` values remain supported in trusted workspaces.

## Non-Goals

- No diagnostics for unsaved text.
- No check on every document change.
- No general filesystem watcher or polling.
- No guaranteed detection of external file operations outside VS Code.
- No Go or TinyGo semantic type checking.
- No generated-Go diagnostics.
- No LSP.
- No formatter.
- No completion.
- No semantic tokens.
- No code actions or quick fixes.
- No Marketplace publishing.
- No extension release.
- No runtime changes.
- No GOX grammar expansion.
- No `goxc check` schema change.
- No root README changes.
- No release preparation.
- No generated extension artifacts.

## Notes

This is a bounded Editor DX step over the existing structured `goxc check` boundary.

It improves feedback for saved authored GOX source while preserving the current lightweight, process-based extension model. It does not establish an LSP, formatter, semantic type checker, or broader IDE platform.