### PR TITLE
docs(release): prepare v0.2.0 preview 6 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `v0.2.0-preview.6` release notes documenting structured `goxc check`
+  diagnostics, the schema-v1 tooling transport, saved-source VS Code
+  diagnostics, Unicode position mapping, multi-root and stale-run handling,
+  Workspace Trust, file lifecycle cleanup, and the diagnostics-focused preview
+  boundary.
 - VS Code inline GOX source diagnostics backed by the schema-v1 `goxc check`
   transport, with manual and saved-file workspace checks, stale-run protection,
   and multi-root isolation.

--- a/docs/release-notes-v0.2.0-preview.6.md
+++ b/docs/release-notes-v0.2.0-preview.6.md
@@ -1,0 +1,219 @@
+# GoFrame v0.2.0-preview.6 Release Notes
+
+## Status / Scope
+
+`v0.2.0-preview.6` is an experimental preview for GoFrame's current
+browser/WASM surface. This release is focused on structured GOX diagnostics and
+saved-source editor feedback.
+
+The validated surface remains interactive browser/WASM applications built with
+the GoFrame runtime, GOX, `goxc`, and standard Go or TinyGo WebAssembly output.
+The new tooling makes authored GOX failures available through a read-only CLI
+contract and the repository's lightweight VS Code extension.
+
+GoFrame is not production-ready and does not provide a stable 1.0 API
+guarantee. This preview does not claim fullstack/server APIs, SSR/hydration,
+Player/Engine, `.gfapp`, formatter, or LSP support. The VS Code extension is
+not published to the Marketplace.
+
+## Highlights
+
+### GOX Tooling
+
+- `goxc check <file-or-directory> [--format=text|json]` validates authored
+  `.gox` source without writing generated output.
+- The command accepts one `.gox` file or recursively checks an authored
+  directory tree, including nested packages. Files are processed in
+  deterministic lexical order, and a diagnostic in one file does not prevent
+  later files from being checked.
+- Checks use the existing in-memory GOX generation path and discard successful
+  generated Go. They do not create `.goframe`, materialize a workspace, write
+  `.gox.go` files, or invoke Go or TinyGo type checking.
+
+### Structured Diagnostics
+
+- Text output remains the default, while `--format=json` provides the
+  versioned schema-v1 tooling transport.
+- A completed clean check exits `0`. A completed check with source diagnostics
+  exits `1`. Operational failures also exit `1` through the normal CLI error
+  path, but they do not produce a completed or partial schema-v1 report.
+- Completed JSON output is one compact document followed by a newline.
+  Completed JSON diagnostic output does not add human-readable text to
+  stderr.
+- Schema-v1 diagnostics contain an absolute authored file path, one-based line,
+  one-based UTF-8 byte column, current `"error"` severity, message, and the
+  authored source line when available. Consumers must reject unsupported
+  schema versions.
+- Exact diagnostic wording remains experimental.
+
+### VS Code Editor Diagnostics
+
+- `GOX: Check Current Project` runs
+  `goxc check <workspace-folder> --format=json` and applies source diagnostics
+  to authored files.
+- Saving an authored `.gox` file checks its owning workspace folder. The
+  diagnostics process is started without a shell and honors the existing,
+  resource-scoped `gox.goxcPath` executable setting.
+- The extension validates schema v1 and treats diagnostic exit `1` as a
+  completed report. Absolute diagnostic paths are mapped to file URIs owned by
+  the checked workspace.
+- One-based UTF-8 byte columns are converted to VS Code UTF-16 editor positions
+  from the saved filesystem bytes that `goxc` checked. Unsafe location mapping
+  falls back to a file-level diagnostic instead of using a misleading raw
+  column.
+- Per-workspace generations prevent stale runs from replacing newer results,
+  previous child processes are cancelled, and multi-root workspaces keep
+  process and diagnostic ownership isolated.
+- A completed report clears stale diagnostics for its workspace. VS Code
+  delete and rename events clear diagnostics for old paths; a rename or move
+  may recheck the destination workspace. These hooks are not general
+  filesystem watch mode.
+- Tool execution requires a trusted workspace. Automatic save and rename
+  failures do not produce popup spam, while operational details are recorded
+  in the dedicated `GOX Diagnostics` Output Channel.
+- Focused pure Node tests and the VS Code Extension CI workflow cover the
+  diagnostics transport, source-position mapping, stale-run coordination,
+  multi-root ownership, and file-lifecycle helpers.
+
+### Browser Evidence
+
+- Todo browser smoke characterizes controlled-input updates, including retained
+  node identity, focus, selection, property writes, and structural DOM work.
+- Synchronous burst updates coalesce through the current animation-frame
+  scheduling path, and keyed reorder bridge operations are attributed
+  separately from focus and selection restoration.
+- Dashboard browser smoke attributes visible-row creation, placement, removal,
+  retained identity, and listener lifecycle during a representative search
+  update.
+- The measured scenarios did not identify a concrete redundant operation class
+  that justified an immediate broad commit-buffer or mutation-queue rewrite.
+  A buffered alternative was not measured, and no production runtime mutation
+  architecture changed in this release line.
+
+### Project And Release Documentation
+
+- README is a version-agnostic project entry point that links to GitHub
+  Releases and the stable release process instead of advancing a hard-coded
+  preview pointer.
+- Release-specific state remains in GitHub Releases, release notes, the
+  changelog, and intentionally versioned evaluator documents.
+- The status-qualified roadmap is the current planning document. Future
+  version slots are planning handles, not current capabilities, schedules, or
+  compatibility promises.
+
+## Compatibility
+
+- `goxc check` is additive. Existing `generate`, `build`, `package`, `export`,
+  `serve`, and other normal toolchain workflows are unchanged.
+- This preview does not change GOX grammar, runtime APIs, package layout, or
+  manifest behavior.
+- Existing VS Code command wrappers remain available. Inline diagnostics
+  require a `goxc` version that contains the `check` command.
+- Valid existing applications are not expected to require migration.
+- Schema v1 is a versioned tooling transport. Consumers should reject
+  unsupported versions, while exact diagnostic wording remains experimental.
+- The editor integration uses saved authored source. It does not change Go or
+  TinyGo compiler diagnostics or type-checking behavior.
+
+## Validation
+
+Release-gate validation for this preview should include:
+
+- `git diff --check`;
+- `node scripts/docs-check.mjs`;
+- `go test ./...`;
+- `go test -race ./pkg/... ./cmd/...`;
+- `go vet ./...`;
+- `go test -tags=goframe_debug ./...`;
+- `go test ./pkg/gox -run 'TestGolden|TestErrorGolden'`;
+- `scripts/check.sh`;
+- `scripts/artifact-check.sh`;
+- `scripts/module-path-check.sh`;
+- `scripts/size-budget.sh`;
+- `scripts/browser-smoke.sh`;
+- `npm ci --prefix extensions/vscode-gox`;
+- `npm test --prefix extensions/vscode-gox`.
+
+The corresponding GitHub Actions workflows are:
+
+- Core;
+- Browser Smoke;
+- WASM Size;
+- VS Code Extension.
+
+These are release-gate requirements, not claims that this docs-only
+preparation task ran the full release suite.
+
+## Known Limitations And Follow-Ups
+
+- Diagnostics describe saved authored `.gox` source only. Unsaved buffer
+  content is not checked, and checks do not run on every edit.
+- `goxc check` validates GOX parsing and generation only. It does not run Go or
+  TinyGo semantic type checking or present generated-Go compiler diagnostics.
+- The editor integration is process-based. It does not provide an LSP,
+  formatter, semantic highlighting, completion, code actions, or quick fixes.
+- The VS Code extension is not published to the Marketplace.
+- Delete and rename cleanup covers VS Code file-operation events, not arbitrary
+  external filesystem changes or general watch mode.
+- Chrome/Chromium remains the strongest browser evidence. Firefox and
+  Safari/WebKit do not have equivalent automated browser-smoke coverage.
+- This preview does not claim production readiness, stable 1.0 APIs,
+  fullstack/server behavior, SSR, or hydration.
+
+## Install
+
+After the tag is published, install the exact preview with:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.6
+```
+
+## Verification
+
+Run:
+
+```bash
+goxc version
+goxc doctor
+goxc check ./examples/counter --format=json
+```
+
+Expected first line after the exact tag is published:
+
+```text
+goxc version v0.2.0-preview.6
+```
+
+The check command should produce valid JSON with `schemaVersion: 1`, `ok: true`,
+and no diagnostics for the valid counter example. Its absolute file paths, if
+present in future schema-compatible output, are environment-specific.
+
+For a quick browser/WASM check:
+
+```bash
+goxc package ./examples/counter --compiler=tinygo
+goxc serve ./examples/counter --port=8080
+```
+
+Use `--compiler=go` when TinyGo is unavailable or when standard Go/WASM output
+is preferred for local inspection.
+
+## Links
+
+- [README](../README.md)
+- [Evaluator guide](evaluator-guide.md)
+- [GOX language](gox-language.md)
+- [API stability](api-stability.md)
+- [Platform support](platform-support.md)
+- [Release process](release.md)
+- [Roadmap](roadmap.md)
+- [Previous preview: v0.2.0-preview.5](release-notes-v0.2.0-preview.5.md)
+- [This preview: v0.2.0-preview.6](release-notes-v0.2.0-preview.6.md)
+
+## Non-Goals
+
+This preview does not add GOX grammar, runtime, package, manifest, or public API
+behavior. It does not add unsaved-buffer analysis, Go/TinyGo semantic checking,
+an LSP, formatter, completion, code actions, general filesystem watch mode, or
+Marketplace distribution. It also does not add a commit buffer, mutation queue,
+production server, fullstack API, SSR, hydration, Player/Engine, or `.gfapp`.

--- a/docs/release-notes-v0.2.0-preview.6.md
+++ b/docs/release-notes-v0.2.0-preview.6.md
@@ -40,10 +40,11 @@ not published to the Marketplace.
 - Completed JSON output is one compact document followed by a newline.
   Completed JSON diagnostic output does not add human-readable text to
   stderr.
-- Schema-v1 diagnostics contain an absolute authored file path, one-based line,
-  one-based UTF-8 byte column, current `"error"` severity, message, and the
-  authored source line when available. Consumers must reject unsupported
-  schema versions.
+- Schema-v1 diagnostics contain an absolute authored file path. `line` and
+  `column` are one-based when available and `0` when unavailable, with `column`
+  measured in UTF-8 bytes. Diagnostics also contain the current `"error"`
+  severity, a message, and the authored source line when available.
+  Consumers must reject unsupported schema versions.
 - Exact diagnostic wording remains experimental.
 
 ### VS Code Editor Diagnostics

--- a/docs/release-notes-v0.2.0-preview.6.md
+++ b/docs/release-notes-v0.2.0-preview.6.md
@@ -68,9 +68,10 @@ not published to the Marketplace.
   delete and rename events clear diagnostics for old paths; a rename or move
   may recheck the destination workspace. These hooks are not general
   filesystem watch mode.
-- Tool execution requires a trusted workspace. Automatic save and rename
-  failures do not produce popup spam, while operational details are recorded
-  in the dedicated `GOX Diagnostics` Output Channel.
+- VS Code Workspace Trust is required before the extension may execute the
+  configured `goxc` executable. Automatic save and rename failures do not
+  produce popup spam, while operational details are recorded in the dedicated
+  `GOX Diagnostics` Output Channel.
 - Focused pure Node tests and the VS Code Extension CI workflow cover the
   diagnostics transport, source-position mapping, stale-run coordination,
   multi-root ownership, and file-lifecycle helpers.

--- a/docs/release.md
+++ b/docs/release.md
@@ -17,6 +17,12 @@ Latest published preview tag:
 v0.2.0-preview.5
 ```
 
+Current preview tag under preparation:
+
+```text
+v0.2.0-preview.6
+```
+
 Subsequent previews should increment the pre-release number.
 
 The current MVP tags remain historical milestone tags. They are not public API
@@ -44,7 +50,8 @@ Before creating a tag:
 - `scripts/check.sh` passes locally or in CI;
 - `scripts/size-budget.sh` passes;
 - `scripts/browser-smoke.sh` passes on a machine with Chrome and localhost bind;
-- VS Code extension JSON validation and compile pass;
+- VS Code extension JSON validation, TypeScript compile, and pure Node tests
+  pass (`npm test --prefix extensions/vscode-gox` covers compile and tests);
 - `scripts/artifact-check.sh` passes;
 - `scripts/module-path-check.sh` passes;
 - release package layout is checked with `goxc package --asset-hash --preload`
@@ -97,6 +104,7 @@ Current preview release note documents:
 - `docs/release-notes-v0.2.0-preview.3.md`
 - `docs/release-notes-v0.2.0-preview.4.md`
 - `docs/release-notes-v0.2.0-preview.5.md`
+- `docs/release-notes-v0.2.0-preview.6.md`
 
 `CHANGELOG.md` remains the factual change log; release notes should summarize
 preview scope, maturity tiers, validation evidence, compatibility notes, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -144,8 +144,9 @@ baseline already exists on current `main`:
 
 - `goxc check <file-or-directory>` performs read-only GOX validation;
 - text output and schema-v1 JSON transport report authored source diagnostics;
-- completed checks exit `0` without diagnostics and `1` when diagnostics or
-  operational failures occur;
+- completed checks exit `0` without diagnostics and `1` when source
+  diagnostics exist; operational failures also exit `1` through the normal CLI
+  error path and do not produce a completed schema-v1 report;
 - the VS Code extension applies saved-source diagnostics without treating
   unsaved editor text as compiler input;
 - one-based UTF-8 byte columns are converted to VS Code UTF-16 positions using
@@ -159,8 +160,10 @@ baseline already exists on current `main`:
 - focused pure Node tests and the VS Code extension CI lane cover the process
   contract and mapping helpers.
 
-This roadmap branch does not prepare `v0.2.0-preview.6`. Release notes, tag,
-GitHub Release body, and publish validation belong to a separate release stage.
+Release notes for `v0.2.0-preview.6` are prepared in the
+[dedicated release document](release-notes-v0.2.0-preview.6.md). The tag,
+GitHub Release body, publication, and exact-install verification remain
+separate steps. The release remains a **Next checkpoint** until publication.
 
 `v0.2.0-preview.7` should exist only for a real maintenance, compatibility, or
 security need. Normal feature progression should move to
@@ -533,8 +536,8 @@ product direction. Historical references remain available in
 
 ## Immediate Sequence
 
-1. Merge the roadmap consolidation.
-2. Prepare and publish `v0.2.0-preview.6` as a separate release stage.
+1. Complete and merge preview.6 release preparation.
+2. Run release gates and publish `v0.2.0-preview.6`.
 3. Begin `v0.3` with an executable Application Model II capability.
 
 The first post-release engineering PR should not be another broad audit or a


### PR DESCRIPTION
## Summary

Prepares repository documentation for the future `v0.2.0-preview.6` release.

This preview is centered on two connected tooling capabilities:

- structured, read-only GOX diagnostics through `goxc check`;
- saved-source inline diagnostics in the lightweight VS Code extension.

The PR adds the durable preview.6 release record, updates the pre-publication release state, corrects the documented `goxc check` process and location semantics, and aligns the current roadmap with the upcoming release checkpoint.

`v0.2.0-preview.5` remains the latest published preview. This PR does not create or publish the preview.6 tag or GitHub Release.

## Status / Scope

This is a documentation-only release-preparation PR for GoFrame's current experimental browser/WASM surface.

Changed files:

- `docs/release-notes-v0.2.0-preview.6.md`;
- `CHANGELOG.md`;
- `docs/release.md`;
- `docs/roadmap.md`.

No runtime, GOX compiler, `goxc`, VS Code extension, package, manifest, example, script, workflow, or dependency behavior changes.

The prepared preview does not claim:

- production readiness;
- stable 1.0 APIs;
- fullstack or server APIs;
- SSR or hydration;
- Player/Engine or `.gfapp`;
- formatter or LSP support;
- VS Code Marketplace publication.

## Highlights

### Structured `goxc check` Diagnostics

The preview notes document the existing read-only validation command:

```text
goxc check <file-or-directory> [--format=text|json]
```

The documented contract includes:

- validation of one authored `.gox` file or an authored directory tree;
- recursive checking of nested authored packages;
- deterministic lexical processing;
- continued checking after an earlier file reports a diagnostic;
- validation through the existing in-memory GOX generation path;
- no generated `.gox.go` output;
- no `.goframe` workspace materialization;
- no build, package, or export output;
- no Go or TinyGo semantic type checking.

The process contract is stated explicitly:

- a completed clean check exits `0`;
- a completed check with source diagnostics exits `1`;
- an operational failure also exits `1`, but through the normal CLI error path;
- operational failures do not produce completed or partial schema-v1 reports.

JSON mode remains a versioned tooling transport rather than a guarantee that exact diagnostic wording is stable.

### Schema-v1 Transport

The release notes record the current machine-readable diagnostic contract:

- absolute authored file paths;
- `line` and `column` values that are one-based when available;
- `line: 0` and `column: 0` as valid representations of unavailable source locations;
- UTF-8 byte encoding for known column values;
- current `"error"` severity;
- source-oriented messages;
- authored source lines when available;
- explicit rejection of unsupported schema versions by consumers.

Completed JSON output remains one compact document followed by a newline.

A completed report with an unavailable position remains a valid diagnostic report. It is not an operational failure.

### VS Code Saved-Source Diagnostics

The preview notes document the current editor integration:

- `GOX: Check Current Project`;
- automatic checks when an authored `.gox` file is saved;
- `goxc check <workspace-folder> --format=json`;
- non-shell child-process execution;
- resource-scoped `gox.goxcPath`;
- strict schema-v1 validation;
- diagnostic exit `1` treated as a completed compiler report;
- mapping of authored absolute paths to workspace-owned file URIs;
- UTF-8 byte-column to UTF-16 editor-position conversion;
- file-level fallback for unavailable source positions;
- per-workspace stale-run generations;
- cancellation of superseded child processes;
- multi-root process and diagnostic isolation;
- cleanup for VS Code delete and rename operations;
- destination-workspace rechecks after relevant moves;
- a dedicated `GOX Diagnostics` Output Channel.

The release notes use the official trust terminology:

> VS Code Workspace Trust is required before the extension may execute the configured `goxc` executable.

Automatic save and rename failures remain quiet rather than producing repeated popup messages.

This remains process-based editor tooling, not an LSP or general filesystem watcher.

### Browser Evidence

The release record also summarizes the browser-smoke evidence added after preview.5:

- controlled-input update attribution;
- synchronous burst-update scheduling evidence;
- keyed reorder bridge-operation attribution;
- retained focus and selection behavior;
- dashboard row creation, placement, removal, and listener-lifecycle attribution.

These measurements did not identify a concrete redundant operation class that justified an immediate broad commit-buffer or mutation-queue rewrite.

A buffered alternative was not implemented or measured, and this release line does not change production runtime mutation architecture.

### Project And Release Documentation

The release notes record the current documentation boundaries:

- README remains a version-agnostic project entry point;
- release-specific state belongs in GitHub Releases, release notes, the changelog, and intentionally versioned evaluator documents;
- `docs/roadmap.md` remains the status-qualified planning document;
- future preview slots remain planning handles rather than shipped capabilities or delivery promises.

## Pre-Publication State

This PR intentionally keeps published and prepared state separate:

```text
Latest published preview:
v0.2.0-preview.5

Preview under preparation:
v0.2.0-preview.6
```

The exact preview.6 install command is documented conditionally:

```text
After the tag is published...
```

This PR does not claim that `v0.2.0-preview.6` is currently installable through its exact tag.

The root README and evaluator guide remain unchanged so their `@latest` workflow continues to describe the latest published preview until preview.6 is actually published.

## Documentation Changes

### `docs/release-notes-v0.2.0-preview.6.md`

Adds the durable preview release record with:

- experimental browser/WASM status and scope;
- `goxc check` behavior;
- schema-v1 diagnostics and unavailable-location semantics;
- VS Code saved-source diagnostics;
- Workspace Trust requirements;
- browser evidence;
- compatibility notes;
- release-gate expectations;
- known limitations;
- conditional exact-install instructions;
- verification commands;
- project documentation links;
- explicit non-goals.

### `CHANGELOG.md`

Adds a factual entry for the preview.6 release-notes document, covering:

- structured `goxc check` diagnostics;
- schema-v1 transport;
- saved-source editor diagnostics;
- Unicode position conversion;
- stale-run and multi-root handling;
- Workspace Trust;
- file-lifecycle cleanup;
- the diagnostics-focused preview boundary.

Existing detailed entries for `goxc check` and VS Code diagnostics remain intact.

### `docs/release.md`

Updates the release process to:

- retain preview.5 as the latest published preview;
- mark preview.6 as under preparation;
- list the new preview.6 release-note document;
- include JSON validation, TypeScript compilation, and pure Node tests in the VS Code extension release gate.

The existing policies remain unchanged:

- no official binary distribution;
- no Marketplace publication;
- manual GitHub Release notes;
- preview releases marked as pre-releases;
- README remains version-agnostic;
- annotated signed tags are preferred when possible.

### `docs/roadmap.md`

Corrects the `goxc check` exit semantics so completed diagnostic reports remain distinct from operational failures.

It also records that:

- preview.6 release notes are prepared;
- tag creation and GitHub Release publication remain separate;
- preview.6 remains the next checkpoint until publication;
- the next engineering line is an executable `v0.3` Application Model II capability.

## Compatibility And Behavior Impact

Documentation impact:

- preview.6 release notes are prepared;
- release documentation distinguishes published preview.5 from prepared preview.6;
- schema-v1 location semantics are documented accurately;
- the roadmap reflects the current release checkpoint;
- Workspace Trust terminology is consistent across release-facing documents.

Runtime and API impact:

- no `pkg/goframe` changes;
- no public runtime API changes;
- no GOX grammar changes;
- no `pkg/gox` implementation changes;
- no `goxc` implementation changes;
- no schema-v1 behavior change;
- no VS Code extension behavior changes;
- no package or manifest changes;
- no migration is required for existing valid applications.

`goxc check` is additive. Existing `generate`, `build`, `package`, `export`, `serve`, and other documented workflows are unchanged.

Inline diagnostics require a `goxc` version that includes the `check` command.

## Validation

Local documentation validation reported:

- [x] frozen base and branch history verification;
- [x] preview.5 remote tag present;
- [x] preview.6 remote tag absent;
- [x] `node scripts/docs-check.mjs`;
- [x] `git diff --check`;
- [x] frozen-base and follow-up-range diff validation;
- [x] focused `TestCheckGenericCompilerErrorUsesSourceFile` coverage;
- [x] release-note title and section assertions;
- [x] conditional exact-install wording;
- [x] schema-v1, zero-location, UTF-8, UTF-16, Marketplace, and Workspace Trust assertions;
- [x] old unconditional location wording removed;
- [x] old generic trust wording removed;
- [x] auto-closing keyword audit;
- [x] README and evaluator guide unchanged;
- [x] exactly the four intended documentation paths changed;
- [x] clean final working tree with no untracked artifacts.

GitHub Actions on the current PR head:

- [x] Core
- [x] Browser Smoke
- [x] WASM Size
- [x] VS Code Extension

Full release gates remain a separate post-merge, pre-tagging step. They include:

- `go test ./...`;
- `go test -race ./pkg/... ./cmd/...`;
- `go vet ./...`;
- `go test -tags=goframe_debug ./...`;
- GOX golden tests;
- repository check, artifact, and module-path scripts;
- WASM size budgets;
- browser smoke;
- VS Code extension dependency, compile, and pure Node test validation.

This PR does not claim that the full release suite was run locally as part of the docs-only preparation task.

## Known Limitations

This preview remains limited to the current browser/WASM surface.

It does not add:

- unsaved-buffer diagnostics;
- checking on every editor change;
- Go or TinyGo semantic type checking;
- generated-Go diagnostics;
- general external filesystem watching;
- an LSP;
- a formatter;
- completion;
- semantic highlighting;
- code actions or quick fixes;
- Marketplace distribution;
- a commit buffer or mutation queue;
- a production server;
- fullstack/server APIs;
- SSR or hydration;
- Player/Engine or `.gfapp`.

Chrome/Chromium remains the strongest automated browser evidence. Equivalent Firefox and Safari/WebKit browser-smoke coverage is not claimed.

## Commit Structure

The four commits form one bounded release-preparation chain:

1. `docs(release): prepare v0.2.0 preview 6 notes`
   - adds the preview.6 release notes;
   - adds the factual changelog entry.

2. `docs(release): align preview 6 preparation state`
   - marks preview.6 under preparation;
   - updates the extension release gate;
   - corrects roadmap process semantics and release sequencing.

3. `docs(release): clarify Workspace Trust requirement`
   - replaces generic trusted-workspace wording with the official VS Code Workspace Trust term;
   - changes no behavior or other release content.

4. `docs(release): clarify schema-v1 location semantics`
   - documents `0` as the valid unavailable-location value for schema-v1 diagnostics;
   - preserves one-based UTF-8 byte columns when source positions are known;
   - changes no schema, CLI, editor, or test behavior.

## Review Follow-Up

The Codex review finding about unavailable schema-v1 locations is addressed by the fourth commit.

The release notes now match the existing implementation and focused test contract:

- known locations are one-based;
- known columns use UTF-8 byte offsets;
- unavailable locations use `0`;
- unavailable locations map safely to file-level editor diagnostics.

No additional repository changes are required for this finding.

## Non-Goals

- No tag creation.
- No GitHub Release creation or editing.
- No release assets.
- No generated release-note dump.
- No post-publication evaluator-guide update.
- No README preview pointer.
- No code or API changes.
- No schema changes.
- No workflow changes.
- No dependency changes.
- No `v0.3` implementation.
- No production-readiness or stable-API claim.

## Next Step

After this PR is merged:

1. run the full release gates against the intended `main` commit;
2. create the signed preview.6 tag;
3. publish a manually written GitHub pre-release;
4. verify the exact tagged installation, `goxc version`, `goxc doctor`, and `goxc check`;
5. align post-publication documentation;
6. begin `v0.3` with an executable Application Model II capability.