### PR TITLE
docs(release): mark v0.2.0 preview 6 as published

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -214,7 +214,7 @@ metadata compatibility policy.
 ```
 
 Local checkout builds write `devel`; tagged module installs write the module
-version recorded in Go build information, such as `v0.2.0-preview.5`.
+version recorded in Go build information, such as `v0.2.0-preview.6`.
 
 `goframe-package.json` is the authoritative current package completion marker.
 `goxc` publishes it last and removes it first during destructive package
@@ -322,7 +322,7 @@ configure a production fallback policy.
 
 The current package contract does not include bundle splitting, asset imports
 from Go/GOX, glob asset patterns, route loaders, SSR/hydration, production
-server fallback automation, or Player/Engine packaging semantics. The package
-surface is limited to explicit app manifests, generated or custom
-`index.html`, static assets under package `assets/`, versioned generated
-metadata, and exportable static browser/WASM artifacts.
+server fallback automation. The package surface is limited to explicit app
+manifests, generated or custom `index.html`, static assets under package
+`assets/`, versioned generated metadata, and exportable static browser/WASM
+artifacts.

--- a/docs/evaluator-guide.md
+++ b/docs/evaluator-guide.md
@@ -1,6 +1,6 @@
 # Evaluator Guide
 
-This guide is for evaluating the `v0.2.0-preview.5` browser/WASM layer. It is
+This guide is for evaluating the `v0.2.0-preview.6` browser/WASM layer. It is
 not a production deployment guide.
 
 ## Prerequisites
@@ -31,6 +31,20 @@ Inside a checkout:
 ```bash
 go install ./cmd/goxc
 goxc doctor
+```
+
+From a repository checkout, verify the structured diagnostics path:
+
+```bash
+goxc check ./examples/counter --format=json
+```
+
+A clean counter check returns one schema-v1 JSON document with:
+
+```text
+schemaVersion: 1
+ok: true
+diagnostics: []
 ```
 
 ## Recommended Evaluation Path
@@ -156,4 +170,4 @@ app. It is not a cross-browser certification suite.
 
 For the guided walkthrough, read the [tutorial](tutorial.md). For release scope
 and limitations, read the
-[v0.2.0-preview.5 release notes](release-notes-v0.2.0-preview.5.md).
+[v0.2.0-preview.6 release notes](release-notes-v0.2.0-preview.6.md).

--- a/docs/release-notes-v0.2.0-preview.6.md
+++ b/docs/release-notes-v0.2.0-preview.6.md
@@ -2,7 +2,7 @@
 
 ## Status / Scope
 
-`v0.2.0-preview.6` is an experimental preview for GoFrame's current
+`v0.2.0-preview.6` is a published experimental preview for GoFrame's current
 browser/WASM surface. This release is focused on structured GOX diagnostics and
 saved-source editor feedback.
 
@@ -13,8 +13,8 @@ contract and the repository's lightweight VS Code extension.
 
 GoFrame is not production-ready and does not provide a stable 1.0 API
 guarantee. This preview does not claim fullstack/server APIs, SSR/hydration,
-Player/Engine, `.gfapp`, formatter, or LSP support. The VS Code extension is
-not published to the Marketplace.
+formatter, or LSP support. The VS Code extension is not published to the
+Marketplace.
 
 ## Highlights
 
@@ -119,7 +119,7 @@ not published to the Marketplace.
 
 ## Validation
 
-Release-gate validation for this preview should include:
+The release candidate passed:
 
 - `git diff --check`;
 - `node scripts/docs-check.mjs`;
@@ -136,15 +136,12 @@ Release-gate validation for this preview should include:
 - `npm ci --prefix extensions/vscode-gox`;
 - `npm test --prefix extensions/vscode-gox`.
 
-The corresponding GitHub Actions workflows are:
+The corresponding GitHub Actions workflows passed on the tagged commit:
 
 - Core;
 - Browser Smoke;
 - WASM Size;
 - VS Code Extension.
-
-These are release-gate requirements, not claims that this docs-only
-preparation task ran the full release suite.
 
 ## Known Limitations And Follow-Ups
 
@@ -164,7 +161,7 @@ preparation task ran the full release suite.
 
 ## Install
 
-After the tag is published, install the exact preview with:
+Install the exact preview with:
 
 ```bash
 go install github.com/graybuton/goframe/cmd/goxc@v0.2.0-preview.6
@@ -180,7 +177,7 @@ goxc doctor
 goxc check ./examples/counter --format=json
 ```
 
-Expected first line after the exact tag is published:
+Expected first line from the exact tagged install:
 
 ```text
 goxc version v0.2.0-preview.6
@@ -218,4 +215,4 @@ This preview does not add GOX grammar, runtime, package, manifest, or public API
 behavior. It does not add unsaved-buffer analysis, Go/TinyGo semantic checking,
 an LSP, formatter, completion, code actions, general filesystem watch mode, or
 Marketplace distribution. It also does not add a commit buffer, mutation queue,
-production server, fullstack API, SSR, hydration, Player/Engine, or `.gfapp`.
+production server, fullstack API, SSR, or hydration.

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,12 +14,6 @@ v0.1.0-mvp10
 Latest published preview tag:
 
 ```text
-v0.2.0-preview.5
-```
-
-Current preview tag under preparation:
-
-```text
 v0.2.0-preview.6
 ```
 
@@ -250,7 +244,6 @@ announcement.
   browser platforms as explicit deferred scope when unverified;
 - reusable/multi-module component identity scope stated explicitly;
 - experimental surfaces named rather than hidden;
-- Player/Engine bounded as inactive and not a preview promise;
 - compatibility/deprecation notes included;
 - supply-chain/tooling evidence stated as lightweight CI/Dependabot/lockfile
   coverage, with no SBOM or scanner claim in the current preview contract;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,7 +123,7 @@ Future features do not become delivery promises by appearing in this document.
 
 | Version line | Theme | Intended capability class | Status |
 |---|---|---|---|
-| `v0.2.0-preview.6` | Diagnostics & Editor DX checkpoint | Publish the current CLI/editor diagnostic boundary as a bounded preview checkpoint. | **Next checkpoint** |
+| `v0.2.0-preview.6` | Diagnostics & Editor DX checkpoint | Published the current CLI/editor diagnostic boundary as a bounded preview checkpoint. | **Current / shipped** |
 | `v0.3.0-preview.*` | Application Model II | Route-driven data, transitions, loaders, mutations, and document state. | **Planned direction** |
 | `v0.4.0-preview.*` | Modular Delivery & Bundle Splitting | Explicit asset, multi-entry WASM, and route-lazy delivery boundaries. | **Candidate** |
 | `v0.5.0-preview.*` | Server Rendering & Prerender | A DOM-independent HTML-rendering subset, static prerender, and evaluated SSR adapters. | **Research** |
@@ -137,10 +137,9 @@ The ordering expresses dependencies and preferred focus. It is not a calendar.
 
 ## `v0.2.0-preview.6` - Diagnostics & Editor DX Checkpoint
 
-Status: **Next checkpoint**.
+Status: **Current / shipped**.
 
-This is the nearest tooling and diagnostics checkpoint. Its implementation
-baseline already exists on current `main`:
+This published tooling and diagnostics checkpoint includes:
 
 - `goxc check <file-or-directory>` performs read-only GOX validation;
 - text output and schema-v1 JSON transport report authored source diagnostics;
@@ -160,10 +159,9 @@ baseline already exists on current `main`:
 - focused pure Node tests and the VS Code extension CI lane cover the process
   contract and mapping helpers.
 
-Release notes for `v0.2.0-preview.6` are prepared in the
-[dedicated release document](release-notes-v0.2.0-preview.6.md). The tag,
-GitHub Release body, publication, and exact-install verification remain
-separate steps. The release remains a **Next checkpoint** until publication.
+`v0.2.0-preview.6` was published as a pre-release. Its durable scope and
+validation evidence are recorded in the
+[dedicated release document](release-notes-v0.2.0-preview.6.md).
 
 `v0.2.0-preview.7` should exist only for a real maintenance, compatibility, or
 security need. Normal feature progression should move to
@@ -516,29 +514,12 @@ entries are deliberately not sequenced or assigned to releases.
 Reservoir entries become version-train work only through an explicit selection
 that defines behavior boundaries, evidence, cost, and non-goals.
 
-## Inactive Directions
-
-Status: **Inactive**.
-
-The following are historical strategic options, not current roadmap items:
-
-- Player/Engine;
-- `.gfapp`;
-- a portable custom host/runtime;
-- desktop or mobile shells;
-- a custom application engine.
-
-Reopening any of these directions requires an explicit maintainer decision.
-Architecture lessons about authored source, runtime APIs, toolchain packaging,
-and deployment contracts may still be reused without reactivating the original
-product direction. Historical references remain available in
-[the Player/Engine inactive direction note](player-vision.md).
-
 ## Immediate Sequence
 
-1. Complete and merge preview.6 release preparation.
-2. Run release gates and publish `v0.2.0-preview.6`.
-3. Begin `v0.3` with an executable Application Model II capability.
+1. Begin `v0.3` with an executable Application Model II capability.
+2. Establish route transition state and cancellation through focused evidence.
+3. Continue toward later `v0.3` capabilities only after the first slice is
+   validated.
 
 The first post-release engineering PR should not be another broad audit or a
 wording-only cleanup. It should provide a bounded, observable capability with


### PR DESCRIPTION
## Summary

Aligns repository documentation with the published
`v0.2.0-preview.6` pre-release.

The tag and GitHub Release were published before this PR. This changeset only
updates repository documentation so it no longer describes preview.6 as under
preparation.

It also updates evaluator and deployment guidance and records
`v0.3 Application Model II` as the immediate engineering line after the
completed diagnostics and Editor DX checkpoint.

## Published Release State

The publication was independently verified before editing:

```text
Tag:
v0.2.0-preview.6

Tag target:
9548345776e6398cd70e8fc58435dd5dab687c7d

Release title:
GoFrame v0.2.0-preview.6

Release state:
published pre-release
```

The exact public module install was also verified:

```text
goxc version v0.2.0-preview.6
goxc doctor → Status: ok
```

A clean schema-v1 check returned:

```text
schemaVersion: 1
ok: true
filesChecked: 1
diagnostics: []
```

A package produced by the tagged binary recorded:

```text
toolchainVersion: v0.2.0-preview.6
```

## Scope

This is a documentation-only post-publication closeout.

Changed files:

- `docs/release.md`;
- `docs/release-notes-v0.2.0-preview.6.md`;
- `docs/evaluator-guide.md`;
- `docs/deployment.md`;
- `docs/roadmap.md`.

The root README remains version-agnostic and is intentionally unchanged.

`CHANGELOG.md` is also unchanged because it already records the preview.6
release-note document and shipped diagnostics capabilities.

## Documentation Changes

### `docs/release.md`

Updates the release process to:

- mark `v0.2.0-preview.6` as the latest published preview;
- remove the preview.6 `under preparation` block;
- preserve the existing tag, validation, publishing, and README policies.

The document continues to state that:

- preview releases use annotated signed tags when possible;
- GitHub Release notes are written manually;
- preview releases are marked as pre-releases;
- no official binary distribution is published;
- the VS Code extension is not distributed through the Marketplace;
- README remains version-agnostic.

### `docs/release-notes-v0.2.0-preview.6.md`

Converts the durable release record from pre-publication to published-state
wording:

- identifies preview.6 as published;
- records that the release candidate passed the documented validation suite;
- states that the corresponding GitHub Actions workflows passed on the tagged
  commit;
- replaces conditional install wording with the available exact-install path;
- updates version verification wording for the tagged binary.

The technical release scope remains unchanged:

- read-only `goxc check`;
- schema-v1 diagnostics;
- saved-source VS Code diagnostics;
- UTF-8 byte-column to UTF-16 editor-position conversion;
- stale-run and multi-root isolation;
- Workspace Trust;
- file lifecycle cleanup;
- current browser/WASM limitations.

### `docs/evaluator-guide.md`

Moves the evaluator target from preview.5 to preview.6.

It also adds a compact structured-diagnostics evaluation path:

```bash
goxc check ./examples/counter --format=json
```

The expected clean result is documented as:

```text
schemaVersion: 1
ok: true
diagnostics: []
```

The guide retains:

- `@latest` as the public CLI install path;
- browser/WASM scope;
- Chrome/Chromium as the strongest browser evidence;
- Go and TinyGo evaluation paths;
- the counter-to-router-dashboard walkthrough;
- current runtime, router, resource, deployment, and platform limitations.

### `docs/deployment.md`

Updates the tagged `toolchainVersion` example:

```text
v0.2.0-preview.5
→
v0.2.0-preview.6
```

No package, export, caching, hosting, or deployment behavior changes.

The current package contract remains limited to static browser/WASM artifacts,
explicit manifests, generated metadata, optional compression, and static-host
deployment.

### `docs/roadmap.md`

Marks the diagnostics and Editor DX checkpoint as:

```text
Current / shipped
```

The roadmap now records that preview.6 was published and links to its durable
release document.

The immediate sequence is updated to:

1. begin `v0.3` with an executable Application Model II capability;
2. establish route transition state and cancellation through focused evidence;
3. continue to later `v0.3` capabilities only after the first slice is
   validated.

The roadmap still does not select final route, loader, action, or mutation API
signatures.

## Commit Structure

The branch contains two focused commits:

1. `docs(release): mark v0.2.0 preview 6 as published`
   - updates the release process;
   - converts preview.6 release notes to published-state wording.

2. `docs: align published preview 6 guidance`
   - updates the evaluator target and diagnostics path;
   - updates the deployment version example;
   - closes the preview.6 roadmap checkpoint and records the next engineering
     line.

## Compatibility And Behavior Impact

Documentation impact:

- preview.6 is documented as the latest published preview;
- evaluator-facing guidance matches the published module;
- deployment metadata examples match the tagged binary;
- roadmap status and sequencing match the completed release cycle.

Runtime and API impact:

- no `pkg/goframe` changes;
- no `pkg/gox` changes;
- no `goxc` changes;
- no VS Code extension changes;
- no schema changes;
- no package or manifest changes;
- no deployment behavior changes;
- no migration is required.

## Validation

Publication verification completed before the documentation changes:

- [x] preview.6 tag exists locally and remotely;
- [x] peeled tag target is
  `9548345776e6398cd70e8fc58435dd5dab687c7d`;
- [x] tag signature is valid;
- [x] GitHub Release is published, not draft, and marked as a pre-release;
- [x] public exact-module installation succeeds;
- [x] `goxc version` reports `v0.2.0-preview.6`;
- [x] `goxc doctor` reports `Status: ok`;
- [x] schema-v1 clean check succeeds;
- [x] tagged package metadata reports `v0.2.0-preview.6`.

Branch validation:

- [x] `node scripts/docs-check.mjs`;
- [x] `git diff --check`;
- [x] frozen-base range validation;
- [x] stale pre-publication wording audit;
- [x] auto-closing keyword audit;
- [x] exact five-file scope audit;
- [x] README unchanged;
- [x] CHANGELOG unchanged;
- [x] API, platform, and architecture docs unchanged;
- [x] clean final working tree with no untracked artifacts.

GitHub Actions on the PR head:

- [ ] Core
- [ ] Browser Smoke
- [ ] WASM Size
- [ ] VS Code Extension

The full release gate was not rerun for this branch because it contains only
publication-state documentation changes. The exact tagged release candidate had
already passed the complete pre-tag validation suite.

## Non-Goals

- No runtime or compiler changes.
- No `goxc` behavior changes.
- No VS Code extension changes.
- No package or manifest changes.
- No CI or dependency changes.
- No README version pointer.
- No changelog rewrite.
- No tag or GitHub Release changes.
- No release asset upload.
- No new roadmap document.
- No route transition implementation.
- No loader, action, or mutation API.
- No `v0.3` implementation.

## Next Step

After this PR is merged, the `v0.2` release cycle is complete.

The next changeset should implement a bounded, observable
`v0.3 Application Model II` capability, beginning with route transition state
and cancellation evidence rather than another broad audit or documentation-only
planning stage.