### PR TITLE
feat(example): demonstrate route-driven async navigation

### DIFF
--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -7,11 +7,15 @@ This example shows a narrow integration pattern:
 - static serving of the packaged standalone app;
 - a same-origin `/api/greeting` endpoint;
 - hash-routed home and greeting content inside a retained application shell;
+- route-owned controlled forms whose active greeting follows the route query;
 - browser-side text loading through experimental `gf.FetchText` and
   `gf.UseResource`;
+- same-target success reload and failed-request retry through the resource's
+  existing `reload` function;
 - cancellation when a greeting target is superseded or its route unmounts;
 - a controlled backend failure and recovery path through later navigation;
-- browser back/forward through the same router and resource lifecycle.
+- direct hash and browser back/forward navigation through the same router,
+  resource, and route-to-form synchronization lifecycle.
 
 It is a reference fixture, not a GoFrame server framework.
 
@@ -38,12 +42,17 @@ Open <http://127.0.0.1:8080>.
 - `goxc package` can produce a browser/WASM bundle that a Go backend serves as
   static files.
 - The backend can expose a same-origin API endpoint beside the packaged app.
-- The stable shell owns the controlled form and stays mounted while
-  `gf.RouterView` switches route content.
-- Form submission builds `/greeting?name=...` with `gf.WithQuery` and navigates
-  with `gf.Navigate` instead of mutating a local resource key.
+- The stable outer shell stays mounted while `gf.RouterView` switches
+  route-owned forms and content.
+- Home and greeting routes own separate controlled drafts. The active greeting
+  route query is the source of truth for the greeting form.
+- A different-name submit builds `/greeting?name=...` with `gf.WithQuery` and
+  navigates with `gf.Navigate`; submitting the current greeting calls the
+  `reload` function returned by `gf.UseResource`.
 - The greeting route decodes `RouteContext.Query()` and owns its request with
   `gf.UseResource`.
+- A dependency-aware route effect synchronizes the greeting draft after direct,
+  Back, or Forward query changes while the `/greeting` pattern stays mounted.
 - The browser text fetch uses `gf.FetchText`; app-specific URL/key construction
   stays local to the example.
 - The app renders the existing `gf.UseResource` failed state for a controlled
@@ -58,7 +67,7 @@ Open <http://127.0.0.1:8080>.
 The executable flow uses only existing GoFrame primitives:
 
 ```text
-controlled shell input
+route-owned controlled input
 → gf.WithQuery("/greeting", ...)
 → gf.Navigate(...)
 → RouterView observes hashchange
@@ -68,42 +77,62 @@ controlled shell input
 → loading, failed, or ready route UI
 ```
 
+When the normalized greeting draft already equals the active route name, the
+submit path skips navigation and calls `UseResource`'s `reload` closure:
+
+```text
+same active name
+→ URL remains unchanged
+→ reload current resource generation
+→ loading
+→ ready or failed
+```
+
 Routes exercised by the browser evidence are:
 
 ```text
 /
 #/greeting?name=Ada
+#/greeting?name=Lin
 #/greeting?name=slow
 #/greeting?name=fail
 ```
 
 The `/greeting` pattern stays mounted across query changes, so a new resource
-key supersedes the previous generation. Navigating to `/` unmounts the route
-owner. Both paths run the cleanup returned by `gf.FetchText` through
-`gf.UseResource` ownership.
+key supersedes the previous generation and the route effect synchronizes the
+controlled draft. Navigating to `/` unmounts the greeting route, form, and
+resource owner. Both cancellation paths run the cleanup returned by
+`gf.FetchText` through `gf.UseResource` ownership.
 
 ## Ownership And Coordination
 
 | Concern | Current owner |
 |---|---|
-| form input | `ServerBackedShell` and one `gf.UseState` slot |
-| URL target construction | the shell submit handler through `gf.WithQuery` |
+| home form draft | `HomeRoute` and its `gf.UseState` slot |
+| greeting form draft | `GreetingRoute` and its `gf.UseState` slot |
+| active greeting source of truth | normalized `RouteContext.Query()` name passed to `GreetingRoute` |
+| route-to-draft synchronization | one `GreetingRoute` effect keyed by the normalized route name |
+| URL target construction | each route submit handler through `gf.WithQuery` |
 | hash navigation | `gf.Navigate`; native history for back/forward |
 | route matching | `gf.RouterView` and the example route table |
 | query decoding | `RouteContext.Query()` |
-| resource key derivation | `GreetingRoute` through `greetingPath` |
+| resource key | `GreetingRoute` through `greetingPath` |
 | request generation | `gf.UseResource` generation state |
+| same-target reload | the active `GreetingRoute` through `UseResource`'s returned `reload` function |
 | cancellation | `gf.UseResource` cleanup invoking `gf.FetchText` cleanup |
 | stale completion suppression | `gf.UseResource` generation checks and `gf.FetchText` active state |
 | loading/failed/ready UI | explicit branches in `GreetingRoute` |
-| shell retention | `ServerBackedShell` composed outside `gf.RouterView` |
+| global shell retention | `App`, `ServerBackedShell`, and the route-content container outside the matched route subtree |
+| same-pattern form/input retention | pattern-keyed `RouterView` reconciliation retains the greeting form and input across query changes and reloads |
 | old-screen retention during pending | not provided; the route shows loading and removes the previous ready result |
 | atomic route + data commit | not provided; the hash target commits before the resource is ready |
 
-Example-local coordination consists of one input state slot, one submit
-handler, one route table, three small route handlers, and one route-owned
-resource hook. Helpers normalize the name, format the route target and request
-key, and render resource status/error text.
+Example-local coordination consists of two mutually exclusive route-owned state
+slots, one Home submit handler, one Greeting submit/reload handler, one focused
+query-to-draft synchronization effect, one route table, three small route
+handlers, and one route-owned resource hook. A shared render helper emits the
+form, while small helpers normalize the name, format the route target and
+request key, and render resource status/error text.
 
 The application contains:
 
@@ -112,30 +141,49 @@ The application contains:
 - app-owned `AbortController` instances: `0`;
 - app-owned cleanup callbacks: `0`;
 - duplicated loading/error state variables: `0`;
-- custom effects for router/resource coordination: `0`.
+- resource lifecycle effects outside `gf.UseResource`: `0`;
+- route/form synchronization effects: `1`.
 
 ## Executable Evidence
 
 `scripts/server-backed-browser-smoke.mjs` installs browser-only instrumentation
 before loading the app. It records greeting fetches and their exact abort
 signals, debug-tag render/update flushes, structural DOM operations, route
-targets, and retained shell nodes. Production runtime code is not
-instrumented.
+targets, global shell identity, and per-scenario form/input identity. Before a
+form scenario starts, the harness waits for the state-owning `HomeRoute` or
+`GreetingRoute` render and patch counts to advance, verifies the controlled
+value, and observes two additional stable frames. Production runtime code is
+not instrumented.
 
-One deterministic run performs eight route-owned fetches:
+Two deterministic runs each perform eleven route-owned fetches:
 
-- four successful `Ada` completions;
-- two controlled `fail` completions;
+- one direct `Lin` completion and five successful `Ada` completions, including
+  same-target reload and Forward history;
+- three controlled `fail` completions, including same-target retry and Back
+  history;
 - two active `slow` requests aborted, one on same-pattern supersede and one on
   route unmount;
 - zero stale slow-result appearances;
-- zero shell, form, input, or route-content identity changes.
+- zero app-root, outer-shell, or route-content-container identity changes;
+- retained greeting form/input nodes for every same-pattern query change and
+  same-target reload;
+- expected form/input remounts when the route pattern changes between `/` and
+  `/greeting`.
 
-Each complete greeting navigation uses two rAF-scheduled update flushes: one
-for the route/loading state and one for completion. Starting a pending slow
-route and unmounting it each use one update flush. The script prints DOM bridge
-operation totals for review but does not make browser-version-dependent totals
-part of the product contract.
+Direct navigation, different-target form navigation, same-target reload, failure,
+retry, recovery, and resource completion were observed with balanced rAF
+requests/callbacks and no microtask fallback. Pending slow starts and route
+unmount each used one update flush. Back and Forward each used three update
+flushes: route/loading, route-to-draft synchronization, and completion. These
+counts and DOM bridge totals are printed observations; the assertions require
+behavioral outcomes, balanced scheduling, attributable component work, and no
+input update leaking into the next scenario rather than fixing incidental DOM
+totals as product contracts.
+
+Direct, Back, and Forward navigation each prove that route target, resource key,
+controlled input, and result refer to the same normalized name. Same-target
+success and failure submissions keep the hash unchanged while starting a new
+resource generation and exposing loading before the new result.
 
 The flow also demonstrates current semantic boundaries: the URL changes before
 data is ready, the previous ready greeting is not retained during pending, and
@@ -148,25 +196,29 @@ The frozen-base and route-driven versions were packaged with TinyGo `0.41.1`
 using `--asset-hash --preload --compress=gzip,br`. The WASM entrypoint was
 resolved through `asset-manifest.json` in both cases.
 
-| Artifact | Frozen base | Route-driven flow | Delta |
-|---|---:|---:|---:|
-| raw WASM | 130,948 B | 156,668 B | +25,720 B (+19.64%) |
-| gzip | 60,254 B | 68,269 B | +8,015 B (+13.30%) |
-| Brotli | 50,504 B | 57,492 B | +6,988 B (+13.84%) |
+| Artifact | Frozen base | Reviewed head | Final | Delta from base | Follow-up delta |
+|---|---:|---:|---:|---:|---:|
+| raw WASM | 130,948 B | 156,668 B | 160,236 B | +29,288 B (+22.37%) | +3,568 B (+2.28%) |
+| gzip | 60,254 B | 68,269 B | 69,233 B | +8,979 B (+14.90%) | +964 B (+1.41%) |
+| Brotli | 50,504 B | 57,492 B | 58,185 B | +7,681 B (+15.21%) | +693 B (+1.21%) |
 
 This example is not part of the global hard size-budget list. The delta is
-evidence for the current router/UI composition and does not authorize a budget
-increase or another shared runtime abstraction.
+evidence for the current router/UI composition. The follow-up cost covers
+route-owned forms, query synchronization, and same-target reload evidence; it
+does not authorize a budget increase or another shared runtime abstraction.
 
 ## Evidence Verdict
 
 Verdict: **SUFFICIENT**.
 
 The existing router, ordinary component composition, `gf.UseResource`, and
-`gf.FetchText` express route-driven loading, failure, recovery, same-pattern
-supersession, unmount cancellation, stale-result suppression, and native
+`gf.FetchText` express route-driven loading, same-target reload/retry, coherent
+URL/input state, failure, recovery, same-pattern supersession, unmount
+cancellation, stale-result suppression, direct hash navigation, and native
 back/forward without duplicating asynchronous lifecycle state in the app. The
-coordination is small and has one clear owner per concern.
+coordination remains small: route/form synchronization adds one ordinary
+effect, while request generation, cancellation, and stale suppression keep one
+existing resource owner.
 
 This flow does not establish a need for a framework-level transition or loader
 API. It also does not prove that old-screen retention or atomic route/data
@@ -198,9 +250,10 @@ node --experimental-websocket scripts/server-backed-browser-smoke.mjs
 
 The browser smoke packages the example, starts the Go backend on a dynamic
 localhost port, opens the app through Chrome/CDP, and verifies route-driven
-loading, exact request aborts, stale-result suppression, controlled failure and
-recovery, native back/forward, retained shell identity, and update/DOM bridge
-evidence.
+loading, same-target reload/retry, direct and history-driven input
+synchronization, exact request aborts, stale-result suppression, controlled
+failure and recovery, global shell retention, same-pattern form/input retention,
+expected cross-pattern remounts, and update/DOM bridge evidence.
 
 ## Non-goals
 

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -6,12 +6,12 @@ This example shows a narrow integration pattern:
 - a plain Go `net/http` backend;
 - static serving of the packaged standalone app;
 - a same-origin `/api/greeting` endpoint;
+- hash-routed home and greeting content inside a retained application shell;
 - browser-side text loading through experimental `gf.FetchText` and
   `gf.UseResource`;
-- a controlled backend failure and recovery path through the same resource/form
-  state;
-- delayed stale backend response handling without overwriting newer rendered
-  data.
+- cancellation when a greeting target is superseded or its route unmounts;
+- a controlled backend failure and recovery path through later navigation;
+- browser back/forward through the same router and resource lifecycle.
 
 It is a reference fixture, not a GoFrame server framework.
 
@@ -38,16 +38,140 @@ Open <http://127.0.0.1:8080>.
 - `goxc package` can produce a browser/WASM bundle that a Go backend serves as
   static files.
 - The backend can expose a same-origin API endpoint beside the packaged app.
-- The app can use existing GoFrame resource/form patterns to load backend data
-  and update rendered UI after form submission.
+- The stable shell owns the controlled form and stays mounted while
+  `gf.RouterView` switches route content.
+- Form submission builds `/greeting?name=...` with `gf.WithQuery` and navigates
+  with `gf.Navigate` instead of mutating a local resource key.
+- The greeting route decodes `RouteContext.Query()` and owns its request with
+  `gf.UseResource`.
 - The browser text fetch uses `gf.FetchText`; app-specific URL/key construction
   stays local to the example.
 - The app renders the existing `gf.UseResource` failed state for a controlled
-  backend error and recovers after a later valid submission.
-- A delayed backend response can be superseded by a newer valid submission
-  without replacing the newer rendered greeting.
+  backend error and recovers after later valid navigation.
+- A delayed backend response is aborted when superseded or unmounted, and it
+  cannot replace the current route result.
 - `gf.FetchText` is a low-level text loader, not a server framework or data
   framework.
+
+## Route Flow
+
+The executable flow uses only existing GoFrame primitives:
+
+```text
+controlled shell input
+→ gf.WithQuery("/greeting", ...)
+→ gf.Navigate(...)
+→ RouterView observes hashchange
+→ RouteContext.Query() derives the name
+→ GreetingRoute derives /api/greeting?name=...
+→ UseResource starts FetchText
+→ loading, failed, or ready route UI
+```
+
+Routes exercised by the browser evidence are:
+
+```text
+/
+#/greeting?name=Ada
+#/greeting?name=slow
+#/greeting?name=fail
+```
+
+The `/greeting` pattern stays mounted across query changes, so a new resource
+key supersedes the previous generation. Navigating to `/` unmounts the route
+owner. Both paths run the cleanup returned by `gf.FetchText` through
+`gf.UseResource` ownership.
+
+## Ownership And Coordination
+
+| Concern | Current owner |
+|---|---|
+| form input | `ServerBackedShell` and one `gf.UseState` slot |
+| URL target construction | the shell submit handler through `gf.WithQuery` |
+| hash navigation | `gf.Navigate`; native history for back/forward |
+| route matching | `gf.RouterView` and the example route table |
+| query decoding | `RouteContext.Query()` |
+| resource key derivation | `GreetingRoute` through `greetingPath` |
+| request generation | `gf.UseResource` generation state |
+| cancellation | `gf.UseResource` cleanup invoking `gf.FetchText` cleanup |
+| stale completion suppression | `gf.UseResource` generation checks and `gf.FetchText` active state |
+| loading/failed/ready UI | explicit branches in `GreetingRoute` |
+| shell retention | `ServerBackedShell` composed outside `gf.RouterView` |
+| old-screen retention during pending | not provided; the route shows loading and removes the previous ready result |
+| atomic route + data commit | not provided; the hash target commits before the resource is ready |
+
+Example-local coordination consists of one input state slot, one submit
+handler, one route table, three small route handlers, and one route-owned
+resource hook. Helpers normalize the name, format the route target and request
+key, and render resource status/error text.
+
+The application contains:
+
+- manual generation counters: `0`;
+- manual stale-result guards: `0`;
+- app-owned `AbortController` instances: `0`;
+- app-owned cleanup callbacks: `0`;
+- duplicated loading/error state variables: `0`;
+- custom effects for router/resource coordination: `0`.
+
+## Executable Evidence
+
+`scripts/server-backed-browser-smoke.mjs` installs browser-only instrumentation
+before loading the app. It records greeting fetches and their exact abort
+signals, debug-tag render/update flushes, structural DOM operations, route
+targets, and retained shell nodes. Production runtime code is not
+instrumented.
+
+One deterministic run performs eight route-owned fetches:
+
+- four successful `Ada` completions;
+- two controlled `fail` completions;
+- two active `slow` requests aborted, one on same-pattern supersede and one on
+  route unmount;
+- zero stale slow-result appearances;
+- zero shell, form, input, or route-content identity changes.
+
+Each complete greeting navigation uses two rAF-scheduled update flushes: one
+for the route/loading state and one for completion. Starting a pending slow
+route and unmounting it each use one update flush. The script prints DOM bridge
+operation totals for review but does not make browser-version-dependent totals
+part of the product contract.
+
+The flow also demonstrates current semantic boundaries: the URL changes before
+data is ready, the previous ready greeting is not retained during pending, and
+route plus data do not commit atomically. Those are observations, not behavior
+simulated with extra application state.
+
+## Size Evidence
+
+The frozen-base and route-driven versions were packaged with TinyGo `0.41.1`
+using `--asset-hash --preload --compress=gzip,br`. The WASM entrypoint was
+resolved through `asset-manifest.json` in both cases.
+
+| Artifact | Frozen base | Route-driven flow | Delta |
+|---|---:|---:|---:|
+| raw WASM | 130,948 B | 156,668 B | +25,720 B (+19.64%) |
+| gzip | 60,254 B | 68,269 B | +8,015 B (+13.30%) |
+| Brotli | 50,504 B | 57,492 B | +6,988 B (+13.84%) |
+
+This example is not part of the global hard size-budget list. The delta is
+evidence for the current router/UI composition and does not authorize a budget
+increase or another shared runtime abstraction.
+
+## Evidence Verdict
+
+Verdict: **SUFFICIENT**.
+
+The existing router, ordinary component composition, `gf.UseResource`, and
+`gf.FetchText` express route-driven loading, failure, recovery, same-pattern
+supersession, unmount cancellation, stale-result suppression, and native
+back/forward without duplicating asynchronous lifecycle state in the app. The
+coordination is small and has one clear owner per concern.
+
+This flow does not establish a need for a framework-level transition or loader
+API. It also does not prove that old-screen retention or atomic route/data
+commit would never be valuable; those stronger semantics were not required by
+this reference flow and remain separate design questions.
 
 ## Project Structure
 
@@ -73,9 +197,10 @@ node --experimental-websocket scripts/server-backed-browser-smoke.mjs
 ```
 
 The browser smoke packages the example, starts the Go backend on a dynamic
-localhost port, opens the app through Chrome/CDP, and verifies initial backend
-data, updated backend data, delayed stale response no-overwrite behavior,
-controlled backend failure UI, and recovery after a later valid form submission.
+localhost port, opens the app through Chrome/CDP, and verifies route-driven
+loading, exact request aborts, stale-result suppression, controlled failure and
+recovery, native back/forward, retained shell identity, and update/DOM bridge
+evidence.
 
 ## Non-goals
 

--- a/examples/server-backed/assets/styles.css
+++ b/examples/server-backed/assets/styles.css
@@ -46,6 +46,35 @@ input {
   padding: 1.4rem;
 }
 
+.panel-heading {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.panel-heading .muted {
+  margin: 0;
+}
+
+.home-link {
+  color: #1c64f2;
+  font-weight: 700;
+}
+
+.route-panel {
+  min-height: 11rem;
+}
+
+.route-target {
+  background: #f4f7fb;
+  border-radius: 12px;
+  color: #40516e;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  overflow-wrap: anywhere;
+  padding: 0.65rem 0.75rem;
+}
+
 .eyebrow,
 .muted {
   color: #61708a;

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -7,38 +7,74 @@ import (
 	gf "github.com/graybuton/goframe/pkg/goframe"
 )
 
+type ServerBackedShellProps struct {
+	Children []gf.Node
+}
+
+type HomeRouteProps struct {
+	Target string
+}
+
+type GreetingRouteProps struct {
+	Name   string
+	Target string
+}
+
+type NotFoundRouteProps struct {
+	Target string
+}
+
+var router = gf.NewHashRouter([]gf.Route{
+	gf.RoutePath("/", homeRoute),
+	gf.RoutePath("/greeting", greetingRoute),
+	gf.NotFoundRoute(notFoundRoute),
+})
+
 func App() gf.Node {
+	return (
+		<main class="server-backed-app" data-testid="server-backed-app">
+			<ServerBackedShell>
+				{gf.RouterView(router)}
+			</ServerBackedShell>
+		</main>
+	)
+}
+
+func ServerBackedShell(props ServerBackedShellProps) gf.Node {
 	name, setName := gf.UseState("GoFrame")
-	submittedName, setSubmittedName := gf.UseState("GoFrame")
-	resource, reload := gf.UseResource(greetingPath(submittedName), gf.FetchText)
 
 	submitGreeting := func(event gf.Event) {
 		event.PreventDefault()
-		next := strings.TrimSpace(name)
-		if next == "" {
-			next = "GoFrame"
+		next := normalizedGreetingName(name)
+		if next != name {
 			setName(next)
 		}
-		if next == submittedName {
-			reload()
-			return
-		}
-		setSubmittedName(next)
+		gf.Navigate(gf.WithQuery("/greeting", gf.QueryValues{
+			"name": {next},
+		}))
 	}
 
 	return (
-		<main class="server-backed-app" data-testid="server-backed-app">
+		<section class="server-backed-shell" data-testid="server-backed-shell">
 			<section class="hero">
 				<p class="eyebrow">Server-backed reference</p>
-				<h1>GoFrame app served by a Go backend</h1>
+				<h1>Route-driven data from a Go backend</h1>
 				<p class="muted">
-					This browser/WASM app is packaged by goxc, served by a plain
-					Go net/http backend, and reads from a same-origin API endpoint.
+					This browser/WASM app keeps its form shell mounted while hash routes
+					own same-origin greeting resources.
 				</p>
 			</section>
 
-			<section class="panel">
-				<h2>Same-origin greeting</h2>
+			<section class="panel" data-testid="greeting-form-panel">
+				<div class="panel-heading">
+					<div>
+						<h2>Same-origin greeting</h2>
+						<p class="muted">Submitting changes the route; route content owns the request.</p>
+					</div>
+					<gf.RouterLink To="/" Class="home-link" TestID="server-backed-home-link">
+						Home
+					</gf.RouterLink>
+				</div>
 				<form class="greeting-form" data-testid="greeting-form" OnSubmit={submitGreeting}>
 					<label class="field">
 						<span>Name</span>
@@ -53,22 +89,88 @@ func App() gf.Node {
 					</label>
 					<button data-testid="greeting-submit" Type="submit">Ask backend</button>
 				</form>
-
-				<p class="muted" data-testid="greeting-resource-key">{greetingPath(submittedName)}</p>
-				<p class="muted" data-testid="greeting-status">{greetingStatus(resource)}</p>
-
-				{resource.Loading() && (
-					<p class="status loading" data-testid="greeting-loading">Loading backend greeting...</p>
-				)}
-				{resource.Failed() && (
-					<div class="status failed" data-testid="greeting-error">{greetingErrorText(resource)}</div>
-				)}
-				{resource.Ready() && (
-					<p class="status message" data-testid="greeting-message">{resource.Value}</p>
-				)}
 			</section>
-		</main>
+
+			<section class="panel route-panel" data-testid="server-backed-route-content">
+				{props.Children}
+			</section>
+		</section>
 	)
+}
+
+func homeRoute(ctx gf.RouteContext) gf.Node {
+	return <HomeRoute Target={routeTarget(ctx)} />
+}
+
+func greetingRoute(ctx gf.RouteContext) gf.Node {
+	return <GreetingRoute
+		Name={normalizedGreetingName(ctx.Query().Get("name"))}
+		Target={routeTarget(ctx)}
+	/>
+}
+
+func notFoundRoute(ctx gf.RouteContext) gf.Node {
+	return <NotFoundRoute Target={routeTarget(ctx)} />
+}
+
+func HomeRoute(props HomeRouteProps) gf.Node {
+	return (
+		<div data-testid="server-backed-home">
+			<p class="eyebrow" data-testid="server-backed-route-name">Home route</p>
+			<h2>Choose a greeting</h2>
+			<p class="muted">The initial route starts no greeting resource.</p>
+			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+		</div>
+	)
+}
+
+func GreetingRoute(props GreetingRouteProps) gf.Node {
+	resource, _ := gf.UseResource(greetingPath(props.Name), gf.FetchText)
+
+	return (
+		<div data-testid="server-backed-greeting-route">
+			<p class="eyebrow" data-testid="server-backed-route-name">Greeting route</p>
+			<h2>Backend response</h2>
+			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+			<p class="muted" data-testid="greeting-resource-key">{greetingPath(props.Name)}</p>
+			<p class="muted" data-testid="greeting-status">{greetingStatus(resource)}</p>
+
+			{resource.Loading() && (
+				<p class="status loading" data-testid="greeting-loading">Loading backend greeting...</p>
+			)}
+			{resource.Failed() && (
+				<div class="status failed" data-testid="greeting-error">{greetingErrorText(resource)}</div>
+			)}
+			{resource.Ready() && (
+				<p class="status message" data-testid="greeting-message">{resource.Value}</p>
+			)}
+		</div>
+	)
+}
+
+func NotFoundRoute(props NotFoundRouteProps) gf.Node {
+	return (
+		<div data-testid="server-backed-not-found">
+			<p class="eyebrow" data-testid="server-backed-route-name">Not found</p>
+			<h2>Unknown route</h2>
+			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+		</div>
+	)
+}
+
+func normalizedGreetingName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "GoFrame"
+	}
+	return name
+}
+
+func routeTarget(ctx gf.RouteContext) string {
+	if ctx.RawQuery == "" {
+		return ctx.Path
+	}
+	return ctx.Path + "?" + ctx.RawQuery
 }
 
 func greetingPath(name string) string {

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -41,54 +41,18 @@ func App() gf.Node {
 }
 
 func ServerBackedShell(props ServerBackedShellProps) gf.Node {
-	name, setName := gf.UseState("GoFrame")
-
-	submitGreeting := func(event gf.Event) {
-		event.PreventDefault()
-		next := normalizedGreetingName(name)
-		if next != name {
-			setName(next)
-		}
-		gf.Navigate(gf.WithQuery("/greeting", gf.QueryValues{
-			"name": {next},
-		}))
-	}
-
 	return (
 		<section class="server-backed-shell" data-testid="server-backed-shell">
 			<section class="hero">
 				<p class="eyebrow">Server-backed reference</p>
 				<h1>Route-driven data from a Go backend</h1>
 				<p class="muted">
-					This browser/WASM app keeps its form shell mounted while hash routes
-					own same-origin greeting resources.
+					This browser/WASM app keeps its outer shell mounted while hash routes
+					own greeting form state and same-origin resources.
 				</p>
-			</section>
-
-			<section class="panel" data-testid="greeting-form-panel">
-				<div class="panel-heading">
-					<div>
-						<h2>Same-origin greeting</h2>
-						<p class="muted">Submitting changes the route; route content owns the request.</p>
-					</div>
-					<gf.RouterLink To="/" Class="home-link" TestID="server-backed-home-link">
-						Home
-					</gf.RouterLink>
-				</div>
-				<form class="greeting-form" data-testid="greeting-form" OnSubmit={submitGreeting}>
-					<label class="field">
-						<span>Name</span>
-						<input
-							data-testid="greeting-name"
-							Type="text"
-							Value={name}
-							OnInput={func(event gf.InputEvent) {
-								setName(event.Value())
-							}}
-						/>
-					</label>
-					<button data-testid="greeting-submit" Type="submit">Ask backend</button>
-				</form>
+				<gf.RouterLink To="/" Class="home-link" TestID="server-backed-home-link">
+					Home
+				</gf.RouterLink>
 			</section>
 
 			<section class="panel route-panel" data-testid="server-backed-route-content">
@@ -114,18 +78,49 @@ func notFoundRoute(ctx gf.RouteContext) gf.Node {
 }
 
 func HomeRoute(props HomeRouteProps) gf.Node {
+	draft, setDraft := gf.UseState("GoFrame")
+	submitGreeting := func(event gf.Event) {
+		event.PreventDefault()
+		next := normalizedGreetingName(draft)
+		if next != draft {
+			setDraft(next)
+		}
+		gf.Navigate(greetingTarget(next))
+	}
+
 	return (
 		<div data-testid="server-backed-home">
 			<p class="eyebrow" data-testid="server-backed-route-name">Home route</p>
 			<h2>Choose a greeting</h2>
 			<p class="muted">The initial route starts no greeting resource.</p>
 			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+			{greetingForm(draft, setDraft, submitGreeting)}
 		</div>
 	)
 }
 
 func GreetingRoute(props GreetingRouteProps) gf.Node {
-	resource, _ := gf.UseResource(greetingPath(props.Name), gf.FetchText)
+	draft, setDraft := gf.UseState(props.Name)
+	gf.UseEffect(func() gf.Cleanup {
+		if draft != props.Name {
+			setDraft(props.Name)
+		}
+		return nil
+	}, gf.Deps(props.Name))
+
+	resource, reload := gf.UseResource(greetingPath(props.Name), gf.FetchText)
+	submitGreeting := func(event gf.Event) {
+		event.PreventDefault()
+		next := normalizedGreetingName(draft)
+		if next != draft {
+			setDraft(next)
+		}
+		if next == props.Name {
+			reload()
+			return
+		}
+		gf.Navigate(greetingTarget(next))
+	}
 
 	return (
 		<div data-testid="server-backed-greeting-route">
@@ -134,6 +129,7 @@ func GreetingRoute(props GreetingRouteProps) gf.Node {
 			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
 			<p class="muted" data-testid="greeting-resource-key">{greetingPath(props.Name)}</p>
 			<p class="muted" data-testid="greeting-status">{greetingStatus(resource)}</p>
+			{greetingForm(draft, setDraft, submitGreeting)}
 
 			{resource.Loading() && (
 				<p class="status loading" data-testid="greeting-loading">Loading backend greeting...</p>
@@ -145,6 +141,25 @@ func GreetingRoute(props GreetingRouteProps) gf.Node {
 				<p class="status message" data-testid="greeting-message">{resource.Value}</p>
 			)}
 		</div>
+	)
+}
+
+func greetingForm(name string, setName func(string), submitGreeting func(gf.Event)) gf.Node {
+	return (
+		<form class="greeting-form" data-testid="greeting-form" OnSubmit={submitGreeting}>
+			<label class="field">
+				<span>Name</span>
+				<input
+					data-testid="greeting-name"
+					Type="text"
+					Value={name}
+					OnInput={func(event gf.InputEvent) {
+						setName(event.Value())
+					}}
+				/>
+			</label>
+			<button data-testid="greeting-submit" Type="submit">Ask backend</button>
+		</form>
 	)
 }
 
@@ -171,6 +186,12 @@ func routeTarget(ctx gf.RouteContext) string {
 		return ctx.Path
 	}
 	return ctx.Path + "?" + ctx.RawQuery
+}
+
+func greetingTarget(name string) string {
+	return gf.WithQuery("/greeting", gf.QueryValues{
+		"name": {name},
+	})
 }
 
 func greetingPath(name string) string {

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -21,6 +21,8 @@ const appURL = `http://127.0.0.1:${backendPort}/?smoke=${Date.now()}`;
 const expectedApp = new URL(appURL);
 const initialName = "GoFrame";
 const initialMessage = "Hello, GoFrame, from Go backend!";
+const directName = "Lin";
+const directMessage = "Hello, Lin, from Go backend!";
 const updatedName = "Ada";
 const updatedMessage = "Hello, Ada, from Go backend!";
 const slowName = "slow";
@@ -71,6 +73,7 @@ try {
 
     await waitForHTTP(`http://127.0.0.1:${backendPort}/`, () => backend.exitCode !== null, "server-backed backend");
     await assertBackendAPI("GoFrame", initialMessage);
+    await assertBackendAPI(directName, directMessage);
     await assertBackendAPI(updatedName, updatedMessage);
     await assertBackendAPI(slowName, slowMessage);
     await assertBackendAPIFailure(failureName, 500);
@@ -118,18 +121,41 @@ try {
         message: "",
         origin: expectedApp.origin,
         input: initialName,
+        appSame: true,
         shellSame: true,
-        formSame: true,
-        inputSame: true,
         routeContentSame: true,
     }, "server-backed initial route");
     assertEvidence(await evidenceState(client), {
         fetchesStarted: 0,
         aborts: 0,
         staleResultAppearances: 0,
+        appIdentityChanges: 0,
         shellIdentityChanges: 0,
-        inputIdentityChanges: 0,
+        routeContentIdentityChanges: 0,
     }, "initial route evidence");
+
+    await startScenario(client, "direct-hash-navigation");
+    await navigateGreetingHash(client, directName);
+    await waitForLoading(client, directName, "direct Lin route loading");
+    await waitForGreeting(client, directMessage, "direct Lin backend greeting");
+    const directReport = await finishScenario(client, "direct-hash-navigation");
+    assertGreetingRouteReport(directReport, "direct hash navigation", {
+        outcome: "success",
+        routeChanges: 1,
+        samePattern: false,
+    });
+    assertState(await appState(client), {
+        route: "greeting",
+        hash: greetingHash(directName),
+        routeTarget: greetingTarget(directName),
+        key: `/api/greeting?name=${encodeURIComponent(directName)}`,
+        status: "ready",
+        message: directMessage,
+        input: directName,
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+    }, "server-backed direct hash navigation");
 
     await prepareGreetingName(client, updatedName);
     await startScenario(client, "successful-navigation");
@@ -147,7 +173,11 @@ try {
     }, "server-backed successful navigation loading");
     await waitForGreeting(client, updatedMessage, "updated backend greeting");
     const successReport = await finishScenario(client, "successful-navigation");
-    assertRouteLoadReport(successReport, "successful navigation");
+    assertGreetingRouteReport(successReport, "successful navigation", {
+        outcome: "success",
+        routeChanges: 1,
+        samePattern: true,
+    });
     assertState(await appState(client), {
         app: true,
         route: "greeting",
@@ -159,18 +189,42 @@ try {
         message: updatedMessage,
         origin: expectedApp.origin,
         input: updatedName,
+        appSame: true,
         shellSame: true,
-        formSame: true,
-        inputSame: true,
         routeContentSame: true,
     }, "server-backed form submit render");
+
+    const successfulReloadBaseline = await evidenceState(client);
+    const successfulReloadHash = (await appState(client)).hash;
+    await startScenario(client, "successful-same-target-reload");
+    await dispatchGreetingSubmit(client);
+    await waitForFetchCount(client, successfulReloadBaseline.fetchesStarted + 1, "successful same-target reload fetch");
+    await waitForLoading(client, updatedName, "successful same-target reload loading");
+    await waitForGreeting(client, updatedMessage, "successful same-target reload ready");
+    const successfulReloadReport = await finishScenario(client, "successful-same-target-reload");
+    assertGreetingRouteReport(successfulReloadReport, "successful same-target reload", {
+        outcome: "success",
+        routeChanges: 0,
+        samePattern: true,
+    });
+    assertState(await appState(client), {
+        hash: successfulReloadHash,
+        routeTarget: greetingTarget(updatedName),
+        status: "ready",
+        message: updatedMessage,
+        input: updatedName,
+    }, "server-backed successful same-target reload");
 
     await prepareGreetingName(client, slowName);
     await startScenario(client, "same-pattern-slow-start");
     await dispatchGreetingSubmit(client);
     const supersededSlowRequest = await waitForSlowActive(client, "same-pattern slow request active");
     const slowStartReport = await finishScenario(client, "same-pattern-slow-start");
-    assertPendingRouteReport(slowStartReport, "same-pattern slow start");
+    assertGreetingRouteReport(slowStartReport, "same-pattern slow start", {
+        outcome: "pending",
+        routeChanges: 1,
+        samePattern: true,
+    });
 
     await prepareGreetingName(client, updatedName);
     await startScenario(client, "same-pattern-supersede");
@@ -180,7 +234,12 @@ try {
     await waitForGreeting(client, updatedMessage, "newer Ada backend greeting after slow request");
     await wait(staleSettleMS);
     const supersedeReport = await finishScenario(client, "same-pattern-supersede");
-    assertRouteLoadReport(supersedeReport, "same-pattern supersede");
+    assertGreetingRouteReport(supersedeReport, "same-pattern supersede", {
+        aborted: 1,
+        outcome: "success",
+        routeChanges: 1,
+        samePattern: true,
+    });
     assertState(await appState(client), {
         app: true,
         route: "greeting",
@@ -193,8 +252,9 @@ try {
         input: updatedName,
         error: "",
         errorNonEmpty: false,
+        appSame: true,
         shellSame: true,
-        inputSame: true,
+        routeContentSame: true,
     }, "server-backed stale slow result ignored");
     assertRequest(await requestEvidence(client, supersededSlowRequest.id), {
         name: slowName,
@@ -207,7 +267,11 @@ try {
     await dispatchGreetingSubmit(client);
     const unmountedSlowRequest = await waitForSlowActive(client, "unmount slow request active");
     const unmountSlowStartReport = await finishScenario(client, "unmount-slow-start");
-    assertPendingRouteReport(unmountSlowStartReport, "unmount slow start");
+    assertGreetingRouteReport(unmountSlowStartReport, "unmount slow start", {
+        outcome: "pending",
+        routeChanges: 1,
+        samePattern: true,
+    });
 
     await startScenario(client, "route-unmount-cancellation");
     await navigateHome(client);
@@ -224,9 +288,9 @@ try {
         loading: false,
         ready: false,
         failed: false,
+        input: initialName,
+        appSame: true,
         shellSame: true,
-        formSame: true,
-        inputSame: true,
         routeContentSame: true,
     }, "server-backed route unmount cancellation");
     assertRequest(await requestEvidence(client, unmountedSlowRequest.id), {
@@ -241,7 +305,11 @@ try {
     await waitForLoading(client, failureName, "controlled backend failure loading");
     await waitForFailure(client, failureMessage, "controlled backend failure");
     const failureReport = await finishScenario(client, "controlled-failure");
-    assertRouteLoadReport(failureReport, "controlled failure");
+    assertGreetingRouteReport(failureReport, "controlled failure", {
+        outcome: "failed",
+        routeChanges: 1,
+        samePattern: false,
+    });
     assertState(await appState(client), {
         app: true,
         route: "greeting",
@@ -253,9 +321,32 @@ try {
         input: failureName,
         error: failureMessage,
         errorNonEmpty: true,
+        appSame: true,
         shellSame: true,
-        inputSame: true,
+        routeContentSame: true,
     }, "server-backed controlled failure render");
+
+    const failedRetryBaseline = await evidenceState(client);
+    const failedRetryHash = (await appState(client)).hash;
+    await startScenario(client, "failed-same-target-retry");
+    await dispatchGreetingSubmit(client);
+    await waitForFetchCount(client, failedRetryBaseline.fetchesStarted + 1, "failed same-target retry fetch");
+    await waitForLoading(client, failureName, "failed same-target retry loading");
+    await waitForFailure(client, failureMessage, "failed same-target retry result");
+    const failedRetryReport = await finishScenario(client, "failed-same-target-retry");
+    assertGreetingRouteReport(failedRetryReport, "failed same-target retry", {
+        outcome: "failed",
+        routeChanges: 0,
+        samePattern: true,
+    });
+    assertState(await appState(client), {
+        hash: failedRetryHash,
+        routeTarget: greetingTarget(failureName),
+        status: failureStatus,
+        input: failureName,
+        error: failureMessage,
+        errorNonEmpty: true,
+    }, "server-backed failed same-target retry");
 
     await prepareGreetingName(client, updatedName);
     await startScenario(client, "failure-recovery");
@@ -263,7 +354,11 @@ try {
     await waitForLoading(client, updatedName, "failure recovery loading");
     await waitForGreeting(client, updatedMessage, "recovered backend greeting");
     const recoveryReport = await finishScenario(client, "failure-recovery");
-    assertRouteLoadReport(recoveryReport, "failure recovery");
+    assertGreetingRouteReport(recoveryReport, "failure recovery", {
+        outcome: "success",
+        routeChanges: 1,
+        samePattern: true,
+    });
     assertState(await appState(client), {
         app: true,
         route: "greeting",
@@ -277,8 +372,9 @@ try {
         input: updatedName,
         error: "",
         errorNonEmpty: false,
+        appSame: true,
         shellSame: true,
-        inputSame: true,
+        routeContentSame: true,
     }, "server-backed recovery render");
 
     await startScenario(client, "browser-back");
@@ -286,15 +382,21 @@ try {
     await waitForLoading(client, failureName, "browser back failure loading");
     await waitForFailure(client, failureMessage, "browser back failed route");
     const backReport = await finishScenario(client, "browser-back");
-    assertRouteLoadReport(backReport, "browser back");
+    assertGreetingRouteReport(backReport, "browser back", {
+        outcome: "failed",
+        routeChanges: 1,
+        samePattern: true,
+    });
     assertState(await appState(client), {
         route: "greeting",
         hash: greetingHash(failureName),
         routeTarget: greetingTarget(failureName),
         status: "failed",
         error: failureMessage,
+        input: failureName,
+        appSame: true,
         shellSame: true,
-        inputSame: true,
+        routeContentSame: true,
     }, "server-backed browser back");
 
     await startScenario(client, "browser-forward");
@@ -302,31 +404,47 @@ try {
     await waitForLoading(client, updatedName, "browser forward Ada loading");
     await waitForGreeting(client, updatedMessage, "browser forward Ada ready");
     const forwardReport = await finishScenario(client, "browser-forward");
-    assertRouteLoadReport(forwardReport, "browser forward");
+    assertGreetingRouteReport(forwardReport, "browser forward", {
+        outcome: "success",
+        routeChanges: 1,
+        samePattern: true,
+    });
     assertState(await appState(client), {
         route: "greeting",
         hash: greetingHash(updatedName),
         routeTarget: greetingTarget(updatedName),
         status: "ready",
         message: updatedMessage,
+        input: updatedName,
+        appSame: true,
         shellSame: true,
-        formSame: true,
-        inputSame: true,
         routeContentSame: true,
     }, "server-backed browser forward");
 
     const finalEvidence = await evidenceState(client);
     assertEvidence(finalEvidence, {
-        fetchesStarted: 8,
+        fetchesStarted: 11,
         aborts: 2,
-        successfulCompletions: 4,
-        failedCompletions: 2,
+        successfulCompletions: 6,
+        failedCompletions: 3,
         staleResultAppearances: 0,
+        appIdentityChanges: 0,
         shellIdentityChanges: 0,
-        formIdentityChanges: 0,
-        inputIdentityChanges: 0,
         routeContentIdentityChanges: 0,
     }, "final route/resource evidence");
+    assertStringArray(finalEvidence.routeTargetsVisited, [
+        "",
+        greetingHash(directName),
+        greetingHash(updatedName),
+        greetingHash(slowName),
+        greetingHash(updatedName),
+        greetingHash(slowName),
+        "#/",
+        greetingHash(failureName),
+        greetingHash(updatedName),
+        greetingHash(failureName),
+        greetingHash(updatedName),
+    ], "route targets visited");
     console.log(`server-backed async navigation evidence: ${JSON.stringify(finalEvidence)}`);
 
     client.close();
@@ -394,21 +512,67 @@ async function initializeBrowserEvidence(client) {
 }
 
 async function prepareGreetingName(client, name) {
-    const prepared = await client.callFunction(`function(name) {
+    const baseline = await client.callFunction(`function(name) {
         const input = document.querySelector("[data-testid='greeting-name']");
         if (!input) {
             return { ok: false, reason: "missing input" };
         }
+        const owner = document.querySelector("[data-testid='server-backed-home']")
+            ? "HomeRoute"
+            : document.querySelector("[data-testid='server-backed-greeting-route']")
+                ? "GreetingRoute"
+                : "";
+        if (!owner) {
+            return { ok: false, reason: "missing state-owning route" };
+        }
+        const renders = window.goframeComponentRenderCounts?.[owner] || 0;
+        const patches = window.goframeComponentPatchCounts?.[owner] || 0;
         input.value = name;
         input.dispatchEvent(new Event("input", { bubbles: true }));
-        return { ok: true, value: input.value };
+        return { ok: true, owner, renders, patches, value: input.value };
     }`, name);
-    if (!prepared?.ok) {
-        throw new Error(`APP FAILURE: could not prepare greeting input: ${JSON.stringify(prepared)}`);
+    if (!baseline?.ok) {
+        throw new Error(`APP FAILURE: could not prepare greeting input: ${JSON.stringify(baseline)}`);
     }
+
+    let updated = null;
     await waitForCondition(async () => {
-        return (await appState(client)).input === name;
-    }, `controlled input ${name}`);
+        updated = await inputPreparationState(client, baseline.owner);
+        return updated.value === name &&
+            updated.renders > baseline.renders &&
+            updated.patches > baseline.patches;
+    }, `controlled input ${name} framework update`);
+
+    await waitForBrowserFrames(client, 2);
+    const settled = await inputPreparationState(client, baseline.owner);
+    if (settled.value !== name ||
+        settled.renders !== updated.renders ||
+        settled.patches !== updated.patches) {
+        throw new Error(`APP FAILURE: controlled input ${name} did not settle: ${JSON.stringify({ baseline, updated, settled })}`);
+    }
+    const report = { name, owner: baseline.owner, baseline, updated, settled };
+    console.log(`server-backed input preparation: ${JSON.stringify(report)}`);
+    return report;
+}
+
+async function inputPreparationState(client, owner) {
+    return await client.callFunction(`function(owner) {
+        return {
+            owner,
+            renders: window.goframeComponentRenderCounts?.[owner] || 0,
+            patches: window.goframeComponentPatchCounts?.[owner] || 0,
+            value: document.querySelector("[data-testid='greeting-name']")?.value ?? "",
+        };
+    }`, owner);
+}
+
+async function waitForBrowserFrames(client, count) {
+    await client.callFunction(`async function(count) {
+        for (let index = 0; index < count; index++) {
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        return true;
+    }`, count);
 }
 
 async function dispatchGreetingSubmit(client) {
@@ -433,6 +597,12 @@ async function waitForGreeting(client, expected, label) {
     }, label);
 }
 
+async function waitForFetchCount(client, expected, label) {
+    await waitForCondition(async () => {
+        return (await evidenceState(client)).fetchesStarted === expected;
+    }, label);
+}
+
 async function waitForLoading(client, name, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
@@ -441,6 +611,7 @@ async function waitForLoading(client, name, label) {
             state.routeTarget === greetingTarget(name) &&
             state.key === `/api/greeting?name=${encodeURIComponent(name)}` &&
             state.status === "loading" &&
+            state.input === name &&
             state.loading &&
             !state.ready &&
             !state.failed;
@@ -486,6 +657,13 @@ async function navigateHome(client) {
     await client.evaluate(`document.querySelector("[data-testid='server-backed-home-link']")?.click()`);
 }
 
+async function navigateGreetingHash(client, name) {
+    await client.callFunction(`function(target) {
+        window.location.hash = target;
+        return window.location.hash;
+    }`, greetingTarget(name));
+}
+
 async function appState(client) {
     return await client.callFunction(`function() {
         const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() ?? "";
@@ -513,9 +691,8 @@ async function appState(client) {
             error,
             errorNonEmpty: error.length > 0,
             origin: window.location.origin,
+            appSame: identity.appSame ?? false,
             shellSame: identity.shellSame ?? false,
-            formSame: identity.formSame ?? false,
-            inputSame: identity.inputSame ?? false,
             routeContentSame: identity.routeContentSame ?? false,
         };
     }`);
@@ -552,35 +729,64 @@ async function finishScenario(client, label) {
     return report;
 }
 
-function assertRouteLoadReport(report, label) {
-    if (report.flushes !== 2 || report.scheduling.requestAnimationFrame !== 2 ||
-        report.scheduling.requestAnimationFrameCallbacks !== 2 ||
-        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
-        report.componentRenders.GreetingRoute < 2 || report.routeContentMutations < 1) {
-        throw new Error(`APP FAILURE: ${label} route/load scheduling changed: ${JSON.stringify(report)}`);
+function assertGreetingRouteReport(report, label, options) {
+    assertSchedulingReport(report, label, "GreetingRoute");
+    const expectedRequests = {
+        started: 1,
+        aborted: options.aborted ?? 0,
+        succeeded: options.outcome === "success" ? 1 : 0,
+        failed: options.outcome === "failed" ? 1 : 0,
+    };
+    assertState(report.requests, expectedRequests, `${label} request delta`);
+    if (report.routeTargets.length !== options.routeChanges || report.routeContentMutations < 1) {
+        throw new Error(`APP FAILURE: ${label} route evidence changed: ${JSON.stringify(report)}`);
     }
-}
-
-function assertPendingRouteReport(report, label) {
-    if (report.flushes !== 1 || report.scheduling.requestAnimationFrame !== 1 ||
-        report.scheduling.requestAnimationFrameCallbacks !== 1 ||
-        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
-        report.componentRenders.GreetingRoute < 1) {
-        throw new Error(`APP FAILURE: ${label} pending scheduling changed: ${JSON.stringify(report)}`);
-    }
+    assertReportIdentity(report, label, options.samePattern);
 }
 
 function assertHomeNavigationReport(report, label) {
-    if (report.flushes !== 1 || report.scheduling.requestAnimationFrame !== 1 ||
-        report.scheduling.requestAnimationFrameCallbacks !== 1 ||
-        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
-        report.componentRenders.HomeRoute < 1 || report.routeContentMutations < 1) {
-        throw new Error(`APP FAILURE: ${label} home scheduling changed: ${JSON.stringify(report)}`);
+    assertSchedulingReport(report, label, "HomeRoute");
+    assertState(report.requests, {
+        started: 0,
+        aborted: 1,
+        succeeded: 0,
+        failed: 0,
+    }, `${label} request delta`);
+    if (report.routeTargets.length !== 1 || report.routeContentMutations < 1) {
+        throw new Error(`APP FAILURE: ${label} home evidence changed: ${JSON.stringify(report)}`);
+    }
+    assertReportIdentity(report, label, false);
+}
+
+function assertSchedulingReport(report, label, component) {
+    if (report.flushes < 1 ||
+        report.scheduling.requestAnimationFrame !== report.scheduling.requestAnimationFrameCallbacks ||
+        report.scheduling.requestAnimationFrameCallbacks !== report.flushes ||
+        report.scheduling.queueMicrotask !== 0 ||
+        report.scheduling.queueMicrotaskCallbacks !== 0 ||
+        report.componentRenders[component] < 1) {
+        throw new Error(`APP FAILURE: ${label} scheduling invariants changed: ${JSON.stringify(report)}`);
     }
 }
 
+function assertReportIdentity(report, label, samePattern) {
+    const expected = {
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+        formSame: samePattern,
+        inputSame: samePattern,
+    };
+    assertState(report.identity, expected, `${label} identity`);
+}
+
 function assertFiniteReport(report, label) {
-    for (const [groupName, group] of Object.entries({ operations: report.operations, scheduling: report.scheduling })) {
+    for (const [groupName, group] of Object.entries({
+        operations: report.operations,
+        scheduling: report.scheduling,
+        componentRenders: report.componentRenders,
+        componentPatches: report.componentPatches,
+    })) {
         for (const [name, value] of Object.entries(group)) {
             if (!Number.isFinite(value) || value < 0) {
                 throw new Error(`APP FAILURE: ${label} ${groupName}.${name} is invalid: ${JSON.stringify(report)}`);
@@ -601,6 +807,13 @@ function assertEvidence(actual, expected, label) {
         throw new Error(`APP FAILURE: ${label}: missing evidence`);
     }
     assertState(actual, expected, label);
+}
+
+function assertStringArray(actual, expected, label) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+    }
+    console.log(`${label}: ok`);
 }
 
 function emptyOperations() {
@@ -663,19 +876,17 @@ function installServerBackedEvidenceExpression() {
     const evidence = {
         stable: null,
         identityChanged: {
+            app: false,
             shell: false,
-            form: false,
-            input: false,
             routeContent: false,
         },
         initialize() {
             this.stable = {
+                app: document.querySelector("[data-testid='server-backed-app']"),
                 shell: document.querySelector("[data-testid='server-backed-shell']"),
-                form: document.querySelector("[data-testid='greeting-form']"),
-                input: document.querySelector("[data-testid='greeting-name']"),
                 routeContent: document.querySelector("[data-testid='server-backed-route-content']"),
             };
-            if (!this.stable.shell || !this.stable.form || !this.stable.input || !this.stable.routeContent) {
+            if (!this.stable.app || !this.stable.shell || !this.stable.routeContent) {
                 return { ready: false };
             }
             routeTargetsVisited.push(window.location.hash);
@@ -696,18 +907,16 @@ function installServerBackedEvidenceExpression() {
         checkIdentity() {
             if (!this.stable) return {};
             const current = {
+                app: document.querySelector("[data-testid='server-backed-app']"),
                 shell: document.querySelector("[data-testid='server-backed-shell']"),
-                form: document.querySelector("[data-testid='greeting-form']"),
-                input: document.querySelector("[data-testid='greeting-name']"),
                 routeContent: document.querySelector("[data-testid='server-backed-route-content']"),
             };
             for (const name of Object.keys(current)) {
                 if (current[name] !== this.stable[name]) this.identityChanged[name] = true;
             }
             return {
+                appSame: !this.identityChanged.app,
                 shellSame: !this.identityChanged.shell,
-                formSame: !this.identityChanged.form,
-                inputSame: !this.identityChanged.input,
                 routeContentSame: !this.identityChanged.routeContent,
             };
         },
@@ -723,9 +932,8 @@ function installServerBackedEvidenceExpression() {
                 successfulCompletions,
                 failedCompletions,
                 staleResultAppearances,
+                appIdentityChanges: this.identityChanged.app ? 1 : 0,
                 shellIdentityChanges: this.identityChanged.shell ? 1 : 0,
-                formIdentityChanges: this.identityChanged.form ? 1 : 0,
-                inputIdentityChanges: this.identityChanged.input ? 1 : 0,
                 routeContentIdentityChanges: this.identityChanged.routeContent ? 1 : 0,
                 routeContentMutations,
                 requests: requests.map((request) => ({ ...request })),
@@ -791,6 +999,8 @@ function installServerBackedEvidenceExpression() {
         requestBaseline: null,
         routeTargetBaseline: 0,
         routeMutationBaseline: 0,
+        formBaseline: null,
+        inputBaseline: null,
         start(label) {
             for (const name of Object.keys(operations)) operations[name] = 0;
             for (const name of Object.keys(scheduling)) scheduling[name] = 0;
@@ -804,6 +1014,8 @@ function installServerBackedEvidenceExpression() {
             };
             this.routeTargetBaseline = routeTargetsVisited.length;
             this.routeMutationBaseline = routeContentMutations;
+            this.formBaseline = document.querySelector("[data-testid='greeting-form']");
+            this.inputBaseline = document.querySelector("[data-testid='greeting-name']");
             this.label = label;
             return true;
         },
@@ -827,6 +1039,11 @@ function installServerBackedEvidenceExpression() {
                 componentPatches,
                 routeContentMutations: routeContentMutations - this.routeMutationBaseline,
                 routeTargets: routeTargetsVisited.slice(this.routeTargetBaseline),
+                identity: {
+                    ...evidence.checkIdentity(),
+                    formSame: document.querySelector("[data-testid='greeting-form']") === this.formBaseline,
+                    inputSame: document.querySelector("[data-testid='greeting-name']") === this.inputBaseline,
+                },
                 requests: {
                     started: requests.length - this.requestBaseline.fetchesStarted,
                     aborted: aborts - this.requestBaseline.aborts,

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,12 +12,14 @@ if (typeof WebSocket === "undefined") {
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const appDir = join(rootDir, "examples", "server-backed");
 const packageDir = join(appDir, ".goframe", "package", "standalone");
+const workspaceAppDir = join(appDir, ".goframe", "work", "dev", "examples", "server-backed", "cmd", "app");
 const chrome = process.env.CHROME ?? "google-chrome";
 const debugPort = Number(process.env.GOFRAME_SERVER_BACKED_CHROME_DEBUG_PORT ?? await pickFreePort());
 const backendPort = Number(process.env.GOFRAME_SERVER_BACKED_SMOKE_PORT ?? await pickFreePort());
 const profile = await mkdtempCompat("goframe-server-backed-smoke-");
 const appURL = `http://127.0.0.1:${backendPort}/?smoke=${Date.now()}`;
 const expectedApp = new URL(appURL);
+const initialName = "GoFrame";
 const initialMessage = "Hello, GoFrame, from Go backend!";
 const updatedName = "Ada";
 const updatedMessage = "Hello, Ada, from Go backend!";
@@ -28,6 +30,15 @@ const staleSettleMS = slowDelayMS + 300;
 const failureName = "fail";
 const failureStatus = "failed";
 const failureMessage = "goframe: fetch returned HTTP 500";
+const componentNames = [
+    "App",
+    "ServerBackedShell",
+    "RouterView",
+    "RouterRoute",
+    "HomeRoute",
+    "GreetingRoute",
+    "NotFoundRoute",
+];
 
 let backend = null;
 let browser = null;
@@ -37,6 +48,7 @@ let browserExit = null;
 
 try {
     await runCommand("go", ["run", "./cmd/goxc", "package", "./examples/server-backed", "--compiler=go"], { cwd: rootDir });
+    await rebuildDebugBundle();
 
     const packageInfo = await stat(packageDir);
     if (!packageInfo.isDirectory()) {
@@ -84,107 +96,238 @@ try {
     const client = await connect(page.webSocketDebuggerUrl);
     await client.call("Runtime.enable");
     await client.call("Page.enable");
+    await client.call("Page.addScriptToEvaluateOnNewDocument", {
+        source: installServerBackedEvidenceExpression(),
+    });
     await navigateToApp(client, appURL);
     await waitForAppPage(client, expectedApp);
-    await waitForGreeting(client, initialMessage, "initial backend greeting");
-    assertState(await appState(client, initialMessage), {
-        app: true,
-        ready: true,
-        failed: false,
-        status: "ready",
-        message: initialMessage,
-        messageMatches: true,
-        origin: expectedApp.origin,
-        input: "GoFrame",
-    }, "server-backed initial render");
+    await initializeBrowserEvidence(client);
 
-    await setGreetingName(client, updatedName);
-    await waitForCondition(async () => {
-        return (await appState(client, initialMessage)).input === updatedName;
-    }, "controlled input update");
-    await wait(100);
-    await submitGreeting(client);
-    await waitForGreeting(client, updatedMessage, "updated backend greeting");
-    assertState(await appState(client, updatedMessage), {
+    assertState(await appState(client), {
         app: true,
+        shell: true,
+        form: true,
+        routeContent: true,
+        route: "home",
+        hash: "",
+        routeTarget: "/",
+        loading: false,
+        ready: false,
+        failed: false,
+        status: "",
+        message: "",
+        origin: expectedApp.origin,
+        input: initialName,
+        shellSame: true,
+        formSame: true,
+        inputSame: true,
+        routeContentSame: true,
+    }, "server-backed initial route");
+    assertEvidence(await evidenceState(client), {
+        fetchesStarted: 0,
+        aborts: 0,
+        staleResultAppearances: 0,
+        shellIdentityChanges: 0,
+        inputIdentityChanges: 0,
+    }, "initial route evidence");
+
+    await prepareGreetingName(client, updatedName);
+    await startScenario(client, "successful-navigation");
+    await dispatchGreetingSubmit(client);
+    await waitForLoading(client, updatedName, "successful navigation loading");
+    assertState(await appState(client), {
+        route: "greeting",
+        hash: greetingHash(updatedName),
+        routeTarget: greetingTarget(updatedName),
+        status: "loading",
+        loading: true,
+        ready: false,
+        failed: false,
+        message: "",
+    }, "server-backed successful navigation loading");
+    await waitForGreeting(client, updatedMessage, "updated backend greeting");
+    const successReport = await finishScenario(client, "successful-navigation");
+    assertRouteLoadReport(successReport, "successful navigation");
+    assertState(await appState(client), {
+        app: true,
+        route: "greeting",
+        hash: greetingHash(updatedName),
+        routeTarget: greetingTarget(updatedName),
         ready: true,
         failed: false,
         status: "ready",
         message: updatedMessage,
-        messageMatches: true,
         origin: expectedApp.origin,
         input: updatedName,
+        shellSame: true,
+        formSame: true,
+        inputSame: true,
+        routeContentSame: true,
     }, "server-backed form submit render");
 
-    await setGreetingName(client, slowName);
-    await waitForCondition(async () => {
-        return (await appState(client, updatedMessage, slowMessage, "name=slow")).input === slowName;
-    }, "slow input update");
-    await submitGreeting(client);
-    await waitForSlowActive(client);
+    await prepareGreetingName(client, slowName);
+    await startScenario(client, "same-pattern-slow-start");
+    await dispatchGreetingSubmit(client);
+    const supersededSlowRequest = await waitForSlowActive(client, "same-pattern slow request active");
+    const slowStartReport = await finishScenario(client, "same-pattern-slow-start");
+    assertPendingRouteReport(slowStartReport, "same-pattern slow start");
 
-    await setGreetingName(client, updatedName);
-    await waitForCondition(async () => {
-        return (await appState(client, updatedMessage, slowMessage, "name=slow")).input === updatedName;
-    }, "newer Ada input update during slow request");
-    await wait(100);
-    await submitGreeting(client);
-    await waitForCondition(async () => {
-        const state = await appState(client, updatedMessage, slowMessage, "name=Ada");
-        return state.input === updatedName && state.keyContainsExpected;
-    }, "newer Ada resource key after slow request");
+    await prepareGreetingName(client, updatedName);
+    await startScenario(client, "same-pattern-supersede");
+    await dispatchGreetingSubmit(client);
+    await waitForLoading(client, updatedName, "newer Ada route loading after slow request");
+    await waitForRequestAbort(client, supersededSlowRequest.id, "same-pattern slow request abort");
     await waitForGreeting(client, updatedMessage, "newer Ada backend greeting after slow request");
     await wait(staleSettleMS);
-    assertState(await appState(client, updatedMessage, slowMessage, "name=Ada"), {
+    const supersedeReport = await finishScenario(client, "same-pattern-supersede");
+    assertRouteLoadReport(supersedeReport, "same-pattern supersede");
+    assertState(await appState(client), {
         app: true,
+        route: "greeting",
+        hash: greetingHash(updatedName),
+        routeTarget: greetingTarget(updatedName),
         ready: true,
         failed: false,
         status: "ready",
         message: updatedMessage,
-        messageMatches: true,
-        messageNotStale: true,
         input: updatedName,
-        keyContainsExpected: true,
         error: "",
         errorNonEmpty: false,
+        shellSame: true,
+        inputSame: true,
     }, "server-backed stale slow result ignored");
+    assertRequest(await requestEvidence(client, supersededSlowRequest.id), {
+        name: slowName,
+        outcome: "aborted",
+        aborted: true,
+    }, "same-pattern superseded request");
 
-    await setGreetingName(client, failureName);
-    await waitForCondition(async () => {
-        return (await appState(client, updatedMessage)).input === failureName;
-    }, "controlled failure input update");
-    await wait(100);
-    await submitGreeting(client);
+    await prepareGreetingName(client, slowName);
+    await startScenario(client, "unmount-slow-start");
+    await dispatchGreetingSubmit(client);
+    const unmountedSlowRequest = await waitForSlowActive(client, "unmount slow request active");
+    const unmountSlowStartReport = await finishScenario(client, "unmount-slow-start");
+    assertPendingRouteReport(unmountSlowStartReport, "unmount slow start");
+
+    await startScenario(client, "route-unmount-cancellation");
+    await navigateHome(client);
+    await waitForRoute(client, "home", "/");
+    await waitForRequestAbort(client, unmountedSlowRequest.id, "route unmount slow request abort");
+    await wait(staleSettleMS);
+    const unmountReport = await finishScenario(client, "route-unmount-cancellation");
+    assertHomeNavigationReport(unmountReport, "route unmount cancellation");
+    assertState(await appState(client), {
+        route: "home",
+        hash: "#/",
+        routeTarget: "/",
+        message: "",
+        loading: false,
+        ready: false,
+        failed: false,
+        shellSame: true,
+        formSame: true,
+        inputSame: true,
+        routeContentSame: true,
+    }, "server-backed route unmount cancellation");
+    assertRequest(await requestEvidence(client, unmountedSlowRequest.id), {
+        name: slowName,
+        outcome: "aborted",
+        aborted: true,
+    }, "route-unmounted request");
+
+    await prepareGreetingName(client, failureName);
+    await startScenario(client, "controlled-failure");
+    await dispatchGreetingSubmit(client);
+    await waitForLoading(client, failureName, "controlled backend failure loading");
     await waitForFailure(client, failureMessage, "controlled backend failure");
-    assertState(await appState(client, updatedMessage), {
+    const failureReport = await finishScenario(client, "controlled-failure");
+    assertRouteLoadReport(failureReport, "controlled failure");
+    assertState(await appState(client), {
         app: true,
+        route: "greeting",
+        hash: greetingHash(failureName),
+        routeTarget: greetingTarget(failureName),
         ready: false,
         failed: true,
         status: failureStatus,
         input: failureName,
         error: failureMessage,
         errorNonEmpty: true,
+        shellSame: true,
+        inputSame: true,
     }, "server-backed controlled failure render");
 
-    await setGreetingName(client, updatedName);
-    await waitForCondition(async () => {
-        return (await appState(client, updatedMessage)).input === updatedName;
-    }, "recovery input update");
-    await wait(100);
-    await submitGreeting(client);
+    await prepareGreetingName(client, updatedName);
+    await startScenario(client, "failure-recovery");
+    await dispatchGreetingSubmit(client);
+    await waitForLoading(client, updatedName, "failure recovery loading");
     await waitForGreeting(client, updatedMessage, "recovered backend greeting");
-    assertState(await appState(client, updatedMessage), {
+    const recoveryReport = await finishScenario(client, "failure-recovery");
+    assertRouteLoadReport(recoveryReport, "failure recovery");
+    assertState(await appState(client), {
         app: true,
+        route: "greeting",
+        hash: greetingHash(updatedName),
+        routeTarget: greetingTarget(updatedName),
         ready: true,
         failed: false,
         status: "ready",
         message: updatedMessage,
-        messageMatches: true,
         origin: expectedApp.origin,
         input: updatedName,
         error: "",
         errorNonEmpty: false,
+        shellSame: true,
+        inputSame: true,
     }, "server-backed recovery render");
+
+    await startScenario(client, "browser-back");
+    await client.evaluate("history.back()");
+    await waitForLoading(client, failureName, "browser back failure loading");
+    await waitForFailure(client, failureMessage, "browser back failed route");
+    const backReport = await finishScenario(client, "browser-back");
+    assertRouteLoadReport(backReport, "browser back");
+    assertState(await appState(client), {
+        route: "greeting",
+        hash: greetingHash(failureName),
+        routeTarget: greetingTarget(failureName),
+        status: "failed",
+        error: failureMessage,
+        shellSame: true,
+        inputSame: true,
+    }, "server-backed browser back");
+
+    await startScenario(client, "browser-forward");
+    await client.evaluate("history.forward()");
+    await waitForLoading(client, updatedName, "browser forward Ada loading");
+    await waitForGreeting(client, updatedMessage, "browser forward Ada ready");
+    const forwardReport = await finishScenario(client, "browser-forward");
+    assertRouteLoadReport(forwardReport, "browser forward");
+    assertState(await appState(client), {
+        route: "greeting",
+        hash: greetingHash(updatedName),
+        routeTarget: greetingTarget(updatedName),
+        status: "ready",
+        message: updatedMessage,
+        shellSame: true,
+        formSame: true,
+        inputSame: true,
+        routeContentSame: true,
+    }, "server-backed browser forward");
+
+    const finalEvidence = await evidenceState(client);
+    assertEvidence(finalEvidence, {
+        fetchesStarted: 8,
+        aborts: 2,
+        successfulCompletions: 4,
+        failedCompletions: 2,
+        staleResultAppearances: 0,
+        shellIdentityChanges: 0,
+        formIdentityChanges: 0,
+        inputIdentityChanges: 0,
+        routeContentIdentityChanges: 0,
+    }, "final route/resource evidence");
+    console.log(`server-backed async navigation evidence: ${JSON.stringify(finalEvidence)}`);
 
     client.close();
     console.log("Server-backed browser smoke: ok");
@@ -220,8 +363,38 @@ async function assertBackendAPIFailure(name, status) {
     }
 }
 
-async function setGreetingName(client, name) {
-    return await client.callFunction(`function(name) {
+async function rebuildDebugBundle() {
+    const manifest = JSON.parse(await readFile(join(packageDir, "asset-manifest.json"), "utf8"));
+    const wasm = manifest.entrypoints?.wasm;
+    if (typeof wasm !== "string" || wasm === "") {
+        throw new Error("HARNESS FAILURE: server-backed asset manifest has no WASM entrypoint");
+    }
+    await runCommand("go", ["build", "-tags=goframe_debug", "-o", join(packageDir, wasm), "."], {
+        cwd: workspaceAppDir,
+        env: {
+            GOOS: "js",
+            GOARCH: "wasm",
+        },
+    });
+}
+
+function greetingTarget(name) {
+    return `/greeting?name=${encodeURIComponent(name)}`;
+}
+
+function greetingHash(name) {
+    return `#${greetingTarget(name)}`;
+}
+
+async function initializeBrowserEvidence(client) {
+    const initialized = await client.evaluate("window.__serverBackedEvidence?.initialize() ?? null");
+    if (!initialized?.ready) {
+        throw new Error(`APP FAILURE: server-backed evidence did not initialize: ${JSON.stringify(initialized)}`);
+    }
+}
+
+async function prepareGreetingName(client, name) {
+    const prepared = await client.callFunction(`function(name) {
         const input = document.querySelector("[data-testid='greeting-name']");
         if (!input) {
             return { ok: false, reason: "missing input" };
@@ -230,9 +403,15 @@ async function setGreetingName(client, name) {
         input.dispatchEvent(new Event("input", { bubbles: true }));
         return { ok: true, value: input.value };
     }`, name);
+    if (!prepared?.ok) {
+        throw new Error(`APP FAILURE: could not prepare greeting input: ${JSON.stringify(prepared)}`);
+    }
+    await waitForCondition(async () => {
+        return (await appState(client)).input === name;
+    }, `controlled input ${name}`);
 }
 
-async function submitGreeting(client) {
+async function dispatchGreetingSubmit(client) {
     return await client.callFunction(`function() {
         const form = document.querySelector("[data-testid='greeting-form']");
         if (!form) {
@@ -249,52 +428,494 @@ async function submitGreeting(client) {
 
 async function waitForGreeting(client, expected, label) {
     await waitForCondition(async () => {
-        const state = await appState(client, expected);
-        return state.ready && state.messageMatches && state.origin === expectedApp.origin;
+        const state = await appState(client);
+        return state.ready && state.message === expected && state.origin === expectedApp.origin;
     }, label);
 }
 
-async function waitForSlowActive(client) {
+async function waitForLoading(client, name, label) {
     await waitForCondition(async () => {
-        const state = await appState(client, updatedMessage, slowMessage, "name=slow");
-        return state.input === slowName &&
-            state.keyContainsExpected &&
+        const state = await appState(client);
+        return state.route === "greeting" &&
+            state.hash === greetingHash(name) &&
+            state.routeTarget === greetingTarget(name) &&
+            state.key === `/api/greeting?name=${encodeURIComponent(name)}` &&
             state.status === "loading" &&
             state.loading &&
             !state.ready &&
             !state.failed;
-    }, "slow backend request active");
+    }, label);
+}
+
+async function waitForSlowActive(client, label) {
+    let request = null;
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        const evidence = await evidenceState(client);
+        request = [...evidence.requests].reverse().find((entry) => entry.name === slowName && entry.outcome === "pending") ?? null;
+        return state.hash === greetingHash(slowName) &&
+            state.status === "loading" &&
+            state.loading &&
+            request !== null;
+    }, label);
+    return request;
+}
+
+async function waitForRequestAbort(client, requestID, label) {
+    await waitForCondition(async () => {
+        const request = await requestEvidence(client, requestID);
+        return request?.aborted === true && request.outcome === "aborted";
+    }, label);
 }
 
 async function waitForFailure(client, expectedError, label) {
     await waitForCondition(async () => {
-        const state = await appState(client, updatedMessage);
+        const state = await appState(client);
         return state.failed && state.status === failureStatus && state.error === expectedError;
     }, label);
 }
 
-async function appState(client, expected, stale = "", keyPart = "") {
-    return await client.callFunction(`function(expected, stale, keyPart) {
+async function waitForRoute(client, route, target) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === route && state.routeTarget === target;
+    }, `route ${route} at ${target}`);
+}
+
+async function navigateHome(client) {
+    await client.evaluate(`document.querySelector("[data-testid='server-backed-home-link']")?.click()`);
+}
+
+async function appState(client) {
+    return await client.callFunction(`function() {
         const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() ?? "";
         const error = document.querySelector("[data-testid='greeting-error']")?.textContent.trim() ?? "";
         const key = document.querySelector("[data-testid='greeting-resource-key']")?.textContent.trim() ?? "";
+        const home = document.querySelector("[data-testid='server-backed-home']");
+        const greeting = document.querySelector("[data-testid='server-backed-greeting-route']");
+        const notFound = document.querySelector("[data-testid='server-backed-not-found']");
+        const identity = window.__serverBackedEvidence?.checkIdentity() ?? {};
         return {
             app: Boolean(document.querySelector("[data-testid='server-backed-app']")),
+            shell: Boolean(document.querySelector("[data-testid='server-backed-shell']")),
+            form: Boolean(document.querySelector("[data-testid='greeting-form']")),
+            routeContent: Boolean(document.querySelector("[data-testid='server-backed-route-content']")),
+            route: home ? "home" : greeting ? "greeting" : notFound ? "notFound" : "missing",
+            hash: window.location.hash,
+            routeTarget: document.querySelector("[data-testid='server-backed-route-target']")?.textContent.trim() ?? "",
             loading: Boolean(document.querySelector("[data-testid='greeting-loading']")),
             ready: Boolean(document.querySelector("[data-testid='greeting-message']")),
             failed: Boolean(document.querySelector("[data-testid='greeting-error']")),
             status: document.querySelector("[data-testid='greeting-status']")?.textContent.trim() ?? "",
             input: document.querySelector("[data-testid='greeting-name']")?.value ?? "",
             key,
-            keyContainsExpected: keyPart === "" || key.includes(keyPart),
             message,
-            messageMatches: message === expected,
-            messageNotStale: stale === "" || message !== stale,
             error,
             errorNonEmpty: error.length > 0,
             origin: window.location.origin,
+            shellSame: identity.shellSame ?? false,
+            formSame: identity.formSame ?? false,
+            inputSame: identity.inputSame ?? false,
+            routeContentSame: identity.routeContentSame ?? false,
         };
-    }`, expected, stale, keyPart);
+    }`);
+}
+
+async function evidenceState(client) {
+    return await client.evaluate("window.__serverBackedEvidence?.snapshot() ?? null");
+}
+
+async function requestEvidence(client, requestID) {
+    return await client.callFunction(`function(requestID) {
+        return window.__serverBackedEvidence?.request(requestID) ?? null;
+    }`, requestID);
+}
+
+async function startScenario(client, label) {
+    const started = await client.callFunction(`function(label) {
+        return window.__serverBackedAudit?.start(label) ?? false;
+    }`, label);
+    if (!started) {
+        throw new Error(`APP FAILURE: server-backed audit did not start ${label}`);
+    }
+}
+
+async function finishScenario(client, label) {
+    const report = await client.callFunction(`function(label) {
+        return window.__serverBackedAudit?.finish(label) ?? null;
+    }`, label);
+    if (!report) {
+        throw new Error(`APP FAILURE: server-backed audit did not finish ${label}`);
+    }
+    assertFiniteReport(report, label);
+    console.log(`server-backed DOM bridge ${label}: ${JSON.stringify(report)}`);
+    return report;
+}
+
+function assertRouteLoadReport(report, label) {
+    if (report.flushes !== 2 || report.scheduling.requestAnimationFrame !== 2 ||
+        report.scheduling.requestAnimationFrameCallbacks !== 2 ||
+        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
+        report.componentRenders.GreetingRoute < 2 || report.routeContentMutations < 1) {
+        throw new Error(`APP FAILURE: ${label} route/load scheduling changed: ${JSON.stringify(report)}`);
+    }
+}
+
+function assertPendingRouteReport(report, label) {
+    if (report.flushes !== 1 || report.scheduling.requestAnimationFrame !== 1 ||
+        report.scheduling.requestAnimationFrameCallbacks !== 1 ||
+        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
+        report.componentRenders.GreetingRoute < 1) {
+        throw new Error(`APP FAILURE: ${label} pending scheduling changed: ${JSON.stringify(report)}`);
+    }
+}
+
+function assertHomeNavigationReport(report, label) {
+    if (report.flushes !== 1 || report.scheduling.requestAnimationFrame !== 1 ||
+        report.scheduling.requestAnimationFrameCallbacks !== 1 ||
+        report.scheduling.queueMicrotask !== 0 || report.scheduling.queueMicrotaskCallbacks !== 0 ||
+        report.componentRenders.HomeRoute < 1 || report.routeContentMutations < 1) {
+        throw new Error(`APP FAILURE: ${label} home scheduling changed: ${JSON.stringify(report)}`);
+    }
+}
+
+function assertFiniteReport(report, label) {
+    for (const [groupName, group] of Object.entries({ operations: report.operations, scheduling: report.scheduling })) {
+        for (const [name, value] of Object.entries(group)) {
+            if (!Number.isFinite(value) || value < 0) {
+                throw new Error(`APP FAILURE: ${label} ${groupName}.${name} is invalid: ${JSON.stringify(report)}`);
+            }
+        }
+    }
+}
+
+function assertRequest(actual, expected, label) {
+    if (!actual) {
+        throw new Error(`APP FAILURE: ${label}: missing request evidence`);
+    }
+    assertState(actual, expected, label);
+}
+
+function assertEvidence(actual, expected, label) {
+    if (!actual) {
+        throw new Error(`APP FAILURE: ${label}: missing evidence`);
+    }
+    assertState(actual, expected, label);
+}
+
+function emptyOperations() {
+    return {
+        createElement: 0,
+        createTextNode: 0,
+        createComment: 0,
+        createDocumentFragment: 0,
+        appendChild: 0,
+        removeChild: 0,
+        replaceChild: 0,
+        insertBefore: 0,
+        setTextNodeValue: 0,
+        setAttribute: 0,
+        removeAttribute: 0,
+        setProperty: 0,
+        addEventListener: 0,
+        removeEventListener: 0,
+        focus: 0,
+        setSelectionRange: 0,
+    };
+}
+
+function installServerBackedEvidenceExpression() {
+    return `(() => {
+    const componentNames = ${JSON.stringify(componentNames)};
+    const slowMessage = ${JSON.stringify(slowMessage)};
+    const requests = [];
+    const routeTargetsVisited = [];
+    const operations = ${JSON.stringify(emptyOperations())};
+    const scheduling = {
+        requestAnimationFrame: 0,
+        requestAnimationFrameCallbacks: 0,
+        queueMicrotask: 0,
+        queueMicrotaskCallbacks: 0,
+    };
+    const renderReports = [];
+    let nextRequestID = 1;
+    let aborts = 0;
+    let successfulCompletions = 0;
+    let failedCompletions = 0;
+    let staleResultAppearances = 0;
+    let routeContentMutations = 0;
+    let lastMessage = "";
+
+    window.goframeComponentRenderCounts = {};
+    window.goframeComponentPatchCounts = {};
+    window.goframeComponentRenderProbe = (name) => {
+        window.goframeComponentRenderCounts[name] =
+            (window.goframeComponentRenderCounts[name] || 0) + 1;
+    };
+    window.goframeComponentPatchProbe = (name) => {
+        window.goframeComponentPatchCounts[name] =
+            (window.goframeComponentPatchCounts[name] || 0) + 1;
+    };
+    window.goframeRenderProbe = (phase, duration) => {
+        renderReports.push({ phase, duration });
+    };
+
+    const evidence = {
+        stable: null,
+        identityChanged: {
+            shell: false,
+            form: false,
+            input: false,
+            routeContent: false,
+        },
+        initialize() {
+            this.stable = {
+                shell: document.querySelector("[data-testid='server-backed-shell']"),
+                form: document.querySelector("[data-testid='greeting-form']"),
+                input: document.querySelector("[data-testid='greeting-name']"),
+                routeContent: document.querySelector("[data-testid='server-backed-route-content']"),
+            };
+            if (!this.stable.shell || !this.stable.form || !this.stable.input || !this.stable.routeContent) {
+                return { ready: false };
+            }
+            routeTargetsVisited.push(window.location.hash);
+            new MutationObserver((records) => {
+                routeContentMutations += records.length;
+                const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() || "";
+                if (message === slowMessage && lastMessage !== slowMessage) {
+                    staleResultAppearances++;
+                }
+                lastMessage = message;
+            }).observe(this.stable.routeContent, {
+                childList: true,
+                subtree: true,
+                characterData: true,
+            });
+            return { ready: true };
+        },
+        checkIdentity() {
+            if (!this.stable) return {};
+            const current = {
+                shell: document.querySelector("[data-testid='server-backed-shell']"),
+                form: document.querySelector("[data-testid='greeting-form']"),
+                input: document.querySelector("[data-testid='greeting-name']"),
+                routeContent: document.querySelector("[data-testid='server-backed-route-content']"),
+            };
+            for (const name of Object.keys(current)) {
+                if (current[name] !== this.stable[name]) this.identityChanged[name] = true;
+            }
+            return {
+                shellSame: !this.identityChanged.shell,
+                formSame: !this.identityChanged.form,
+                inputSame: !this.identityChanged.input,
+                routeContentSame: !this.identityChanged.routeContent,
+            };
+        },
+        request(id) {
+            const request = requests.find((entry) => entry.id === id);
+            return request ? { ...request } : null;
+        },
+        snapshot() {
+            return {
+                routeTargetsVisited: [...routeTargetsVisited],
+                fetchesStarted: requests.length,
+                aborts,
+                successfulCompletions,
+                failedCompletions,
+                staleResultAppearances,
+                shellIdentityChanges: this.identityChanged.shell ? 1 : 0,
+                formIdentityChanges: this.identityChanged.form ? 1 : 0,
+                inputIdentityChanges: this.identityChanged.input ? 1 : 0,
+                routeContentIdentityChanges: this.identityChanged.routeContent ? 1 : 0,
+                routeContentMutations,
+                requests: requests.map((request) => ({ ...request })),
+            };
+        },
+    };
+    window.__serverBackedEvidence = evidence;
+
+    window.addEventListener("hashchange", () => {
+        routeTargetsVisited.push(window.location.hash);
+    });
+
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = function(input, init) {
+        const requestURL = new URL(typeof input === "string" ? input : input.url, window.location.href);
+        if (requestURL.pathname !== "/api/greeting") {
+            return originalFetch(input, init);
+        }
+        const signal = init?.signal;
+        const request = {
+            id: nextRequestID++,
+            name: requestURL.searchParams.get("name") || "",
+            target: requestURL.pathname + requestURL.search,
+            outcome: "pending",
+            aborted: false,
+        };
+        requests.push(request);
+        if (signal) {
+            signal.addEventListener("abort", () => {
+                if (request.aborted) return;
+                request.aborted = true;
+                request.outcome = "aborted";
+                aborts++;
+            }, { once: true });
+        }
+        return originalFetch(input, init).then((response) => {
+            // Keep loading observable without changing the backend or runtime.
+            return new Promise((resolve) => {
+                window.setTimeout(() => {
+                    if (!request.aborted) {
+                        request.outcome = response.ok ? "success" : "failed";
+                        if (response.ok) successfulCompletions++;
+                        else failedCompletions++;
+                    }
+                    resolve(response);
+                }, request.name === ${JSON.stringify(slowName)} ? 0 : 140);
+            });
+        }, (error) => {
+            if (signal?.aborted) {
+                request.aborted = true;
+                request.outcome = "aborted";
+            } else {
+                request.outcome = "failed";
+                failedCompletions++;
+            }
+            throw error;
+        });
+    };
+
+    const audit = {
+        componentBaseline: null,
+        renderBaseline: 0,
+        requestBaseline: null,
+        routeTargetBaseline: 0,
+        routeMutationBaseline: 0,
+        start(label) {
+            for (const name of Object.keys(operations)) operations[name] = 0;
+            for (const name of Object.keys(scheduling)) scheduling[name] = 0;
+            this.componentBaseline = snapshotComponentCounts();
+            this.renderBaseline = renderReports.length;
+            this.requestBaseline = {
+                fetchesStarted: requests.length,
+                aborts,
+                successfulCompletions,
+                failedCompletions,
+            };
+            this.routeTargetBaseline = routeTargetsVisited.length;
+            this.routeMutationBaseline = routeContentMutations;
+            this.label = label;
+            return true;
+        },
+        finish(label) {
+            if (!this.componentBaseline || this.label !== label) return null;
+            const current = snapshotComponentCounts();
+            const componentRenders = {};
+            const componentPatches = {};
+            for (const name of componentNames) {
+                componentRenders[name] = current.renders[name] - this.componentBaseline.renders[name];
+                componentPatches[name] = current.patches[name] - this.componentBaseline.patches[name];
+            }
+            const updates = renderReports.slice(this.renderBaseline).filter((entry) => entry.phase === "update");
+            return {
+                scenario: label,
+                flushes: updates.length,
+                updateDurations: updates.map((entry) => entry.duration),
+                scheduling: { ...scheduling },
+                operations: { ...operations },
+                componentRenders,
+                componentPatches,
+                routeContentMutations: routeContentMutations - this.routeMutationBaseline,
+                routeTargets: routeTargetsVisited.slice(this.routeTargetBaseline),
+                requests: {
+                    started: requests.length - this.requestBaseline.fetchesStarted,
+                    aborted: aborts - this.requestBaseline.aborts,
+                    succeeded: successfulCompletions - this.requestBaseline.successfulCompletions,
+                    failed: failedCompletions - this.requestBaseline.failedCompletions,
+                },
+            };
+        },
+    };
+    window.__serverBackedAudit = audit;
+
+    const wrap = (owner, name, counter) => {
+        const original = owner[name];
+        owner[name] = function(...args) {
+            operations[counter]++;
+            return original.apply(this, args);
+        };
+    };
+    wrap(Document.prototype, "createElement", "createElement");
+    wrap(Document.prototype, "createTextNode", "createTextNode");
+    wrap(Document.prototype, "createComment", "createComment");
+    wrap(Document.prototype, "createDocumentFragment", "createDocumentFragment");
+    wrap(Node.prototype, "appendChild", "appendChild");
+    wrap(Node.prototype, "removeChild", "removeChild");
+    wrap(Node.prototype, "replaceChild", "replaceChild");
+    wrap(Node.prototype, "insertBefore", "insertBefore");
+    wrap(Element.prototype, "setAttribute", "setAttribute");
+    wrap(Element.prototype, "removeAttribute", "removeAttribute");
+    wrap(EventTarget.prototype, "addEventListener", "addEventListener");
+    wrap(EventTarget.prototype, "removeEventListener", "removeEventListener");
+    wrap(HTMLElement.prototype, "focus", "focus");
+
+    const nodeValue = Object.getOwnPropertyDescriptor(Node.prototype, "nodeValue");
+    Object.defineProperty(Node.prototype, "nodeValue", {
+        configurable: nodeValue.configurable,
+        enumerable: nodeValue.enumerable,
+        get: nodeValue.get,
+        set(value) {
+            operations.setTextNodeValue++;
+            return nodeValue.set.call(this, value);
+        },
+    });
+    const inputValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
+    Object.defineProperty(HTMLInputElement.prototype, "value", {
+        configurable: inputValue.configurable,
+        enumerable: inputValue.enumerable,
+        get: inputValue.get,
+        set(value) {
+            operations.setProperty++;
+            return inputValue.set.call(this, value);
+        },
+    });
+    const setSelectionRange = HTMLInputElement.prototype.setSelectionRange;
+    HTMLInputElement.prototype.setSelectionRange = function(...args) {
+        operations.setSelectionRange++;
+        return setSelectionRange.apply(this, args);
+    };
+
+    const requestAnimationFrame = window.requestAnimationFrame;
+    window.requestAnimationFrame = function(callback) {
+        scheduling.requestAnimationFrame++;
+        return requestAnimationFrame.call(window, (...args) => {
+            scheduling.requestAnimationFrameCallbacks++;
+            return callback(...args);
+        });
+    };
+    const queueMicrotask = window.queueMicrotask;
+    if (typeof queueMicrotask === "function") {
+        window.queueMicrotask = function(callback) {
+            scheduling.queueMicrotask++;
+            return queueMicrotask.call(window, () => {
+                scheduling.queueMicrotaskCallbacks++;
+                return callback();
+            });
+        };
+    }
+
+    return true;
+
+    function snapshotComponentCounts() {
+        const renders = {};
+        const patches = {};
+        for (const name of componentNames) {
+            renders[name] = window.goframeComponentRenderCounts[name] || 0;
+            patches[name] = window.goframeComponentPatchCounts[name] || 0;
+        }
+        return { renders, patches };
+    }
+})()`;
 }
 
 function assertState(actual, expected, label) {
@@ -533,6 +1154,7 @@ function runCommand(command, args, options = {}) {
             stdio: "inherit",
             env: {
                 ...process.env,
+                ...options.env,
                 GOWORK: "off",
             },
         });


### PR DESCRIPTION
## Summary

Extends the existing `server-backed` reference example with a deterministic
route-driven asynchronous data flow built entirely from GoFrame's current
primitives:

```text
WithQuery
→ Navigate
→ RouterView
→ RouteContext.Query
→ UseResource
→ FetchText
```

The change tests whether the current router, component ownership, and resource
model can express:

- route-driven loading;
- direct hash navigation;
- same-target reload and retry;
- request cancellation;
- stale-result suppression;
- failure and recovery;
- native browser Back and Forward;
- coherent URL, form, resource-key, and result state.

The resulting evidence verdict remains:

```text
SUFFICIENT
```

For this reference flow, the existing composition is sufficient and does not
justify a public route-transition or route-loader API.

## Scope

Changed files:

- `examples/server-backed/cmd/app/app.gox`;
- `examples/server-backed/assets/styles.css`;
- `examples/server-backed/README.md`;
- `scripts/server-backed-browser-smoke.mjs`.

No production runtime, public API, router implementation, resource
implementation, GOX compiler, `goxc`, workflow, dependency, or size-budget
changes are included.

## Application Flow

The example now provides:

```text
/
#/greeting?name=Lin
#/greeting?name=Ada
#/greeting?name=slow
#/greeting?name=fail
```

A stable outer `ServerBackedShell` remains mounted outside `RouterView`.

The route subtree owns the active form and data lifecycle:

```text
App
└── ServerBackedShell
    └── RouterView
        ├── HomeRoute
        │   └── controlled greeting form
        ├── GreetingRoute
        │   ├── controlled greeting form
        │   └── UseResource(..., FetchText)
        └── NotFoundRoute
```

### Different-target submission

When the normalized form draft differs from the active route name:

1. the route builds `/greeting?name=...` with `gf.WithQuery`;
2. `gf.Navigate` updates the hash;
3. `RouterView` observes `hashchange`;
4. `RouteContext.Query()` provides the active name;
5. `GreetingRoute` derives the same-origin API key;
6. `gf.UseResource` starts the request through `gf.FetchText`.

### Same-target submission

When the normalized form draft already matches the active route name:

```text
URL remains unchanged
→ UseResource.reload()
→ loading
→ ready or failed
```

This preserves the previous example's explicit reload behavior without adding a
query nonce, timestamp, manual generation counter, or intermediate route.

## Ownership

| Concern | Owner |
|---|---|
| home form draft | `HomeRoute` and one `gf.UseState` slot |
| greeting form draft | `GreetingRoute` and one `gf.UseState` slot |
| active greeting source of truth | normalized `RouteContext.Query()` value |
| route-to-draft synchronization | one `GreetingRoute` effect keyed by the route name |
| URL construction | route submit handlers through `gf.WithQuery` |
| hash navigation | `gf.Navigate` and native browser history |
| route matching | `gf.RouterView` |
| resource key | `GreetingRoute` through `greetingPath` |
| request generation | `gf.UseResource` |
| same-target reload | `GreetingRoute` through the returned `reload` function |
| cancellation | resource cleanup invoking `gf.FetchText` cleanup |
| stale-result suppression | `UseResource` generation checks and `FetchText` active state |
| loading/failed/ready UI | explicit branches in `GreetingRoute` |
| global shell retention | `App`, `ServerBackedShell`, and the route-content container |
| same-pattern form/input retention | pattern-keyed route reconciliation |
| old-screen retention during pending | not provided |
| atomic route-and-data commit | not provided |

The application contains:

```text
manual generation counters: 0
manual stale-result guards: 0
app-owned AbortController instances: 0
app-owned cleanup callbacks: 0
duplicated loading/error state variables: 0
resource lifecycle effects outside UseResource: 0
route/form synchronization effects: 1
```

## Route And Form Synchronization

The active greeting query is the source of truth for the greeting form.

`GreetingRoute` initializes its controlled draft from the normalized query name
and uses a dependency-aware effect to synchronize the draft when the same
`/greeting` route pattern receives a different query through:

- direct hash navigation;
- form navigation;
- browser Back;
- browser Forward.

This keeps the following values aligned:

```text
hash target
route target
resource key
controlled input
rendered result
```

The synchronization uses ordinary component state and effects. It does not add
another router subscription, mutable cross-boundary registry, or asynchronous
resource lifecycle.

## Browser Evidence

The focused Chrome/CDP smoke verifies:

- an initial home route with no greeting request;
- direct hash navigation to `Lin`;
- successful form navigation to `Ada`;
- successful same-target `Ada` reload;
- same-pattern supersession of an active `slow` request;
- cancellation when the greeting route unmounts;
- explicit HTTP 500 resource failure;
- failed same-target `fail` retry;
- recovery from `fail` to `Ada`;
- native browser Back to `fail`;
- native browser Forward to `Ada`;
- route-query and controlled-input synchronization;
- global shell retention;
- same-pattern greeting form and input retention;
- expected form/input remount across `/` and `/greeting`;
- update scheduling and DOM bridge observations.

One deterministic run records:

```text
fetches started: 11
successful completions: 6
controlled failures: 3
abort events: 2
stale result appearances: 0
app-root identity changes: 0
outer-shell identity changes: 0
route-content identity changes: 0
```

The two aborts cover:

1. a slow request superseded by a newer query target;
2. a slow request cancelled when its route owner unmounts.

Cancellation is observed through the real `AbortSignal` passed to browser
`fetch`, rather than inferred only from the absence of stale UI.

## Input Preparation And Scheduling

The browser harness no longer treats a direct DOM value assignment as proof
that GoFrame state has updated.

Before submitting a form, it now:

1. identifies the state-owning `HomeRoute` or `GreetingRoute`;
2. captures its render and patch counters;
3. writes the input value and dispatches the input event;
4. waits for both render and patch counters to advance;
5. verifies the controlled value;
6. observes two additional stable animation frames;
7. starts scenario instrumentation only after the update has settled.

This prevents a pending input update from leaking into the following scenario's
scheduling measurements.

Behavioral assertions require:

- at least one attributable update;
- balanced rAF requests and callbacks;
- no unexpected microtask fallback;
- the expected route component to render;
- the correct request outcome;
- the correct route and form state;
- the expected identity contract.

Observed flush and DOM-operation totals are printed for review but are not
treated as browser-independent product contracts.

## Identity Contract

The evidence distinguishes global and route-local identity.

### Retained across all navigation

```text
application root
outer shell
route-content container
```

### Retained across the same `/greeting` pattern

```text
greeting form
greeting input
```

This includes:

- query changes;
- supersession;
- failure and recovery;
- same-target reload;
- same-target retry;
- Back and Forward within the greeting pattern.

### Expected to remount across route patterns

```text
/
↔
/greeting
```

Home and greeting forms are separate route-owned components, so their remount
across different route patterns is intentional.

## Current Semantic Boundary

The flow also records what the current composition does not provide:

- the URL changes before route data is ready;
- the previous ready result is removed during pending;
- route and data do not commit atomically;
- Back and Forward refetch because no cache exists;
- redirect coordination is not exercised;
- multi-resource transition coordination is not exercised.

These are observed limitations, not future transition behavior simulated with
additional application state.

## Size Evidence

The frozen base, originally reviewed head, and final branch were packaged with
TinyGo `0.41.1` using identical release-like options:

```text
--compiler=tinygo
--asset-hash
--preload
--compress=gzip,br
```

The WASM entrypoint was resolved through `asset-manifest.json`.

| Artifact | Frozen base | Reviewed head | Final | Delta from base | Follow-up delta |
|---|---:|---:|---:|---:|---:|
| Raw WASM | 130,948 B | 156,668 B | 160,236 B | +29,288 B (+22.37%) | +3,568 B (+2.28%) |
| Gzip | 60,254 B | 68,269 B | 69,233 B | +8,979 B (+14.90%) | +964 B (+1.41%) |
| Brotli | 50,504 B | 57,492 B | 58,185 B | +7,681 B (+15.21%) | +693 B (+1.21%) |

The example is not part of the global hard size-budget list. No budget was added
or increased.

The follow-up delta covers route-owned forms, query-to-draft synchronization,
and same-target reload/retry behavior. It does not authorize another shared
runtime abstraction without separate user-value and size evidence.

## Evidence Verdict

```text
SUFFICIENT
```

The existing router, ordinary component composition, `gf.UseResource`, and
`gf.FetchText` express:

- route-driven loading;
- coherent URL and controlled-input state;
- direct hash navigation;
- same-target reload and retry;
- failure and recovery;
- same-pattern supersession;
- route-unmount cancellation;
- stale-result suppression;
- native Back and Forward;
- retained outer-shell ownership.

The application-level coordination remains bounded:

- two mutually exclusive route-owned state slots;
- two submit handlers;
- one query-to-draft synchronization effect;
- one route table;
- three route handlers;
- one route-owned resource hook;
- small normalization and rendering helpers.

Request generation, cancellation, and stale suppression remain owned by the
existing resource model.

This result does not prove that old-screen retention or atomic route-and-data
commit would never be useful. It shows that this reference flow does not
establish a need for a public transition or route-loader API.

## Review Follow-Up

The Codex review findings are addressed as follows:

### Repeated same-target submissions

`GreetingRoute` now calls the `reload` function returned by `UseResource` when
the normalized form draft matches the current route name.

Both successful reload and failed retry are covered by browser evidence.

### Route query and input divergence

Home and greeting forms now own separate route-local state.

`GreetingRoute` synchronizes its controlled draft from the normalized route
query during direct, Back, and Forward navigation.

### Input preparation race

The browser harness now waits for the state-owning route component's render and
patch counters to advance, verifies the controlled value, and observes two
stable frames before beginning scenario instrumentation.

## Commit Structure

The branch contains five signed commits:

1. `feat(example): add route-driven greeting flow`
   - adds the stable shell and hash-routed greeting flow;
   - moves asynchronous data ownership into route content.

2. `test(browser): verify async navigation lifecycle`
   - adds cancellation, stale-result, failure, recovery, history, identity, and
     scheduling evidence.

3. `docs(example): record async navigation evidence`
   - records the original ownership analysis, size impact, and evidence verdict.

4. `fix(example): align greeting forms with route state`
   - restores same-target reload and retry;
   - moves controlled form state into route owners;
   - synchronizes the greeting draft from the active query;
   - removes the browser input-preparation race;
   - adds direct navigation and retry evidence.

5. `docs(example): update async navigation evidence`
   - updates ownership, behavior, browser counts, size measurements, limitations,
     and the final verdict.

## Validation

Local validation reported:

- [x] focused `server-backed` Go tests;
- [x] focused `pkg/goframe` tests;
- [x] browser-smoke syntax validation;
- [x] corrected focused server-backed browser smoke, run twice;
- [x] matching route, retry, cancellation, identity, and scheduling evidence;
- [x] `scripts/check.sh`;
- [x] `scripts/browser-smoke.sh`;
- [x] clean release-like package rebuild;
- [x] `scripts/size-budget.sh` with unchanged budgets;
- [x] `node scripts/docs-check.mjs`;
- [x] `git diff --check`;
- [x] clean final working tree with no generated artifacts.

GitHub Actions on the final PR head:

- [x] Core
- [x] Browser Smoke
- [x] WASM Size
- [x] VS Code Extension

## Compatibility And Behavior Impact

Example behavior:

- form state is now route-owned;
- the greeting query is authoritative for the active greeting form;
- different-name submission navigates;
- same-name submission reloads the current resource;
- direct and history navigation synchronize the controlled input;
- greeting data remains owned by the matched route;
- the outer shell remains mounted across navigation.

Framework behavior:

- no public API changes;
- no runtime behavior changes;
- no router implementation changes;
- no resource implementation changes;
- no GOX grammar or compiler changes;
- no `goxc` changes;
- no migration is required.

## Non-Goals

- No public route-transition API.
- No route-loader API.
- No shared lifecycle extraction.
- No history/path router.
- No global resource cache.
- No Suspense-like rendering.
- No actions or mutation framework.
- No redirect framework.
- No SSR or hydration.
- No new example.
- No workflow or dependency changes.
- No size-budget increase.
- No roadmap, audit, or release work.

## Decision After This PR

This PR closes the evidence question for the implemented reference flow:

```text
current router + component + resource composition is sufficient
```

It does not authorize a private lifecycle helper or public loader as an
automatic follow-up.

Any future transition work must begin from a separately demonstrated
application need, such as:

- retaining the previous screen while the next route prepares;
- atomic route-and-data commit;
- redirect coordination;
- coordinated loading of multiple route resources;
- another repeated application-level gap.