### PR TITLE
feat(goxc): add watched development workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Watched `goxc dev` workflow with serialized full-package rebuilds, effective
+  authored-input polling, quiet-period debounce, last-successful-package
+  recovery, loopback-only no-store serving, and manual browser refresh.
 - `v0.2.0-preview.6` release notes documenting structured `goxc check`
   diagnostics, the schema-v1 tooling transport, saved-source VS Code
   diagnostics, Unicode position mapping, multi-root and stale-run handling,

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ it does not write generated `.gox.go` files next to authored source by default.
   context, events, reconciliation, resources, routing, and fixed-height
   virtualization.
 - `pkg/gox`: GOX lexer/parser/codegen with source-oriented diagnostics.
-- `cmd/goxc`: check, generate, build, package, export, serve, size, clean,
+- `cmd/goxc`: check, generate, build, package, export, serve, dev, size, clean,
   doctor, and version commands.
 - Examples and scripts that exercise the runtime, compiler, package workflow,
   browser smoke paths, and WASM size budgets.
@@ -110,6 +110,8 @@ it does not write generated `.gox.go` files next to authored source by default.
 - [GOX language](docs/gox-language.md) - syntax, diagnostics, and limits.
 - [Runtime model](docs/runtime-model.md) - component identity, hooks,
   reconciliation, resources, and errors.
+- [Local development](docs/development.md) - watched development packaging,
+  loopback serving, failure recovery, and current non-goals.
 - [Deployment](docs/deployment.md) - package layout, asset hashing, preloads,
   export, and cache-safe static delivery.
 - [API stability](docs/api-stability.md) and
@@ -409,6 +411,7 @@ Common commands:
 | `goxc export <app> --out <dir>` | Copy the latest package to an explicit deploy directory. |
 | `goxc size <app>` | Report size from `.goframe/package/standalone`. |
 | `goxc serve <app>` | Serve the local package for development. |
+| `goxc dev <app>` | Package, serve, and rebuild effective authored inputs for local development. |
 | `goxc clean <app>` | Remove tool-owned workspace/build/package artifacts. |
 | `goxc doctor` | Check local Go/TinyGo/compression/runtime-shim tools. |
 
@@ -545,6 +548,7 @@ Runtime topics:
 Toolchain and delivery:
 
 - [Multi-package GOX workspace](docs/multi-package-workspace.md)
+- [Local development workflow](docs/development.md)
 - [Cache-safe package delivery](docs/deployment.md)
 - [Manifest compatibility](docs/manifest-compatibility.md)
 - [Symlink and file safety policy](docs/security-symlink-policy.md)

--- a/cmd/goxc/cli_test.go
+++ b/cmd/goxc/cli_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCommandUsage(t *testing.T) {
-	for _, command := range []string{"check", "generate", "build", "package", "export", "serve", "size", "doctor", "clean", "version"} {
+	for _, command := range []string{"check", "generate", "build", "package", "export", "serve", "dev", "size", "doctor", "clean", "version"} {
 		t.Run(command, func(t *testing.T) {
 			var output bytes.Buffer
 			commandUsage(&output, command)

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -408,18 +408,12 @@ func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
 
 	manifest, err := loadManifest(collector.appDir)
 	if err != nil {
-		if collector.haveAssets {
-			_ = collector.collectAssets(&snapshot, collector.lastAssets)
-		}
-		return snapshot, devBuildableScanError{err: err}
+		return snapshot, collector.collectRetainedAssets(&snapshot, err)
 	}
 	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
 	_, planErr := planPackageAssets(collector.appDir, manifest, wasmLogicalName, packageOptions{compress: map[string]bool{}})
 	if planErr != nil {
-		if collector.haveAssets {
-			_ = collector.collectAssets(&snapshot, collector.lastAssets)
-		}
-		return snapshot, devBuildableScanError{err: planErr}
+		return snapshot, collector.collectRetainedAssets(&snapshot, planErr)
 	}
 
 	spec, err := collector.assetWatchSpec(manifest)
@@ -432,6 +426,15 @@ func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
 		return snapshot, err
 	}
 	return snapshot, nil
+}
+
+func (collector *devSnapshotCollector) collectRetainedAssets(snapshot *devSnapshot, scanErr error) error {
+	if collector.haveAssets {
+		if err := collector.collectAssets(snapshot, collector.lastAssets); err != nil {
+			scanErr = errors.Join(scanErr, err)
+		}
+	}
+	return devBuildableScanError{err: scanErr}
 }
 
 func (collector *devSnapshotCollector) collectAuthoredSource(snapshot *devSnapshot) error {
@@ -547,11 +550,17 @@ func (collector *devSnapshotCollector) assetWatchSpec(manifest projectManifest) 
 
 func (collector *devSnapshotCollector) collectAssets(snapshot *devSnapshot, spec devAssetWatchSpec) error {
 	for _, directory := range spec.directories {
+		if err := validatePathBelowRoot(collector.appDir, directory.path, "watched asset directory", true); err != nil {
+			return err
+		}
 		if err := collector.collectAssetDirectory(snapshot, directory); err != nil {
 			return err
 		}
 	}
 	for _, file := range spec.files {
+		if err := validatePathBelowRoot(collector.appDir, file, "watched asset path", true); err != nil {
+			return err
+		}
 		if err := collector.collectFile(snapshot, file, true); err != nil {
 			return err
 		}

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -1,0 +1,856 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultDevPollInterval = 200 * time.Millisecond
+	defaultDevDebounce     = 150 * time.Millisecond
+	devShutdownTimeout     = 5 * time.Second
+)
+
+type devOptions struct {
+	appDir    string
+	compiler  string
+	workspace string
+	port      int
+}
+
+type devBuildRequest struct {
+	Number  int
+	Initial bool
+	Changed []string
+}
+
+type devBuildEvent struct {
+	Request  devBuildRequest
+	Err      error
+	Duration time.Duration
+}
+
+type devHooks struct {
+	BuildStarted  func(devBuildRequest)
+	BuildFinished func(devBuildEvent)
+	ServerStarted func(string)
+}
+
+type devDependencies struct {
+	packageApp   func(packageOptions) error
+	listen       func(string, string) (net.Listener, error)
+	pollInterval time.Duration
+	debounce     time.Duration
+	stdout       io.Writer
+	stderr       io.Writer
+	hooks        devHooks
+}
+
+func defaultDevDependencies() devDependencies {
+	return devDependencies{
+		packageApp:   packageApp,
+		listen:       net.Listen,
+		pollInterval: defaultDevPollInterval,
+		debounce:     defaultDevDebounce,
+		stdout:       os.Stdout,
+		stderr:       os.Stderr,
+	}
+}
+
+func devCommand(args []string) error {
+	options, err := parseDevOptions(args)
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	return runDev(ctx, options, defaultDevDependencies())
+}
+
+func parseDevOptions(args []string) (devOptions, error) {
+	options := devOptions{port: 8080}
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		switch {
+		case strings.HasPrefix(arg, "--compiler="):
+			options.compiler = strings.TrimPrefix(arg, "--compiler=")
+		case arg == "--compiler":
+			index++
+			if index >= len(args) {
+				return devOptions{}, errors.New("--compiler requires a value")
+			}
+			options.compiler = args[index]
+		case strings.HasPrefix(arg, "--port="):
+			port, err := strconv.Atoi(strings.TrimPrefix(arg, "--port="))
+			if err != nil {
+				return devOptions{}, fmt.Errorf("invalid port: %w", err)
+			}
+			options.port = port
+		case arg == "--port":
+			index++
+			if index >= len(args) {
+				return devOptions{}, errors.New("--port requires a value")
+			}
+			port, err := strconv.Atoi(args[index])
+			if err != nil {
+				return devOptions{}, fmt.Errorf("invalid port: %w", err)
+			}
+			options.port = port
+		case strings.HasPrefix(arg, "--workspace="):
+			options.workspace = strings.TrimPrefix(arg, "--workspace=")
+		case arg == "--workspace":
+			index++
+			if index >= len(args) {
+				return devOptions{}, errors.New("--workspace requires a value")
+			}
+			options.workspace = args[index]
+		case strings.HasPrefix(arg, "-"):
+			return devOptions{}, fmt.Errorf("unknown dev flag %q", arg)
+		case options.appDir == "":
+			options.appDir = arg
+		default:
+			return devOptions{}, fmt.Errorf("unexpected dev argument %q", arg)
+		}
+	}
+	if options.appDir == "" {
+		return devOptions{}, errors.New("usage: goxc dev <app-directory> [--compiler=go|tinygo] [--port=8080] [--workspace=directory]")
+	}
+	if options.compiler != "" {
+		if err := validateCompiler(options.compiler); err != nil {
+			return devOptions{}, err
+		}
+	}
+	if options.port < 0 || options.port > 65535 {
+		return devOptions{}, errors.New("port must be between 0 and 65535")
+	}
+	return options, nil
+}
+
+func runDev(ctx context.Context, options devOptions, dependencies devDependencies) error {
+	dependencies = normalizeDevDependencies(dependencies)
+	if err := ensureAppDirectory(options.appDir); err != nil {
+		return err
+	}
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    options.appDir,
+		compiler:  options.compiler,
+		workspace: options.workspace,
+	})
+	if err != nil {
+		return err
+	}
+	if err := validateWorkspaceRoot(layout); err != nil {
+		return err
+	}
+
+	collector := newDevSnapshotCollector(layout.AppDir)
+	server := newDevServer(layout.PackageDir, options.port, dependencies)
+
+	build := func(request devBuildRequest) error {
+		err := dependencies.packageApp(packageOptions{
+			appDir:    layout.AppDir,
+			compiler:  options.compiler,
+			workspace: options.workspace,
+			compress:  map[string]bool{},
+		})
+		if err != nil {
+			return err
+		}
+		if err := verifyPublishedPackage(layout.PackageDir); err != nil {
+			return err
+		}
+		if !server.started() {
+			if err := server.start(); err != nil {
+				return devFatalError{err: err}
+			}
+		}
+		return nil
+	}
+
+	runErr := runDevCoordinator(ctx, devCoordinatorConfig{
+		scan:         collector.collect,
+		build:        build,
+		serverErrors: server.errors(),
+		pollInterval: dependencies.pollInterval,
+		debounce:     dependencies.debounce,
+		stdout:       dependencies.stdout,
+		stderr:       dependencies.stderr,
+		hooks:        dependencies.hooks,
+	})
+	shutdownErr := server.shutdown()
+	if runErr != nil {
+		return runErr
+	}
+	return shutdownErr
+}
+
+func normalizeDevDependencies(dependencies devDependencies) devDependencies {
+	defaults := defaultDevDependencies()
+	if dependencies.packageApp == nil {
+		dependencies.packageApp = defaults.packageApp
+	}
+	if dependencies.listen == nil {
+		dependencies.listen = defaults.listen
+	}
+	if dependencies.pollInterval <= 0 {
+		dependencies.pollInterval = defaults.pollInterval
+	}
+	if dependencies.debounce <= 0 {
+		dependencies.debounce = defaults.debounce
+	}
+	if dependencies.stdout == nil {
+		dependencies.stdout = defaults.stdout
+	}
+	if dependencies.stderr == nil {
+		dependencies.stderr = defaults.stderr
+	}
+	return dependencies
+}
+
+type devServer struct {
+	packageDir string
+	port       int
+	listen     func(string, string) (net.Listener, error)
+	stdout     io.Writer
+	hooks      devHooks
+
+	mu       sync.Mutex
+	server   *http.Server
+	listener net.Listener
+	errCh    chan error
+}
+
+func newDevServer(packageDir string, port int, dependencies devDependencies) *devServer {
+	return &devServer{
+		packageDir: packageDir,
+		port:       port,
+		listen:     dependencies.listen,
+		stdout:     dependencies.stdout,
+		hooks:      dependencies.hooks,
+		errCh:      make(chan error, 1),
+	}
+}
+
+func (server *devServer) start() error {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.server != nil {
+		return nil
+	}
+	if err := directoryNoFollow(server.packageDir, "development package directory"); err != nil {
+		return err
+	}
+	listener, err := server.listen("tcp", fmt.Sprintf("127.0.0.1:%d", server.port))
+	if err != nil {
+		return fmt.Errorf("start development server: %w", err)
+	}
+	httpServer := &http.Server{Handler: devStaticHandler(server.packageDir)}
+	server.listener = listener
+	server.server = httpServer
+	url := "http://" + listener.Addr().String()
+	fmt.Fprintf(server.stdout, "development server ready at %s\n", url)
+	if server.hooks.ServerStarted != nil {
+		server.hooks.ServerStarted(url)
+	}
+	go func() {
+		err := httpServer.Serve(listener)
+		if err == nil || errors.Is(err, http.ErrServerClosed) {
+			return
+		}
+		select {
+		case server.errCh <- fmt.Errorf("development server failed: %w", err):
+		default:
+		}
+	}()
+	return nil
+}
+
+func (server *devServer) started() bool {
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	return server.server != nil
+}
+
+func (server *devServer) errors() <-chan error {
+	return server.errCh
+}
+
+func (server *devServer) shutdown() error {
+	server.mu.Lock()
+	httpServer := server.server
+	server.mu.Unlock()
+	if httpServer == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), devShutdownTimeout)
+	defer cancel()
+	if err := httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("shut down development server: %w", err)
+	}
+	return nil
+}
+
+func devStaticHandler(directory string) http.Handler {
+	handler := staticHandler(directory)
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Cache-Control", "no-store")
+		handler.ServeHTTP(response, request)
+	})
+}
+
+type devFatalError struct {
+	err error
+}
+
+func (failure devFatalError) Error() string {
+	return failure.err.Error()
+}
+
+func (failure devFatalError) Unwrap() error {
+	return failure.err
+}
+
+type devSnapshot struct {
+	files map[string]string
+}
+
+func newDevSnapshot() devSnapshot {
+	return devSnapshot{files: map[string]string{}}
+}
+
+func (snapshot devSnapshot) paths() []string {
+	paths := make([]string, 0, len(snapshot.files))
+	for path := range snapshot.files {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func devSnapshotsEqual(first, second devSnapshot) bool {
+	if len(first.files) != len(second.files) {
+		return false
+	}
+	for path, fingerprint := range first.files {
+		if second.files[path] != fingerprint {
+			return false
+		}
+	}
+	return true
+}
+
+func diffDevSnapshots(previous, current devSnapshot) []string {
+	changed := map[string]struct{}{}
+	for path, fingerprint := range previous.files {
+		if current.files[path] != fingerprint {
+			changed[path] = struct{}{}
+		}
+	}
+	for path, fingerprint := range current.files {
+		if previous.files[path] != fingerprint {
+			changed[path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(changed))
+	for path := range changed {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+type devSnapshotCollector struct {
+	appDir     string
+	lastAssets devAssetWatchSpec
+	haveAssets bool
+}
+
+type devAssetWatchSpec struct {
+	directories []devAssetDirectory
+	files       []string
+}
+
+type devAssetDirectory struct {
+	path     string
+	required bool
+}
+
+func newDevSnapshotCollector(appDir string) *devSnapshotCollector {
+	return &devSnapshotCollector{appDir: appDir}
+}
+
+func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
+	snapshot := newDevSnapshot()
+	if err := collector.collectAuthoredSource(&snapshot); err != nil {
+		return snapshot, err
+	}
+	if err := collector.collectFile(&snapshot, filepath.Join(collector.appDir, manifestName), true); err != nil {
+		return snapshot, err
+	}
+	if err := collector.collectModuleInputs(&snapshot); err != nil {
+		return snapshot, err
+	}
+
+	manifest, err := loadManifest(collector.appDir)
+	if err != nil {
+		if collector.haveAssets {
+			_ = collector.collectAssets(&snapshot, collector.lastAssets)
+		}
+		return snapshot, devBuildableScanError{err: err}
+	}
+	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
+	_, planErr := planPackageAssets(collector.appDir, manifest, wasmLogicalName, packageOptions{compress: map[string]bool{}})
+	if planErr != nil {
+		if collector.haveAssets {
+			_ = collector.collectAssets(&snapshot, collector.lastAssets)
+		}
+		return snapshot, devBuildableScanError{err: planErr}
+	}
+
+	spec, err := collector.assetWatchSpec(manifest)
+	if err != nil {
+		return snapshot, err
+	}
+	collector.lastAssets = spec
+	collector.haveAssets = true
+	if err := collector.collectAssets(&snapshot, spec); err != nil {
+		return snapshot, err
+	}
+	return snapshot, nil
+}
+
+func (collector *devSnapshotCollector) collectAuthoredSource(snapshot *devSnapshot) error {
+	return filepath.WalkDir(collector.appDir, func(current string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("inspect watched source %s: %w", current, err)
+		}
+		if current == collector.appDir {
+			return nil
+		}
+		relative, err := filepath.Rel(collector.appDir, current)
+		if err != nil {
+			return fmt.Errorf("resolve watched source %s: %w", current, err)
+		}
+		if shouldSkipWorkspaceSource(relative, entry) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("watched source %s is a symlink; symlink paths are not supported", current)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(current, ".gox.go") {
+			return nil
+		}
+		extension := strings.ToLower(filepath.Ext(current))
+		if extension != ".go" && extension != ".gox" {
+			return nil
+		}
+		return collector.collectFile(snapshot, current, false)
+	})
+}
+
+func (collector *devSnapshotCollector) collectModuleInputs(snapshot *devSnapshot) error {
+	paths, err := devModuleInputPaths(collector.appDir)
+	if err != nil {
+		return err
+	}
+	for _, modulePath := range paths {
+		if err := collector.collectFile(snapshot, modulePath, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func devModuleInputPaths(appDir string) ([]string, error) {
+	current, err := filepath.Abs(appDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve application directory: %w", err)
+	}
+	for {
+		goMod := filepath.Join(current, "go.mod")
+		info, err := os.Lstat(goMod)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return nil, fmt.Errorf("watched module file %s is a symlink; symlink paths are not supported", goMod)
+			}
+			return []string{goMod, filepath.Join(current, "go.sum")}, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("inspect watched module file %s: %w", goMod, err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return nil, nil
+		}
+		current = parent
+	}
+}
+
+func (collector *devSnapshotCollector) assetWatchSpec(manifest projectManifest) (devAssetWatchSpec, error) {
+	var spec devAssetWatchSpec
+	switch manifest.Assets.Mode {
+	case manifestAssetsAuto:
+		assetsPath := filepath.Join(collector.appDir, assetDirectoryName)
+		info, err := os.Lstat(assetsPath)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return devAssetWatchSpec{}, fmt.Errorf("asset directory %s is a symlink; symlink paths are not supported", assetsPath)
+			}
+			if info.IsDir() {
+				spec.directories = append(spec.directories, devAssetDirectory{path: assetsPath})
+				return spec, nil
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return devAssetWatchSpec{}, fmt.Errorf("inspect asset directory %s: %w", assetsPath, err)
+		}
+		spec.directories = append(spec.directories, devAssetDirectory{path: assetsPath})
+		spec.files = append(spec.files, filepath.Join(collector.appDir, indexHTMLAssetName))
+	case manifestAssetsDirectory:
+		spec.directories = append(spec.directories, devAssetDirectory{
+			path:     filepath.Join(collector.appDir, filepath.FromSlash(manifest.Assets.Directory)),
+			required: true,
+		})
+	case manifestAssetsList:
+		for _, asset := range manifest.Assets.List {
+			spec.files = append(spec.files, filepath.Join(collector.appDir, filepath.FromSlash(asset)))
+		}
+	default:
+		return devAssetWatchSpec{}, fmt.Errorf("assets in %s has unsupported internal mode", manifestName)
+	}
+	sort.Slice(spec.directories, func(first, second int) bool {
+		return spec.directories[first].path < spec.directories[second].path
+	})
+	sort.Strings(spec.files)
+	return spec, nil
+}
+
+func (collector *devSnapshotCollector) collectAssets(snapshot *devSnapshot, spec devAssetWatchSpec) error {
+	for _, directory := range spec.directories {
+		if err := collector.collectAssetDirectory(snapshot, directory); err != nil {
+			return err
+		}
+	}
+	for _, file := range spec.files {
+		if err := collector.collectFile(snapshot, file, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (collector *devSnapshotCollector) collectAssetDirectory(snapshot *devSnapshot, directory devAssetDirectory) error {
+	info, err := os.Lstat(directory.path)
+	if errors.Is(err, os.ErrNotExist) {
+		snapshot.files[collector.displayPath(directory.path)+"/"] = "missing"
+		if directory.required {
+			return fmt.Errorf("watched asset directory %s does not exist", directory.path)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect watched asset directory %s: %w", directory.path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("watched asset directory %s is a symlink; symlink paths are not supported", directory.path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("watched asset directory %s is not a directory", directory.path)
+	}
+	snapshot.files[collector.displayPath(directory.path)+"/"] = "directory"
+	return filepath.WalkDir(directory.path, func(current string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("inspect watched asset %s: %w", current, err)
+		}
+		if current == directory.path {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("watched asset %s is a symlink; symlink paths are not supported", current)
+		}
+		if entry.IsDir() {
+			snapshot.files[collector.displayPath(current)+"/"] = "directory"
+			return nil
+		}
+		return collector.collectFile(snapshot, current, false)
+	})
+}
+
+func (collector *devSnapshotCollector) collectFile(snapshot *devSnapshot, file string, allowMissing bool) error {
+	info, err := os.Lstat(file)
+	if errors.Is(err, os.ErrNotExist) && allowMissing {
+		snapshot.files[collector.displayPath(file)] = "missing"
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect watched input %s: %w", file, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("watched input %s is a symlink; symlink paths are not supported", file)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("watched input %s is not a regular file", file)
+	}
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read watched input %s: %w", file, err)
+	}
+	sum := sha256.Sum256(content)
+	snapshot.files[collector.displayPath(file)] = "sha256:" + hex.EncodeToString(sum[:])
+	return nil
+}
+
+func (collector *devSnapshotCollector) displayPath(file string) string {
+	relative, err := filepath.Rel(collector.appDir, file)
+	if err != nil {
+		return filepath.ToSlash(file)
+	}
+	return filepath.ToSlash(relative)
+}
+
+type devCoordinatorConfig struct {
+	scan         func() (devSnapshot, error)
+	build        func(devBuildRequest) error
+	serverErrors <-chan error
+	pollInterval time.Duration
+	debounce     time.Duration
+	stdout       io.Writer
+	stderr       io.Writer
+	hooks        devHooks
+}
+
+type devBuildableScanError struct {
+	err error
+}
+
+func (failure devBuildableScanError) Error() string {
+	return failure.err.Error()
+}
+
+func (failure devBuildableScanError) Unwrap() error {
+	return failure.err
+}
+
+func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
+	if config.scan == nil || config.build == nil {
+		return errors.New("development coordinator requires scan and build functions")
+	}
+	if config.pollInterval <= 0 || config.debounce <= 0 {
+		return errors.New("development coordinator intervals must be positive")
+	}
+	if config.stdout == nil {
+		config.stdout = io.Discard
+	}
+	if config.stderr == nil {
+		config.stderr = io.Discard
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	lastAttempted, scanErr := config.scan()
+	haveHealthySnapshot := scanErr == nil
+	lastScanError := reportDevScanState(config.stderr, "", scanErr)
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err := runDevBuild(config, devBuildRequest{Number: 1, Initial: true}); err != nil {
+		var fatal devFatalError
+		if errors.As(err, &fatal) {
+			return fatal.err
+		}
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	buildNumber := 1
+	pollTicker := time.NewTicker(config.pollInterval)
+	defer pollTicker.Stop()
+	var debounceTimer *time.Timer
+	var debounceC <-chan time.Time
+	var pending devSnapshot
+	havePending := false
+	forcePending := false
+
+	stopDebounce := func() {
+		if debounceTimer == nil {
+			return
+		}
+		if !debounceTimer.Stop() {
+			select {
+			case <-debounceTimer.C:
+			default:
+			}
+		}
+		debounceC = nil
+	}
+	resetDebounce := func() {
+		if debounceTimer == nil {
+			debounceTimer = time.NewTimer(config.debounce)
+		} else {
+			stopDebounce()
+			debounceTimer.Reset(config.debounce)
+		}
+		debounceC = debounceTimer.C
+	}
+	defer func() {
+		if debounceTimer != nil {
+			stopDebounce()
+		}
+	}()
+
+	handleScan := func(snapshot devSnapshot, err error) {
+		previousError := lastScanError
+		lastScanError = reportDevScanState(config.stderr, lastScanError, err)
+		if err != nil {
+			var buildable devBuildableScanError
+			if errors.As(err, &buildable) {
+				if !devSnapshotsEqual(lastAttempted, snapshot) {
+					if !havePending || !devSnapshotsEqual(pending, snapshot) {
+						pending = snapshot
+						havePending = true
+						forcePending = false
+						resetDebounce()
+					}
+					return
+				}
+			}
+			havePending = false
+			forcePending = false
+			stopDebounce()
+			return
+		}
+		recovered := previousError != ""
+		if !haveHealthySnapshot {
+			recovered = true
+			haveHealthySnapshot = true
+		}
+		if recovered || !devSnapshotsEqual(lastAttempted, snapshot) {
+			if !havePending || !devSnapshotsEqual(pending, snapshot) || recovered {
+				pending = snapshot
+				havePending = true
+				forcePending = recovered
+				resetDebounce()
+			}
+			return
+		}
+		if havePending && forcePending {
+			return
+		}
+		havePending = false
+		forcePending = false
+		stopDebounce()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-config.serverErrors:
+			if err != nil {
+				return err
+			}
+		case <-pollTicker.C:
+			snapshot, err := config.scan()
+			handleScan(snapshot, err)
+		case <-debounceC:
+			debounceC = nil
+			havePending = false
+			if ctx.Err() != nil {
+				return nil
+			}
+			changed := diffDevSnapshots(lastAttempted, pending)
+			if len(changed) == 0 && !forcePending {
+				continue
+			}
+			if len(changed) == 0 {
+				changed = []string{"watch inputs recovered"}
+			}
+			lastAttempted = pending
+			forcePending = false
+			buildNumber++
+			err := runDevBuild(config, devBuildRequest{
+				Number:  buildNumber,
+				Changed: changed,
+			})
+			var fatal devFatalError
+			if errors.As(err, &fatal) {
+				return fatal.err
+			}
+			if ctx.Err() != nil {
+				return nil
+			}
+			snapshot, scanErr := config.scan()
+			handleScan(snapshot, scanErr)
+		}
+	}
+}
+
+func runDevBuild(config devCoordinatorConfig, request devBuildRequest) error {
+	classification := "rebuild"
+	changeSummary := summarizeDevChanges(request.Changed)
+	if request.Initial {
+		classification = "initial"
+		changeSummary = "initial inputs"
+	}
+	fmt.Fprintf(config.stdout, "dev build %d (%s): %s\n", request.Number, classification, changeSummary)
+	if config.hooks.BuildStarted != nil {
+		config.hooks.BuildStarted(request)
+	}
+	started := time.Now()
+	err := config.build(request)
+	duration := time.Since(started)
+	event := devBuildEvent{Request: request, Err: err, Duration: duration}
+	if config.hooks.BuildFinished != nil {
+		config.hooks.BuildFinished(event)
+	}
+	if err != nil {
+		fmt.Fprintf(config.stderr, "dev build %d failed after %s: %v\n", request.Number, duration.Round(time.Millisecond), err)
+		return err
+	}
+	fmt.Fprintf(config.stdout, "dev build %d succeeded after %s\n", request.Number, duration.Round(time.Millisecond))
+	return nil
+}
+
+func summarizeDevChanges(changed []string) string {
+	const limit = 6
+	if len(changed) <= limit {
+		return strings.Join(changed, ", ")
+	}
+	return fmt.Sprintf("%s, and %d more", strings.Join(changed[:limit], ", "), len(changed)-limit)
+}
+
+func reportDevScanState(output io.Writer, previous string, err error) string {
+	if err == nil {
+		if previous != "" {
+			fmt.Fprintln(output, "dev watch recovered")
+		}
+		return ""
+	}
+	current := err.Error()
+	if current != previous {
+		fmt.Fprintf(output, "dev watch error: %v\n", err)
+	}
+	return current
+}

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -575,6 +575,10 @@ func (collector *devSnapshotCollector) collectAssetDirectory(snapshot *devSnapsh
 		return fmt.Errorf("watched asset directory %s is a symlink; symlink paths are not supported", directory.path)
 	}
 	if !info.IsDir() {
+		if !directory.required {
+			snapshot.files[collector.displayPath(directory.path)+"/"] = "missing"
+			return nil
+		}
 		return fmt.Errorf("watched asset directory %s is not a directory", directory.path)
 	}
 	snapshot.files[collector.displayPath(directory.path)+"/"] = "directory"

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -664,6 +664,14 @@ func (failure devBuildableScanError) Unwrap() error {
 	return failure.err
 }
 
+func devScanAllowsBuild(err error) bool {
+	if err == nil {
+		return true
+	}
+	var buildable devBuildableScanError
+	return errors.As(err, &buildable)
+}
+
 func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
 	if config.scan == nil || config.build == nil {
 		return errors.New("development coordinator requires scan and build functions")
@@ -681,23 +689,40 @@ func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
 		return nil
 	}
 
-	lastAttempted, scanErr := config.scan()
+	initialSnapshot, scanErr := config.scan()
 	haveHealthySnapshot := scanErr == nil
 	lastScanError := reportDevScanState(config.stderr, "", scanErr)
 	if ctx.Err() != nil {
 		return nil
 	}
-	if err := runDevBuild(config, devBuildRequest{Number: 1, Initial: true}); err != nil {
-		var fatal devFatalError
-		if errors.As(err, &fatal) {
-			return fatal.err
+
+	lastAttempted := newDevSnapshot()
+	buildNumber := 0
+	attemptBuild := func(snapshot devSnapshot, changed []string) error {
+		initial := buildNumber == 0
+		buildNumber++
+		lastAttempted = snapshot
+		if initial {
+			changed = nil
+		}
+		return runDevBuild(config, devBuildRequest{
+			Number:  buildNumber,
+			Initial: initial,
+			Changed: changed,
+		})
+	}
+	if devScanAllowsBuild(scanErr) {
+		if err := attemptBuild(initialSnapshot, nil); err != nil {
+			var fatal devFatalError
+			if errors.As(err, &fatal) {
+				return fatal.err
+			}
 		}
 	}
 	if ctx.Err() != nil {
 		return nil
 	}
 
-	buildNumber := 1
 	pollTicker := time.NewTicker(config.pollInterval)
 	defer pollTicker.Stop()
 	var debounceTimer *time.Timer
@@ -736,18 +761,33 @@ func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
 	handleScan := func(snapshot devSnapshot, err error) {
 		previousError := lastScanError
 		lastScanError = reportDevScanState(config.stderr, lastScanError, err)
+		if !devScanAllowsBuild(err) {
+			havePending = false
+			forcePending = false
+			stopDebounce()
+			return
+		}
+		if buildNumber == 0 {
+			if err == nil {
+				haveHealthySnapshot = true
+			}
+			if !havePending || !devSnapshotsEqual(pending, snapshot) {
+				pending = snapshot
+				havePending = true
+				forcePending = true
+				resetDebounce()
+			}
+			return
+		}
 		if err != nil {
-			var buildable devBuildableScanError
-			if errors.As(err, &buildable) {
-				if !devSnapshotsEqual(lastAttempted, snapshot) {
-					if !havePending || !devSnapshotsEqual(pending, snapshot) {
-						pending = snapshot
-						havePending = true
-						forcePending = false
-						resetDebounce()
-					}
-					return
+			if !devSnapshotsEqual(lastAttempted, snapshot) {
+				if !havePending || !devSnapshotsEqual(pending, snapshot) {
+					pending = snapshot
+					havePending = true
+					forcePending = false
+					resetDebounce()
 				}
+				return
 			}
 			havePending = false
 			forcePending = false
@@ -794,19 +834,14 @@ func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
 				return nil
 			}
 			changed := diffDevSnapshots(lastAttempted, pending)
-			if len(changed) == 0 && !forcePending {
+			if buildNumber > 0 && len(changed) == 0 && !forcePending {
 				continue
 			}
-			if len(changed) == 0 {
+			if buildNumber > 0 && len(changed) == 0 {
 				changed = []string{"watch inputs recovered"}
 			}
-			lastAttempted = pending
 			forcePending = false
-			buildNumber++
-			err := runDevBuild(config, devBuildRequest{
-				Number:  buildNumber,
-				Changed: changed,
-			})
+			err := attemptBuild(pending, changed)
 			var fatal devFatalError
 			if errors.As(err, &fatal) {
 				return fatal.err

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	devIntegrationPoll     = 10 * time.Millisecond
+	devIntegrationDebounce = 50 * time.Millisecond
+)
+
+func TestDevRealWorkflow(t *testing.T) {
+	repositoryRoot, ok := findRepositoryRoot(".")
+	if !ok {
+		t.Fatal("repository root not found")
+	}
+	appDir := filepath.Join(t.TempDir(), "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeDevIntegrationApp(t, appDir, repositoryRoot, "initial")
+
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOFLAGS", "-mod=mod")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builds := make(chan devBuildEvent, 32)
+	serverURLs := make(chan string, 2)
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{
+			appDir:    appDir,
+			compiler:  "go",
+			workspace: workspace,
+			port:      0,
+		}, dependencies)
+	}()
+
+	initial := waitDevEvent(t, builds)
+	assertDevEvent(t, initial, 1, true, false)
+	serverURL := waitDevServerURL(t, serverURLs)
+	assertDevHTTPContains(t, serverURL+"/", "GoFrame dev integration")
+	assertDevHTTPHeader(t, serverURL+"/", "Cache-Control", "no-store")
+	initialMetadata := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
+	if got := decodeDevPackageMetadata(t, initialMetadata).Name; got != "initial" {
+		t.Fatalf("initial package name = %q, want initial", got)
+	}
+
+	writeDevIntegrationGOX(t, appDir, "GOX rebuild")
+	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+
+	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"Go rebuild\" }\n")
+	assertDevEvent(t, waitDevEvent(t, builds), 3, false, false)
+
+	writeTestFile(t, appDir, "assets/message.txt", "asset rebuild")
+	assertDevEvent(t, waitDevEvent(t, builds), 4, false, false)
+	assertDevHTTPBody(t, serverURL+"/assets/message.txt", "asset rebuild")
+
+	writeTestFile(t, appDir, manifestName, `{"name":"renamed","compiler":"tinygo","assets":"assets"}`)
+	assertDevEvent(t, waitDevEvent(t, builds), 5, false, false)
+	metadataBeforeFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
+	metadata := decodeDevPackageMetadata(t, metadataBeforeFailure)
+	if metadata.Name != "renamed" || metadata.Compiler != "go" {
+		t.Fatalf("manifest rebuild metadata = %+v, want renamed package with fixed Go override", metadata)
+	}
+
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main><p>broken</main>
+}
+`)
+	failed := waitDevEvent(t, builds)
+	assertDevEvent(t, failed, 6, false, true)
+	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeFailure {
+		t.Fatalf("failed build replaced package metadata:\nold=%s\nnew=%s", metadataBeforeFailure, got)
+	}
+	assertDevHTTPBody(t, serverURL+"/assets/message.txt", "asset rebuild")
+
+	writeDevIntegrationGOX(t, appDir, "recovered")
+	assertDevEvent(t, waitDevEvent(t, builds), 7, false, false)
+	metadataBeforeGoFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
+
+	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return missingSymbol }\n")
+	assertDevEvent(t, waitDevEvent(t, builds), 8, false, true)
+	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeGoFailure {
+		t.Fatalf("Go compiler failure replaced package metadata:\nold=%s\nnew=%s", metadataBeforeGoFailure, got)
+	}
+	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"Go recovered\" }\n")
+	assertDevEvent(t, waitDevEvent(t, builds), 9, false, false)
+	metadataBeforeManifestFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
+
+	writeTestFile(t, appDir, manifestName, `{"name":`)
+	assertDevEvent(t, waitDevEvent(t, builds), 10, false, true)
+	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeManifestFailure {
+		t.Fatalf("manifest failure replaced package metadata:\nold=%s\nnew=%s", metadataBeforeManifestFailure, got)
+	}
+	writeTestFile(t, appDir, manifestName, `{"name":"renamed","compiler":"tinygo","assets":"assets"}`)
+	assertDevEvent(t, waitDevEvent(t, builds), 11, false, false)
+
+	for _, value := range []string{"burst one", "burst two", "burst final"} {
+		writeTestFile(t, appDir, "message.go", fmt.Sprintf("package main\n\nfunc message() string { return %q }\n", value))
+		time.Sleep(8 * time.Millisecond)
+	}
+	burst := waitDevEvent(t, builds)
+	assertDevEvent(t, burst, 12, false, false)
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+
+	writeTestFile(t, appDir, ".goframe/ignored.go", "package ignored\n")
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+	writeTestFile(t, workspace, "tool-output.txt", "ignored\n")
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatalf("runDev() shutdown error: %v", err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
+
+func TestDevInitialFailureRecoversBeforeServerStarts(t *testing.T) {
+	repositoryRoot, ok := findRepositoryRoot(".")
+	if !ok {
+		t.Fatal("repository root not found")
+	}
+	appDir := filepath.Join(t.TempDir(), "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeDevIntegrationApp(t, appDir, repositoryRoot, "initial-failure")
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main><p>broken</main>
+}
+`)
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOFLAGS", "-mod=mod")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builds := make(chan devBuildEvent, 8)
+	serverURLs := make(chan string, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{
+			appDir:    appDir,
+			workspace: workspace,
+			port:      0,
+		}, devIntegrationDependencies(builds, serverURLs))
+	}()
+
+	failed := waitDevEvent(t, builds)
+	assertDevEvent(t, failed, 1, true, true)
+	select {
+	case url := <-serverURLs:
+		t.Fatalf("server started after failed initial package: %s", url)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	writeDevIntegrationGOX(t, appDir, "fixed initial source")
+	recovered := waitDevEvent(t, builds)
+	assertDevEvent(t, recovered, 2, false, false)
+	serverURL := waitDevServerURL(t, serverURLs)
+	assertDevHTTPContains(t, serverURL+"/", "GoFrame dev integration")
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatal(err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
+
+func devIntegrationDependencies(builds chan<- devBuildEvent, serverURLs chan<- string) devDependencies {
+	dependencies := defaultDevDependencies()
+	dependencies.pollInterval = devIntegrationPoll
+	dependencies.debounce = devIntegrationDebounce
+	dependencies.stdout = io.Discard
+	dependencies.stderr = io.Discard
+	dependencies.hooks.BuildFinished = func(event devBuildEvent) {
+		builds <- event
+	}
+	dependencies.hooks.ServerStarted = func(url string) {
+		serverURLs <- url
+	}
+	return dependencies
+}
+
+func writeDevIntegrationApp(t *testing.T, appDir, repositoryRoot, name string) {
+	t.Helper()
+	writeTestFile(t, appDir, "go.mod", fmt.Sprintf(`module example.com/devapp
+
+go 1.22
+
+require %s v0.0.0
+
+replace %s => %s
+`, canonicalModulePath, canonicalModulePath, filepath.ToSlash(repositoryRoot)))
+	writeTestFile(t, appDir, manifestName, fmt.Sprintf(`{"name":%q,"compiler":"go","assets":"assets"}`, name))
+	writeTestFile(t, appDir, "main.go", `//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}
+`)
+	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"initial\" }\n")
+	writeDevIntegrationGOX(t, appDir, "initial")
+	writeTestFile(t, appDir, "assets/index.html", `<!doctype html>
+<html><body><div id="root">GoFrame dev integration</div><script src="wasm_exec.js"></script><script>fetch("bundle.wasm")</script></body></html>
+`)
+	writeTestFile(t, appDir, "assets/message.txt", "initial asset")
+}
+
+func writeDevIntegrationGOX(t *testing.T, appDir, label string) {
+	t.Helper()
+	writeTestFile(t, appDir, "app.gox", fmt.Sprintf(`package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main><h1>%s</h1><p>{message()}</p></main>
+}
+`, label))
+}
+
+func waitDevEvent(t *testing.T, builds <-chan devBuildEvent) devBuildEvent {
+	t.Helper()
+	select {
+	case event := <-builds:
+		return event
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out waiting for real development build")
+		return devBuildEvent{}
+	}
+}
+
+func assertDevEvent(t *testing.T, event devBuildEvent, number int, initial, wantFailure bool) {
+	t.Helper()
+	if event.Request.Number != number || event.Request.Initial != initial {
+		t.Fatalf("build event = %+v, want number=%d initial=%v", event.Request, number, initial)
+	}
+	if wantFailure && event.Err == nil {
+		t.Fatalf("build %d succeeded, want failure", number)
+	}
+	if !wantFailure && event.Err != nil {
+		t.Fatalf("build %d failed: %v", number, event.Err)
+	}
+}
+
+func assertNoDevEvent(t *testing.T, builds <-chan devBuildEvent, duration time.Duration) {
+	t.Helper()
+	select {
+	case event := <-builds:
+		t.Fatalf("unexpected development build event: %+v", event)
+	case <-time.After(duration):
+	}
+}
+
+func waitDevServerURL(t *testing.T, urls <-chan string) string {
+	t.Helper()
+	select {
+	case url := <-urls:
+		return url
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for development server URL")
+		return ""
+	}
+}
+
+func readDevHTTPBody(t *testing.T, url string) string {
+	t.Helper()
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer response.Body.Close()
+	content, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d, body=%q", url, response.StatusCode, content)
+	}
+	return string(content)
+}
+
+func assertDevHTTPBody(t *testing.T, url, want string) {
+	t.Helper()
+	if got := readDevHTTPBody(t, url); got != want {
+		t.Fatalf("GET %s body = %q, want %q", url, got, want)
+	}
+}
+
+func assertDevHTTPContains(t *testing.T, url, want string) {
+	t.Helper()
+	if got := readDevHTTPBody(t, url); !strings.Contains(got, want) {
+		t.Fatalf("GET %s body does not contain %q: %q", url, want, got)
+	}
+}
+
+func assertDevHTTPHeader(t *testing.T, url, name, want string) {
+	t.Helper()
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if got := response.Header.Get(name); got != want {
+		t.Fatalf("GET %s %s = %q, want %q", url, name, got, want)
+	}
+}
+
+func decodeDevPackageMetadata(t *testing.T, content string) packageMetadata {
+	t.Helper()
+	var metadata packageMetadata
+	if err := json.Unmarshal([]byte(content), &metadata); err != nil {
+		t.Fatalf("decode package metadata: %v\n%s", err, content)
+	}
+	return metadata
+}
+
+func waitDevRun(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for development command shutdown")
+		return nil
+	}
+}
+
+func waitDevListenerClosed(t *testing.T, serverURL string) {
+	t.Helper()
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		response, err := client.Get(serverURL + "/")
+		if err != nil {
+			return
+		}
+		response.Body.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("development listener at %s remained open after shutdown", serverURL)
+}

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -1,0 +1,594 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDevOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want devOptions
+	}{
+		{
+			name: "defaults",
+			args: []string{"app"},
+			want: devOptions{appDir: "app", port: 8080},
+		},
+		{
+			name: "equals forms",
+			args: []string{"--compiler=tinygo", "--port=0", "--workspace=work", "app"},
+			want: devOptions{appDir: "app", compiler: "tinygo", port: 0, workspace: "work"},
+		},
+		{
+			name: "separate forms",
+			args: []string{"app", "--compiler", "go", "--port", "3210", "--workspace", "work"},
+			want: devOptions{appDir: "app", compiler: "go", port: 3210, workspace: "work"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseDevOptions(test.args)
+			if err != nil {
+				t.Fatalf("parseDevOptions() error: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("options = %+v, want %+v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDevOptionsRejectInvalidArguments(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing app", want: "usage: goxc dev"},
+		{name: "missing compiler", args: []string{"app", "--compiler"}, want: "--compiler requires a value"},
+		{name: "invalid compiler", args: []string{"app", "--compiler=other"}, want: "use go or tinygo"},
+		{name: "missing port", args: []string{"app", "--port"}, want: "--port requires a value"},
+		{name: "invalid port", args: []string{"app", "--port=nope"}, want: "invalid port"},
+		{name: "negative port", args: []string{"app", "--port=-1"}, want: "between 0 and 65535"},
+		{name: "large port", args: []string{"app", "--port=65536"}, want: "between 0 and 65535"},
+		{name: "missing workspace", args: []string{"app", "--workspace"}, want: "--workspace requires a value"},
+		{name: "unknown flag", args: []string{"app", "--reload"}, want: "unknown dev flag"},
+		{name: "second app", args: []string{"app", "other"}, want: "unexpected dev argument"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseDevOptions(test.args)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("parseDevOptions(%#v) error = %v, want %q", test.args, err, test.want)
+			}
+		})
+	}
+}
+
+func TestDevAppearsInTopLevelUsage(t *testing.T) {
+	var output bytes.Buffer
+	usage(&output)
+	if !strings.Contains(output.String(), "dev <app>") {
+		t.Fatalf("top-level usage does not list dev:\n%s", output.String())
+	}
+}
+
+func TestDevHelpUsage(t *testing.T) {
+	if !commandHelpRequested([]string{"--help"}) {
+		t.Fatal("dev --help was not recognized as a help request")
+	}
+	var output bytes.Buffer
+	commandUsage(&output, "dev")
+	if !strings.Contains(output.String(), "goxc dev <app-directory> [--compiler=go|tinygo] [--port=8080] [--workspace=directory]") {
+		t.Fatalf("dev help does not contain the command contract:\n%s", output.String())
+	}
+}
+
+func TestDevSnapshotIncludesAuthoredAssetsAndModuleInputs(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, root, "go.mod", "module example.com/dev\n\ngo 1.22\n")
+	writeTestFile(t, root, "go.sum", "example.com/dependency v1.0.0 h1:test\n")
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "app.gox", "package main\nfunc App() any { return nil }\n")
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, "app.gox.go", "generated\n")
+	writeTestFile(t, appDir, "assets/index.html", "<div id=\"root\"></div>")
+	writeTestFile(t, appDir, "assets/styles.css", "body{}")
+	for _, relative := range []string{
+		".goframe/ignored.go",
+		"build/ignored.go",
+		"dist/ignored.gox",
+		"node_modules/ignored.go",
+		".git/ignored.go",
+		".goxc-tmp/ignored.gox",
+	} {
+		writeTestFile(t, appDir, relative, "package ignored\n")
+	}
+
+	collector := newDevSnapshotCollector(appDir)
+	snapshot, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() error: %v", err)
+	}
+	for _, want := range []string{
+		"../go.mod",
+		"../go.sum",
+		"app.gox",
+		"assets/",
+		"assets/index.html",
+		"assets/styles.css",
+		manifestName,
+		"main.go",
+	} {
+		if _, ok := snapshot.files[want]; !ok {
+			t.Errorf("snapshot missing %q: %#v", want, snapshot.paths())
+		}
+	}
+	for _, excluded := range []string{
+		"app.gox.go",
+		".goframe/ignored.go",
+		"build/ignored.go",
+		"dist/ignored.gox",
+		"node_modules/ignored.go",
+		".git/ignored.go",
+		".goxc-tmp/ignored.gox",
+	} {
+		if _, ok := snapshot.files[excluded]; ok {
+			t.Errorf("snapshot includes excluded %q", excluded)
+		}
+	}
+	paths := snapshot.paths()
+	if !sort.StringsAreSorted(paths) {
+		t.Fatalf("snapshot paths are not sorted: %#v", paths)
+	}
+}
+
+func TestDevSnapshotDetectsAssetAndModuleChanges(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, root, "go.mod", "module example.com/dev\n\ngo 1.22\n")
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, "assets/index.html", "first")
+	collector := newDevSnapshotCollector(appDir)
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, "assets/nested/data.txt", "new")
+	created, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDevChangedPath(t, initial, created, "assets/nested/data.txt")
+
+	if err := os.Remove(filepath.Join(appDir, "assets", "nested", "data.txt")); err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDevChangedPath(t, created, deleted, "assets/nested/data.txt")
+
+	writeTestFile(t, root, "go.sum", "module sum\n")
+	withSum, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDevChangedPath(t, deleted, withSum, "../go.sum")
+	if err := os.Remove(filepath.Join(root, "go.sum")); err != nil {
+		t.Fatal(err)
+	}
+	withoutSum, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDevChangedPath(t, withSum, withoutSum, "../go.sum")
+
+	writeTestFile(t, root, "go.mod", "module example.com/dev\n\ngo 1.23\n")
+	withUpdatedModule, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDevChangedPath(t, withoutSum, withUpdatedModule, "../go.mod")
+}
+
+func TestDevSnapshotUsesLastAssetsDuringMalformedManifest(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, "assets/styles.css", "first")
+	collector := newDevSnapshotCollector(appDir)
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatalf("initial collect() error: %v", err)
+	}
+	writeTestFile(t, appDir, manifestName, `{"compiler":`)
+	writeTestFile(t, appDir, "assets/styles.css", "second")
+	broken, err := collector.collect()
+	if err == nil || !strings.Contains(err.Error(), "parse goframe.json") {
+		t.Fatalf("malformed collect error = %v", err)
+	}
+	if _, ok := broken.files["assets/styles.css"]; !ok {
+		t.Fatalf("malformed-manifest snapshot lost last asset set: %#v", broken.paths())
+	}
+	assertDevChangedPath(t, initial, broken, "assets/styles.css")
+
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "assets/new.txt", "recovered")
+	recovered, err := collector.collect()
+	if err != nil {
+		t.Fatalf("recovered collect() error: %v", err)
+	}
+	if _, ok := recovered.files["assets/new.txt"]; !ok {
+		t.Fatalf("recovered snapshot missing new asset: %#v", recovered.paths())
+	}
+}
+
+func TestDevSnapshotRejectsSymlinksWithoutTraversal(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	external := filepath.Join(root, "external.css")
+	writeTestFile(t, root, "external.css", "secret")
+	if err := os.MkdirAll(filepath.Join(appDir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(appDir, "assets", "styles.css")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := newDevSnapshotCollector(appDir).collect()
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("collect() error = %v, want symlink rejection", err)
+	}
+	assertFileContent(t, external, "secret")
+}
+
+func TestDevStaticHandlerAddsNoStore(t *testing.T) {
+	directory := t.TempDir()
+	writeServeFixture(t, directory, "index.html", "dev")
+	response := httptest.NewRecorder()
+	devStaticHandler(directory).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	if response.Code != http.StatusOK || response.Body.String() != "dev" {
+		t.Fatalf("response = %d %q", response.Code, response.Body.String())
+	}
+	if got := response.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestDevCoordinatorDebouncesAndCoalescesBurst(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	builds := make(chan devBuildRequest, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 40*time.Millisecond, nil)
+	initial := waitDevBuild(t, builds)
+	if !initial.Initial || initial.Number != 1 {
+		t.Fatalf("initial request = %+v", initial)
+	}
+
+	scanner.set(devTestSnapshot("app.gox", "two"), nil)
+	time.Sleep(8 * time.Millisecond)
+	scanner.set(devTestSnapshot("app.gox", "three"), nil)
+	time.Sleep(8 * time.Millisecond)
+	scanner.set(devTestSnapshot("app.gox", "four"), nil)
+	rebuild := waitDevBuild(t, builds)
+	if rebuild.Initial || rebuild.Number != 2 || strings.Join(rebuild.Changed, ",") != "app.gox" {
+		t.Fatalf("rebuild request = %+v", rebuild)
+	}
+	assertNoDevBuild(t, builds, 100*time.Millisecond)
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatalf("coordinator error: %v", err)
+	}
+}
+
+func TestDevCoordinatorSerializesAndQueuesOneFollowUp(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	builds := make(chan devBuildRequest, 8)
+	releaseSecond := make(chan struct{})
+	var active atomic.Int32
+	var maximum atomic.Int32
+	build := func(request devBuildRequest) error {
+		current := active.Add(1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		builds <- request
+		if request.Number == 2 {
+			<-releaseSecond
+		}
+		active.Add(-1)
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, build, 3*time.Millisecond, 20*time.Millisecond, nil)
+	waitDevBuild(t, builds)
+	scanner.set(devTestSnapshot("app.gox", "two"), nil)
+	second := waitDevBuild(t, builds)
+	if second.Number != 2 {
+		t.Fatalf("second request = %+v", second)
+	}
+	scanner.set(devTestSnapshot("app.gox", "three"), nil)
+	time.Sleep(10 * time.Millisecond)
+	scanner.set(devTestSnapshot("app.gox", "four"), nil)
+	close(releaseSecond)
+	third := waitDevBuild(t, builds)
+	if third.Number != 3 || strings.Join(third.Changed, ",") != "app.gox" {
+		t.Fatalf("follow-up request = %+v", third)
+	}
+	assertNoDevBuild(t, builds, 80*time.Millisecond)
+	if got := maximum.Load(); got != 1 {
+		t.Fatalf("maximum concurrent builds = %d, want 1", got)
+	}
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevCoordinatorFailureWaitsForAnotherChange(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	builds := make(chan devBuildRequest, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		if request.Number == 2 {
+			return errors.New("authored source failed")
+		}
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+	waitDevBuild(t, builds)
+	scanner.set(devTestSnapshot("app.gox", "broken"), nil)
+	failed := waitDevBuild(t, builds)
+	if failed.Number != 2 {
+		t.Fatalf("failed request = %+v", failed)
+	}
+	assertNoDevBuild(t, builds, 80*time.Millisecond)
+	scanner.set(devTestSnapshot("app.gox", "fixed"), nil)
+	recovered := waitDevBuild(t, builds)
+	if recovered.Number != 3 {
+		t.Fatalf("recovery request = %+v", recovered)
+	}
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevCoordinatorCancellationDuringBuildStartsNoFollowUp(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	builds := make(chan devBuildRequest, 8)
+	release := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		if request.Number == 2 {
+			<-release
+		}
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+	waitDevBuild(t, builds)
+	scanner.set(devTestSnapshot("app.gox", "two"), nil)
+	waitDevBuild(t, builds)
+	scanner.set(devTestSnapshot("app.gox", "three"), nil)
+	cancel()
+	close(release)
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+}
+
+func TestDevCoordinatorCancellationDuringIdleStops(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	builds := make(chan devBuildRequest, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+	waitDevBuild(t, builds)
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+}
+
+func TestDevCoordinatorSuppressesRepeatedScanErrors(t *testing.T) {
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	scanner.set(devTestSnapshot("app.gox", "one"), errors.New("unreadable watched input"))
+	builds := make(chan devBuildRequest, 8)
+	var stderr bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, &stderr)
+	waitDevBuild(t, builds)
+	time.Sleep(40 * time.Millisecond)
+	if got := strings.Count(stderr.String(), "dev watch error:"); got != 1 {
+		t.Fatalf("watch error count = %d, output:\n%s", got, stderr.String())
+	}
+	scanner.set(devTestSnapshot("app.gox", "one"), nil)
+	waitDevBuild(t, builds)
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(stderr.String(), "dev watch recovered"); got != 1 {
+		t.Fatalf("watch recovery count = %d, output:\n%s", got, stderr.String())
+	}
+}
+
+func TestDevRunTreatsListenerFailureAsFatal(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	packageCalls := 0
+	dependencies := defaultDevDependencies()
+	dependencies.stdout = &bytes.Buffer{}
+	dependencies.stderr = &bytes.Buffer{}
+	dependencies.packageApp = func(options packageOptions) error {
+		packageCalls++
+		layout, err := newBuildLayout(layoutOptions{appDir: options.appDir, compiler: "go", workspace: options.workspace})
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(layout.PackageDir, 0o755); err != nil {
+			return err
+		}
+		writeCompleteCurrentPackage(t, layout.PackageDir)
+		return nil
+	}
+	dependencies.listen = func(string, string) (net.Listener, error) {
+		return nil, errors.New("address unavailable")
+	}
+	err := runDev(context.Background(), devOptions{appDir: appDir, port: 0}, dependencies)
+	if err == nil || !strings.Contains(err.Error(), "start development server") {
+		t.Fatalf("runDev() error = %v, want listener failure", err)
+	}
+	if packageCalls != 1 {
+		t.Fatalf("package calls = %d, want 1", packageCalls)
+	}
+}
+
+func assertDevChangedPath(t *testing.T, previous, current devSnapshot, want string) {
+	t.Helper()
+	for _, path := range diffDevSnapshots(previous, current) {
+		if path == want {
+			return
+		}
+	}
+	t.Fatalf("changed paths = %#v, want %q", diffDevSnapshots(previous, current), want)
+}
+
+type fakeDevScanner struct {
+	mu       sync.Mutex
+	snapshot devSnapshot
+	err      error
+}
+
+func newFakeDevScanner(snapshot devSnapshot) *fakeDevScanner {
+	return &fakeDevScanner{snapshot: snapshot}
+}
+
+func (scanner *fakeDevScanner) set(snapshot devSnapshot, err error) {
+	scanner.mu.Lock()
+	defer scanner.mu.Unlock()
+	scanner.snapshot = snapshot
+	scanner.err = err
+}
+
+func (scanner *fakeDevScanner) scan() (devSnapshot, error) {
+	scanner.mu.Lock()
+	defer scanner.mu.Unlock()
+	copy := newDevSnapshot()
+	for path, fingerprint := range scanner.snapshot.files {
+		copy.files[path] = fingerprint
+	}
+	return copy, scanner.err
+}
+
+func devTestSnapshot(values ...string) devSnapshot {
+	if len(values)%2 != 0 {
+		panic("devTestSnapshot requires path/fingerprint pairs")
+	}
+	snapshot := newDevSnapshot()
+	for index := 0; index < len(values); index += 2 {
+		snapshot.files[values[index]] = values[index+1]
+	}
+	return snapshot
+}
+
+func startDevCoordinator(
+	t *testing.T,
+	ctx context.Context,
+	scan func() (devSnapshot, error),
+	build func(devBuildRequest) error,
+	pollInterval time.Duration,
+	debounce time.Duration,
+	stderr *bytes.Buffer,
+) <-chan error {
+	t.Helper()
+	if stderr == nil {
+		stderr = &bytes.Buffer{}
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- runDevCoordinator(ctx, devCoordinatorConfig{
+			scan:         scan,
+			build:        build,
+			pollInterval: pollInterval,
+			debounce:     debounce,
+			stdout:       &bytes.Buffer{},
+			stderr:       stderr,
+		})
+	}()
+	return done
+}
+
+func waitDevBuild(t *testing.T, builds <-chan devBuildRequest) devBuildRequest {
+	t.Helper()
+	select {
+	case request := <-builds:
+		return request
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for development build")
+		return devBuildRequest{}
+	}
+}
+
+func assertNoDevBuild(t *testing.T, builds <-chan devBuildRequest, duration time.Duration) {
+	t.Helper()
+	select {
+	case request := <-builds:
+		t.Fatalf("unexpected development build: %+v", request)
+	case <-time.After(duration):
+	}
+}
+
+func waitDevDone(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for development coordinator shutdown")
+		return nil
+	}
+}
+
+func Example_parseDevOptions() {
+	options, _ := parseDevOptions([]string{"app", "--port=0"})
+	fmt.Println(options.appDir, options.port)
+	// Output: app 0
+}

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -531,6 +531,139 @@ func TestDevStaticHandlerAddsNoStore(t *testing.T) {
 	}
 }
 
+func TestDevInitialWatchBuildableErrorStartsInitialBuild(t *testing.T) {
+	broken := devTestSnapshot(manifestName, "broken")
+	scanner := newFakeDevScanner(broken)
+	scanner.set(broken, devBuildableScanError{err: errors.New("parse goframe.json")})
+	builds := make(chan devBuildRequest, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+
+	assertInitialDevBuild(t, waitDevBuild(t, builds))
+	scanner.set(devTestSnapshot(manifestName, "fixed"), nil)
+	recovered := waitDevBuild(t, builds)
+	if recovered.Number != 2 || recovered.Initial {
+		t.Fatalf("recovery request = %+v, want build 2 with Initial=false", recovered)
+	}
+
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevInitialWatchBlockedUntilHealthy(t *testing.T) {
+	blocked := errors.New("unsafe watched module input")
+	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
+	scanner.set(devTestSnapshot("app.gox", "one"), blocked)
+	builds := make(chan devBuildRequest, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	assertDevCoordinatorRunning(t, done)
+	scanner.set(devTestSnapshot("app.gox", "two"), blocked)
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	assertDevCoordinatorRunning(t, done)
+
+	scanner.set(devTestSnapshot("app.gox", "two"), nil)
+	assertInitialDevBuild(t, waitDevBuild(t, builds))
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevInitialWatchBlockedToBuildableStartsInitialBuild(t *testing.T) {
+	snapshot := devTestSnapshot(manifestName, "same")
+	scanner := newFakeDevScanner(snapshot)
+	scanner.set(snapshot, errors.New("unsafe watched manifest path"))
+	builds := make(chan devBuildRequest, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	scanner.set(snapshot, devBuildableScanError{err: errors.New("parse goframe.json")})
+	assertInitialDevBuild(t, waitDevBuild(t, builds))
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevInitialWatchCancellationBeforeBuild(t *testing.T) {
+	snapshot := devTestSnapshot("app.gox", "one")
+	scanner := newFakeDevScanner(snapshot)
+	scanner.set(snapshot, errors.New("unsafe watched module input"))
+	builds := make(chan devBuildRequest, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, scanner.scan, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+	assertNoDevBuild(t, builds, 30*time.Millisecond)
+}
+
+func TestDevInitialWatchSymlinkedModuleBlocksBuild(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	moduleRoot := filepath.Join(root, "module-root")
+	appDir := filepath.Join(moduleRoot, "app")
+	writeTestFile(t, moduleRoot, "go.mod.target", "module example.com/dev\n\ngo 1.22\n")
+	if err := os.Symlink("go.mod.target", filepath.Join(moduleRoot, "go.mod")); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	collector := newDevSnapshotCollector(appDir)
+
+	_, scanErr := collector.collect()
+	if scanErr == nil || !strings.Contains(scanErr.Error(), "symlink") {
+		t.Fatalf("initial collect() error = %v, want symlink rejection", scanErr)
+	}
+	var buildable devBuildableScanError
+	if errors.As(scanErr, &buildable) {
+		t.Fatalf("symlinked module error is buildable: %v", scanErr)
+	}
+
+	builds := make(chan devBuildRequest, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := startDevCoordinator(t, ctx, collector.collect, func(request devBuildRequest) error {
+		builds <- request
+		return nil
+	}, 3*time.Millisecond, 20*time.Millisecond, nil)
+
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar changedWhileBlocked = true\n")
+	assertNoDevBuild(t, builds, 40*time.Millisecond)
+	assertDevCoordinatorRunning(t, done)
+
+	if err := os.Remove(filepath.Join(moduleRoot, "go.mod")); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, moduleRoot, "go.mod", "module example.com/dev\n\ngo 1.22\n")
+	assertInitialDevBuild(t, waitDevBuild(t, builds))
+	cancel()
+	if err := waitDevDone(t, done); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDevCoordinatorDebouncesAndCoalescesBurst(t *testing.T) {
 	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
 	builds := make(chan devBuildRequest, 8)
@@ -678,7 +811,6 @@ func TestDevCoordinatorCancellationDuringIdleStops(t *testing.T) {
 
 func TestDevCoordinatorSuppressesRepeatedScanErrors(t *testing.T) {
 	scanner := newFakeDevScanner(devTestSnapshot("app.gox", "one"))
-	scanner.set(devTestSnapshot("app.gox", "one"), errors.New("unreadable watched input"))
 	builds := make(chan devBuildRequest, 8)
 	var stderr bytes.Buffer
 	ctx, cancel := context.WithCancel(context.Background())
@@ -687,18 +819,20 @@ func TestDevCoordinatorSuppressesRepeatedScanErrors(t *testing.T) {
 		return nil
 	}, 3*time.Millisecond, 20*time.Millisecond, &stderr)
 	waitDevBuild(t, builds)
+	scanner.set(devTestSnapshot("app.gox", "one"), errors.New("unreadable watched input"))
 	time.Sleep(40 * time.Millisecond)
-	if got := strings.Count(stderr.String(), "dev watch error:"); got != 1 {
-		t.Fatalf("watch error count = %d, output:\n%s", got, stderr.String())
-	}
 	scanner.set(devTestSnapshot("app.gox", "one"), nil)
 	waitDevBuild(t, builds)
 	cancel()
 	if err := waitDevDone(t, done); err != nil {
 		t.Fatal(err)
 	}
-	if got := strings.Count(stderr.String(), "dev watch recovered"); got != 1 {
-		t.Fatalf("watch recovery count = %d, output:\n%s", got, stderr.String())
+	output := stderr.String()
+	if got := strings.Count(output, "dev watch error:"); got != 1 {
+		t.Fatalf("watch error count = %d, output:\n%s", got, output)
+	}
+	if got := strings.Count(output, "dev watch recovered"); got != 1 {
+		t.Fatalf("watch recovery count = %d, output:\n%s", got, output)
 	}
 }
 
@@ -754,6 +888,22 @@ func assertDevBuildableScanError(t *testing.T, err error, contains ...string) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("collect() error = %v, want %q", err, want)
 		}
+	}
+}
+
+func assertInitialDevBuild(t *testing.T, request devBuildRequest) {
+	t.Helper()
+	if request.Number != 1 || !request.Initial || len(request.Changed) != 0 {
+		t.Fatalf("initial request = %+v, want build 1 with Initial=true and no changed paths", request)
+	}
+}
+
+func assertDevCoordinatorRunning(t *testing.T, done <-chan error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		t.Fatalf("development coordinator exited while watch was blocked: %v", err)
+	default:
 	}
 }
 

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -352,6 +352,150 @@ func TestDevSnapshotUsesLastAssetsDuringMalformedManifest(t *testing.T) {
 	}
 }
 
+func TestDevSnapshotRetainedAssetFileRejectsIntermediateSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	assetPath := ".site/static/styles.css"
+	manifest := `{"compiler":"go","assets":[".site/static/styles.css"]}`
+	writeTestFile(t, appDir, manifestName, manifest)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, assetPath, "local first")
+	collector := newDevSnapshotCollector(appDir)
+
+	healthy, err := collector.collect()
+	if err != nil {
+		t.Fatalf("initial collect() error: %v", err)
+	}
+	if _, ok := healthy.files[assetPath]; !ok {
+		t.Fatalf("initial snapshot missing retained asset file: %#v", healthy.paths())
+	}
+
+	writeTestFile(t, appDir, manifestName, `{"compiler":`)
+	staticPath := filepath.Join(appDir, ".site", "static")
+	if err := os.RemoveAll(staticPath); err != nil {
+		t.Fatal(err)
+	}
+	externalDir := filepath.Join(root, "external-file-assets")
+	writeTestFile(t, externalDir, "styles.css", "external first")
+	if err := os.Symlink(externalDir, staticPath); err != nil {
+		t.Fatal(err)
+	}
+
+	unsafeSnapshot, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json", "symlink")
+	if _, ok := unsafeSnapshot.files[assetPath]; ok {
+		t.Fatalf("external retained asset file was fingerprinted: %#v", unsafeSnapshot.files)
+	}
+	unsafeError := err.Error()
+
+	writeTestFile(t, externalDir, "styles.css", "external second")
+	changedExternal, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json", "symlink")
+	if err.Error() != unsafeError {
+		t.Fatalf("repeated retained-file error changed:\nfirst:  %s\nsecond: %s", unsafeError, err)
+	}
+	if !devSnapshotsEqual(unsafeSnapshot, changedExternal) {
+		t.Fatalf("external file content changed safe snapshot: %#v", diffDevSnapshots(unsafeSnapshot, changedExternal))
+	}
+
+	if err := os.Remove(staticPath); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, assetPath, "local restored")
+	retained, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json")
+	if strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("restored retained-file error still reports symlink: %v", err)
+	}
+	if _, ok := retained.files[assetPath]; !ok {
+		t.Fatalf("restored retained asset file missing: %#v", retained.paths())
+	}
+
+	writeTestFile(t, appDir, manifestName, manifest)
+	recovered, err := collector.collect()
+	if err != nil {
+		t.Fatalf("recovered collect() error: %v", err)
+	}
+	if _, ok := recovered.files[assetPath]; !ok {
+		t.Fatalf("recovered snapshot missing local asset file: %#v", recovered.paths())
+	}
+}
+
+func TestDevSnapshotRetainedAssetDirectoryRejectsIntermediateSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	assetDirectory := ".site/static/public"
+	assetPath := assetDirectory + "/data.txt"
+	manifest := `{"compiler":"go","assets":".site/static/public"}`
+	writeTestFile(t, appDir, manifestName, manifest)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, assetPath, "local first")
+	collector := newDevSnapshotCollector(appDir)
+
+	healthy, err := collector.collect()
+	if err != nil {
+		t.Fatalf("initial collect() error: %v", err)
+	}
+	if _, ok := healthy.files[assetPath]; !ok {
+		t.Fatalf("initial snapshot missing retained directory asset: %#v", healthy.paths())
+	}
+
+	writeTestFile(t, appDir, manifestName, `{"compiler":`)
+	staticPath := filepath.Join(appDir, ".site", "static")
+	if err := os.RemoveAll(staticPath); err != nil {
+		t.Fatal(err)
+	}
+	externalDir := filepath.Join(root, "external-directory-assets")
+	writeTestFile(t, externalDir, "public/data.txt", "external first")
+	if err := os.Symlink(externalDir, staticPath); err != nil {
+		t.Fatal(err)
+	}
+
+	unsafeSnapshot, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json", "symlink")
+	if _, ok := unsafeSnapshot.files[assetDirectory+"/"]; ok {
+		t.Fatalf("external retained asset directory was traversed: %#v", unsafeSnapshot.files)
+	}
+	if _, ok := unsafeSnapshot.files[assetPath]; ok {
+		t.Fatalf("external retained directory asset was fingerprinted: %#v", unsafeSnapshot.files)
+	}
+	unsafeError := err.Error()
+
+	writeTestFile(t, externalDir, "public/data.txt", "external second")
+	changedExternal, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json", "symlink")
+	if err.Error() != unsafeError {
+		t.Fatalf("repeated retained-directory error changed:\nfirst:  %s\nsecond: %s", unsafeError, err)
+	}
+	if !devSnapshotsEqual(unsafeSnapshot, changedExternal) {
+		t.Fatalf("external directory content changed safe snapshot: %#v", diffDevSnapshots(unsafeSnapshot, changedExternal))
+	}
+
+	if err := os.Remove(staticPath); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, assetPath, "local restored")
+	retained, err := collector.collect()
+	assertDevBuildableScanError(t, err, "parse goframe.json")
+	if strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("restored retained-directory error still reports symlink: %v", err)
+	}
+	if _, ok := retained.files[assetPath]; !ok {
+		t.Fatalf("restored retained directory asset missing: %#v", retained.paths())
+	}
+
+	writeTestFile(t, appDir, manifestName, manifest)
+	recovered, err := collector.collect()
+	if err != nil {
+		t.Fatalf("recovered collect() error: %v", err)
+	}
+	if _, ok := recovered.files[assetPath]; !ok {
+		t.Fatalf("recovered snapshot missing local directory asset: %#v", recovered.paths())
+	}
+}
+
 func TestDevSnapshotRejectsSymlinksWithoutTraversal(t *testing.T) {
 	requireSymlinkSupport(t)
 	root := t.TempDir()
@@ -598,6 +742,19 @@ func assertDevChangedPath(t *testing.T, previous, current devSnapshot, want stri
 		}
 	}
 	t.Fatalf("changed paths = %#v, want %q", diffDevSnapshots(previous, current), want)
+}
+
+func assertDevBuildableScanError(t *testing.T, err error, contains ...string) {
+	t.Helper()
+	var buildable devBuildableScanError
+	if !errors.As(err, &buildable) {
+		t.Fatalf("collect() error = %v, want devBuildableScanError", err)
+	}
+	for _, want := range contains {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("collect() error = %v, want %q", err, want)
+		}
+	}
 }
 
 type fakeDevScanner struct {

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -210,6 +210,115 @@ func TestDevSnapshotDetectsAssetAndModuleChanges(t *testing.T) {
 	assertDevChangedPath(t, withoutSum, withUpdatedModule, "../go.mod")
 }
 
+func TestDevSnapshotAutoAssetsIgnoresNonDirectoryAndDetectsDirectoryTransitions(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, indexHTMLAssetName, "<main>fallback</main>")
+	writeTestFile(t, appDir, assetDirectoryName, "ignored first")
+	collector := newDevSnapshotCollector(appDir)
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatalf("initial collect() error: %v", err)
+	}
+	if got := initial.files[assetDirectoryName+"/"]; got != "missing" {
+		t.Fatalf("non-directory auto assets marker = %q, want missing", got)
+	}
+	if _, ok := initial.files[assetDirectoryName]; ok {
+		t.Fatalf("non-directory auto assets content was fingerprinted: %#v", initial.files)
+	}
+	if _, ok := initial.files[indexHTMLAssetName]; !ok {
+		t.Fatalf("fallback index missing from snapshot: %#v", initial.paths())
+	}
+
+	writeTestFile(t, appDir, assetDirectoryName, "ignored second")
+	withChangedIgnoredFile, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after ignored file change: %v", err)
+	}
+	if !devSnapshotsEqual(initial, withChangedIgnoredFile) {
+		t.Fatalf("ignored auto assets content changed snapshot paths: %#v", diffDevSnapshots(initial, withChangedIgnoredFile))
+	}
+
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar sourceChanged = true\n")
+	withSourceChange, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after source change: %v", err)
+	}
+	assertDevChangedPath(t, withChangedIgnoredFile, withSourceChange, "main.go")
+
+	if err := os.Remove(filepath.Join(appDir, assetDirectoryName)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(appDir, assetDirectoryName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withDirectory, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after directory transition: %v", err)
+	}
+	if got := withDirectory.files[assetDirectoryName+"/"]; got != "directory" {
+		t.Fatalf("auto assets directory marker = %q, want directory", got)
+	}
+	if _, ok := withDirectory.files[indexHTMLAssetName]; ok {
+		t.Fatalf("fallback index remained effective with assets directory: %#v", withDirectory.paths())
+	}
+	assertDevChangedPath(t, withSourceChange, withDirectory, assetDirectoryName+"/")
+
+	writeTestFile(t, appDir, "assets/styles.css", "body{}")
+	withDirectoryAsset, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after directory asset creation: %v", err)
+	}
+	if _, ok := withDirectoryAsset.files["assets/styles.css"]; !ok {
+		t.Fatalf("directory asset missing from snapshot: %#v", withDirectoryAsset.paths())
+	}
+	assertDevChangedPath(t, withDirectory, withDirectoryAsset, "assets/styles.css")
+
+	if err := os.RemoveAll(filepath.Join(appDir, assetDirectoryName)); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, assetDirectoryName, "ignored again")
+	withFallback, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after fallback transition: %v", err)
+	}
+	if got := withFallback.files[assetDirectoryName+"/"]; got != "missing" {
+		t.Fatalf("fallback auto assets marker = %q, want missing", got)
+	}
+	if _, ok := withFallback.files[indexHTMLAssetName]; !ok {
+		t.Fatalf("root index missing after fallback transition: %#v", withFallback.paths())
+	}
+	if _, ok := withFallback.files["assets/styles.css"]; ok {
+		t.Fatalf("removed directory asset remained in snapshot: %#v", withFallback.paths())
+	}
+	assertDevChangedPath(t, withDirectoryAsset, withFallback, assetDirectoryName+"/")
+
+	if err := os.Remove(filepath.Join(appDir, assetDirectoryName)); err != nil {
+		t.Fatal(err)
+	}
+	withMissingPath, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after removing ignored path: %v", err)
+	}
+	if !devSnapshotsEqual(withFallback, withMissingPath) {
+		t.Fatalf("missing and non-directory auto assets differ: %#v", diffDevSnapshots(withFallback, withMissingPath))
+	}
+}
+
+func TestDevSnapshotExplicitAssetDirectoryRejectsNonDirectory(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, assetDirectoryName, "not a directory")
+
+	_, err := newDevSnapshotCollector(appDir).collect()
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("collect() error = %v, want explicit asset-directory rejection", err)
+	}
+}
+
 func TestDevSnapshotUsesLastAssetsDuringMalformedManifest(t *testing.T) {
 	appDir := t.TempDir()
 	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)

--- a/cmd/goxc/main.go
+++ b/cmd/goxc/main.go
@@ -71,6 +71,12 @@ func main() {
 			return
 		}
 		err = serveCommand(os.Args[2:])
+	case "dev":
+		if commandHelpRequested(os.Args[2:]) {
+			commandUsage(os.Stdout, "dev")
+			return
+		}
+		err = devCommand(os.Args[2:])
 	case "clean":
 		if commandHelpRequested(os.Args[2:]) {
 			commandUsage(os.Stdout, "clean")
@@ -105,6 +111,7 @@ func usage(output io.Writer) {
 	fmt.Fprintln(output, "  export <app> --out    copy the latest standalone package to a deploy directory")
 	fmt.Fprintln(output, "  size <app-or-dir>     report artifact sizes")
 	fmt.Fprintln(output, "  serve [app]           serve a packaged application locally")
+	fmt.Fprintln(output, "  dev <app>             package, serve, and rebuild authored changes")
 	fmt.Fprintln(output, "  clean <app>           remove build and package artifacts")
 	fmt.Fprintln(output, "  doctor                inspect the local toolchain")
 	fmt.Fprintln(output, "  version               print goxc and compiler versions")
@@ -144,6 +151,9 @@ func commandUsage(output io.Writer, command string) {
 		fmt.Fprintln(output, "usage: goxc serve <app-directory> [--port=8080] [--workspace=directory]")
 		fmt.Fprintln(output, "       goxc serve --dir=directory [--port=8080]")
 		fmt.Fprintln(output, "serve a packaged application locally on 127.0.0.1")
+	case "dev":
+		fmt.Fprintln(output, "usage: goxc dev <app-directory> [--compiler=go|tinygo] [--port=8080] [--workspace=directory]")
+		fmt.Fprintln(output, "package, serve, and rebuild authored changes on 127.0.0.1")
 	case "size":
 		fmt.Fprintln(output, "usage: goxc size <app-directory-or-package-directory> [--workspace=directory]")
 		fmt.Fprintln(output, "report raw and compressed package artifact sizes")

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -39,6 +39,13 @@ namespace collisions, lexical and physical source/output overlap, partial
 publication metadata, custom/generated standalone `index.html` integrity,
 fail-closed legacy ownership, and dev-server symlink entries.
 
+The same Core `go test` gate covers the watched `goxc dev` workflow. Pure tests
+exercise option parsing, content snapshots, debounce, serialized coordination,
+failure recovery, and shutdown with injected dependencies. A focused integration
+test uses the real standard Go WASM package and static-server path in a temporary
+external application and workspace. Core CI does not claim a TinyGo dev-loop
+automation pass.
+
 ### WASM Size
 
 `.github/workflows/ci-wasm-size.yml` runs on pull requests, pushes to `main`,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -247,6 +247,8 @@ Default command outputs:
 - `goxc package <app>` writes standalone output to
   `.goframe/package/standalone`;
 - `goxc serve <app>` serves `.goframe/package/standalone`;
+- `goxc dev <app>` rebuilds and serves the latest completed development package
+  from `.goframe/package/standalone`;
 - `goxc size <app>` reads `.goframe/package/standalone`;
 - `goxc export <app> --out <dir>` copies the standalone package to an explicit
   deployment directory.
@@ -288,6 +290,27 @@ The materialized hidden workspace supports `"entry": "."` apps and child entry
 packages such as `"./cmd/app"`, `"cmd/app"`, `"./src/app"`, and `"app"` when
 they point to package directories inside the app root. GOX discovery remains
 app-root-wide so imported internal packages get generated files too.
+
+## Watched Local Development
+
+`goxc dev <app>` combines the existing development package path with a watched
+local server. It runs a full package after effective authored inputs change,
+keeps the last completed package available through ordinary source or compiler
+failures, and serves only the standalone package on `127.0.0.1`. Development
+responses use `Cache-Control: no-store`; a manual browser refresh loads the
+latest successful package.
+
+This differs from the explicit one-shot workflow:
+
+```bash
+goxc package <app> --compiler=tinygo
+goxc serve <app> --port=8080
+```
+
+`goxc dev` does not enable asset hashing, preload injection, gzip, or Brotli.
+Those release-oriented options remain explicit `goxc package` concerns, followed
+by `goxc export` when a visible deployment directory is needed. The development
+server is loopback-only and is not production hosting.
 
 ## Cache Policy
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,112 @@
+# Local Development Workflow
+
+`goxc dev` packages a browser/WASM application, serves the latest completed
+package, and rebuilds it when effective authored inputs change:
+
+```bash
+goxc dev <app-directory> [--compiler=go|tinygo] [--port=8080] [--workspace=directory]
+```
+
+goxc dev is a local development workflow, not production hosting.
+
+## Start And Serve
+
+The command validates the application and workspace roots, collects an initial
+input snapshot, and runs the existing development package path. The HTTP server
+starts only after a complete package has been published and verified. It binds
+to `127.0.0.1`; pass `--port=0` to select an available local port and read the
+actual URL from the command output.
+
+An initial authored-source, manifest, generation, or compilation failure is
+reported in the terminal without ending the process. The command continues
+watching and starts the server after a later correction produces the first
+complete package. Invalid command options, unsafe app or workspace roots, and a
+listener bind failure remain command errors.
+
+Development output uses the normal standalone package location:
+
+```text
+<app>/.goframe/package/standalone
+```
+
+With `--workspace`, the package is placed in the app-specific external
+workspace defined by the existing workspace contract. The source tree is not
+served.
+
+If `--compiler` is omitted, every accepted build uses the compiler currently
+selected by `goframe.json`. A command-line `--compiler=go` or
+`--compiler=tinygo` override remains fixed until the process exits.
+
+## Watched Inputs
+
+The development loop observes the effective inputs used by packaging:
+
+- authored `.gox` and `.go` files below the app root;
+- `goframe.json`;
+- the asset directory or asset files selected by the manifest;
+- file creation, modification, deletion, and rename inside a selected asset
+  directory;
+- the nearest effective `go.mod` and its corresponding `go.sum`.
+
+Snapshots use content fingerprints. Polling and quiet-period debounce are
+internal implementation details, not timing compatibility contracts. Accepted
+change batches run as serialized full package attempts. A change detected
+during a build queues one follow-up attempt, and an unchanged snapshot does not
+start another build.
+
+The watcher does not traverse tool-owned, dependency, VCS, or legacy output
+directories:
+
+```text
+.goframe/**
+build/**
+dist/**
+node_modules/**
+.git/**
+.goxc-tmp/**
+```
+
+Adjacent generated `*.gox.go` files are also ignored. Watched symlinks are not
+followed. An unsafe or unreadable watched input is reported once while it
+remains unchanged; scanning reports recovery after the path becomes valid
+again. A malformed manifest keeps the last resolved asset set under observation
+until the manifest can be parsed and the effective assets recomputed.
+
+## Failures And Recovery
+
+After a successful package, ordinary GOX diagnostics, Go compiler errors, and
+manifest errors leave the last completed package available. The server remains
+on the same listener, the failed snapshot is not retried indefinitely, and a
+later authored change starts a new package attempt. Successful recovery replaces
+the package through the normal publication path.
+
+This preservation guarantee does not override existing package publication or
+filesystem failure semantics. A failure that invalidates package ownership or
+completion metadata is reported as such.
+
+The server adds `Cache-Control: no-store` to development responses. Refresh the
+browser manually after a successful rebuild to load the latest completed
+package.
+
+## Shutdown
+
+`Ctrl-C` stops polling and prevents another build from starting. If a package
+attempt is already running, the command waits for that in-process attempt to
+return, then shuts down the HTTP server and exits successfully.
+
+## Current Limits
+
+Each accepted change batch performs a full development package. The command
+does not provide:
+
+- browser auto-reload or auto-open;
+- an error overlay;
+- HMR or browser state preservation;
+- incremental compilation or an incremental build cache;
+- source maps;
+- file watching outside the effective app and module inputs;
+- remote-network binding, history-routing fallback, or production compression
+  negotiation.
+
+Build failures are terminal output only. Release asset hashing, preload hints,
+gzip, and Brotli remain explicit `goxc package` concerns.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,7 +39,7 @@ The current baseline includes:
 - the GOX language and compiler, including typed component boundaries,
   package-qualified component tags, fragments, expression-oriented rendering,
   nested markup in Go callbacks, and source-oriented diagnostics;
-- the `goxc` check, generate, build, package, export, serve, size, clean,
+- the `goxc` check, generate, build, package, export, serve, dev, size, clean,
   doctor, and version workflow for standard Go and TinyGo WebAssembly output;
 - generated component identity based on Go package identity where available,
   plus multi-package and child-entry application evidence;
@@ -204,6 +204,11 @@ Design boundaries:
 The line remains subject to focused design and executable evidence before any
 public contract is selected.
 
+The completed async-navigation and server-backed mutation evidence found the
+existing router, component ownership, resource lifecycle, and example-local
+request coordination sufficient for the audited flows. Those stages did not
+select a public route-loader, Action, Mutation, or cache-invalidation API.
+
 ## `v0.4.0-preview.*` - Modular Delivery & Bundle Splitting
 
 Status: **Candidate**. This line must keep distinct delivery concepts separate.
@@ -318,7 +323,8 @@ Resumability, server components, and selective or streaming hydration remain
 
 ## `v0.7.0-preview.*` - Dev Loop & Language Services
 
-Status: **Candidate**.
+Status: **Candidate**, with the bounded watched development command now
+**Current / shipped**.
 
 The CLI-backed saved-source diagnostics in current `main` are
 **Current / shipped**. Semantic tooling remains future language-service work.
@@ -327,7 +333,7 @@ Candidate sequence:
 
 | Planning slot | Candidate capability |
 |---|---|
-| `preview.1` | Incremental development command. |
+| `preview.1` | Watched development command with serialized full-package rebuilds. |
 | `preview.2` | Browser reload and error overlay. |
 | `preview.3` | GOX-to-generated source maps. |
 | `preview.4` | Deterministic formatter. |
@@ -336,7 +342,8 @@ Candidate sequence:
 
 Potential surface, subject to design and evidence:
 
-- `goxc dev` with incremental GOX generation and a bounded build cache;
+- the current `goxc dev` full-package workflow, with later incremental build
+  work requiring separate evidence;
 - browser reload with compiler and source error presentation;
 - GOX-to-generated source maps shared by compiler and editor tooling;
 - a deterministic formatter with explicit syntax-governance rules;
@@ -481,8 +488,7 @@ entries are deliberately not sequenced or assigned to releases.
 
 ### Toolchain
 
-- incremental build cache;
-- development server workflow;
+- incremental build-cache research;
 - bundle graph;
 - multi-entry packaging;
 - prerender;
@@ -516,11 +522,13 @@ that defines behavior boundaries, evidence, cost, and non-goals.
 
 ## Immediate Sequence
 
-1. Begin `v0.3` with an executable Application Model II capability.
-2. Establish route transition state and cancellation through focused evidence.
-3. Continue toward later `v0.3` capabilities only after the first slice is
-   validated.
+1. Establish the bounded watched `goxc dev` command as the immediate selected
+   toolchain capability.
+2. Validate full-package rebuilds, failure recovery, loopback serving, and
+   clean shutdown through focused Go evidence.
+3. Keep browser reload and browser error presentation as a later candidate,
+   selected only after the first workflow evidence is complete.
 
-The first post-release engineering PR should not be another broad audit or a
-wording-only cleanup. It should provide a bounded, observable capability with
-focused evidence. This roadmap does not choose final `v0.3` API signatures.
+The application-model evidence does not justify adding a loader, Action, or
+Mutation API. The selected development-loop slice does not imply incremental
+compilation, HMR, source maps, or a broader language-service commitment.


### PR DESCRIPTION
## Summary

Adds `goxc dev`, a one-command local development loop for GoFrame
browser/WASM applications.

```bash
goxc dev <app-directory> \
  [--compiler=go|tinygo] \
  [--port=8080] \
  [--workspace=directory]
```

The command creates an initial development package, serves it on
`127.0.0.1`, watches effective application inputs, and rebuilds after saved
changes.

It reuses the existing package, workspace, and static-server paths rather than
introducing a separate build system.

## What changed

- Watches authored `.gox` and `.go` files, `goframe.json`, effective assets,
  and the nearest `go.mod` and `go.sum`.
- Uses content fingerprints and quiet-period debounce to coalesce save bursts.
- Serializes package attempts and queues at most one follow-up build when files
  change during an active build.
- Keeps the last completed package available after ordinary GOX, Go compiler,
  or manifest failures.
- Recovers automatically after a later correcting edit.
- Starts the server only after the first package has been published and
  verified.
- Supports an external workspace, compiler override, and ephemeral port `0`.
- Adds `Cache-Control: no-store` to development responses and shuts down cleanly
  on interruption.
- Documents the command, its development-only scope, and its current
  limitations.

## Validation

The change includes focused tests for CLI parsing, watched-input selection,
asset and module changes, symlink rejection, debounce, build serialization,
failure recovery, scan-error suppression, and shutdown.

A real temporary-application integration test exercises the standard Go WASM
package and HTTP server workflow, including:

- GOX, Go, asset, and manifest rebuilds;
- initial and post-success build failures;
- preservation of the previous package;
- recovery after correction;
- burst coalescing;
- ignored tool-owned output;
- listener closure on shutdown.

The full Go, race, vet, documentation, artifact, module-path, package, and size
gates pass locally.

## Compatibility and limits

This is an additive experimental `goxc` command. It does not change runtime,
GOX, manifest, package-metadata, dependency, or public framework API contracts.

Each accepted change batch still performs a full package. Browser refresh is
manual, and build errors remain terminal-only.

This PR does not add browser auto-reload, an error overlay, HMR, state
preservation, incremental compilation, source maps, remote serving, or
production-hosting behavior.