### PR TITLE
feat(goxc): reload browsers after successful dev builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Added
 
 - Watched `goxc dev` workflow with serialized full-package rebuilds, effective
-  authored-input polling, quiet-period debounce, last-successful-package
-  recovery, loopback-only no-store serving, and manual browser refresh.
+  authored-input polling, quiet-period debounce, verified process-private
+  generation serving, last-successful-generation failure preservation,
+  loopback-only no-store serving, and successful-build full-page browser reload
+  without HMR or a browser error overlay.
 - `v0.2.0-preview.6` release notes documenting structured `goxc check`
   diagnostics, the schema-v1 tooling transport, saved-source VS Code
   diagnostics, Unicode position mapping, multi-root and stale-run handling,

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -54,23 +54,27 @@ type devHooks struct {
 }
 
 type devDependencies struct {
-	packageApp   func(packageOptions) error
-	listen       func(string, string) (net.Listener, error)
-	pollInterval time.Duration
-	debounce     time.Duration
-	stdout       io.Writer
-	stderr       io.Writer
-	hooks        devHooks
+	packageApp    func(packageOptions) error
+	listen        func(string, string) (net.Listener, error)
+	pollInterval  time.Duration
+	debounce      time.Duration
+	shutdownGrace time.Duration
+	shutdownDrain time.Duration
+	stdout        io.Writer
+	stderr        io.Writer
+	hooks         devHooks
 }
 
 func defaultDevDependencies() devDependencies {
 	return devDependencies{
-		packageApp:   packageApp,
-		listen:       net.Listen,
-		pollInterval: defaultDevPollInterval,
-		debounce:     defaultDevDebounce,
-		stdout:       os.Stdout,
-		stderr:       os.Stderr,
+		packageApp:    packageApp,
+		listen:        net.Listen,
+		pollInterval:  defaultDevPollInterval,
+		debounce:      defaultDevDebounce,
+		shutdownGrace: devShutdownTimeout,
+		shutdownDrain: devShutdownTimeout,
+		stdout:        os.Stdout,
+		stderr:        os.Stderr,
 	}
 }
 
@@ -221,6 +225,12 @@ func normalizeDevDependencies(dependencies devDependencies) devDependencies {
 	if dependencies.debounce <= 0 {
 		dependencies.debounce = defaults.debounce
 	}
+	if dependencies.shutdownGrace <= 0 {
+		dependencies.shutdownGrace = defaults.shutdownGrace
+	}
+	if dependencies.shutdownDrain <= 0 {
+		dependencies.shutdownDrain = defaults.shutdownDrain
+	}
 	if dependencies.stdout == nil {
 		dependencies.stdout = defaults.stdout
 	}
@@ -231,13 +241,15 @@ func normalizeDevDependencies(dependencies devDependencies) devDependencies {
 }
 
 type devServer struct {
-	packageDir  string
-	port        int
-	listen      func(string, string) (net.Listener, error)
-	stdout      io.Writer
-	hooks       devHooks
-	generations *devGenerationManager
-	reload      *devReloadBroker
+	packageDir    string
+	port          int
+	listen        func(string, string) (net.Listener, error)
+	stdout        io.Writer
+	hooks         devHooks
+	generations   *devGenerationManager
+	reload        *devReloadBroker
+	shutdownGrace time.Duration
+	shutdownDrain time.Duration
 
 	mu       sync.Mutex
 	server   *http.Server
@@ -255,14 +267,16 @@ func newDevServer(packageDir string, port int, dependencies devDependencies) (*d
 		return nil, err
 	}
 	return &devServer{
-		packageDir:  packageDir,
-		port:        port,
-		listen:      dependencies.listen,
-		stdout:      dependencies.stdout,
-		hooks:       dependencies.hooks,
-		generations: generations,
-		reload:      newDevReloadBroker(instance),
-		errCh:       make(chan error, 1),
+		packageDir:    packageDir,
+		port:          port,
+		listen:        dependencies.listen,
+		stdout:        dependencies.stdout,
+		hooks:         dependencies.hooks,
+		generations:   generations,
+		reload:        newDevReloadBroker(instance),
+		shutdownGrace: dependencies.shutdownGrace,
+		shutdownDrain: dependencies.shutdownDrain,
+		errCh:         make(chan error, 1),
 	}, nil
 }
 
@@ -328,15 +342,21 @@ func (server *devServer) shutdown() error {
 	httpServer := server.server
 	server.mu.Unlock()
 	server.reload.close()
-	var shutdownErr error
+	var shutdownErr, closeErr error
 	if httpServer != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), devShutdownTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), server.shutdownGrace)
 		if err := httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			shutdownErr = fmt.Errorf("shut down development server: %w", err)
+			if err := httpServer.Close(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				closeErr = fmt.Errorf("force close development server: %w", err)
+			}
 		}
 		cancel()
 	}
-	return errors.Join(shutdownErr, server.generations.close())
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), server.shutdownDrain)
+	generationErr := server.generations.close(drainCtx)
+	cancelDrain()
+	return errors.Join(shutdownErr, closeErr, generationErr)
 }
 
 func devStaticHandler(directory string) http.Handler {

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -159,7 +159,10 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 	}
 
 	collector := newDevSnapshotCollector(layout.AppDir)
-	server := newDevServer(layout.PackageDir, options.port, dependencies)
+	server, err := newDevServer(layout.PackageDir, options.port, dependencies)
+	if err != nil {
+		return err
+	}
 
 	build := func(request devBuildRequest) error {
 		err := dependencies.packageApp(packageOptions{
@@ -171,7 +174,7 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 		if err != nil {
 			return err
 		}
-		if err := verifyPublishedPackage(layout.PackageDir); err != nil {
+		if _, err := server.activatePackage(); err != nil {
 			return err
 		}
 		if !server.started() {
@@ -223,11 +226,12 @@ func normalizeDevDependencies(dependencies devDependencies) devDependencies {
 }
 
 type devServer struct {
-	packageDir string
-	port       int
-	listen     func(string, string) (net.Listener, error)
-	stdout     io.Writer
-	hooks      devHooks
+	packageDir  string
+	port        int
+	listen      func(string, string) (net.Listener, error)
+	stdout      io.Writer
+	hooks       devHooks
+	generations *devGenerationManager
 
 	mu       sync.Mutex
 	server   *http.Server
@@ -235,15 +239,24 @@ type devServer struct {
 	errCh    chan error
 }
 
-func newDevServer(packageDir string, port int, dependencies devDependencies) *devServer {
-	return &devServer{
-		packageDir: packageDir,
-		port:       port,
-		listen:     dependencies.listen,
-		stdout:     dependencies.stdout,
-		hooks:      dependencies.hooks,
-		errCh:      make(chan error, 1),
+func newDevServer(packageDir string, port int, dependencies devDependencies) (*devServer, error) {
+	generations, err := newDevGenerationManager()
+	if err != nil {
+		return nil, err
 	}
+	return &devServer{
+		packageDir:  packageDir,
+		port:        port,
+		listen:      dependencies.listen,
+		stdout:      dependencies.stdout,
+		hooks:       dependencies.hooks,
+		generations: generations,
+		errCh:       make(chan error, 1),
+	}, nil
+}
+
+func (server *devServer) activatePackage() (uint64, error) {
+	return server.generations.activatePackage(server.packageDir)
 }
 
 func (server *devServer) start() error {
@@ -252,14 +265,11 @@ func (server *devServer) start() error {
 	if server.server != nil {
 		return nil
 	}
-	if err := directoryNoFollow(server.packageDir, "development package directory"); err != nil {
-		return err
-	}
 	listener, err := server.listen("tcp", fmt.Sprintf("127.0.0.1:%d", server.port))
 	if err != nil {
 		return fmt.Errorf("start development server: %w", err)
 	}
-	httpServer := &http.Server{Handler: devStaticHandler(server.packageDir)}
+	httpServer := &http.Server{Handler: devGenerationHandler(server.generations)}
 	server.listener = listener
 	server.server = httpServer
 	url := "http://" + listener.Addr().String()
@@ -294,15 +304,15 @@ func (server *devServer) shutdown() error {
 	server.mu.Lock()
 	httpServer := server.server
 	server.mu.Unlock()
-	if httpServer == nil {
-		return nil
+	var shutdownErr error
+	if httpServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), devShutdownTimeout)
+		if err := httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			shutdownErr = fmt.Errorf("shut down development server: %w", err)
+		}
+		cancel()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), devShutdownTimeout)
-	defer cancel()
-	if err := httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return fmt.Errorf("shut down development server: %w", err)
-	}
-	return nil
+	return errors.Join(shutdownErr, server.generations.close())
 }
 
 func devStaticHandler(directory string) http.Handler {

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -46,9 +46,11 @@ type devBuildEvent struct {
 }
 
 type devHooks struct {
-	BuildStarted  func(devBuildRequest)
-	BuildFinished func(devBuildEvent)
-	ServerStarted func(string)
+	BuildStarted        func(devBuildRequest)
+	BuildFinished       func(devBuildEvent)
+	GenerationActivated func(uint64)
+	ReloadPublished     func(uint64)
+	ServerStarted       func(string)
 }
 
 type devDependencies struct {
@@ -232,6 +234,7 @@ type devServer struct {
 	stdout      io.Writer
 	hooks       devHooks
 	generations *devGenerationManager
+	reload      *devReloadBroker
 
 	mu       sync.Mutex
 	server   *http.Server
@@ -251,12 +254,25 @@ func newDevServer(packageDir string, port int, dependencies devDependencies) (*d
 		stdout:      dependencies.stdout,
 		hooks:       dependencies.hooks,
 		generations: generations,
+		reload:      newDevReloadBroker(),
 		errCh:       make(chan error, 1),
 	}, nil
 }
 
 func (server *devServer) activatePackage() (uint64, error) {
-	return server.generations.activatePackage(server.packageDir)
+	notify := server.started()
+	generation, err := server.generations.activatePackage(server.packageDir)
+	if err != nil {
+		return 0, err
+	}
+	server.reload.activate(generation, notify)
+	if server.hooks.GenerationActivated != nil {
+		server.hooks.GenerationActivated(generation)
+	}
+	if notify && server.hooks.ReloadPublished != nil {
+		server.hooks.ReloadPublished(generation)
+	}
+	return generation, nil
 }
 
 func (server *devServer) start() error {
@@ -269,7 +285,7 @@ func (server *devServer) start() error {
 	if err != nil {
 		return fmt.Errorf("start development server: %w", err)
 	}
-	httpServer := &http.Server{Handler: devGenerationHandler(server.generations)}
+	httpServer := &http.Server{Handler: devReloadHandler(server.generations, server.reload)}
 	server.listener = listener
 	server.server = httpServer
 	url := "http://" + listener.Addr().String()
@@ -304,6 +320,7 @@ func (server *devServer) shutdown() error {
 	server.mu.Lock()
 	httpServer := server.server
 	server.mu.Unlock()
+	server.reload.close()
 	var shutdownErr error
 	if httpServer != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), devShutdownTimeout)

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -176,6 +176,9 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 		if err != nil {
 			return err
 		}
+		if ctx.Err() != nil {
+			return nil
+		}
 		if _, err := server.activatePackage(); err != nil {
 			return err
 		}
@@ -243,6 +246,10 @@ type devServer struct {
 }
 
 func newDevServer(packageDir string, port int, dependencies devDependencies) (*devServer, error) {
+	instance, err := newDevReloadInstance()
+	if err != nil {
+		return nil, err
+	}
 	generations, err := newDevGenerationManager()
 	if err != nil {
 		return nil, err
@@ -254,7 +261,7 @@ func newDevServer(packageDir string, port int, dependencies devDependencies) (*d
 		stdout:      dependencies.stdout,
 		hooks:       dependencies.hooks,
 		generations: generations,
-		reload:      newDevReloadBroker(),
+		reload:      newDevReloadBroker(instance),
 		errCh:       make(chan error, 1),
 	}, nil
 }

--- a/cmd/goxc/dev_generation.go
+++ b/cmd/goxc/dev_generation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,7 +16,11 @@ type devGenerationManager struct {
 	nextID      uint64
 	active      *devGeneration
 	generations map[uint64]*devGeneration
+	leaseCount  int
+	closing     bool
 	closed      bool
+	drained     chan struct{}
+	drainClosed bool
 }
 
 type devGeneration struct {
@@ -40,6 +45,7 @@ func newDevGenerationManager() (*devGenerationManager, error) {
 	return &devGenerationManager{
 		root:        root,
 		generations: map[uint64]*devGeneration{},
+		drained:     make(chan struct{}),
 	}, nil
 }
 
@@ -49,9 +55,9 @@ func (manager *devGenerationManager) activatePackage(packageDir string) (uint64,
 	}
 
 	manager.mu.Lock()
-	if manager.closed {
+	if manager.closing || manager.closed {
 		manager.mu.Unlock()
-		return 0, errors.New("development generation manager is closed")
+		return 0, errors.New("development generation manager is closing")
 	}
 	root := manager.root
 	manager.mu.Unlock()
@@ -75,9 +81,9 @@ func (manager *devGenerationManager) activatePackage(packageDir string) (uint64,
 	}
 
 	manager.mu.Lock()
-	if manager.closed {
+	if manager.closing || manager.closed {
 		manager.mu.Unlock()
-		return 0, errors.New("development generation manager is closed")
+		return 0, errors.New("development generation manager is closing")
 	}
 	manager.nextID++
 	id := manager.nextID
@@ -120,13 +126,14 @@ func (manager *devGenerationManager) activeID() (uint64, bool) {
 func (manager *devGenerationManager) acquire() (*devGenerationLease, error) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
-	if manager.closed {
-		return nil, errors.New("development generation manager is closed")
+	if manager.closing || manager.closed {
+		return nil, errors.New("development generation manager is closing")
 	}
 	if manager.active == nil {
 		return nil, errors.New("no completed development generation is active")
 	}
 	manager.active.leases++
+	manager.leaseCount++
 	return &devGenerationLease{
 		manager:    manager,
 		generation: manager.active,
@@ -155,10 +162,14 @@ func (manager *devGenerationManager) release(generation *devGeneration) error {
 		return fmt.Errorf("development generation %d has no active request lease", generation.id)
 	}
 	generation.leases--
+	manager.leaseCount--
 	var removeDirectory string
-	if generation.retired && generation.leases == 0 {
+	if !manager.closing && generation.retired && generation.leases == 0 {
 		delete(manager.generations, generation.id)
 		removeDirectory = generation.directory
+	}
+	if manager.closing && manager.leaseCount == 0 {
+		manager.signalDrainedLocked()
 	}
 	manager.mu.Unlock()
 
@@ -170,28 +181,47 @@ func (manager *devGenerationManager) release(generation *devGeneration) error {
 	return nil
 }
 
-func (manager *devGenerationManager) close() error {
+func (manager *devGenerationManager) close(ctx context.Context) error {
 	manager.mu.Lock()
 	if manager.closed {
 		manager.mu.Unlock()
 		return nil
 	}
-	for _, generation := range manager.generations {
-		if generation.leases != 0 {
-			manager.mu.Unlock()
-			return fmt.Errorf("close development generations with %d active request leases", generation.leases)
+	if !manager.closing {
+		manager.closing = true
+		if manager.leaseCount == 0 {
+			manager.signalDrainedLocked()
 		}
 	}
-	root := manager.root
-	manager.closed = true
-	manager.active = nil
-	manager.generations = nil
+	drained := manager.drained
 	manager.mu.Unlock()
 
-	if err := os.RemoveAll(root); err != nil {
+	select {
+	case <-drained:
+	case <-ctx.Done():
+		return fmt.Errorf("wait for development generation leases to drain: %w", ctx.Err())
+	}
+
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.closed {
+		return nil
+	}
+	if err := os.RemoveAll(manager.root); err != nil {
 		return fmt.Errorf("remove development generation root: %w", err)
 	}
+	manager.active = nil
+	manager.generations = nil
+	manager.closed = true
 	return nil
+}
+
+func (manager *devGenerationManager) signalDrainedLocked() {
+	if manager.drainClosed {
+		return
+	}
+	manager.drainClosed = true
+	close(manager.drained)
 }
 
 func devGenerationHandler(manager *devGenerationManager) http.Handler {

--- a/cmd/goxc/dev_generation.go
+++ b/cmd/goxc/dev_generation.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type devGenerationManager struct {
+	mu          sync.Mutex
+	root        string
+	nextID      uint64
+	active      *devGeneration
+	generations map[uint64]*devGeneration
+	closed      bool
+}
+
+type devGeneration struct {
+	id        uint64
+	directory string
+	leases    int
+	retired   bool
+}
+
+type devGenerationLease struct {
+	manager    *devGenerationManager
+	generation *devGeneration
+	once       sync.Once
+	err        error
+}
+
+func newDevGenerationManager() (*devGenerationManager, error) {
+	root, err := os.MkdirTemp("", "goxc-dev-generations-*")
+	if err != nil {
+		return nil, fmt.Errorf("create development generation root: %w", err)
+	}
+	return &devGenerationManager{
+		root:        root,
+		generations: map[uint64]*devGeneration{},
+	}, nil
+}
+
+func (manager *devGenerationManager) activatePackage(packageDir string) (uint64, error) {
+	if err := verifyPublishedPackage(packageDir); err != nil {
+		return 0, err
+	}
+
+	manager.mu.Lock()
+	if manager.closed {
+		manager.mu.Unlock()
+		return 0, errors.New("development generation manager is closed")
+	}
+	root := manager.root
+	manager.mu.Unlock()
+
+	staging, err := os.MkdirTemp(root, ".staging-*")
+	if err != nil {
+		return 0, fmt.Errorf("create staging development generation: %w", err)
+	}
+	keepStaging := false
+	defer func() {
+		if !keepStaging {
+			_ = os.RemoveAll(staging)
+		}
+	}()
+
+	if err := publishPackageArtifacts(packageDir, staging); err != nil {
+		return 0, fmt.Errorf("copy development generation: %w", err)
+	}
+	if err := verifyPublishedPackage(staging); err != nil {
+		return 0, fmt.Errorf("verify development generation: %w", err)
+	}
+
+	manager.mu.Lock()
+	if manager.closed {
+		manager.mu.Unlock()
+		return 0, errors.New("development generation manager is closed")
+	}
+	manager.nextID++
+	id := manager.nextID
+	directory := filepath.Join(manager.root, fmt.Sprintf("generation-%020d", id))
+	if err := os.Rename(staging, directory); err != nil {
+		manager.mu.Unlock()
+		return 0, fmt.Errorf("complete development generation %d: %w", id, err)
+	}
+	keepStaging = true
+
+	generation := &devGeneration{id: id, directory: directory}
+	manager.generations[id] = generation
+	retired := manager.active
+	manager.active = generation
+	var removeDirectory string
+	if retired != nil {
+		retired.retired = true
+		if retired.leases == 0 {
+			delete(manager.generations, retired.id)
+			removeDirectory = retired.directory
+		}
+	}
+	manager.mu.Unlock()
+
+	if removeDirectory != "" {
+		_ = os.RemoveAll(removeDirectory)
+	}
+	return id, nil
+}
+
+func (manager *devGenerationManager) activeID() (uint64, bool) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.active == nil {
+		return 0, false
+	}
+	return manager.active.id, true
+}
+
+func (manager *devGenerationManager) acquire() (*devGenerationLease, error) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.closed {
+		return nil, errors.New("development generation manager is closed")
+	}
+	if manager.active == nil {
+		return nil, errors.New("no completed development generation is active")
+	}
+	manager.active.leases++
+	return &devGenerationLease{
+		manager:    manager,
+		generation: manager.active,
+	}, nil
+}
+
+func (lease *devGenerationLease) ID() uint64 {
+	return lease.generation.id
+}
+
+func (lease *devGenerationLease) Directory() string {
+	return lease.generation.directory
+}
+
+func (lease *devGenerationLease) Release() error {
+	lease.once.Do(func() {
+		lease.err = lease.manager.release(lease.generation)
+	})
+	return lease.err
+}
+
+func (manager *devGenerationManager) release(generation *devGeneration) error {
+	manager.mu.Lock()
+	if generation.leases <= 0 {
+		manager.mu.Unlock()
+		return fmt.Errorf("development generation %d has no active request lease", generation.id)
+	}
+	generation.leases--
+	var removeDirectory string
+	if generation.retired && generation.leases == 0 {
+		delete(manager.generations, generation.id)
+		removeDirectory = generation.directory
+	}
+	manager.mu.Unlock()
+
+	if removeDirectory != "" {
+		if err := os.RemoveAll(removeDirectory); err != nil {
+			return fmt.Errorf("remove retired development generation %d: %w", generation.id, err)
+		}
+	}
+	return nil
+}
+
+func (manager *devGenerationManager) close() error {
+	manager.mu.Lock()
+	if manager.closed {
+		manager.mu.Unlock()
+		return nil
+	}
+	for _, generation := range manager.generations {
+		if generation.leases != 0 {
+			manager.mu.Unlock()
+			return fmt.Errorf("close development generations with %d active request leases", generation.leases)
+		}
+	}
+	root := manager.root
+	manager.closed = true
+	manager.active = nil
+	manager.generations = nil
+	manager.mu.Unlock()
+
+	if err := os.RemoveAll(root); err != nil {
+		return fmt.Errorf("remove development generation root: %w", err)
+	}
+	return nil
+}
+
+func devGenerationHandler(manager *devGenerationManager) http.Handler {
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		lease, err := manager.acquire()
+		if err != nil {
+			http.Error(response, "development package is not ready", http.StatusServiceUnavailable)
+			return
+		}
+		defer lease.Release()
+		devStaticHandler(lease.Directory()).ServeHTTP(response, request)
+	})
+}

--- a/cmd/goxc/dev_generation_test.go
+++ b/cmd/goxc/dev_generation_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestDevGenerationFirstCompletedActivation(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+
+	id, err := manager.activatePackage(packageDir)
+	if err != nil {
+		t.Fatalf("activatePackage() error: %v", err)
+	}
+	if id != 1 {
+		t.Fatalf("generation ID = %d, want 1", id)
+	}
+	if active, ok := manager.activeID(); !ok || active != id {
+		t.Fatalf("active generation = %d, %v, want 1, true", active, ok)
+	}
+
+	lease, err := manager.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if samePath(lease.Directory(), packageDir) {
+		t.Fatal("active development generation aliases the canonical package directory")
+	}
+	assertFileContent(t, filepath.Join(lease.Directory(), indexHTMLAssetName), "generation one")
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDevGenerationHandlerNeverServesCanonicalPackage(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "completed generation")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, indexHTMLAssetName), []byte("mutable canonical package"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	devGenerationHandler(manager).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	if response.Code != http.StatusOK || response.Body.String() != "completed generation" {
+		t.Fatalf("response = %d %q, want completed generation", response.Code, response.Body.String())
+	}
+}
+
+func TestDevGenerationCopyFailurePreservesActiveGeneration(t *testing.T) {
+	requireSymlinkSupport(t)
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+
+	external := filepath.Join(t.TempDir(), "external.txt")
+	if err := os.WriteFile(external, []byte("external"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(packageDir, "assets", "linked.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.activatePackage(packageDir); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("activatePackage() error = %v, want symlink rejection", err)
+	}
+	if active, ok := manager.activeID(); !ok || active != 1 {
+		t.Fatalf("active generation = %d, %v, want preserved generation 1", active, ok)
+	}
+	assertActiveDevGenerationContent(t, manager, "generation one")
+}
+
+func TestDevGenerationVerificationFailurePreservesActiveGeneration(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(packageDir, "assets", "bundle.12345678.wasm")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := manager.activatePackage(packageDir); err == nil || !strings.Contains(err.Error(), "integrity verification") {
+		t.Fatalf("activatePackage() error = %v, want verification failure", err)
+	}
+	if active, ok := manager.activeID(); !ok || active != 1 {
+		t.Fatalf("active generation = %d, %v, want preserved generation 1", active, ok)
+	}
+	assertActiveDevGenerationContent(t, manager, "generation one")
+}
+
+func TestDevGenerationActivationRetainsInflightGeneration(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	oldLease, err := manager.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDirectory := oldLease.Directory()
+
+	writeDevGenerationPackage(t, packageDir, "generation two")
+	if id, err := manager.activatePackage(packageDir); err != nil || id != 2 {
+		t.Fatalf("second activation = %d, %v, want 2, nil", id, err)
+	}
+	assertFileContent(t, filepath.Join(oldDirectory, indexHTMLAssetName), "generation one")
+	assertActiveDevGenerationContent(t, manager, "generation two")
+	if _, err := os.Stat(oldDirectory); err != nil {
+		t.Fatalf("leased retired generation was removed early: %v", err)
+	}
+
+	if err := oldLease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(oldDirectory); !os.IsNotExist(err) {
+		t.Fatalf("retired generation remained after final lease: %v", err)
+	}
+}
+
+func TestDevGenerationShutdownRemovesPrivateRoot(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager, err := newDevGenerationManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := manager.root
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("generation root remained after shutdown: %v", err)
+	}
+}
+
+func TestDevGenerationConcurrentAcquireActivateRelease(t *testing.T) {
+	manager := newTestDevGenerationManager(t)
+	packages := make([]string, 8)
+	for index := range packages {
+		packages[index] = t.TempDir()
+		writeDevGenerationPackage(t, packages[index], fmt.Sprintf("generation %d", index+1))
+	}
+	if _, err := manager.activatePackage(packages[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	start := make(chan struct{})
+	errors := make(chan error, 32)
+	var workers sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for iteration := 0; iteration < 100; iteration++ {
+				lease, err := manager.acquire()
+				if err != nil {
+					errors <- err
+					return
+				}
+				if _, err := os.ReadFile(filepath.Join(lease.Directory(), indexHTMLAssetName)); err != nil {
+					errors <- err
+					_ = lease.Release()
+					return
+				}
+				if err := lease.Release(); err != nil {
+					errors <- err
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	for index := 1; index < len(packages); index++ {
+		if _, err := manager.activatePackage(packages[index]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	workers.Wait()
+	close(errors)
+	for err := range errors {
+		t.Errorf("concurrent generation operation: %v", err)
+	}
+}
+
+func newTestDevGenerationManager(t *testing.T) *devGenerationManager {
+	t.Helper()
+	manager, err := newDevGenerationManager()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := manager.close(); err != nil {
+			t.Errorf("close development generations: %v", err)
+		}
+	})
+	return manager
+}
+
+func writeDevGenerationPackage(t *testing.T, directory, index string) {
+	t.Helper()
+	writeCompleteCurrentPackage(t, directory)
+	if err := os.WriteFile(filepath.Join(directory, indexHTMLAssetName), []byte(index), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertActiveDevGenerationContent(t *testing.T, manager *devGenerationManager, want string) {
+	t.Helper()
+	lease, err := manager.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	assertFileContent(t, filepath.Join(lease.Directory(), indexHTMLAssetName), want)
+}

--- a/cmd/goxc/dev_generation_test.go
+++ b/cmd/goxc/dev_generation_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestDevGenerationFirstCompletedActivation(t *testing.T) {
@@ -134,7 +137,7 @@ func TestDevGenerationActivationRetainsInflightGeneration(t *testing.T) {
 	}
 }
 
-func TestDevGenerationShutdownRemovesPrivateRoot(t *testing.T) {
+func TestDevGenerationCloseWithNoLeasesRemovesPrivateRoot(t *testing.T) {
 	packageDir := t.TempDir()
 	writeDevGenerationPackage(t, packageDir, "generation one")
 	manager, err := newDevGenerationManager()
@@ -145,11 +148,163 @@ func TestDevGenerationShutdownRemovesPrivateRoot(t *testing.T) {
 	if _, err := manager.activatePackage(packageDir); err != nil {
 		t.Fatal(err)
 	}
-	if err := manager.close(); err != nil {
+	if err := manager.close(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(root); !os.IsNotExist(err) {
 		t.Fatalf("generation root remained after shutdown: %v", err)
+	}
+}
+
+func TestDevGenerationCloseWaitsForActiveLease(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := manager.root
+
+	baseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	closeCtx := newObservedDoneContext(baseCtx)
+	closed := make(chan error, 1)
+	go func() {
+		closed <- manager.close(closeCtx)
+	}()
+	waitForObservedDone(t, closeCtx)
+
+	if _, err := manager.acquire(); err == nil || !strings.Contains(err.Error(), "closing") {
+		t.Fatalf("acquire() after close began error = %v, want closing error", err)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("generation root removed with an active lease: %v", err)
+	}
+	select {
+	case err := <-closed:
+		t.Fatalf("close returned before lease release: %v", err)
+	default:
+	}
+
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close() error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("close did not finish after the active lease was released")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("generation root remained after lease drain: %v", err)
+	}
+	if err := manager.close(context.Background()); err != nil {
+		t.Fatalf("repeated close() error: %v", err)
+	}
+}
+
+func TestDevGenerationCloseTimeoutCanRecoverAfterRelease(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := manager.acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := manager.root
+
+	expired, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	err = manager.close(expired)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "leases to drain") {
+		t.Fatalf("close() error = %v, want generation lease drain deadline", err)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("generation root removed after drain timeout: %v", err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.close(context.Background()); err != nil {
+		t.Fatalf("close() after release error: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("generation root remained after recovered close: %v", err)
+	}
+}
+
+func TestDevGenerationConcurrentAcquireReleaseClose(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "generation one")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 16
+	acquired := make(chan struct{}, workers)
+	release := make(chan struct{})
+	errorCh := make(chan error, workers)
+	var group sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			lease, err := manager.acquire()
+			if err != nil {
+				errorCh <- err
+				return
+			}
+			acquired <- struct{}{}
+			<-release
+			if _, err := manager.acquire(); err == nil {
+				errorCh <- errors.New("acquire succeeded after close began")
+			}
+			if err := lease.Release(); err != nil {
+				errorCh <- err
+			}
+		}()
+	}
+	for worker := 0; worker < workers; worker++ {
+		<-acquired
+	}
+
+	baseCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	closeCtx := newObservedDoneContext(baseCtx)
+	closed := make(chan error, 1)
+	go func() {
+		closed <- manager.close(closeCtx)
+	}()
+	waitForObservedDone(t, closeCtx)
+	close(release)
+	group.Wait()
+	close(errorCh)
+	for err := range errorCh {
+		t.Errorf("concurrent close operation: %v", err)
+	}
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("close() error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("close did not finish after concurrent releases")
+	}
+	manager.mu.Lock()
+	leaseCount := manager.leaseCount
+	manager.mu.Unlock()
+	if leaseCount != 0 {
+		t.Fatalf("active lease count = %d, want 0", leaseCount)
 	}
 }
 
@@ -210,11 +365,39 @@ func newTestDevGenerationManager(t *testing.T) *devGenerationManager {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if err := manager.close(); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := manager.close(ctx); err != nil {
 			t.Errorf("close development generations: %v", err)
 		}
 	})
 	return manager
+}
+
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func newObservedDoneContext(ctx context.Context) *observedDoneContext {
+	return &observedDoneContext{Context: ctx, observed: make(chan struct{})}
+}
+
+func (ctx *observedDoneContext) Done() <-chan struct{} {
+	ctx.once.Do(func() {
+		close(ctx.observed)
+	})
+	return ctx.Context.Done()
+}
+
+func waitForObservedDone(t *testing.T, ctx *observedDoneContext) {
+	t.Helper()
+	select {
+	case <-ctx.observed:
+	case <-time.After(time.Second):
+		t.Fatal("close did not begin waiting for generation leases")
+	}
 }
 
 func writeDevGenerationPackage(t *testing.T, directory, index string) {

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,7 +36,15 @@ func TestDevRealWorkflow(t *testing.T) {
 	defer cancel()
 	builds := make(chan devBuildEvent, 32)
 	serverURLs := make(chan string, 2)
+	generations := make(chan uint64, 16)
+	reloads := make(chan uint64, 16)
 	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) {
+		generations <- generation
+	}
+	dependencies.hooks.ReloadPublished = func(generation uint64) {
+		reloads <- generation
+	}
 	done := make(chan error, 1)
 	go func() {
 		done <- runDev(ctx, devOptions{
@@ -48,6 +57,8 @@ func TestDevRealWorkflow(t *testing.T) {
 
 	initial := waitDevEvent(t, builds)
 	assertDevEvent(t, initial, 1, true, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
 	serverURL := waitDevServerURL(t, serverURLs)
 	assertDevHTTPContains(t, serverURL+"/", "GoFrame dev integration")
 	assertDevHTTPHeader(t, serverURL+"/", "Cache-Control", "no-store")
@@ -58,16 +69,24 @@ func TestDevRealWorkflow(t *testing.T) {
 
 	writeDevIntegrationGOX(t, appDir, "GOX rebuild")
 	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+	assertDevGenerationEvent(t, generations, 2)
+	assertDevGenerationEvent(t, reloads, 2)
 
 	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"Go rebuild\" }\n")
 	assertDevEvent(t, waitDevEvent(t, builds), 3, false, false)
+	assertDevGenerationEvent(t, generations, 3)
+	assertDevGenerationEvent(t, reloads, 3)
 
 	writeTestFile(t, appDir, "assets/message.txt", "asset rebuild")
 	assertDevEvent(t, waitDevEvent(t, builds), 4, false, false)
+	assertDevGenerationEvent(t, generations, 4)
+	assertDevGenerationEvent(t, reloads, 4)
 	assertDevHTTPBody(t, serverURL+"/assets/message.txt", "asset rebuild")
 
 	writeTestFile(t, appDir, manifestName, `{"name":"renamed","compiler":"tinygo","assets":"assets"}`)
 	assertDevEvent(t, waitDevEvent(t, builds), 5, false, false)
+	assertDevGenerationEvent(t, generations, 5)
+	assertDevGenerationEvent(t, reloads, 5)
 	metadataBeforeFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
 	metadata := decodeDevPackageMetadata(t, metadataBeforeFailure)
 	if metadata.Name != "renamed" || metadata.Compiler != "go" {
@@ -84,6 +103,8 @@ func App() gf.Node {
 `)
 	failed := waitDevEvent(t, builds)
 	assertDevEvent(t, failed, 6, false, true)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
 	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeFailure {
 		t.Fatalf("failed build replaced package metadata:\nold=%s\nnew=%s", metadataBeforeFailure, got)
 	}
@@ -91,24 +112,34 @@ func App() gf.Node {
 
 	writeDevIntegrationGOX(t, appDir, "recovered")
 	assertDevEvent(t, waitDevEvent(t, builds), 7, false, false)
+	assertDevGenerationEvent(t, generations, 6)
+	assertDevGenerationEvent(t, reloads, 6)
 	metadataBeforeGoFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
 
 	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return missingSymbol }\n")
 	assertDevEvent(t, waitDevEvent(t, builds), 8, false, true)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
 	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeGoFailure {
 		t.Fatalf("Go compiler failure replaced package metadata:\nold=%s\nnew=%s", metadataBeforeGoFailure, got)
 	}
 	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"Go recovered\" }\n")
 	assertDevEvent(t, waitDevEvent(t, builds), 9, false, false)
+	assertDevGenerationEvent(t, generations, 7)
+	assertDevGenerationEvent(t, reloads, 7)
 	metadataBeforeManifestFailure := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
 
 	writeTestFile(t, appDir, manifestName, `{"name":`)
 	assertDevEvent(t, waitDevEvent(t, builds), 10, false, true)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
 	if got := readDevHTTPBody(t, serverURL+"/"+packageMetadataName); got != metadataBeforeManifestFailure {
 		t.Fatalf("manifest failure replaced package metadata:\nold=%s\nnew=%s", metadataBeforeManifestFailure, got)
 	}
 	writeTestFile(t, appDir, manifestName, `{"name":"renamed","compiler":"tinygo","assets":"assets"}`)
 	assertDevEvent(t, waitDevEvent(t, builds), 11, false, false)
+	assertDevGenerationEvent(t, generations, 8)
+	assertDevGenerationEvent(t, reloads, 8)
 
 	for _, value := range []string{"burst one", "burst two", "burst final"} {
 		writeTestFile(t, appDir, "message.go", fmt.Sprintf("package main\n\nfunc message() string { return %q }\n", value))
@@ -116,6 +147,8 @@ func App() gf.Node {
 	}
 	burst := waitDevEvent(t, builds)
 	assertDevEvent(t, burst, 12, false, false)
+	assertDevGenerationEvent(t, generations, 9)
+	assertDevGenerationEvent(t, reloads, 9)
 	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
 
 	writeTestFile(t, appDir, ".goframe/ignored.go", "package ignored\n")
@@ -126,6 +159,95 @@ func App() gf.Node {
 	cancel()
 	if err := waitDevRun(t, done); err != nil {
 		t.Fatalf("runDev() shutdown error: %v", err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
+
+func TestDevRealWorkflowServesCompletedGenerationDuringPublication(t *testing.T) {
+	appDir := filepath.Join(t.TempDir(), "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	oldPackage := t.TempDir()
+	newPackage := t.TempDir()
+	writeDevGenerationPackage(t, oldPackage, "old completed index")
+	writeDevGenerationPackage(t, newPackage, "new completed index")
+	if err := os.WriteFile(filepath.Join(oldPackage, "assets", "bundle.12345678.wasm"), []byte("old completed wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(newPackage, "assets", "bundle.12345678.wasm"), []byte("new completed wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	builds := make(chan devBuildEvent, 4)
+	serverURLs := make(chan string, 1)
+	generations := make(chan uint64, 4)
+	reloads := make(chan uint64, 4)
+	publicationOpen := make(chan struct{})
+	releasePublication := make(chan struct{})
+	packageCalls := 0
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) {
+		generations <- generation
+	}
+	dependencies.hooks.ReloadPublished = func(generation uint64) {
+		reloads <- generation
+	}
+	dependencies.packageApp = func(options packageOptions) error {
+		packageCalls++
+		layout, err := newBuildLayout(layoutOptions{appDir: options.appDir, compiler: "go", workspace: options.workspace})
+		if err != nil {
+			return err
+		}
+		if packageCalls == 1 {
+			return replaceDevCanonicalPackage(oldPackage, layout.PackageDir)
+		}
+		if err := os.RemoveAll(layout.PackageDir); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(layout.PackageDir, 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(layout.PackageDir, indexHTMLAssetName), []byte("partial canonical index"), 0o644); err != nil {
+			return err
+		}
+		close(publicationOpen)
+		<-releasePublication
+		return replaceDevCanonicalPackage(newPackage, layout.PackageDir)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{appDir: appDir, compiler: "go", workspace: workspace, port: 0}, dependencies)
+	}()
+
+	assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
+	serverURL := waitDevServerURL(t, serverURLs)
+	oldMetadata := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
+	assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("old completed index", 1))
+	assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "old completed wasm")
+
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar rebuild = true\n")
+	waitDevSignal(t, publicationOpen, "mutable canonical publication")
+	for request := 0; request < 12; request++ {
+		assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("old completed index", 1))
+		assertDevHTTPBody(t, serverURL+"/"+packageMetadataName, oldMetadata)
+		assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "old completed wasm")
+	}
+	close(releasePublication)
+	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+	assertDevGenerationEvent(t, generations, 2)
+	assertDevGenerationEvent(t, reloads, 2)
+	assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("new completed index", 2))
+	assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "new completed wasm")
+
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatal(err)
 	}
 	waitDevListenerClosed(t, serverURL)
 }
@@ -155,17 +277,28 @@ func App() gf.Node {
 	defer cancel()
 	builds := make(chan devBuildEvent, 8)
 	serverURLs := make(chan string, 2)
+	generations := make(chan uint64, 2)
+	reloads := make(chan uint64, 2)
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) {
+		generations <- generation
+	}
+	dependencies.hooks.ReloadPublished = func(generation uint64) {
+		reloads <- generation
+	}
 	done := make(chan error, 1)
 	go func() {
 		done <- runDev(ctx, devOptions{
 			appDir:    appDir,
 			workspace: workspace,
 			port:      0,
-		}, devIntegrationDependencies(builds, serverURLs))
+		}, dependencies)
 	}()
 
 	failed := waitDevEvent(t, builds)
 	assertDevEvent(t, failed, 1, true, true)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
 	select {
 	case url := <-serverURLs:
 		t.Fatalf("server started after failed initial package: %s", url)
@@ -175,6 +308,8 @@ func App() gf.Node {
 	writeDevIntegrationGOX(t, appDir, "fixed initial source")
 	recovered := waitDevEvent(t, builds)
 	assertDevEvent(t, recovered, 2, false, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
 	serverURL := waitDevServerURL(t, serverURLs)
 	assertDevHTTPContains(t, serverURL+"/", "GoFrame dev integration")
 	cancel()
@@ -275,6 +410,27 @@ func assertNoDevEvent(t *testing.T, builds <-chan devBuildEvent, duration time.D
 	}
 }
 
+func assertDevGenerationEvent(t *testing.T, events <-chan uint64, want uint64) {
+	t.Helper()
+	select {
+	case got := <-events:
+		if got != want {
+			t.Fatalf("development generation event = %d, want %d", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for development generation %d", want)
+	}
+}
+
+func assertNoDevGenerationEvent(t *testing.T, events <-chan uint64) {
+	t.Helper()
+	select {
+	case generation := <-events:
+		t.Fatalf("unexpected development generation event %d", generation)
+	default:
+	}
+}
+
 func waitDevServerURL(t *testing.T, urls <-chan string) string {
 	t.Helper()
 	select {
@@ -364,4 +520,26 @@ func waitDevListenerClosed(t *testing.T, serverURL string) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatalf("development listener at %s remained open after shutdown", serverURL)
+}
+
+func replaceDevCanonicalPackage(source, destination string) error {
+	if err := os.RemoveAll(destination); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return err
+	}
+	if err := publishPackageArtifacts(source, destination); err != nil {
+		return err
+	}
+	return verifyPublishedPackage(destination)
+}
+
+func waitDevSignal(t *testing.T, signal <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
 }

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -377,6 +379,90 @@ func TestDevCancellationDuringBuildSkipsGenerationAndReload(t *testing.T) {
 			t.Fatalf("generation root remained after canceled initial build: %v", err)
 		}
 	})
+}
+
+func TestDevServerShutdownForceClosesActiveGenerationLease(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "completed generation")
+	manager := newTestDevGenerationManager(t)
+	if _, err := manager.activatePackage(packageDir); err != nil {
+		t.Fatal(err)
+	}
+	root := manager.root
+
+	leaseHeld := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	handlerDone := make(chan error, 1)
+	handler := http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		lease, err := manager.acquire()
+		if err != nil {
+			handlerDone <- err
+			return
+		}
+		close(leaseHeld)
+		<-request.Context().Done()
+		close(requestCanceled)
+		handlerDone <- lease.Release()
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpServer := &http.Server{Handler: handler}
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- httpServer.Serve(listener)
+	}()
+	server := &devServer{
+		generations:   manager,
+		reload:        newDevReloadBroker(testDevReloadInstance),
+		server:        httpServer,
+		listener:      listener,
+		shutdownGrace: 20 * time.Millisecond,
+		shutdownDrain: time.Second,
+	}
+
+	requestDone := make(chan error, 1)
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	go func() {
+		response, err := client.Get("http://" + listener.Addr().String() + "/blocked")
+		if response != nil {
+			response.Body.Close()
+		}
+		requestDone <- err
+	}()
+	waitDevSignal(t, leaseHeld, "active HTTP generation lease")
+
+	shutdownErr := server.shutdown()
+	if !errors.Is(shutdownErr, context.DeadlineExceeded) || !strings.Contains(shutdownErr.Error(), "shut down development server") {
+		t.Fatalf("shutdown() error = %v, want precise graceful deadline", shutdownErr)
+	}
+	waitDevSignal(t, requestCanceled, "forced request cancellation")
+	select {
+	case err := <-handlerDone:
+		if err != nil {
+			t.Fatalf("release generation lease: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP handler did not return after force close")
+	}
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP request did not terminate after force close")
+	}
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Serve() error = %v, want http.ErrServerClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP server goroutine remained active after shutdown")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatalf("generation root remained after forced shutdown: %v", err)
+	}
 }
 
 func TestDevInitialFailureRecoversBeforeServerStarts(t *testing.T) {

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -228,13 +228,13 @@ func TestDevRealWorkflowServesCompletedGenerationDuringPublication(t *testing.T)
 	assertNoDevGenerationEvent(t, reloads)
 	serverURL := waitDevServerURL(t, serverURLs)
 	oldMetadata := readDevHTTPBody(t, serverURL+"/"+packageMetadataName)
-	assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("old completed index", 1))
+	assertDevInjectedHTTPBody(t, serverURL+"/", "old completed index", 1)
 	assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "old completed wasm")
 
 	writeTestFile(t, appDir, "main.go", "package main\n\nvar rebuild = true\n")
 	waitDevSignal(t, publicationOpen, "mutable canonical publication")
 	for request := 0; request < 12; request++ {
-		assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("old completed index", 1))
+		assertDevInjectedHTTPBody(t, serverURL+"/", "old completed index", 1)
 		assertDevHTTPBody(t, serverURL+"/"+packageMetadataName, oldMetadata)
 		assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "old completed wasm")
 	}
@@ -242,7 +242,7 @@ func TestDevRealWorkflowServesCompletedGenerationDuringPublication(t *testing.T)
 	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
 	assertDevGenerationEvent(t, generations, 2)
 	assertDevGenerationEvent(t, reloads, 2)
-	assertDevHTTPBody(t, serverURL+"/", injectDevReloadClient("new completed index", 2))
+	assertDevInjectedHTTPBody(t, serverURL+"/", "new completed index", 2)
 	assertDevHTTPBody(t, serverURL+"/assets/bundle.12345678.wasm", "new completed wasm")
 
 	cancel()
@@ -250,6 +250,133 @@ func TestDevRealWorkflowServesCompletedGenerationDuringPublication(t *testing.T)
 		t.Fatal(err)
 	}
 	waitDevListenerClosed(t, serverURL)
+}
+
+func TestDevCancellationDuringBuildSkipsGenerationAndReload(t *testing.T) {
+	t.Run("later rebuild", func(t *testing.T) {
+		appDir := filepath.Join(t.TempDir(), "app")
+		workspace := filepath.Join(t.TempDir(), "workspace")
+		writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+		writeTestFile(t, appDir, "main.go", "package main\n")
+		completedPackage := t.TempDir()
+		writeDevGenerationPackage(t, completedPackage, "initial completed index")
+
+		builds := make(chan devBuildEvent, 4)
+		serverURLs := make(chan string, 1)
+		generations := make(chan uint64, 4)
+		reloads := make(chan uint64, 4)
+		packageCalls := make(chan int, 4)
+		releaseSecond := make(chan struct{})
+		callNumber := 0
+		dependencies := devIntegrationDependencies(builds, serverURLs)
+		dependencies.hooks.GenerationActivated = func(generation uint64) {
+			generations <- generation
+		}
+		dependencies.hooks.ReloadPublished = func(generation uint64) {
+			reloads <- generation
+		}
+		dependencies.packageApp = func(options packageOptions) error {
+			callNumber++
+			packageCalls <- callNumber
+			if callNumber == 2 {
+				<-releaseSecond
+				return nil
+			}
+			if callNumber != 1 {
+				return fmt.Errorf("unexpected package call %d", callNumber)
+			}
+			layout, err := newBuildLayout(layoutOptions{appDir: options.appDir, compiler: "go", workspace: options.workspace})
+			if err != nil {
+				return err
+			}
+			return replaceDevCanonicalPackage(completedPackage, layout.PackageDir)
+		}
+
+		rootsBefore := devGenerationRootSet(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			done <- runDev(ctx, devOptions{appDir: appDir, compiler: "go", workspace: workspace, port: 0}, dependencies)
+		}()
+
+		assertDevPackageCall(t, packageCalls, 1)
+		assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+		assertDevGenerationEvent(t, generations, 1)
+		assertNoDevGenerationEvent(t, reloads)
+		serverURL := waitDevServerURL(t, serverURLs)
+		generationRoot := assertOneNewDevGenerationRoot(t, rootsBefore)
+
+		writeTestFile(t, appDir, "main.go", "package main\n\nvar rebuild = true\n")
+		assertDevPackageCall(t, packageCalls, 2)
+		writeTestFile(t, appDir, "main.go", "package main\n\nvar followUp = true\n")
+		cancel()
+		close(releaseSecond)
+
+		assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+		if err := waitDevRun(t, done); err != nil {
+			t.Fatalf("runDev() shutdown error: %v", err)
+		}
+		waitDevListenerClosed(t, serverURL)
+		assertNoDevGenerationEvent(t, generations)
+		assertNoDevGenerationEvent(t, reloads)
+		assertNoDevPackageCall(t, packageCalls)
+		if _, err := os.Stat(generationRoot); !os.IsNotExist(err) {
+			t.Fatalf("generation root remained after canceled rebuild: %v", err)
+		}
+	})
+
+	t.Run("initial build", func(t *testing.T) {
+		appDir := filepath.Join(t.TempDir(), "app")
+		workspace := filepath.Join(t.TempDir(), "workspace")
+		writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+		writeTestFile(t, appDir, "main.go", "package main\n")
+
+		builds := make(chan devBuildEvent, 2)
+		serverURLs := make(chan string, 1)
+		generations := make(chan uint64, 2)
+		reloads := make(chan uint64, 2)
+		packageCalls := make(chan int, 2)
+		releasePackage := make(chan struct{})
+		dependencies := devIntegrationDependencies(builds, serverURLs)
+		dependencies.hooks.GenerationActivated = func(generation uint64) {
+			generations <- generation
+		}
+		dependencies.hooks.ReloadPublished = func(generation uint64) {
+			reloads <- generation
+		}
+		dependencies.packageApp = func(packageOptions) error {
+			packageCalls <- 1
+			<-releasePackage
+			return nil
+		}
+
+		rootsBefore := devGenerationRootSet(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			done <- runDev(ctx, devOptions{appDir: appDir, compiler: "go", workspace: workspace, port: 0}, dependencies)
+		}()
+
+		assertDevPackageCall(t, packageCalls, 1)
+		generationRoot := assertOneNewDevGenerationRoot(t, rootsBefore)
+		cancel()
+		close(releasePackage)
+		assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+		if err := waitDevRun(t, done); err != nil {
+			t.Fatalf("runDev() shutdown error: %v", err)
+		}
+		assertNoDevGenerationEvent(t, generations)
+		assertNoDevGenerationEvent(t, reloads)
+		assertNoDevPackageCall(t, packageCalls)
+		select {
+		case url := <-serverURLs:
+			t.Fatalf("server started after canceled initial package: %s", url)
+		default:
+		}
+		if _, err := os.Stat(generationRoot); !os.IsNotExist(err) {
+			t.Fatalf("generation root remained after canceled initial build: %v", err)
+		}
+	})
 }
 
 func TestDevInitialFailureRecoversBeforeServerStarts(t *testing.T) {
@@ -467,6 +594,29 @@ func assertDevHTTPBody(t *testing.T, url, want string) {
 	}
 }
 
+func assertDevInjectedHTTPBody(t *testing.T, url, canonical string, generation uint64) {
+	t.Helper()
+	got := readDevHTTPBody(t, url)
+	if !strings.HasPrefix(got, canonical+"\n<script ") {
+		t.Fatalf("GET %s body does not preserve canonical index %q: %q", url, canonical, got)
+	}
+	if strings.Count(got, devReloadMarker) != 1 {
+		t.Fatalf("GET %s reload marker count = %d, want 1", url, strings.Count(got, devReloadMarker))
+	}
+	if !strings.Contains(got, fmt.Sprintf(`data-goframe-generation="%d"`, generation)) {
+		t.Fatalf("GET %s body does not contain generation %d: %q", url, generation, got)
+	}
+	instancePrefix := `data-goframe-instance="`
+	instanceStart := strings.Index(got, instancePrefix)
+	if instanceStart < 0 {
+		t.Fatalf("GET %s body does not contain a reload instance: %q", url, got)
+	}
+	instanceValue := got[instanceStart+len(instancePrefix):]
+	if end := strings.IndexByte(instanceValue, '"'); end <= 0 {
+		t.Fatalf("GET %s body has an empty reload instance: %q", url, got)
+	}
+}
+
 func assertDevHTTPContains(t *testing.T, url, want string) {
 	t.Helper()
 	if got := readDevHTTPBody(t, url); !strings.Contains(got, want) {
@@ -542,4 +692,54 @@ func waitDevSignal(t *testing.T, signal <-chan struct{}, label string) {
 	case <-time.After(3 * time.Second):
 		t.Fatalf("timed out waiting for %s", label)
 	}
+}
+
+func assertDevPackageCall(t *testing.T, calls <-chan int, want int) {
+	t.Helper()
+	select {
+	case got := <-calls:
+		if got != want {
+			t.Fatalf("package call = %d, want %d", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for package call %d", want)
+	}
+}
+
+func assertNoDevPackageCall(t *testing.T, calls <-chan int) {
+	t.Helper()
+	select {
+	case call := <-calls:
+		t.Fatalf("unexpected package call %d", call)
+	default:
+	}
+}
+
+func devGenerationRootSet(t *testing.T) map[string]struct{} {
+	t.Helper()
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "goxc-dev-generations-") {
+			roots[filepath.Join(os.TempDir(), entry.Name())] = struct{}{}
+		}
+	}
+	return roots
+}
+
+func assertOneNewDevGenerationRoot(t *testing.T, before map[string]struct{}) string {
+	t.Helper()
+	var added []string
+	for root := range devGenerationRootSet(t) {
+		if _, ok := before[root]; !ok {
+			added = append(added, root)
+		}
+	}
+	if len(added) != 1 {
+		t.Fatalf("new development generation roots = %#v, want one", added)
+	}
+	return added[0]
 }

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	devEventsPath       = "/_goframe/dev/events"
+	devReloadScriptPath = "/_goframe/dev/reload.js"
+	devReloadMarker     = "data-goframe-dev-reload"
+)
+
+const devReloadClient = `(function () {
+    var script = document.currentScript;
+    var generation = script && script.getAttribute("data-goframe-generation");
+    if (!generation || typeof window.EventSource !== "function") return;
+    var source = new EventSource("/_goframe/dev/events?generation=" + encodeURIComponent(generation));
+    var reloading = false;
+    source.addEventListener("reload", function () {
+        if (reloading) return;
+        reloading = true;
+        source.close();
+        window.location.reload();
+    });
+    window.addEventListener("beforeunload", function () { source.close(); }, { once: true });
+})();
+`
+
+type devReloadBroker struct {
+	mu             sync.Mutex
+	current        uint64
+	nextSubscriber uint64
+	subscribers    map[uint64]*devReloadSubscriber
+	closed         bool
+}
+
+type devReloadSubscriber struct {
+	id         uint64
+	events     chan uint64
+	lastQueued uint64
+}
+
+type devReloadSubscription struct {
+	broker *devReloadBroker
+	id     uint64
+	events <-chan uint64
+	once   sync.Once
+}
+
+func newDevReloadBroker() *devReloadBroker {
+	return &devReloadBroker{subscribers: map[uint64]*devReloadSubscriber{}}
+}
+
+func (broker *devReloadBroker) activate(generation uint64, notify bool) {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if broker.closed || generation <= broker.current {
+		return
+	}
+	broker.current = generation
+	if !notify {
+		return
+	}
+	for _, subscriber := range broker.subscribers {
+		broker.queueLocked(subscriber, generation)
+	}
+}
+
+func (broker *devReloadBroker) subscribe(generation uint64) (*devReloadSubscription, error) {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if broker.closed {
+		return nil, errors.New("development reload broker is closed")
+	}
+	broker.nextSubscriber++
+	subscriber := &devReloadSubscriber{
+		id:     broker.nextSubscriber,
+		events: make(chan uint64, 1),
+	}
+	broker.subscribers[subscriber.id] = subscriber
+	if generation < broker.current {
+		broker.queueLocked(subscriber, broker.current)
+	}
+	return &devReloadSubscription{
+		broker: broker,
+		id:     subscriber.id,
+		events: subscriber.events,
+	}, nil
+}
+
+func (broker *devReloadBroker) queueLocked(subscriber *devReloadSubscriber, generation uint64) {
+	if generation <= subscriber.lastQueued {
+		return
+	}
+	select {
+	case <-subscriber.events:
+	default:
+	}
+	subscriber.events <- generation
+	subscriber.lastQueued = generation
+}
+
+func (subscription *devReloadSubscription) Events() <-chan uint64 {
+	return subscription.events
+}
+
+func (subscription *devReloadSubscription) Close() {
+	subscription.once.Do(func() {
+		subscription.broker.unsubscribe(subscription.id)
+	})
+}
+
+func (broker *devReloadBroker) unsubscribe(id uint64) {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	subscriber, ok := broker.subscribers[id]
+	if !ok {
+		return
+	}
+	delete(broker.subscribers, id)
+	close(subscriber.events)
+}
+
+func (broker *devReloadBroker) subscriberCount() int {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	return len(broker.subscribers)
+}
+
+func (broker *devReloadBroker) close() {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if broker.closed {
+		return
+	}
+	broker.closed = true
+	for id, subscriber := range broker.subscribers {
+		delete(broker.subscribers, id)
+		close(subscriber.events)
+	}
+}
+
+func devReloadHandler(generations *devGenerationManager, broker *devReloadBroker) http.Handler {
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case devEventsPath:
+			serveDevEvents(response, request, broker)
+			return
+		case devReloadScriptPath:
+			serveDevReloadClient(response, request)
+			return
+		}
+
+		lease, err := generations.acquire()
+		if err != nil {
+			http.Error(response, "development package is not ready", http.StatusServiceUnavailable)
+			return
+		}
+		defer lease.Release()
+		if request.Method == http.MethodGet || request.Method == http.MethodHead {
+			if path, err := sanitizeServePath(request.URL.Path, request.URL.RawPath); err == nil && (path == "/" || path == "/index.html") {
+				serveDevIndex(response, request, lease)
+				return
+			}
+		}
+		devStaticHandler(lease.Directory()).ServeHTTP(response, request)
+	})
+}
+
+func serveDevEvents(response http.ResponseWriter, request *http.Request, broker *devReloadBroker) {
+	if request.Method != http.MethodGet {
+		response.Header().Set("Allow", http.MethodGet)
+		http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	generation, err := strconv.ParseUint(request.URL.Query().Get("generation"), 10, 64)
+	if err != nil {
+		http.Error(response, "invalid development generation", http.StatusBadRequest)
+		return
+	}
+	flusher, ok := response.(http.Flusher)
+	if !ok {
+		http.Error(response, "streaming is unavailable", http.StatusInternalServerError)
+		return
+	}
+	subscription, err := broker.subscribe(generation)
+	if err != nil {
+		http.Error(response, "development reload is shutting down", http.StatusServiceUnavailable)
+		return
+	}
+	defer subscription.Close()
+
+	response.Header().Set("Content-Type", "text/event-stream")
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("X-Accel-Buffering", "no")
+	_, _ = fmt.Fprint(response, ": connected\n\n")
+	flusher.Flush()
+
+	for {
+		select {
+		case <-request.Context().Done():
+			return
+		case generation, ok := <-subscription.Events():
+			if !ok {
+				return
+			}
+			if _, err := fmt.Fprintf(response, "event: reload\ndata: %d\n\n", generation); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func serveDevReloadClient(response http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodGet && request.Method != http.MethodHead {
+		response.Header().Set("Allow", "GET, HEAD")
+		http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("Content-Type", "text/javascript; charset=utf-8")
+	response.Header().Set("Content-Length", strconv.Itoa(len(devReloadClient)))
+	response.WriteHeader(http.StatusOK)
+	if request.Method == http.MethodGet {
+		_, _ = response.Write([]byte(devReloadClient))
+	}
+}
+
+func serveDevIndex(response http.ResponseWriter, request *http.Request, lease *devGenerationLease) {
+	indexPath := filepath.Join(lease.Directory(), indexHTMLAssetName)
+	if err := validatePathBelowRoot(lease.Directory(), indexPath, "development index", false); err != nil {
+		http.NotFound(response, request)
+		return
+	}
+	if _, err := regularFileNoFollow(indexPath, "development index"); err != nil {
+		http.NotFound(response, request)
+		return
+	}
+	content, err := os.ReadFile(indexPath)
+	if err != nil {
+		http.Error(response, "read development index", http.StatusInternalServerError)
+		return
+	}
+	injected := injectDevReloadClient(string(content), lease.ID())
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	response.Header().Set("Content-Length", strconv.Itoa(len(injected)))
+	response.WriteHeader(http.StatusOK)
+	if request.Method == http.MethodGet {
+		_, _ = response.Write([]byte(injected))
+	}
+}
+
+func injectDevReloadClient(content string, generation uint64) string {
+	if strings.Contains(content, devReloadMarker) {
+		return content
+	}
+	tag := fmt.Sprintf(`<script %s src="%s" data-goframe-generation="%d"></script>`, devReloadMarker, devReloadScriptPath, generation)
+	lower := strings.ToLower(content)
+	if index := strings.LastIndex(lower, "</body>"); index >= 0 {
+		return content[:index] + tag + "\n" + content[index:]
+	}
+	if content == "" || strings.HasSuffix(content, "\n") {
+		return content + tag + "\n"
+	}
+	return content + "\n" + tag + "\n"
+}

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,9 +21,10 @@ const (
 
 const devReloadClient = `(function () {
     var script = document.currentScript;
+    var instance = script && script.getAttribute("data-goframe-instance");
     var generation = script && script.getAttribute("data-goframe-generation");
-    if (!generation || typeof window.EventSource !== "function") return;
-    var source = new EventSource("/_goframe/dev/events?generation=" + encodeURIComponent(generation));
+    if (!instance || !generation || typeof window.EventSource !== "function") return;
+    var source = new EventSource("/_goframe/dev/events?instance=" + encodeURIComponent(instance) + "&generation=" + encodeURIComponent(generation));
     var reloading = false;
     source.addEventListener("reload", function () {
         if (reloading) return;
@@ -35,6 +38,7 @@ const devReloadClient = `(function () {
 
 type devReloadBroker struct {
 	mu             sync.Mutex
+	instance       string
 	current        uint64
 	nextSubscriber uint64
 	subscribers    map[uint64]*devReloadSubscriber
@@ -54,8 +58,19 @@ type devReloadSubscription struct {
 	once   sync.Once
 }
 
-func newDevReloadBroker() *devReloadBroker {
-	return &devReloadBroker{subscribers: map[uint64]*devReloadSubscriber{}}
+func newDevReloadInstance() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("create development reload instance: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+func newDevReloadBroker(instance string) *devReloadBroker {
+	return &devReloadBroker{
+		instance:    instance,
+		subscribers: map[uint64]*devReloadSubscriber{},
+	}
 }
 
 func (broker *devReloadBroker) activate(generation uint64, notify bool) {
@@ -73,20 +88,24 @@ func (broker *devReloadBroker) activate(generation uint64, notify bool) {
 	}
 }
 
-func (broker *devReloadBroker) subscribe(generation uint64) (*devReloadSubscription, error) {
+func (broker *devReloadBroker) subscribe(instance string, generation uint64) (*devReloadSubscription, error) {
 	broker.mu.Lock()
 	defer broker.mu.Unlock()
 	if broker.closed {
 		return nil, errors.New("development reload broker is closed")
 	}
+	generationFloor := generation
+	if instance != broker.instance {
+		generationFloor = 0
+	}
 	broker.nextSubscriber++
 	subscriber := &devReloadSubscriber{
 		id:              broker.nextSubscriber,
 		events:          make(chan uint64, 1),
-		generationFloor: generation,
+		generationFloor: generationFloor,
 	}
 	broker.subscribers[subscriber.id] = subscriber
-	if generation < broker.current {
+	if generationFloor < broker.current {
 		broker.queueLocked(subscriber, broker.current)
 	}
 	return &devReloadSubscription{
@@ -167,7 +186,7 @@ func devReloadHandler(generations *devGenerationManager, broker *devReloadBroker
 		defer lease.Release()
 		if request.Method == http.MethodGet || request.Method == http.MethodHead {
 			if path, err := sanitizeServePath(request.URL.Path, request.URL.RawPath); err == nil && (path == "/" || path == "/index.html") {
-				serveDevIndex(response, request, lease)
+				serveDevIndex(response, request, lease, broker.instance)
 				return
 			}
 		}
@@ -181,8 +200,14 @@ func serveDevEvents(response http.ResponseWriter, request *http.Request, broker 
 		http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	generation, err := strconv.ParseUint(request.URL.Query().Get("generation"), 10, 64)
-	if err != nil {
+	query := request.URL.Query()
+	instance := query.Get("instance")
+	if instance == "" {
+		http.Error(response, "invalid development instance", http.StatusBadRequest)
+		return
+	}
+	generation, err := strconv.ParseUint(query.Get("generation"), 10, 64)
+	if err != nil || generation == 0 {
 		http.Error(response, "invalid development generation", http.StatusBadRequest)
 		return
 	}
@@ -191,7 +216,7 @@ func serveDevEvents(response http.ResponseWriter, request *http.Request, broker 
 		http.Error(response, "streaming is unavailable", http.StatusInternalServerError)
 		return
 	}
-	subscription, err := broker.subscribe(generation)
+	subscription, err := broker.subscribe(instance, generation)
 	if err != nil {
 		http.Error(response, "development reload is shutting down", http.StatusServiceUnavailable)
 		return
@@ -235,7 +260,7 @@ func serveDevReloadClient(response http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func serveDevIndex(response http.ResponseWriter, request *http.Request, lease *devGenerationLease) {
+func serveDevIndex(response http.ResponseWriter, request *http.Request, lease *devGenerationLease, instance string) {
 	indexPath := filepath.Join(lease.Directory(), indexHTMLAssetName)
 	if err := validatePathBelowRoot(lease.Directory(), indexPath, "development index", false); err != nil {
 		http.NotFound(response, request)
@@ -250,7 +275,7 @@ func serveDevIndex(response http.ResponseWriter, request *http.Request, lease *d
 		http.Error(response, "read development index", http.StatusInternalServerError)
 		return
 	}
-	injected := injectDevReloadClient(string(content), lease.ID())
+	injected := injectDevReloadClient(string(content), instance, lease.ID())
 	response.Header().Set("Cache-Control", "no-store")
 	response.Header().Set("Content-Type", "text/html; charset=utf-8")
 	response.Header().Set("Content-Length", strconv.Itoa(len(injected)))
@@ -260,17 +285,43 @@ func serveDevIndex(response http.ResponseWriter, request *http.Request, lease *d
 	}
 }
 
-func injectDevReloadClient(content string, generation uint64) string {
+func injectDevReloadClient(content, instance string, generation uint64) string {
 	if strings.Contains(content, devReloadMarker) {
 		return content
 	}
-	tag := fmt.Sprintf(`<script %s src="%s" data-goframe-generation="%d"></script>`, devReloadMarker, devReloadScriptPath, generation)
-	lower := strings.ToLower(content)
-	if index := strings.LastIndex(lower, "</body>"); index >= 0 {
+	tag := fmt.Sprintf(`<script %s src="%s" data-goframe-instance="%s" data-goframe-generation="%d"></script>`, devReloadMarker, devReloadScriptPath, instance, generation)
+	if index := lastASCIIFoldIndex(content, "</body>"); index >= 0 {
 		return content[:index] + tag + "\n" + content[index:]
 	}
 	if content == "" || strings.HasSuffix(content, "\n") {
 		return content + tag + "\n"
 	}
 	return content + "\n" + tag + "\n"
+}
+
+func lastASCIIFoldIndex(content, target string) int {
+	if target == "" {
+		return len(content)
+	}
+	for index := len(content) - len(target); index >= 0; index-- {
+		matched := true
+		for offset := range len(target) {
+			left := content[index+offset]
+			right := target[offset]
+			if left >= 'A' && left <= 'Z' {
+				left += 'a' - 'A'
+			}
+			if right >= 'A' && right <= 'Z' {
+				right += 'a' - 'A'
+			}
+			if left != right {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return index
+		}
+	}
+	return -1
 }

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -42,9 +42,9 @@ type devReloadBroker struct {
 }
 
 type devReloadSubscriber struct {
-	id         uint64
-	events     chan uint64
-	lastQueued uint64
+	id              uint64
+	events          chan uint64
+	generationFloor uint64
 }
 
 type devReloadSubscription struct {
@@ -81,8 +81,9 @@ func (broker *devReloadBroker) subscribe(generation uint64) (*devReloadSubscript
 	}
 	broker.nextSubscriber++
 	subscriber := &devReloadSubscriber{
-		id:     broker.nextSubscriber,
-		events: make(chan uint64, 1),
+		id:              broker.nextSubscriber,
+		events:          make(chan uint64, 1),
+		generationFloor: generation,
 	}
 	broker.subscribers[subscriber.id] = subscriber
 	if generation < broker.current {
@@ -96,7 +97,7 @@ func (broker *devReloadBroker) subscribe(generation uint64) (*devReloadSubscript
 }
 
 func (broker *devReloadBroker) queueLocked(subscriber *devReloadSubscriber, generation uint64) {
-	if generation <= subscriber.lastQueued {
+	if generation <= subscriber.generationFloor {
 		return
 	}
 	select {
@@ -104,7 +105,7 @@ func (broker *devReloadBroker) queueLocked(subscriber *devReloadSubscriber, gene
 	default:
 	}
 	subscriber.events <- generation
-	subscriber.lastQueued = generation
+	subscriber.generationFloor = generation
 }
 
 func (subscription *devReloadSubscription) Events() <-chan uint64 {

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -46,6 +46,26 @@ func TestDevReloadPublishesToTwoSubscribersOnce(t *testing.T) {
 	assertNoQueuedDevReload(t, second)
 }
 
+func TestDevReloadSubscriberAlreadyOnActivatingGenerationDoesNotReload(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	oldPage := mustDevReloadSubscription(t, broker, 1)
+	newPage := mustDevReloadSubscription(t, broker, 2)
+	defer oldPage.Close()
+	defer newPage.Close()
+
+	broker.activate(2, true)
+	assertDevReloadGeneration(t, oldPage, 2)
+	assertNoQueuedDevReload(t, oldPage)
+	assertNoQueuedDevReload(t, newPage)
+
+	broker.activate(3, true)
+	assertDevReloadGeneration(t, oldPage, 3)
+	assertDevReloadGeneration(t, newPage, 3)
+	assertNoQueuedDevReload(t, oldPage)
+	assertNoQueuedDevReload(t, newPage)
+}
+
 func TestDevReloadSlowSubscriberCollapsesToNewestGeneration(t *testing.T) {
 	broker := newDevReloadBroker()
 	broker.activate(1, false)

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -11,10 +11,13 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
+const testDevReloadInstance = "0123456789abcdef0123456789abcdef"
+
 func TestDevReloadSameGenerationConnectionWaits(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	subscription := mustDevReloadSubscription(t, broker, 1)
 	defer subscription.Close()
@@ -22,7 +25,7 @@ func TestDevReloadSameGenerationConnectionWaits(t *testing.T) {
 }
 
 func TestDevReloadStaleGenerationReceivesCatchUp(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(3, false)
 	subscription := mustDevReloadSubscription(t, broker, 1)
 	defer subscription.Close()
@@ -31,7 +34,7 @@ func TestDevReloadStaleGenerationReceivesCatchUp(t *testing.T) {
 }
 
 func TestDevReloadPublishesToTwoSubscribersOnce(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	first := mustDevReloadSubscription(t, broker, 1)
 	second := mustDevReloadSubscription(t, broker, 1)
@@ -47,7 +50,7 @@ func TestDevReloadPublishesToTwoSubscribersOnce(t *testing.T) {
 }
 
 func TestDevReloadSubscriberAlreadyOnActivatingGenerationDoesNotReload(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	oldPage := mustDevReloadSubscription(t, broker, 1)
 	newPage := mustDevReloadSubscription(t, broker, 2)
@@ -66,8 +69,30 @@ func TestDevReloadSubscriberAlreadyOnActivatingGenerationDoesNotReload(t *testin
 	assertNoQueuedDevReload(t, newPage)
 }
 
+func TestDevReloadProcessInstanceMismatchCatchesUpWithoutAffectingCurrentClient(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activate(2, false)
+	currentPage := mustDevReloadSubscription(t, broker, 2)
+	previousProcess, err := broker.subscribe("fedcba9876543210fedcba9876543210", 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer currentPage.Close()
+	defer previousProcess.Close()
+
+	assertDevReloadGeneration(t, previousProcess, 2)
+	assertNoQueuedDevReload(t, previousProcess)
+	assertNoQueuedDevReload(t, currentPage)
+
+	broker.activate(3, true)
+	assertDevReloadGeneration(t, previousProcess, 3)
+	assertDevReloadGeneration(t, currentPage, 3)
+	assertNoQueuedDevReload(t, previousProcess)
+	assertNoQueuedDevReload(t, currentPage)
+}
+
 func TestDevReloadSlowSubscriberCollapsesToNewestGeneration(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	subscription := mustDevReloadSubscription(t, broker, 1)
 	defer subscription.Close()
@@ -80,7 +105,7 @@ func TestDevReloadSlowSubscriberCollapsesToNewestGeneration(t *testing.T) {
 }
 
 func TestDevReloadDisconnectAndShutdownReleaseSubscribers(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	first := mustDevReloadSubscription(t, broker, 0)
 	second := mustDevReloadSubscription(t, broker, 0)
 	if got := broker.subscriberCount(); got != 2 {
@@ -101,7 +126,7 @@ func TestDevReloadDisconnectAndShutdownReleaseSubscribers(t *testing.T) {
 }
 
 func TestDevReloadConcurrentPublishSubscribeDisconnect(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	var workers sync.WaitGroup
 	for worker := 0; worker < 12; worker++ {
@@ -109,7 +134,7 @@ func TestDevReloadConcurrentPublishSubscribeDisconnect(t *testing.T) {
 		go func(worker int) {
 			defer workers.Done()
 			for iteration := 0; iteration < 100; iteration++ {
-				subscription, err := broker.subscribe(uint64(worker % 4))
+				subscription, err := broker.subscribe(testDevReloadInstance, uint64(worker%4))
 				if err != nil {
 					return
 				}
@@ -132,14 +157,14 @@ func TestDevReloadConcurrentPublishSubscribeDisconnect(t *testing.T) {
 }
 
 func TestDevReloadEventsEndpointStreamsReload(t *testing.T) {
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(1, false)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 		serveDevEvents(response, request, broker)
 	}))
 	defer server.Close()
 
-	response, err := http.Get(server.URL + "?generation=1")
+	response, err := http.Get(server.URL + "?instance=" + testDevReloadInstance + "&generation=1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,9 +198,72 @@ func TestDevReloadEventsEndpointStreamsReload(t *testing.T) {
 
 func TestDevReloadEventsEndpointRejectsUnsupportedMethod(t *testing.T) {
 	response := httptest.NewRecorder()
-	serveDevEvents(response, httptest.NewRequest(http.MethodPost, devEventsPath+"?generation=1", nil), newDevReloadBroker())
+	serveDevEvents(response, httptest.NewRequest(http.MethodPost, devEventsPath+"?instance="+testDevReloadInstance+"&generation=1", nil), newDevReloadBroker(testDevReloadInstance))
 	if response.Code != http.StatusMethodNotAllowed || response.Header().Get("Allow") != http.MethodGet {
 		t.Fatalf("response = %d Allow=%q, want 405 GET", response.Code, response.Header().Get("Allow"))
+	}
+}
+
+func TestDevReloadEventsEndpointRejectsMalformedOrMissingSubscriptionParameters(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	for _, test := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "missing instance", path: devEventsPath + "?generation=1", want: "invalid development instance"},
+		{name: "missing generation", path: devEventsPath + "?instance=" + testDevReloadInstance, want: "invalid development generation"},
+		{name: "malformed generation", path: devEventsPath + "?instance=" + testDevReloadInstance + "&generation=nope", want: "invalid development generation"},
+		{name: "zero generation", path: devEventsPath + "?instance=" + testDevReloadInstance + "&generation=0", want: "invalid development generation"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			serveDevEvents(response, httptest.NewRequest(http.MethodGet, test.path, nil), broker)
+			if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), test.want) {
+				t.Fatalf("response = %d %q, want 400 containing %q", response.Code, response.Body.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestDevReloadInjectionBodyCaseVariants(t *testing.T) {
+	for _, closingTag := range []string{"</body>", "</BODY>", "</BoDy>"} {
+		t.Run(closingTag, func(t *testing.T) {
+			canonical := "<!doctype html><html><body><main>app</main>" + closingTag + "</html>"
+			tag := fmt.Sprintf(`<script %s src="%s" data-goframe-instance="%s" data-goframe-generation="7"></script>`, devReloadMarker, devReloadScriptPath, testDevReloadInstance)
+			want := strings.Replace(canonical, closingTag, tag+"\n"+closingTag, 1)
+			got := injectDevReloadClient(canonical, testDevReloadInstance, 7)
+			if got != want {
+				t.Fatalf("injected index = %q, want %q", got, want)
+			}
+			if strings.Count(got, devReloadMarker) != 1 {
+				t.Fatalf("reload marker count = %d, want 1", strings.Count(got, devReloadMarker))
+			}
+		})
+	}
+}
+
+func TestDevReloadInjectionPreservesUnicodeByteOffsets(t *testing.T) {
+	const canonical = "<!doctype html><html><body><main>İstanbul</main></BoDy></html>"
+	original := canonical
+	tag := fmt.Sprintf(`<script %s src="%s" data-goframe-instance="%s" data-goframe-generation="9"></script>`, devReloadMarker, devReloadScriptPath, testDevReloadInstance)
+	want := strings.Replace(canonical, "</BoDy>", tag+"\n</BoDy>", 1)
+	got := injectDevReloadClient(canonical, testDevReloadInstance, 9)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("injected index is not valid UTF-8: %q", got)
+	}
+	if got != want {
+		t.Fatalf("injected index = %q, want %q", got, want)
+	}
+	if !strings.Contains(got, "<main>İstanbul</main>") {
+		t.Fatalf("non-ASCII content changed: %q", got)
+	}
+	if canonical != original {
+		t.Fatalf("canonical input changed from %q to %q", original, canonical)
+	}
+	if strings.Count(got, devReloadMarker) != 1 {
+		t.Fatalf("reload marker count = %d, want 1", strings.Count(got, devReloadMarker))
 	}
 }
 
@@ -188,7 +276,7 @@ func TestDevReloadHandlerInjectsOneGenerationClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(generation, false)
 	handler := devReloadHandler(manager, broker)
 
@@ -202,7 +290,7 @@ func TestDevReloadHandlerInjectsOneGenerationClient(t *testing.T) {
 		if strings.Count(body, devReloadMarker) != 1 {
 			t.Fatalf("GET %s reload marker count = %d, body=%q", requestPath, strings.Count(body, devReloadMarker), body)
 		}
-		wantTag := fmt.Sprintf(`%s src="%s" data-goframe-generation="%d"`, devReloadMarker, devReloadScriptPath, generation)
+		wantTag := fmt.Sprintf(`%s src="%s" data-goframe-instance="%s" data-goframe-generation="%d"`, devReloadMarker, devReloadScriptPath, testDevReloadInstance, generation)
 		if !strings.Contains(body, wantTag) || strings.Index(body, wantTag) > strings.Index(strings.ToLower(body), "</body>") {
 			t.Fatalf("GET %s did not inject generation client before body: %q", requestPath, body)
 		}
@@ -230,7 +318,7 @@ func TestDevReloadHandlerAppendsClientWithoutClosingBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	broker := newDevReloadBroker()
+	broker := newDevReloadBroker(testDevReloadInstance)
 	broker.activate(generation, false)
 	response := httptest.NewRecorder()
 	devReloadHandler(manager, broker).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
@@ -245,7 +333,7 @@ func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
 	if response.Code != http.StatusOK || response.Header().Get("Cache-Control") != "no-store" {
 		t.Fatalf("reload client response = %d Cache-Control=%q", response.Code, response.Header().Get("Cache-Control"))
 	}
-	for _, want := range []string{"EventSource", "data-goframe-generation", "window.location.reload()"} {
+	for _, want := range []string{"EventSource", "data-goframe-instance", "data-goframe-generation", "window.location.reload()"} {
 		if !strings.Contains(response.Body.String(), want) {
 			t.Fatalf("reload client missing %q: %q", want, response.Body.String())
 		}
@@ -260,7 +348,7 @@ func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
 
 func mustDevReloadSubscription(t *testing.T, broker *devReloadBroker, generation uint64) *devReloadSubscription {
 	t.Helper()
-	subscription, err := broker.subscribe(generation)
+	subscription, err := broker.subscribe(broker.instance, generation)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDevReloadSameGenerationConnectionWaits(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	defer subscription.Close()
+	assertNoQueuedDevReload(t, subscription)
+}
+
+func TestDevReloadStaleGenerationReceivesCatchUp(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(3, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	defer subscription.Close()
+	assertDevReloadGeneration(t, subscription, 3)
+	assertNoQueuedDevReload(t, subscription)
+}
+
+func TestDevReloadPublishesToTwoSubscribersOnce(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	first := mustDevReloadSubscription(t, broker, 1)
+	second := mustDevReloadSubscription(t, broker, 1)
+	defer first.Close()
+	defer second.Close()
+
+	broker.activate(2, true)
+	assertDevReloadGeneration(t, first, 2)
+	assertDevReloadGeneration(t, second, 2)
+	broker.activate(2, true)
+	assertNoQueuedDevReload(t, first)
+	assertNoQueuedDevReload(t, second)
+}
+
+func TestDevReloadSlowSubscriberCollapsesToNewestGeneration(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	defer subscription.Close()
+
+	broker.activate(2, true)
+	broker.activate(3, true)
+	broker.activate(4, true)
+	assertDevReloadGeneration(t, subscription, 4)
+	assertNoQueuedDevReload(t, subscription)
+}
+
+func TestDevReloadDisconnectAndShutdownReleaseSubscribers(t *testing.T) {
+	broker := newDevReloadBroker()
+	first := mustDevReloadSubscription(t, broker, 0)
+	second := mustDevReloadSubscription(t, broker, 0)
+	if got := broker.subscriberCount(); got != 2 {
+		t.Fatalf("subscriber count = %d, want 2", got)
+	}
+	first.Close()
+	if got := broker.subscriberCount(); got != 1 {
+		t.Fatalf("subscriber count after disconnect = %d, want 1", got)
+	}
+	broker.close()
+	if got := broker.subscriberCount(); got != 0 {
+		t.Fatalf("subscriber count after shutdown = %d, want 0", got)
+	}
+	if _, ok := <-second.Events(); ok {
+		t.Fatal("subscriber channel remained open after shutdown")
+	}
+	second.Close()
+}
+
+func TestDevReloadConcurrentPublishSubscribeDisconnect(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	var workers sync.WaitGroup
+	for worker := 0; worker < 12; worker++ {
+		workers.Add(1)
+		go func(worker int) {
+			defer workers.Done()
+			for iteration := 0; iteration < 100; iteration++ {
+				subscription, err := broker.subscribe(uint64(worker % 4))
+				if err != nil {
+					return
+				}
+				select {
+				case <-subscription.Events():
+				default:
+				}
+				subscription.Close()
+			}
+		}(worker)
+	}
+	for generation := uint64(2); generation < 80; generation++ {
+		broker.activate(generation, true)
+	}
+	workers.Wait()
+	broker.close()
+	if got := broker.subscriberCount(); got != 0 {
+		t.Fatalf("subscriber count = %d, want 0", got)
+	}
+}
+
+func TestDevReloadEventsEndpointStreamsReload(t *testing.T) {
+	broker := newDevReloadBroker()
+	broker.activate(1, false)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		serveDevEvents(response, request, broker)
+	}))
+	defer server.Close()
+
+	response, err := http.Get(server.URL + "?generation=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.StatusCode)
+	}
+	if got := response.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+	if got := response.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	reader := bufio.NewReader(response.Body)
+	if line, err := reader.ReadString('\n'); err != nil || line != ": connected\n" {
+		t.Fatalf("initial SSE line = %q, %v", line, err)
+	}
+	if line, err := reader.ReadString('\n'); err != nil || line != "\n" {
+		t.Fatalf("initial SSE separator = %q, %v", line, err)
+	}
+
+	broker.activate(2, true)
+	for _, want := range []string{"event: reload\n", "data: 2\n", "\n"} {
+		if line, err := reader.ReadString('\n'); err != nil || line != want {
+			t.Fatalf("SSE line = %q, %v, want %q", line, err, want)
+		}
+	}
+	response.Body.Close()
+	waitForDevReloadSubscriberCount(t, broker, 0)
+}
+
+func TestDevReloadEventsEndpointRejectsUnsupportedMethod(t *testing.T) {
+	response := httptest.NewRecorder()
+	serveDevEvents(response, httptest.NewRequest(http.MethodPost, devEventsPath+"?generation=1", nil), newDevReloadBroker())
+	if response.Code != http.StatusMethodNotAllowed || response.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("response = %d Allow=%q, want 405 GET", response.Code, response.Header().Get("Allow"))
+	}
+}
+
+func TestDevReloadHandlerInjectsOneGenerationClient(t *testing.T) {
+	packageDir := t.TempDir()
+	canonicalIndex := "<!doctype html><html><body><main>app</main></body></html>"
+	writeDevGenerationPackage(t, packageDir, canonicalIndex)
+	manager := newTestDevGenerationManager(t)
+	generation, err := manager.activatePackage(packageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broker := newDevReloadBroker()
+	broker.activate(generation, false)
+	handler := devReloadHandler(manager, broker)
+
+	for _, requestPath := range []string{"/", "/index.html"} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, requestPath, nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d", requestPath, response.Code)
+		}
+		body := response.Body.String()
+		if strings.Count(body, devReloadMarker) != 1 {
+			t.Fatalf("GET %s reload marker count = %d, body=%q", requestPath, strings.Count(body, devReloadMarker), body)
+		}
+		wantTag := fmt.Sprintf(`%s src="%s" data-goframe-generation="%d"`, devReloadMarker, devReloadScriptPath, generation)
+		if !strings.Contains(body, wantTag) || strings.Index(body, wantTag) > strings.Index(strings.ToLower(body), "</body>") {
+			t.Fatalf("GET %s did not inject generation client before body: %q", requestPath, body)
+		}
+		if got := response.Header().Get("Cache-Control"); got != "no-store" {
+			t.Fatalf("GET %s Cache-Control = %q", requestPath, got)
+		}
+	}
+	assertFileContent(t, filepath.Join(packageDir, indexHTMLAssetName), canonicalIndex)
+
+	head := httptest.NewRecorder()
+	handler.ServeHTTP(head, httptest.NewRequest(http.MethodHead, "/", nil))
+	if head.Code != http.StatusOK || head.Body.Len() != 0 {
+		t.Fatalf("HEAD response = %d %q, want 200 with no body", head.Code, head.Body.String())
+	}
+	if length, err := strconv.Atoi(head.Header().Get("Content-Length")); err != nil || length <= len(canonicalIndex) {
+		t.Fatalf("HEAD Content-Length = %q, want injected length", head.Header().Get("Content-Length"))
+	}
+}
+
+func TestDevReloadHandlerAppendsClientWithoutClosingBody(t *testing.T) {
+	packageDir := t.TempDir()
+	writeDevGenerationPackage(t, packageDir, "<main>app</main>")
+	manager := newTestDevGenerationManager(t)
+	generation, err := manager.activatePackage(packageDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broker := newDevReloadBroker()
+	broker.activate(generation, false)
+	response := httptest.NewRecorder()
+	devReloadHandler(manager, broker).ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	if !strings.HasSuffix(response.Body.String(), "</script>\n") || strings.Count(response.Body.String(), devReloadMarker) != 1 {
+		t.Fatalf("injected body = %q", response.Body.String())
+	}
+}
+
+func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
+	response := httptest.NewRecorder()
+	serveDevReloadClient(response, httptest.NewRequest(http.MethodGet, devReloadScriptPath, nil))
+	if response.Code != http.StatusOK || response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("reload client response = %d Cache-Control=%q", response.Code, response.Header().Get("Cache-Control"))
+	}
+	for _, want := range []string{"EventSource", "data-goframe-generation", "window.location.reload()"} {
+		if !strings.Contains(response.Body.String(), want) {
+			t.Fatalf("reload client missing %q: %q", want, response.Body.String())
+		}
+	}
+
+	head := httptest.NewRecorder()
+	serveDevReloadClient(head, httptest.NewRequest(http.MethodHead, devReloadScriptPath, nil))
+	if head.Code != http.StatusOK || head.Body.Len() != 0 {
+		t.Fatalf("HEAD reload client = %d %q", head.Code, head.Body.String())
+	}
+}
+
+func mustDevReloadSubscription(t *testing.T, broker *devReloadBroker, generation uint64) *devReloadSubscription {
+	t.Helper()
+	subscription, err := broker.subscribe(generation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return subscription
+}
+
+func assertDevReloadGeneration(t *testing.T, subscription *devReloadSubscription, want uint64) {
+	t.Helper()
+	select {
+	case got, ok := <-subscription.Events():
+		if !ok || got != want {
+			t.Fatalf("reload event = %d, %v, want %d, true", got, ok, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for generation %d", want)
+	}
+}
+
+func assertNoQueuedDevReload(t *testing.T, subscription *devReloadSubscription) {
+	t.Helper()
+	select {
+	case generation, ok := <-subscription.Events():
+		t.Fatalf("unexpected reload event = %d, %v", generation, ok)
+	default:
+	}
+}
+
+func waitForDevReloadSubscriberCount(t *testing.T, broker *devReloadBroker, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if broker.subscriberCount() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("subscriber count = %d, want %d", broker.subscriberCount(), want)
+}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -100,6 +100,13 @@ identity. It also covers route Error Boundary fallback and safe navigation
 recovery in the reference app. It also covers the resource example for explicit
 loading/ready/failed state, reload, stale completion guards, and
 cleanup-after-unmount behavior.
+The suite also runs a focused `goxc dev` reload lifecycle against a temporary
+standard-Go browser/WASM application. It verifies the initial non-reloading
+connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure
+preservation and recovery, two connected pages, current and stale generation
+reconnection, completed-generation serving during a later package attempt, and
+shutdown cleanup. This is standard-Go browser evidence; it does not claim a
+TinyGo development-reload pass.
 The persistent `examples/server-backed` smoke records a narrow Go `net/http`
 backend integration boundary. A packaged GoFrame browser/WASM app is served by
 a same-origin Go backend and renders data from `/api/greeting` before and after

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,8 @@
 # Local Development Workflow
 
 `goxc dev` packages a browser/WASM application, serves the latest completed
-package, and rebuilds it when effective authored inputs change:
+development generation, rebuilds it when effective authored inputs change, and
+reloads connected browser pages after successful rebuilds:
 
 ```bash
 goxc dev <app-directory> [--compiler=go|tinygo] [--port=8080] [--workspace=directory]
@@ -12,10 +13,11 @@ goxc dev is a local development workflow, not production hosting.
 ## Start And Serve
 
 The command validates the application and workspace roots, collects an initial
-input snapshot, and runs the existing development package path. The HTTP server
-starts only after a complete package has been published and verified. It binds
-to `127.0.0.1`; pass `--port=0` to select an available local port and read the
-actual URL from the command output.
+input snapshot, and runs the existing development package path. After verifying
+the canonical package, it copies and verifies a process-private completed
+generation. The HTTP server starts only after that generation is active. It
+binds to `127.0.0.1`; pass `--port=0` to select an available local port and read
+the actual URL from the command output.
 
 An initial authored-source, manifest, generation, or compilation failure is
 reported in the terminal without ending the process. The command continues
@@ -31,7 +33,9 @@ Development output uses the normal standalone package location:
 
 With `--workspace`, the package is placed in the app-specific external
 workspace defined by the existing workspace contract. The source tree is not
-served.
+served. The development server also does not serve the mutable canonical
+package directly. Each request uses one verified generation for its full
+response, and retired generations remain until their active requests finish.
 
 If `--compiler` is omitted, every accepted build uses the compiler currently
 selected by `goframe.json`. A command-line `--compiler=go` or
@@ -75,33 +79,53 @@ until the manifest can be parsed and the effective assets recomputed.
 ## Failures And Recovery
 
 After a successful package, ordinary GOX diagnostics, Go compiler errors, and
-manifest errors leave the last completed package available. The server remains
-on the same listener, the failed snapshot is not retried indefinitely, and a
-later authored change starts a new package attempt. Successful recovery replaces
-the package through the normal publication path.
+manifest errors leave the last completed generation available. The server
+remains on the same listener, the failed snapshot is not retried indefinitely,
+and a later authored change starts a new package attempt. Successful recovery
+publishes and verifies the canonical package, activates a new completed
+generation, and reloads connected pages.
 
 This preservation guarantee does not override existing package publication or
-filesystem failure semantics. A failure that invalidates package ownership or
-completion metadata is reported as such.
+filesystem failure semantics. A failure that invalidates package ownership,
+generation copying, or completion metadata is reported as such and does not
+replace the active generation.
 
-The server adds `Cache-Control: no-store` to development responses. Refresh the
-browser manually after a successful rebuild to load the latest completed
-package.
+## Browser Reload
+
+The server adds `Cache-Control: no-store` to development responses and injects
+one same-origin development script into `/` and `/index.html` responses. The
+script connects to a development-only Server-Sent Events endpoint. The initial
+page connects without reloading itself. Every later successful accepted build
+activates one completed generation before publishing one reload event, and the
+browser performs an ordinary full-document reload.
+
+Failed builds publish no event, so the current page and last completed
+generation remain available. A successful recovery activates a new generation
+and reloads connected pages. A page reconnecting with the current generation
+waits for a later build; a page reconnecting with an older generation receives
+one catch-up reload.
+
+Reload injection changes only development HTTP responses. It does not modify
+the canonical `index.html`, asset manifest, package metadata, exported packages,
+or ordinary `goxc serve` behavior. A strict Content Security Policy that blocks
+the injected same-origin script is a current development limitation; the
+server does not rewrite CSP headers.
 
 ## Shutdown
 
 `Ctrl-C` stops polling and prevents another build from starting. If a package
 attempt is already running, the command waits for that in-process attempt to
-return, then shuts down the HTTP server and exits successfully.
+return, then closes reload connections, shuts down the HTTP server, removes its
+process-private generation root, and exits successfully.
 
 ## Current Limits
 
 Each accepted change batch performs a full development package. The command
 does not provide:
 
-- browser auto-reload or auto-open;
+- browser auto-open;
 - an error overlay;
-- HMR or browser state preservation;
+- HMR or browser state preservation; a full-page reload resets browser state;
 - incremental compilation or an incremental build cache;
 - source maps;
 - file watching outside the effective app and module inputs;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -323,8 +323,9 @@ Resumability, server components, and selective or streaming hydration remain
 
 ## `v0.7.0-preview.*` - Dev Loop & Language Services
 
-Status: **Candidate**, with the bounded watched development command now
-**Current / shipped**.
+Status: **Candidate**, with the bounded watched development command and
+successful-build browser reload now **Current / shipped**. Browser build-error
+presentation remains **Candidate**.
 
 The CLI-backed saved-source diagnostics in current `main` are
 **Current / shipped**. Semantic tooling remains future language-service work.
@@ -334,7 +335,7 @@ Candidate sequence:
 | Planning slot | Candidate capability |
 |---|---|
 | `preview.1` | Watched development command with serialized full-package rebuilds. |
-| `preview.2` | Browser reload and error overlay. |
+| `preview.2` | Successful-build browser reload is current; browser build-error overlay remains candidate. |
 | `preview.3` | GOX-to-generated source maps. |
 | `preview.4` | Deterministic formatter. |
 | `preview.5` | LSP baseline. |
@@ -344,7 +345,9 @@ Potential surface, subject to design and evidence:
 
 - the current `goxc dev` full-package workflow, with later incremental build
   work requiring separate evidence;
-- browser reload with compiler and source error presentation;
+- the current completed-generation serving and successful-build full-page
+  reload workflow;
+- browser compiler and source error presentation as a separate candidate;
 - GOX-to-generated source maps shared by compiler and editor tooling;
 - a deterministic formatter with explicit syntax-governance rules;
 - diagnostics, hover, completion, definition, and references;
@@ -522,12 +525,10 @@ that defines behavior boundaries, evidence, cost, and non-goals.
 
 ## Immediate Sequence
 
-1. Establish the bounded watched `goxc dev` command as the immediate selected
-   toolchain capability.
-2. Validate full-package rebuilds, failure recovery, loopback serving, and
-   clean shutdown through focused Go evidence.
-3. Keep browser reload and browser error presentation as a later candidate,
-   selected only after the first workflow evidence is complete.
+1. Retain the bounded watched `goxc dev` command as **Current / shipped**.
+2. Retain completed-generation serving and successful-build browser reload as
+   **Current / shipped** after focused Go and browser evidence.
+3. Keep browser build-error presentation as a separate later candidate.
 
 The application-model evidence does not justify adding a loader, Action, or
 Mutation API. The selected development-loop slice does not imply incremental

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -383,6 +383,11 @@ run_with_server ./examples/resource "$RESOURCE_PORT" "$RESOURCE_URL" \
 	node --experimental-websocket scripts/resource-browser-smoke.mjs
 
 echo
+echo "== goxc dev reload browser smoke =="
+export GOFRAME_DEV_RELOAD_CHROME_DEBUG_PORT="${GOFRAME_DEV_RELOAD_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/goxc-dev-reload-browser-smoke.mjs
+
+echo
 echo "== Server-backed reference browser smoke =="
 export GOFRAME_SERVER_BACKED_CHROME_DEBUG_PORT="${GOFRAME_SERVER_BACKED_CHROME_DEBUG_PORT:-$(pick_free_port)}"
 node --experimental-websocket scripts/server-backed-browser-smoke.mjs

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -1,0 +1,636 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const repositoryRoot = process.cwd();
+const chrome = process.env.CHROME ?? "google-chrome";
+const root = await mkdtemp(join(tmpdir(), "goframe-dev-reload-smoke-"));
+const appDir = join(root, "app");
+const workspace = join(root, "workspace");
+const profile = join(root, "chrome-profile");
+const localGoxc = join(root, "bin", "goxc");
+const goxc = process.env.GOXC || localGoxc;
+const debugPort = Number(process.env.GOFRAME_DEV_RELOAD_CHROME_DEBUG_PORT || await freePort());
+const generationRootsBefore = await listGenerationRoots();
+
+let dev = null;
+let browser = null;
+let client1 = null;
+let client2 = null;
+let devOutput = "";
+let browserError = "";
+const lines = [];
+const counters = {
+    successfulPackageAttempts: 0,
+    failedPackageAttempts: 0,
+    completedGenerations: 0,
+    generationActivations: 0,
+    reloadEventsPublished: 0,
+    catchUpReloads: 0,
+    requestsServedByOldGeneration: 0,
+    responses404DuringBuild: 0,
+};
+
+try {
+    await writeApplication("gox-initial", "go-initial", "index-initial");
+    if (!process.env.GOXC) {
+        await mkdir(dirname(localGoxc), { recursive: true });
+        await runProcess("go", ["build", "-o", localGoxc, "./cmd/goxc"], { cwd: repositoryRoot });
+    }
+
+    dev = spawn(goxc, ["dev", appDir, "--compiler=go", "--port=0", `--workspace=${workspace}`], {
+        cwd: repositoryRoot,
+        env: {
+            ...process.env,
+            GOWORK: "off",
+            GOPROXY: "off",
+            GOSUMDB: "off",
+            GOFLAGS: "-mod=mod",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+    captureLines(dev.stdout, "stdout");
+    captureLines(dev.stderr, "stderr");
+    const serverLine = await waitForLine((line) => line.text.includes("development server ready at "), 30_000);
+    const serverURL = serverLine.text.match(/http:\/\/\S+/)?.[0];
+    if (!serverURL) throw new Error(`HARNESS FAILURE: development URL missing from ${serverLine.text}`);
+    await waitForBuild(1, "succeeded");
+    counters.successfulPackageAttempts++;
+    counters.completedGenerations++;
+    counters.generationActivations++;
+
+    const packageDir = await findCanonicalPackageDirectory(workspace);
+    const canonicalIndex = await readFile(join(packageDir, "index.html"), "utf8");
+    assert(!canonicalIndex.includes("data-goframe-dev-reload"), "canonical package index contains the development reload tag");
+    const manifest = JSON.parse(await readFile(join(packageDir, "asset-manifest.json"), "utf8"));
+    const wasmPath = manifest.entrypoints.wasm;
+
+    browser = spawn(chrome, [
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profile}`,
+        "about:blank",
+    ], { stdio: ["ignore", "ignore", "pipe"] });
+    browser.stderr.on("data", (chunk) => { browserError += chunk; });
+
+    const initialTarget = await waitForPage(debugPort);
+    client1 = await connect(initialTarget.webSocketDebuggerUrl);
+    await prepareClient(client1);
+    await navigate(client1, `${serverURL}/?smoke=initial`);
+    const initial = await waitForPageState(client1, { gox: "gox-initial", go: "go-initial", index: "index-initial" });
+    assert(initial.pageLoads === 1, `initial page loads = ${initial.pageLoads}, want 1`);
+    assert(initial.generation === 1, `initial generation = ${initial.generation}, want 1`);
+    await waitForEventSourceOpen(client1, 1);
+    await wait(250);
+    const stableInitial = await pageState(client1);
+    assert(stableInitial.pageLoads === 1 && stableInitial.reloadEvents === 0, `initial page reloaded spontaneously: ${JSON.stringify(stableInitial)}`);
+    console.log("initial load: ok");
+
+    let nextBuild = 2;
+    let activeGeneration = 1;
+
+    const goxBaseline = await pageState(client1);
+    const goxStart = lines.length;
+    await writeGOX("gox-rebuild");
+    await waitForBuildStarted(nextBuild, goxStart);
+    const publicationProbe = probeOldGenerationUntilBuildCompletes(serverURL, wasmPath, activeGeneration, nextBuild);
+    await waitForBuild(nextBuild, "succeeded", goxStart);
+    const publicationEvidence = await publicationProbe;
+    counters.requestsServedByOldGeneration += publicationEvidence.oldGenerationResponses;
+    counters.responses404DuringBuild += publicationEvidence.responses404;
+    assert(publicationEvidence.oldGenerationResponses > 0, "no old-generation response was observed during the later build");
+    await assertSuccessfulReload(client1, goxBaseline, { gox: "gox-rebuild", go: "go-initial", index: "index-initial" }, ++activeGeneration);
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("GOX rebuild reload: ok");
+
+    const goBaseline = await pageState(client1);
+    await writeGoMessage("go-rebuild");
+    await waitForBuild(nextBuild, "succeeded");
+    await assertSuccessfulReload(client1, goBaseline, { gox: "gox-rebuild", go: "go-rebuild", index: "index-initial" }, ++activeGeneration);
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("Go rebuild reload: ok");
+
+    const indexBaseline = await pageState(client1);
+    await writeIndex("index-rebuild");
+    await waitForBuild(nextBuild, "succeeded");
+    await assertSuccessfulReload(client1, indexBaseline, { gox: "gox-rebuild", go: "go-rebuild", index: "index-rebuild" }, ++activeGeneration);
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("asset/index rebuild reload: ok");
+
+    const burstBaseline = await pageState(client1);
+    const burstStart = lines.length;
+    for (const value of ["burst-one", "burst-two", "burst-final"]) {
+        await writeGOX(value);
+        await wait(20);
+    }
+    await waitForBuild(nextBuild, "succeeded", burstStart);
+    await assertSuccessfulReload(client1, burstBaseline, { gox: "burst-final", go: "go-rebuild", index: "index-rebuild" }, ++activeGeneration);
+    recordSuccessfulReload();
+    nextBuild++;
+    await wait(500);
+    assert(countBuildStartsSince(burstStart) === 1, `burst saves produced ${countBuildStartsSince(burstStart)} package attempts, want 1`);
+    console.log("burst rebuild collapse: ok");
+
+    const failureBaseline = await pageState(client1);
+    const failureStart = lines.length;
+    await writeFile(join(appDir, "app.gox"), `package main\n\nfunc App() { return <main>broken</main> }\n`);
+    await waitForBuild(nextBuild, "failed", failureStart);
+    counters.failedPackageAttempts++;
+    nextBuild++;
+    const failureRoot = await fetch(`${serverURL}/`, { cache: "no-store" });
+    const failureMetadata = await fetch(`${serverURL}/goframe-package.json`, { cache: "no-store" });
+    assert(failureRoot.ok && failureMetadata.ok, `last successful package unavailable after failure: ${failureRoot.status}/${failureMetadata.status}`);
+    await wait(250);
+    const afterFailure = await pageState(client1);
+    assert(afterFailure.pageLoads === failureBaseline.pageLoads && afterFailure.reloadEvents === failureBaseline.reloadEvents,
+        `failed build reloaded the browser: ${JSON.stringify({ failureBaseline, afterFailure })}`);
+    assert(afterFailure.generation === activeGeneration, `failed build changed generation to ${afterFailure.generation}`);
+    console.log("failed build preservation: ok");
+
+    const recoveryBaseline = afterFailure;
+    await writeGOX("recovered");
+    await waitForBuild(nextBuild, "succeeded");
+    await assertSuccessfulReload(client1, recoveryBaseline, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" }, ++activeGeneration);
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("failed build recovery reload: ok");
+
+    const secondTarget = await client1.call("Target.createTarget", { url: "about:blank" });
+    const target = await waitForTarget(debugPort, secondTarget.targetId);
+    client2 = await connect(target.webSocketDebuggerUrl);
+    await prepareClient(client2);
+    await navigate(client2, `${serverURL}/?smoke=second-client`);
+    const secondInitial = await waitForPageState(client2, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" });
+    await waitForEventSourceOpen(client2, 1);
+    await wait(250);
+    assert((await pageState(client2)).pageLoads === 1, "second client entered an initial reload loop");
+
+    const firstMultiBaseline = await pageState(client1);
+    const secondMultiBaseline = await pageState(client2);
+    await writeGoMessage("two-clients");
+    await waitForBuild(nextBuild, "succeeded");
+    const nextGeneration = ++activeGeneration;
+    await Promise.all([
+        assertSuccessfulReload(client1, firstMultiBaseline, { gox: "recovered", go: "two-clients", index: "index-rebuild" }, nextGeneration),
+        assertSuccessfulReload(client2, secondMultiBaseline, { gox: "recovered", go: "two-clients", index: "index-rebuild" }, nextGeneration),
+    ]);
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("two-client reload: ok");
+
+    const currentReconnect = await pageState(client1);
+    await reconnectReloadClient(client1, activeGeneration);
+    await waitForEventSourceOpen(client1, currentReconnect.eventSourceOpens + 1);
+    await wait(250);
+    const afterCurrentReconnect = await pageState(client1);
+    assert(afterCurrentReconnect.pageLoads === currentReconnect.pageLoads && afterCurrentReconnect.reloadEvents === currentReconnect.reloadEvents,
+        `current-generation reconnect reloaded: ${JSON.stringify(afterCurrentReconnect)}`);
+    console.log("same-generation reconnect: ok");
+
+    await reconnectReloadClient(client1, activeGeneration - 1);
+    const caughtUp = await waitForPageState(client1, {
+        gox: "recovered",
+        go: "two-clients",
+        index: "index-rebuild",
+        pageLoads: afterCurrentReconnect.pageLoads + 1,
+        reloadEvents: afterCurrentReconnect.reloadEvents + 1,
+        generation: activeGeneration,
+    });
+    counters.catchUpReloads++;
+    assert(caughtUp.generation === activeGeneration, `catch-up loaded generation ${caughtUp.generation}`);
+    console.log("stale-generation catch-up reload: ok");
+
+    const client1Final = await pageState(client1);
+    const client2Final = await pageState(client2);
+    const generationRoots = [...await listGenerationRoots()].filter((entry) => !generationRootsBefore.has(entry));
+    assert(generationRoots.length === 1, `development generation roots = ${JSON.stringify(generationRoots)}, want one`);
+    dev.kill("SIGINT");
+    const devExit = await waitForExit(dev, 15_000);
+    assert(devExit.code === 0, `goxc dev exited with ${JSON.stringify(devExit)}\n${devOutput}`);
+    dev = null;
+    await waitForHTTPShutdown(serverURL);
+    await waitForNoEventStreams(client1);
+    await waitForNoEventStreams(client2);
+    for (const generationRoot of generationRoots) {
+        assert(!existsSync(join(tmpdir(), generationRoot)), `generation root remained after shutdown: ${generationRoot}`);
+    }
+
+    console.log(`successful package attempts: ${counters.successfulPackageAttempts}`);
+    console.log(`failed package attempts: ${counters.failedPackageAttempts}`);
+    console.log(`completed generations: ${counters.completedGenerations}`);
+    console.log(`generation activations: ${counters.generationActivations}`);
+    console.log(`reload events published: ${counters.reloadEventsPublished}`);
+    console.log(`reload events received by client 1: ${client1Final.reloadEvents}`);
+    console.log(`reload events received by client 2: ${client2Final.reloadEvents}`);
+    console.log(`catch-up reloads: ${counters.catchUpReloads}`);
+    console.log("connected subscribers at shutdown: 0");
+    console.log(`requests served by old generation during later build: ${counters.requestsServedByOldGeneration}`);
+    console.log(`404 responses during later build: ${counters.responses404DuringBuild}`);
+    console.log("goxc dev reload browser smoke: ok");
+} catch (error) {
+    throw new Error(`${error.message}\n\nDevelopment output:\n${devOutput.slice(-12000)}\n\nChrome stderr:\n${browserError.slice(-6000)}`);
+} finally {
+    client1?.close();
+    client2?.close();
+    if (dev) {
+        await stopProcess(dev, "SIGINT", 5000);
+    }
+    if (browser) {
+        await stopProcess(browser, "SIGTERM", 3000);
+    }
+    await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+function recordSuccessfulReload() {
+    counters.successfulPackageAttempts++;
+    counters.completedGenerations++;
+    counters.generationActivations++;
+    counters.reloadEventsPublished++;
+}
+
+async function writeApplication(gox, go, index) {
+    await mkdir(join(appDir, "assets"), { recursive: true });
+    await writeFile(join(appDir, "go.mod"), `module example.com/goframe-dev-reload\n\ngo 1.22\n\nrequire github.com/graybuton/goframe v0.0.0\n\nreplace github.com/graybuton/goframe => ${repositoryRoot}\n`);
+    await writeFile(join(appDir, "goframe.json"), `{"name":"dev-reload-smoke","entry":".","compiler":"go","assets":"assets"}\n`);
+    await writeFile(join(appDir, "main.go"), `//go:build js && wasm\n\npackage main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc main() {\n    done := make(chan struct{})\n    gf.Mount("root", App)\n    <-done\n}\n`);
+    await writeGoMessage(go);
+    await writeGOX(gox);
+    await writeIndex(index);
+    await writeFile(join(appDir, "assets", "marker.txt"), "complete asset\n");
+}
+
+async function writeGOX(value) {
+    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span></main>\n}\n`);
+}
+
+async function writeGoMessage(value) {
+    await writeFile(join(appDir, "message.go"), `package main\n\nfunc message() string { return ${JSON.stringify(value)} }\n`);
+}
+
+async function writeIndex(value) {
+    await writeFile(join(appDir, "assets", "index.html"), `<!doctype html>
+<html><body>
+<div id="index-version">${value}</div>
+<div id="page-load-count"></div>
+<div id="root">Loading...</div>
+<script>
+var count = Number(sessionStorage.getItem("goframe-dev-page-loads") || "0") + 1;
+sessionStorage.setItem("goframe-dev-page-loads", String(count));
+document.querySelector("#page-load-count").textContent = String(count);
+</script>
+<script src="wasm_exec.js"></script>
+<script>var go = new Go(); WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject).then(function (result) { go.run(result.instance); });</script>
+</body></html>
+`);
+}
+
+async function prepareClient(client) {
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Network.enable");
+    client.eventStreams = new Set();
+    client.on("Network.requestWillBeSent", ({ requestId, request }) => {
+        if (request.url.includes("/_goframe/dev/events")) client.eventStreams.add(requestId);
+    });
+    const finish = ({ requestId }) => client.eventStreams.delete(requestId);
+    client.on("Network.loadingFinished", finish);
+    client.on("Network.loadingFailed", finish);
+    await client.call("Page.addScriptToEvaluateOnNewDocument", { source: reloadEvidenceScript() });
+}
+
+function reloadEvidenceScript() {
+    return `(() => {
+        const NativeEventSource = window.EventSource;
+        if (typeof NativeEventSource !== "function") return;
+        window.__goframeDevEventSources = [];
+        const increment = (key) => {
+            const next = Number(sessionStorage.getItem(key) || "0") + 1;
+            sessionStorage.setItem(key, String(next));
+        };
+        function WrappedEventSource(url, options) {
+            const source = options === undefined ? new NativeEventSource(url) : new NativeEventSource(url, options);
+            window.__goframeDevEventSources.push(source);
+            source.addEventListener("open", () => increment("goframe-dev-event-source-opens"));
+            source.addEventListener("reload", () => increment("goframe-dev-reload-events"));
+            return source;
+        }
+        WrappedEventSource.prototype = NativeEventSource.prototype;
+        Object.setPrototypeOf(WrappedEventSource, NativeEventSource);
+        window.EventSource = WrappedEventSource;
+    })()`;
+}
+
+async function pageState(client) {
+    return await client.evaluate(`(() => {
+        const script = document.querySelector("script[data-goframe-dev-reload]");
+        return {
+            href: location.href,
+            readyState: document.readyState,
+            gox: document.querySelector("#gox-version")?.textContent || "",
+            go: document.querySelector("#go-version")?.textContent || "",
+            index: document.querySelector("#index-version")?.textContent || "",
+            pageLoads: Number(sessionStorage.getItem("goframe-dev-page-loads") || "0"),
+            reloadEvents: Number(sessionStorage.getItem("goframe-dev-reload-events") || "0"),
+            eventSourceOpens: Number(sessionStorage.getItem("goframe-dev-event-source-opens") || "0"),
+            generation: Number(script?.getAttribute("data-goframe-generation") || "0"),
+            reloadTags: document.querySelectorAll("script[data-goframe-dev-reload]").length,
+        };
+    })()`);
+}
+
+async function waitForPageState(client, expected) {
+    let last = null;
+    for (let attempt = 0; attempt < 300; attempt++) {
+        last = await pageState(client);
+        const matches = Object.entries(expected).every(([key, value]) => last[key] === value);
+        if (matches && last.readyState === "complete" && last.reloadTags === 1) return last;
+        await wait(50);
+    }
+    throw new Error(`HARNESS FAILURE: page state did not match ${JSON.stringify(expected)}; last=${JSON.stringify(last)}`);
+}
+
+async function assertSuccessfulReload(client, baseline, expected, generation) {
+    const state = await waitForPageState(client, {
+        ...expected,
+        pageLoads: baseline.pageLoads + 1,
+        reloadEvents: baseline.reloadEvents + 1,
+        generation,
+    });
+    assert(state.reloadTags === 1, `reload tag count = ${state.reloadTags}, want 1`);
+}
+
+async function reconnectReloadClient(client, generation) {
+    await client.evaluate(`(() => {
+        for (const source of window.__goframeDevEventSources || []) source.close();
+        const script = document.createElement("script");
+        script.src = ${JSON.stringify("/_goframe/dev/reload.js")} + "?reconnect=" + Date.now();
+        script.setAttribute("data-goframe-generation", ${JSON.stringify(String(generation))});
+        document.body.appendChild(script);
+    })()`);
+}
+
+async function waitForEventSourceOpen(client, want) {
+    for (let attempt = 0; attempt < 200; attempt++) {
+        const state = await pageState(client);
+        if (state.eventSourceOpens >= want) return;
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: EventSource open count did not reach ${want}`);
+}
+
+async function probeOldGenerationUntilBuildCompletes(serverURL, wasmPath, generation, build) {
+    let oldGenerationResponses = 0;
+    let responses404 = 0;
+    assert(!hasBuildResult(build, "succeeded"), `build ${build} completed before the publication probe started`);
+    const [indexResponse, metadataResponse, wasmResponse] = await Promise.all([
+        fetch(`${serverURL}/?publication=0`, { cache: "no-store" }),
+        fetch(`${serverURL}/goframe-package.json?publication=0`, { cache: "no-store" }),
+        fetch(`${serverURL}/${wasmPath}?publication=0`, { cache: "no-store" }),
+    ]);
+    for (const response of [indexResponse, metadataResponse, wasmResponse]) {
+        if (response.status === 404) responses404++;
+        assert(response.ok, `HTTP ${response.status} during later build for ${response.url}`);
+    }
+    const index = await indexResponse.text();
+    const metadata = await metadataResponse.json();
+    const wasm = await wasmResponse.arrayBuffer();
+    const servedGeneration = Number(index.match(/data-goframe-generation="(\d+)"/)?.[1] || "0");
+    assert(metadata.version === 1 && wasm.byteLength > 0, "partial package response observed during later build");
+    if (servedGeneration === generation) oldGenerationResponses += 3;
+    return { oldGenerationResponses, responses404 };
+}
+
+function captureLines(stream, source) {
+    let buffer = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+        devOutput += chunk;
+        buffer += chunk;
+        while (buffer.includes("\n")) {
+            const index = buffer.indexOf("\n");
+            lines.push({ source, text: buffer.slice(0, index).replace(/\r$/, "") });
+            buffer = buffer.slice(index + 1);
+        }
+    });
+}
+
+async function waitForLine(predicate, timeout = 20_000, start = 0) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+        const line = lines.slice(start).find(predicate);
+        if (line) return line;
+        if (dev?.exitCode !== null) throw new Error(`HARNESS FAILURE: goxc dev exited early with ${dev.exitCode}`);
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: timed out waiting for development output\n${devOutput}`);
+}
+
+async function waitForBuild(number, result, start = 0) {
+    return await waitForLine((line) => line.text.includes(`dev build ${number} ${result}`), 30_000, start);
+}
+
+async function waitForBuildStarted(number, start = 0) {
+    return await waitForLine((line) => line.text.startsWith(`dev build ${number} (`), 30_000, start);
+}
+
+function hasBuildResult(number, result) {
+    return lines.some((line) => line.text.includes(`dev build ${number} ${result}`));
+}
+
+function countBuildStartsSince(start) {
+    return lines.slice(start).filter((line) => /^dev build \d+ \((initial|rebuild)\):/.test(line.text)).length;
+}
+
+async function findCanonicalPackageDirectory(root) {
+    for (let attempt = 0; attempt < 100; attempt++) {
+        const found = await findDirectoryEnding(root, join("package", "standalone"));
+        if (found) return found;
+        await wait(50);
+    }
+    throw new Error(`HARNESS FAILURE: canonical package directory not found below ${root}`);
+}
+
+async function findDirectoryEnding(root, suffix) {
+    let entries;
+    try {
+        entries = await readdir(root, { withFileTypes: true });
+    } catch {
+        return null;
+    }
+    for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const path = join(root, entry.name);
+        if (path.endsWith(suffix)) return path;
+        const nested = await findDirectoryEnding(path, suffix);
+        if (nested) return nested;
+    }
+    return null;
+}
+
+async function listGenerationRoots() {
+    const entries = await readdir(tmpdir(), { withFileTypes: true });
+    return new Set(entries.filter((entry) => entry.isDirectory() && entry.name.startsWith("goxc-dev-generations-")).map((entry) => entry.name));
+}
+
+async function runProcess(command, args, options) {
+    const child = spawn(command, args, { ...options, stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    const result = await waitForExit(child, 60_000);
+    if (result.code !== 0) throw new Error(`${command} ${args.join(" ")} failed: ${output}`);
+}
+
+async function freePort() {
+    return await new Promise((resolvePort, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            server.close(() => resolvePort(address.port));
+        });
+    });
+}
+
+async function waitForPage(port) {
+    for (let attempt = 0; attempt < 100; attempt++) {
+        try {
+            const targets = await fetchTargets(port);
+            const page = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+            if (page) return page;
+        } catch {}
+        await wait(50);
+    }
+    throw new Error("HARNESS FAILURE: Chrome DevTools did not become ready");
+}
+
+async function waitForTarget(port, targetID) {
+    for (let attempt = 0; attempt < 100; attempt++) {
+        const target = (await fetchTargets(port)).find((entry) => entry.id === targetID && entry.webSocketDebuggerUrl);
+        if (target) return target;
+        await wait(50);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome target ${targetID} did not become ready`);
+}
+
+async function fetchTargets(port) {
+    const response = await fetch(`http://127.0.0.1:${port}/json`);
+    if (!response.ok) throw new Error(`CDP /json returned HTTP ${response.status}`);
+    return await response.json();
+}
+
+async function navigate(client, url) {
+    await client.call("Page.navigate", { url });
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolveOpen, reject) => {
+        socket.addEventListener("open", resolveOpen, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+    let nextID = 1;
+    const pending = new Map();
+    const listeners = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (message.id && pending.has(message.id)) {
+            const request = pending.get(message.id);
+            pending.delete(message.id);
+            if (message.error) request.reject(new Error(message.error.message));
+            else request.resolve(message.result);
+            return;
+        }
+        for (const listener of listeners.get(message.method) || []) listener(message.params || {});
+    });
+    return {
+        eventStreams: new Set(),
+        call(method, params = {}) {
+            return new Promise((resolveCall, reject) => {
+                const id = nextID++;
+                pending.set(id, { resolve: resolveCall, reject });
+                socket.send(JSON.stringify({ id, method, params }));
+            });
+        },
+        on(method, listener) {
+            const current = listeners.get(method) || [];
+            current.push(listener);
+            listeners.set(method, current);
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", { expression, returnByValue: true, awaitPromise: true });
+            if (result.exceptionDetails) throw new Error(`browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            return result.result.value;
+        },
+        close() { socket.close(); },
+    };
+}
+
+async function waitForNoEventStreams(client) {
+    for (let attempt = 0; attempt < 100; attempt++) {
+        if (client.eventStreams.size === 0) return;
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: ${client.eventStreams.size} EventSource requests remained after shutdown`);
+}
+
+async function waitForHTTPShutdown(serverURL) {
+    for (let attempt = 0; attempt < 100; attempt++) {
+        try {
+            await fetch(`${serverURL}/`, { signal: AbortSignal.timeout(100) });
+        } catch {
+            return;
+        }
+        await wait(25);
+    }
+    throw new Error("HARNESS FAILURE: development HTTP listener remained open after shutdown");
+}
+
+async function waitForExit(child, timeout) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return { code: child.exitCode, signal: child.signalCode };
+    }
+    return await new Promise((resolveExit, reject) => {
+        const onExit = (code, signal) => {
+            clearTimeout(timer);
+            resolveExit({ code, signal });
+        };
+        const timer = setTimeout(() => {
+            child.off("exit", onExit);
+            reject(new Error("process exit timed out"));
+        }, timeout);
+        child.once("exit", onExit);
+    });
+}
+
+async function stopProcess(child, signal, timeout) {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    child.kill(signal);
+    try {
+        await waitForExit(child, timeout);
+        return;
+    } catch {}
+
+    child.kill("SIGKILL");
+    await waitForExit(child, timeout).catch(() => {});
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error(`APP FAILURE: ${message}`);
+}
+
+function wait(duration) {
+    return new Promise((resolveWait) => setTimeout(resolveWait, duration));
+}

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -36,8 +36,12 @@ const counters = {
     reloadEventsPublished: 0,
     catchUpReloads: 0,
     previousProcessCatchUpReloads: 0,
-    requestsServedByOldGeneration: 0,
+    publicationProbeBatches: 0,
+    completeResponsesDuringBuild: 0,
+    oldGenerationIndexResponses: 0,
+    newGenerationIndexResponses: 0,
     responses404DuringBuild: 0,
+    partialResponsesDuringBuild: 0,
 };
 
 try {
@@ -106,12 +110,20 @@ try {
     const goxStart = lines.length;
     await writeGOX("gox-rebuild");
     await waitForBuildStarted(nextBuild, goxStart);
-    const publicationProbe = probeOldGenerationUntilBuildCompletes(serverURL, wasmPath, activeGeneration, nextBuild);
-    await waitForBuild(nextBuild, "succeeded", goxStart);
-    const publicationEvidence = await publicationProbe;
-    counters.requestsServedByOldGeneration += publicationEvidence.oldGenerationResponses;
+    const [, publicationEvidence] = await Promise.all([
+        waitForBuild(nextBuild, "succeeded", goxStart),
+        probeCompletedGenerationUntilBuildCompletes(serverURL, wasmPath, activeGeneration, nextBuild),
+    ]);
+    counters.publicationProbeBatches += publicationEvidence.batches;
+    counters.completeResponsesDuringBuild += publicationEvidence.completeResponses;
+    counters.oldGenerationIndexResponses += publicationEvidence.oldGenerationIndexResponses;
+    counters.newGenerationIndexResponses += publicationEvidence.newGenerationIndexResponses;
     counters.responses404DuringBuild += publicationEvidence.responses404;
-    assert(publicationEvidence.oldGenerationResponses > 0, "no old-generation response was observed during the later build");
+    counters.partialResponsesDuringBuild += publicationEvidence.partialResponses;
+    assert(publicationEvidence.batches > 0, "publication probe issued no request batches");
+    assert(publicationEvidence.completeResponses > 0, "publication probe observed no complete responses");
+    assert(publicationEvidence.responses404 === 0, `publication probe observed ${publicationEvidence.responses404} HTTP 404 responses`);
+    assert(publicationEvidence.partialResponses === 0, `publication probe observed ${publicationEvidence.partialResponses} partial responses`);
     await assertSuccessfulReload(client1, goxBaseline, { gox: "gox-rebuild", go: "go-initial", index: "index-initial" }, ++activeGeneration);
     recordSuccessfulReload();
     nextBuild++;
@@ -287,8 +299,12 @@ try {
     console.log(`catch-up reloads: ${counters.catchUpReloads}`);
     console.log(`previous-process catch-up reloads: ${counters.previousProcessCatchUpReloads}`);
     console.log("connected subscribers at shutdown: 0");
-    console.log(`requests served by old generation during later build: ${counters.requestsServedByOldGeneration}`);
-    console.log(`404 responses during later build: ${counters.responses404DuringBuild}`);
+    console.log(`publication probe batches: ${counters.publicationProbeBatches}`);
+    console.log(`complete responses during rebuild: ${counters.completeResponsesDuringBuild}`);
+    console.log(`old-generation index responses: ${counters.oldGenerationIndexResponses}`);
+    console.log(`new-generation index responses: ${counters.newGenerationIndexResponses}`);
+    console.log(`404 responses during rebuild: ${counters.responses404DuringBuild}`);
+    console.log(`partial responses during rebuild: ${counters.partialResponsesDuringBuild}`);
     console.log("goxc dev reload browser smoke: ok");
 } catch (error) {
     throw new Error(`${error.message}\n\nDevelopment output:\n${devOutput.slice(-12000)}\n\nChrome stderr:\n${browserError.slice(-6000)}`);
@@ -444,26 +460,83 @@ async function waitForEventSourceOpen(client, want) {
     throw new Error(`HARNESS FAILURE: EventSource open count did not reach ${want}`);
 }
 
-async function probeOldGenerationUntilBuildCompletes(serverURL, wasmPath, generation, build) {
-    let oldGenerationResponses = 0;
-    let responses404 = 0;
-    assert(!hasBuildResult(build, "succeeded"), `build ${build} completed before the publication probe started`);
+async function probeCompletedGenerationUntilBuildCompletes(serverURL, wasmPath, generation, build) {
+    const evidence = {
+        batches: 0,
+        completeResponses: 0,
+        oldGenerationIndexResponses: 0,
+        newGenerationIndexResponses: 0,
+        responses404: 0,
+        partialResponses: 0,
+    };
+    const deadline = Date.now() + 30_000;
+    for (;;) {
+        if (hasBuildResult(build, "failed")) {
+            throw new Error(`APP FAILURE: dev build ${build} failed during the publication probe`);
+        }
+        if (dev && (dev.exitCode !== null || dev.signalCode !== null)) {
+            throw new Error(`HARNESS FAILURE: goxc dev exited during publication probe for build ${build}`);
+        }
+        if (Date.now() >= deadline) {
+            throw new Error(`HARNESS FAILURE: publication probe timed out waiting for build ${build}`);
+        }
+
+        const batch = await probeCompletedGenerationBatch(serverURL, wasmPath, generation, build, evidence.batches);
+        evidence.batches++;
+        evidence.completeResponses += batch.completeResponses;
+        evidence.oldGenerationIndexResponses += batch.oldGenerationIndexResponses;
+        evidence.newGenerationIndexResponses += batch.newGenerationIndexResponses;
+        evidence.responses404 += batch.responses404;
+        evidence.partialResponses += batch.partialResponses;
+
+        if (hasBuildResult(build, "failed")) {
+            throw new Error(`APP FAILURE: dev build ${build} failed during the publication probe`);
+        }
+        if (hasBuildResult(build, "succeeded")) return evidence;
+        await wait(0);
+    }
+}
+
+async function probeCompletedGenerationBatch(serverURL, wasmPath, generation, build, batch) {
+    const signal = AbortSignal.timeout(5_000);
+    const query = `publication=${build}-${batch}`;
     const [indexResponse, metadataResponse, wasmResponse] = await Promise.all([
-        fetch(`${serverURL}/?publication=0`, { cache: "no-store" }),
-        fetch(`${serverURL}/goframe-package.json?publication=0`, { cache: "no-store" }),
-        fetch(`${serverURL}/${wasmPath}?publication=0`, { cache: "no-store" }),
+        fetch(`${serverURL}/?${query}`, { cache: "no-store", signal }),
+        fetch(`${serverURL}/goframe-package.json?${query}`, { cache: "no-store", signal }),
+        fetch(`${serverURL}/${wasmPath}?${query}`, { cache: "no-store", signal }),
     ]);
+    let responses404 = 0;
     for (const response of [indexResponse, metadataResponse, wasmResponse]) {
         if (response.status === 404) responses404++;
-        assert(response.ok, `HTTP ${response.status} during later build for ${response.url}`);
+        assert(response.ok, `HTTP ${response.status} during publication probe for ${response.url}`);
     }
+
     const index = await indexResponse.text();
-    const metadata = await metadataResponse.json();
+    const metadataText = await metadataResponse.text();
     const wasm = await wasmResponse.arrayBuffer();
+    let metadata = null;
+    try {
+        metadata = JSON.parse(metadataText);
+    } catch {}
+
+    const markerCount = index.split("data-goframe-dev-reload").length - 1;
     const servedGeneration = Number(index.match(/data-goframe-generation="(\d+)"/)?.[1] || "0");
-    assert(metadata.version === 1 && wasm.byteLength > 0, "partial package response observed during later build");
-    if (servedGeneration === generation) oldGenerationResponses += 3;
-    return { oldGenerationResponses, responses404 };
+    const indexComplete = markerCount === 1
+        && servedGeneration > 0
+        && (servedGeneration === generation || servedGeneration === generation + 1);
+    const metadataComplete = metadata?.version === 1 && metadata?.entrypoints?.wasm === wasmPath;
+    const wasmComplete = wasm.byteLength > 0;
+    const partialResponses = [indexComplete, metadataComplete, wasmComplete].filter((complete) => !complete).length;
+    assert(partialResponses === 0,
+        `partial package response during publication probe: ${JSON.stringify({ markerCount, servedGeneration, metadata, wasmBytes: wasm.byteLength })}`);
+
+    return {
+        completeResponses: 3,
+        oldGenerationIndexResponses: servedGeneration === generation ? 1 : 0,
+        newGenerationIndexResponses: servedGeneration === generation + 1 ? 1 : 0,
+        responses404,
+        partialResponses,
+    };
 }
 
 async function openReloadProbe(serverURL, instance, generation) {

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -24,6 +24,7 @@ let dev = null;
 let browser = null;
 let client1 = null;
 let client2 = null;
+let activationGapProbe = null;
 let devOutput = "";
 let browserError = "";
 const lines = [];
@@ -34,6 +35,7 @@ const counters = {
     generationActivations: 0,
     reloadEventsPublished: 0,
     catchUpReloads: 0,
+    previousProcessCatchUpReloads: 0,
     requestsServedByOldGeneration: 0,
     responses404DuringBuild: 0,
 };
@@ -89,6 +91,8 @@ try {
     const initial = await waitForPageState(client1, { gox: "gox-initial", go: "go-initial", index: "index-initial" });
     assert(initial.pageLoads === 1, `initial page loads = ${initial.pageLoads}, want 1`);
     assert(initial.generation === 1, `initial generation = ${initial.generation}, want 1`);
+    assert(/^[0-9a-f]{32}$/.test(initial.instance), `initial process instance = ${JSON.stringify(initial.instance)}, want a 32-character hex token`);
+    const activeInstance = initial.instance;
     await waitForEventSourceOpen(client1, 1);
     await wait(250);
     const stableInitial = await pageState(client1);
@@ -173,12 +177,15 @@ try {
     await prepareClient(client2);
     await navigate(client2, `${serverURL}/?smoke=second-client`);
     const secondInitial = await waitForPageState(client2, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" });
+    assert(secondInitial.instance === activeInstance, `second client process instance = ${secondInitial.instance}, want ${activeInstance}`);
     await waitForEventSourceOpen(client2, 1);
     await wait(250);
     assert((await pageState(client2)).pageLoads === 1, "second client entered an initial reload loop");
 
     const firstMultiBaseline = await pageState(client1);
     const secondMultiBaseline = await pageState(client2);
+    activationGapProbe = await openReloadProbe(serverURL, activeInstance, activeGeneration + 1);
+    await activationGapProbe.waitConnected();
     await writeGoMessage("two-clients");
     await waitForBuild(nextBuild, "succeeded");
     const nextGeneration = ++activeGeneration;
@@ -188,10 +195,32 @@ try {
     ]);
     recordSuccessfulReload();
     nextBuild++;
+    await wait(100);
+    activationGapProbe.assertHealthy();
+    assert(activationGapProbe.events.length === 0,
+        `activation-gap subscriber received its declared generation: ${JSON.stringify(activationGapProbe.events)}`);
     console.log("two-client reload: ok");
 
+    const firstGapFollowUpBaseline = await pageState(client1);
+    const secondGapFollowUpBaseline = await pageState(client2);
+    await writeGoMessage("activation-gap-follow-up");
+    await waitForBuild(nextBuild, "succeeded");
+    const gapFollowUpGeneration = ++activeGeneration;
+    await Promise.all([
+        assertSuccessfulReload(client1, firstGapFollowUpBaseline, { gox: "recovered", go: "activation-gap-follow-up", index: "index-rebuild" }, gapFollowUpGeneration),
+        assertSuccessfulReload(client2, secondGapFollowUpBaseline, { gox: "recovered", go: "activation-gap-follow-up", index: "index-rebuild" }, gapFollowUpGeneration),
+    ]);
+    recordSuccessfulReload();
+    nextBuild++;
+    await activationGapProbe.waitForEvents(1);
+    assert(JSON.stringify(activationGapProbe.events) === JSON.stringify([gapFollowUpGeneration]),
+        `activation-gap subscriber events = ${JSON.stringify(activationGapProbe.events)}, want [${gapFollowUpGeneration}]`);
+    await activationGapProbe.close();
+    activationGapProbe = null;
+    console.log("same-generation activation gap: ok");
+
     const currentReconnect = await pageState(client1);
-    await reconnectReloadClient(client1, activeGeneration);
+    await reconnectReloadClient(client1, activeInstance, activeGeneration);
     await waitForEventSourceOpen(client1, currentReconnect.eventSourceOpens + 1);
     await wait(250);
     const afterCurrentReconnect = await pageState(client1);
@@ -199,10 +228,10 @@ try {
         `current-generation reconnect reloaded: ${JSON.stringify(afterCurrentReconnect)}`);
     console.log("same-generation reconnect: ok");
 
-    await reconnectReloadClient(client1, activeGeneration - 1);
+    await reconnectReloadClient(client1, activeInstance, activeGeneration - 1);
     const caughtUp = await waitForPageState(client1, {
         gox: "recovered",
-        go: "two-clients",
+        go: "activation-gap-follow-up",
         index: "index-rebuild",
         pageLoads: afterCurrentReconnect.pageLoads + 1,
         reloadEvents: afterCurrentReconnect.reloadEvents + 1,
@@ -211,6 +240,27 @@ try {
     counters.catchUpReloads++;
     assert(caughtUp.generation === activeGeneration, `catch-up loaded generation ${caughtUp.generation}`);
     console.log("stale-generation catch-up reload: ok");
+
+    const previousProcessBaseline = caughtUp;
+    const previousInstance = activeInstance === "f".repeat(32) ? "e".repeat(32) : "f".repeat(32);
+    await reconnectReloadClient(client1, previousInstance, activeGeneration + 1000);
+    const previousProcessCaughtUp = await waitForPageState(client1, {
+        gox: "recovered",
+        go: "activation-gap-follow-up",
+        index: "index-rebuild",
+        pageLoads: previousProcessBaseline.pageLoads + 1,
+        reloadEvents: previousProcessBaseline.reloadEvents + 1,
+        generation: activeGeneration,
+        instance: activeInstance,
+    });
+    counters.catchUpReloads++;
+    counters.previousProcessCatchUpReloads++;
+    await wait(250);
+    const stablePreviousProcessCatchUp = await pageState(client1);
+    assert(stablePreviousProcessCatchUp.pageLoads === previousProcessCaughtUp.pageLoads
+        && stablePreviousProcessCatchUp.reloadEvents === previousProcessCaughtUp.reloadEvents,
+        `previous-process catch-up entered a reload loop: ${JSON.stringify(stablePreviousProcessCatchUp)}`);
+    console.log("previous-process catch-up reload: ok");
 
     const client1Final = await pageState(client1);
     const client2Final = await pageState(client2);
@@ -235,6 +285,7 @@ try {
     console.log(`reload events received by client 1: ${client1Final.reloadEvents}`);
     console.log(`reload events received by client 2: ${client2Final.reloadEvents}`);
     console.log(`catch-up reloads: ${counters.catchUpReloads}`);
+    console.log(`previous-process catch-up reloads: ${counters.previousProcessCatchUpReloads}`);
     console.log("connected subscribers at shutdown: 0");
     console.log(`requests served by old generation during later build: ${counters.requestsServedByOldGeneration}`);
     console.log(`404 responses during later build: ${counters.responses404DuringBuild}`);
@@ -242,6 +293,7 @@ try {
 } catch (error) {
     throw new Error(`${error.message}\n\nDevelopment output:\n${devOutput.slice(-12000)}\n\nChrome stderr:\n${browserError.slice(-6000)}`);
 } finally {
+    await activationGapProbe?.close();
     client1?.close();
     client2?.close();
     if (dev) {
@@ -345,6 +397,7 @@ async function pageState(client) {
             reloadEvents: Number(sessionStorage.getItem("goframe-dev-reload-events") || "0"),
             eventSourceOpens: Number(sessionStorage.getItem("goframe-dev-event-source-opens") || "0"),
             generation: Number(script?.getAttribute("data-goframe-generation") || "0"),
+            instance: script?.getAttribute("data-goframe-instance") || "",
             reloadTags: document.querySelectorAll("script[data-goframe-dev-reload]").length,
         };
     })()`);
@@ -371,11 +424,12 @@ async function assertSuccessfulReload(client, baseline, expected, generation) {
     assert(state.reloadTags === 1, `reload tag count = ${state.reloadTags}, want 1`);
 }
 
-async function reconnectReloadClient(client, generation) {
+async function reconnectReloadClient(client, instance, generation) {
     await client.evaluate(`(() => {
         for (const source of window.__goframeDevEventSources || []) source.close();
         const script = document.createElement("script");
         script.src = ${JSON.stringify("/_goframe/dev/reload.js")} + "?reconnect=" + Date.now();
+        script.setAttribute("data-goframe-instance", ${JSON.stringify(String(instance))});
         script.setAttribute("data-goframe-generation", ${JSON.stringify(String(generation))});
         document.body.appendChild(script);
     })()`);
@@ -410,6 +464,67 @@ async function probeOldGenerationUntilBuildCompletes(serverURL, wasmPath, genera
     assert(metadata.version === 1 && wasm.byteLength > 0, "partial package response observed during later build");
     if (servedGeneration === generation) oldGenerationResponses += 3;
     return { oldGenerationResponses, responses404 };
+}
+
+async function openReloadProbe(serverURL, instance, generation) {
+    const controller = new AbortController();
+    const response = await fetch(`${serverURL}/_goframe/dev/events?instance=${encodeURIComponent(instance)}&generation=${encodeURIComponent(generation)}`, {
+        signal: controller.signal,
+    });
+    assert(response.ok && response.body, `activation-gap probe HTTP ${response.status}`);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const state = {
+        connected: false,
+        events: [],
+        failure: null,
+    };
+    let buffer = "";
+    const pump = (async () => {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) return;
+            buffer += decoder.decode(value, { stream: true });
+            for (;;) {
+                const boundary = buffer.indexOf("\n\n");
+                if (boundary < 0) break;
+                const block = buffer.slice(0, boundary);
+                buffer = buffer.slice(boundary + 2);
+                if (block.startsWith(": connected")) state.connected = true;
+                const event = block.split("\n").find((line) => line.startsWith("event: "))?.slice(7);
+                const data = block.split("\n").find((line) => line.startsWith("data: "))?.slice(6);
+                if (event === "reload" && data) state.events.push(Number(data));
+            }
+        }
+    })().catch((error) => {
+        if (!controller.signal.aborted) state.failure = error;
+    });
+
+    const waitFor = async (predicate, label) => {
+        for (let attempt = 0; attempt < 200; attempt++) {
+            if (state.failure) throw state.failure;
+            if (predicate()) return;
+            await wait(25);
+        }
+        throw new Error(`HARNESS FAILURE: timed out waiting for ${label}`);
+    };
+    return {
+        events: state.events,
+        assertHealthy() {
+            if (state.failure) throw state.failure;
+        },
+        async waitConnected() {
+            await waitFor(() => state.connected, "activation-gap SSE connection");
+        },
+        async waitForEvents(count) {
+            await waitFor(() => state.events.length >= count, `${count} activation-gap SSE events`);
+        },
+        async close() {
+            controller.abort();
+            await reader.cancel().catch(() => {});
+            await pump;
+        },
+    };
 }
 
 function captureLines(stream, source) {


### PR DESCRIPTION
## Summary

Adds automatic full-page browser reloads to `goxc dev` after successful rebuilds.

The development server now serves verified, process-private package generations
instead of reading directly from the mutable canonical package directory. This
keeps the last completed application available while another package is being
built or published.

## What changed

- Copies and verifies each successful development package before activation.
- Serves every HTTP response from one immutable completed generation.
- Keeps retired generations alive until their active requests finish.
- Injects a development-only reload client into `/` and `/index.html` responses.
- Uses Server-Sent Events to notify connected pages after generation activation.
- Reloads each connected page once after a successful accepted build.
- Preserves the active generation and sends no reload after failed builds.
- Reloads normally after a later successful recovery.
- Supports multiple clients and stale-generation catch-up without
  same-generation reload loops.
- Removes temporary generations and closes reload connections during shutdown.

Canonical package artifacts, exported output, and ordinary `goxc serve` behavior
remain unchanged.

## Validation

The change includes focused and race-enabled coverage for:

- generation creation, verification, activation, request leases, and cleanup;
- serving the previous generation during mutable package publication;
- reload delivery, deduplication, slow-client collapsing, and reconnect behavior;
- GOX, Go, asset, burst-save, failure, recovery, and shutdown workflows.

A real Chrome browser smoke test exercises a temporary standard-Go WASM
application with initial load, successful rebuild reloads, failure preservation,
two connected pages, stale-generation catch-up, and cleanup.

The full Go, race, vet, documentation, artifact, module-path, and browser-smoke
gates pass locally.

## Compatibility and limits

This is an additive development-tooling change. It does not alter the GoFrame
runtime, GOX language, package metadata, dependency model, or public framework
API.

Each accepted change batch still performs a full package, and browser refresh is
a normal full-document reload that resets page state.

This PR does not add an error overlay, HMR, state preservation, incremental
compilation, source maps, browser auto-open, remote serving, or production
hosting behavior. Build errors remain terminal-only.