### PR TITLE
fix(runtime): make lifecycle state transactional across failed renders

### DIFF
--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -110,7 +110,7 @@ type componentInstance struct {
 	stateIndex       int
 	effectSlots      []*effectSlot
 	effectIndex      int
-	unmountSlots     []*unmountSlot
+	unmountSlots     []Cleanup
 	unmountIndex     int
 	lifecycleAttempt renderLifecycleAttempt
 	contextSlots     []*contextSubscription
@@ -172,14 +172,11 @@ func shouldSkipMemoizedProps(instance *componentInstance, nextNode ComponentNode
 func renderComponentInstance(instance *componentInstance) (rendered Node) {
 	previous := currentComponent
 	currentComponent = instance
-	attemptStarted := false
 	contextFinalizationStarted := false
 	defer func() {
 		currentComponent = previous
 		if recovered := recover(); recovered != nil {
-			if attemptStarted {
-				rollbackLifecycleRenderAttempt(instance)
-			}
+			rollbackLifecycleRenderAttempt(instance)
 			if isRuntimeInvariantPanic(recovered) {
 				panic(recovered)
 			}
@@ -197,9 +194,11 @@ func renderComponentInstance(instance *componentInstance) (rendered Node) {
 			rendered = Empty()
 		}
 	}()
+	return renderComponentLifecycle(instance, &contextFinalizationStarted)
+}
 
+func renderComponentLifecycle(instance *componentInstance, contextFinalizationStarted *bool) Node {
 	beginLifecycleRenderAttempt(instance)
-	attemptStarted = true
 	instance.stateIndex = 0
 	instance.effectIndex = 0
 	instance.unmountIndex = 0
@@ -209,11 +208,10 @@ func renderComponentInstance(instance *componentInstance) (rendered Node) {
 
 	reportComponentRender(instance.name)
 	node := instance.node.render()
-	contextFinalizationStarted = true
+	*contextFinalizationStarted = true
 	finishComponentContextRender(instance)
-	rendered = Child(node)
+	rendered := Child(node)
 	commitLifecycleRenderAttempt(instance)
-	attemptStarted = false
 	return rendered
 }
 

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -112,6 +112,7 @@ type componentInstance struct {
 	effectIndex      int
 	unmountSlots     []*unmountSlot
 	unmountIndex     int
+	lifecycleAttempt renderLifecycleAttempt
 	contextSlots     []*contextSubscription
 	contextIndex     int
 	contextProviders map[int]*contextProvider
@@ -171,20 +172,20 @@ func shouldSkipMemoizedProps(instance *componentInstance, nextNode ComponentNode
 func renderComponentInstance(instance *componentInstance) (rendered Node) {
 	previous := currentComponent
 	currentComponent = instance
-	instance.stateIndex = 0
-	instance.effectIndex = 0
-	instance.unmountIndex = 0
-	instance.contextIndex = 0
-	instance.providedContexts = instance.providedContexts[:0]
-	clearComponentDirty(instance)
+	attemptStarted := false
+	contextFinalizationStarted := false
 	defer func() {
 		currentComponent = previous
 		if recovered := recover(); recovered != nil {
+			if attemptStarted {
+				rollbackLifecycleRenderAttempt(instance)
+			}
 			if isRuntimeInvariantPanic(recovered) {
 				panic(recovered)
 			}
-			finishComponentContextRender(instance)
-			cancelPendingEffectsForRenderFailure(instance)
+			if !contextFinalizationStarted {
+				finishComponentContextRender(instance)
+			}
 			info := ErrorInfo{
 				Phase:     ErrorPhaseRender,
 				Component: runtimeComponentName(instance),
@@ -197,10 +198,23 @@ func renderComponentInstance(instance *componentInstance) (rendered Node) {
 		}
 	}()
 
+	beginLifecycleRenderAttempt(instance)
+	attemptStarted = true
+	instance.stateIndex = 0
+	instance.effectIndex = 0
+	instance.unmountIndex = 0
+	instance.contextIndex = 0
+	instance.providedContexts = instance.providedContexts[:0]
+	clearComponentDirty(instance)
+
 	reportComponentRender(instance.name)
 	node := instance.node.render()
+	contextFinalizationStarted = true
 	finishComponentContextRender(instance)
-	return Child(node)
+	rendered = Child(node)
+	commitLifecycleRenderAttempt(instance)
+	attemptStarted = false
+	return rendered
 }
 
 func markComponentDirty(instance *componentInstance) {
@@ -314,6 +328,7 @@ func deactivateComponent(instance *componentInstance) {
 	instance.stateSlots = nil
 	instance.effectSlots = nil
 	instance.unmountSlots = nil
+	releaseLifecycleRenderAttempt(instance)
 	instance.contextSlots = nil
 	instance.contextProviders = nil
 	instance.providedContexts = nil

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -193,6 +193,26 @@ type unmountSlot struct {
 	cleanup Cleanup
 }
 
+type effectRenderUpdate struct {
+	index  int
+	kind   effectKind
+	effect func() Cleanup
+	deps   EffectDeps
+	queue  bool
+	slot   *effectSlot
+}
+
+type unmountRenderUpdate struct {
+	index   int
+	cleanup Cleanup
+}
+
+type renderLifecycleAttempt struct {
+	active   bool
+	effects  []effectRenderUpdate
+	unmounts []unmountRenderUpdate
+}
+
 var (
 	pendingEffects  []*effectSlot
 	flushingEffects bool
@@ -211,10 +231,14 @@ func UseUnmount(cleanup Cleanup) {
 	instance := requireCurrentComponent("UseUnmount")
 	index := instance.unmountIndex
 	instance.unmountIndex++
-	if index == len(instance.unmountSlots) {
-		instance.unmountSlots = append(instance.unmountSlots, &unmountSlot{})
+	if index > len(instance.unmountSlots) {
+		panic("goframe: invalid unmount hook index")
 	}
-	instance.unmountSlots[index].cleanup = cleanup
+	attempt := requireLifecycleRenderAttempt(instance)
+	attempt.unmounts = append(attempt.unmounts, unmountRenderUpdate{
+		index:   index,
+		cleanup: cleanup,
+	})
 }
 
 // UseEffect runs effect after mount. With Deps it reruns after dependency
@@ -240,27 +264,30 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 	instance := requireCurrentComponent("UseEffect")
 	index := instance.effectIndex
 	instance.effectIndex++
-	if index == len(instance.effectSlots) {
-		slot := &effectSlot{
-			owner:  instance,
-			kind:   kind,
-			effect: effect,
-			deps:   copyDeps(deps),
-		}
-		instance.effectSlots = append(instance.effectSlots, slot)
-		queueEffect(slot)
-		return
+	if index > len(instance.effectSlots) {
+		panic("goframe: invalid effect hook index")
 	}
 
-	slot := instance.effectSlots[index]
-	if slot.kind != kind {
-		panic("goframe: lifecycle hook type changed between component renders")
+	update := effectRenderUpdate{
+		index:  index,
+		kind:   kind,
+		effect: effect,
 	}
-	slot.effect = effect
-	if shouldRunEffect(slot, deps) {
-		slot.deps = copyDeps(deps)
-		queueEffect(slot)
+	if index == len(instance.effectSlots) {
+		update.deps = copyDeps(deps)
+		update.queue = true
+	} else {
+		slot := instance.effectSlots[index]
+		if slot.kind != kind {
+			panic("goframe: lifecycle hook type changed between component renders")
+		}
+		if shouldRunEffect(slot, deps) {
+			update.deps = copyDeps(deps)
+			update.queue = true
+		}
 	}
+	attempt := requireLifecycleRenderAttempt(instance)
+	attempt.effects = append(attempt.effects, update)
 }
 
 func requireCurrentComponent(hook string) *componentInstance {
@@ -269,6 +296,86 @@ func requireCurrentComponent(hook string) *componentInstance {
 		panic("goframe: " + hook + " must be called during component render")
 	}
 	return instance
+}
+
+func beginLifecycleRenderAttempt(instance *componentInstance) {
+	if instance == nil {
+		panic("goframe: lifecycle render attempt requires a component")
+	}
+	attempt := &instance.lifecycleAttempt
+	if attempt.active {
+		panic("goframe: component lifecycle render attempt is already active")
+	}
+	attempt.active = true
+	attempt.effects = attempt.effects[:0]
+	attempt.unmounts = attempt.unmounts[:0]
+}
+
+func requireLifecycleRenderAttempt(instance *componentInstance) *renderLifecycleAttempt {
+	if instance == nil || !instance.lifecycleAttempt.active {
+		panic("goframe: lifecycle hook requires an active render attempt")
+	}
+	return &instance.lifecycleAttempt
+}
+
+func commitLifecycleRenderAttempt(instance *componentInstance) {
+	attempt := requireLifecycleRenderAttempt(instance)
+	for index := range attempt.effects {
+		update := &attempt.effects[index]
+		var slot *effectSlot
+		if update.index == len(instance.effectSlots) {
+			slot = &effectSlot{
+				owner: instance,
+				kind:  update.kind,
+			}
+			instance.effectSlots = append(instance.effectSlots, slot)
+		} else {
+			slot = instance.effectSlots[update.index]
+		}
+		slot.effect = update.effect
+		if update.queue {
+			slot.deps = update.deps
+		}
+		update.slot = slot
+	}
+	for _, update := range attempt.unmounts {
+		if update.index == len(instance.unmountSlots) {
+			instance.unmountSlots = append(instance.unmountSlots, &unmountSlot{
+				cleanup: update.cleanup,
+			})
+			continue
+		}
+		instance.unmountSlots[update.index].cleanup = update.cleanup
+	}
+	for index := range attempt.effects {
+		update := &attempt.effects[index]
+		if update.queue {
+			queueEffect(update.slot)
+		}
+	}
+	finishLifecycleRenderAttempt(attempt)
+}
+
+func rollbackLifecycleRenderAttempt(instance *componentInstance) {
+	if instance == nil || !instance.lifecycleAttempt.active {
+		return
+	}
+	finishLifecycleRenderAttempt(&instance.lifecycleAttempt)
+}
+
+func finishLifecycleRenderAttempt(attempt *renderLifecycleAttempt) {
+	clear(attempt.effects)
+	clear(attempt.unmounts)
+	attempt.effects = attempt.effects[:0]
+	attempt.unmounts = attempt.unmounts[:0]
+	attempt.active = false
+}
+
+func releaseLifecycleRenderAttempt(instance *componentInstance) {
+	if instance == nil {
+		return
+	}
+	instance.lifecycleAttempt = renderLifecycleAttempt{}
 }
 
 func shouldRunEffect(slot *effectSlot, deps EffectDeps) bool {

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -189,22 +189,12 @@ type effectSlot struct {
 	hasRun  bool
 }
 
-type unmountSlot struct {
-	cleanup Cleanup
-}
-
 type effectRenderUpdate struct {
-	index  int
-	kind   effectKind
 	effect func() Cleanup
 	deps   EffectDeps
-	queue  bool
 	slot   *effectSlot
-}
-
-type unmountRenderUpdate struct {
-	index   int
-	cleanup Cleanup
+	kind   effectKind
+	queue  bool
 }
 
 type lifecycleRenderParticipant interface {
@@ -215,8 +205,10 @@ type lifecycleRenderParticipant interface {
 type renderLifecycleAttempt struct {
 	active       bool
 	effects      []effectRenderUpdate
-	unmounts     []unmountRenderUpdate
+	unmounts     []Cleanup
 	participants []lifecycleRenderParticipant
+	// Keep hook commit indirect so hook-free TinyGo apps discard effect machinery.
+	commitHooks func(*componentInstance)
 }
 
 var (
@@ -241,10 +233,8 @@ func UseUnmount(cleanup Cleanup) {
 	if index != len(attempt.unmounts) {
 		panic("goframe: invalid unmount hook index")
 	}
-	attempt.unmounts = append(attempt.unmounts, unmountRenderUpdate{
-		index:   index,
-		cleanup: cleanup,
-	})
+	attempt.commitHooks = commitLifecycleHooks
+	attempt.unmounts = append(attempt.unmounts, cleanup)
 }
 
 // UseEffect runs effect after mount. With Deps it reruns after dependency
@@ -274,9 +264,9 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 	if index != len(attempt.effects) {
 		panic("goframe: invalid effect hook index")
 	}
+	attempt.commitHooks = commitLifecycleHooks
 
 	update := effectRenderUpdate{
-		index:  index,
 		kind:   kind,
 		effect: effect,
 	}
@@ -288,6 +278,7 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 		if slot.kind != kind {
 			panic("goframe: lifecycle hook type changed between component renders")
 		}
+		update.slot = slot
 		if shouldRunEffect(slot, deps) {
 			update.deps = copyDeps(deps)
 			update.queue = true
@@ -313,9 +304,6 @@ func beginLifecycleRenderAttempt(instance *componentInstance) {
 		panic("goframe: component lifecycle render attempt is already active")
 	}
 	attempt.active = true
-	attempt.effects = attempt.effects[:0]
-	attempt.unmounts = attempt.unmounts[:0]
-	attempt.participants = attempt.participants[:0]
 }
 
 func requireLifecycleRenderAttempt(instance *componentInstance) *renderLifecycleAttempt {
@@ -330,17 +318,23 @@ func commitLifecycleRenderAttempt(instance *componentInstance) {
 	for _, participant := range attempt.participants {
 		participant.commitLifecycleRender(attempt)
 	}
+	if attempt.commitHooks != nil {
+		attempt.commitHooks(instance)
+	}
+	finishLifecycleRenderAttempt(attempt)
+}
+
+func commitLifecycleHooks(instance *componentInstance) {
+	attempt := &instance.lifecycleAttempt
 	for index := range attempt.effects {
 		update := &attempt.effects[index]
-		var slot *effectSlot
-		if update.index == len(instance.effectSlots) {
+		slot := update.slot
+		if slot == nil {
 			slot = &effectSlot{
 				owner: instance,
 				kind:  update.kind,
 			}
 			instance.effectSlots = append(instance.effectSlots, slot)
-		} else {
-			slot = instance.effectSlots[update.index]
 		}
 		slot.effect = update.effect
 		if update.queue {
@@ -348,22 +342,16 @@ func commitLifecycleRenderAttempt(instance *componentInstance) {
 		}
 		update.slot = slot
 	}
-	for _, update := range attempt.unmounts {
-		if update.index == len(instance.unmountSlots) {
-			instance.unmountSlots = append(instance.unmountSlots, &unmountSlot{
-				cleanup: update.cleanup,
-			})
-			continue
-		}
-		instance.unmountSlots[update.index].cleanup = update.cleanup
+	if len(attempt.unmounts) > len(instance.unmountSlots) {
+		instance.unmountSlots = append(instance.unmountSlots, attempt.unmounts[len(instance.unmountSlots):]...)
 	}
+	copy(instance.unmountSlots, attempt.unmounts)
 	for index := range attempt.effects {
 		update := &attempt.effects[index]
 		if update.queue {
 			queueEffect(update.slot)
 		}
 	}
-	finishLifecycleRenderAttempt(attempt)
 }
 
 func rollbackLifecycleRenderAttempt(instance *componentInstance) {
@@ -381,6 +369,7 @@ func finishLifecycleRenderAttempt(attempt *renderLifecycleAttempt) {
 	clear(attempt.effects)
 	clear(attempt.unmounts)
 	clear(attempt.participants)
+	attempt.commitHooks = nil
 	attempt.effects = attempt.effects[:0]
 	attempt.unmounts = attempt.unmounts[:0]
 	attempt.participants = attempt.participants[:0]
@@ -496,10 +485,10 @@ func runUnmountCleanups(instance *componentInstance) {
 		}
 		slot.owner = nil
 	}
-	for _, slot := range instance.unmountSlots {
-		if slot != nil && slot.cleanup != nil {
-			runUnmountCleanup(instance, slot.cleanup)
-			slot.cleanup = nil
+	for index, cleanup := range instance.unmountSlots {
+		if cleanup != nil {
+			runUnmountCleanup(instance, cleanup)
+			instance.unmountSlots[index] = nil
 		}
 	}
 }

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -207,10 +207,16 @@ type unmountRenderUpdate struct {
 	cleanup Cleanup
 }
 
+type lifecycleRenderParticipant interface {
+	commitLifecycleRender(*renderLifecycleAttempt)
+	rollbackLifecycleRender(*renderLifecycleAttempt)
+}
+
 type renderLifecycleAttempt struct {
-	active   bool
-	effects  []effectRenderUpdate
-	unmounts []unmountRenderUpdate
+	active       bool
+	effects      []effectRenderUpdate
+	unmounts     []unmountRenderUpdate
+	participants []lifecycleRenderParticipant
 }
 
 var (
@@ -309,6 +315,7 @@ func beginLifecycleRenderAttempt(instance *componentInstance) {
 	attempt.active = true
 	attempt.effects = attempt.effects[:0]
 	attempt.unmounts = attempt.unmounts[:0]
+	attempt.participants = attempt.participants[:0]
 }
 
 func requireLifecycleRenderAttempt(instance *componentInstance) *renderLifecycleAttempt {
@@ -320,6 +327,9 @@ func requireLifecycleRenderAttempt(instance *componentInstance) *renderLifecycle
 
 func commitLifecycleRenderAttempt(instance *componentInstance) {
 	attempt := requireLifecycleRenderAttempt(instance)
+	for _, participant := range attempt.participants {
+		participant.commitLifecycleRender(attempt)
+	}
 	for index := range attempt.effects {
 		update := &attempt.effects[index]
 		var slot *effectSlot
@@ -360,14 +370,20 @@ func rollbackLifecycleRenderAttempt(instance *componentInstance) {
 	if instance == nil || !instance.lifecycleAttempt.active {
 		return
 	}
-	finishLifecycleRenderAttempt(&instance.lifecycleAttempt)
+	attempt := &instance.lifecycleAttempt
+	for _, participant := range attempt.participants {
+		participant.rollbackLifecycleRender(attempt)
+	}
+	finishLifecycleRenderAttempt(attempt)
 }
 
 func finishLifecycleRenderAttempt(attempt *renderLifecycleAttempt) {
 	clear(attempt.effects)
 	clear(attempt.unmounts)
+	clear(attempt.participants)
 	attempt.effects = attempt.effects[:0]
 	attempt.unmounts = attempt.unmounts[:0]
+	attempt.participants = attempt.participants[:0]
 	attempt.active = false
 }
 
@@ -375,6 +391,7 @@ func releaseLifecycleRenderAttempt(instance *componentInstance) {
 	if instance == nil {
 		return
 	}
+	rollbackLifecycleRenderAttempt(instance)
 	instance.lifecycleAttempt = renderLifecycleAttempt{}
 }
 

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -237,10 +237,10 @@ func UseUnmount(cleanup Cleanup) {
 	instance := requireCurrentComponent("UseUnmount")
 	index := instance.unmountIndex
 	instance.unmountIndex++
-	if index > len(instance.unmountSlots) {
+	attempt := requireLifecycleRenderAttempt(instance)
+	if index != len(attempt.unmounts) {
 		panic("goframe: invalid unmount hook index")
 	}
-	attempt := requireLifecycleRenderAttempt(instance)
 	attempt.unmounts = append(attempt.unmounts, unmountRenderUpdate{
 		index:   index,
 		cleanup: cleanup,
@@ -270,7 +270,8 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 	instance := requireCurrentComponent("UseEffect")
 	index := instance.effectIndex
 	instance.effectIndex++
-	if index > len(instance.effectSlots) {
+	attempt := requireLifecycleRenderAttempt(instance)
+	if index != len(attempt.effects) {
 		panic("goframe: invalid effect hook index")
 	}
 
@@ -279,7 +280,7 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 		kind:   kind,
 		effect: effect,
 	}
-	if index == len(instance.effectSlots) {
+	if index >= len(instance.effectSlots) {
 		update.deps = copyDeps(deps)
 		update.queue = true
 	} else {
@@ -292,7 +293,6 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 			update.queue = true
 		}
 	}
-	attempt := requireLifecycleRenderAttempt(instance)
 	attempt.effects = append(attempt.effects, update)
 }
 

--- a/pkg/goframe/effects_test.go
+++ b/pkg/goframe/effects_test.go
@@ -230,6 +230,195 @@ func TestUseUnmountOutsideComponentPanics(t *testing.T) {
 	UseUnmount(func() {})
 }
 
+func TestMultipleNewEffectsCommitInOrder(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	instance := testComponentInstance("MultipleEffects", func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "setup A")
+			return func() {
+				events = append(events, "cleanup A")
+			}
+		})
+		UseEffect(func() Cleanup {
+			events = append(events, "setup B")
+			return func() {
+				events = append(events, "cleanup B")
+			}
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	assertEffectEvents(t, events, nil)
+	if len(instance.effectSlots) != 2 {
+		t.Fatalf("committed effect slots = %d, want 2", len(instance.effectSlots))
+	}
+	if len(pendingEffects) != 2 || pendingEffects[0] != instance.effectSlots[0] || pendingEffects[1] != instance.effectSlots[1] {
+		t.Fatalf("pending effects = %#v, want one ordered entry per committed slot", pendingEffects)
+	}
+
+	flushPendingEffects()
+	assertEffectEvents(t, events, []string{"setup A", "setup B"})
+	deactivateComponent(instance)
+	assertEffectEvents(t, events, []string{"setup A", "setup B", "cleanup A", "cleanup B"})
+}
+
+func TestMultipleNewEffectsRollbackAndRetry(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	fail := true
+	instance := testComponentInstance("MultipleEffectRetry", func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "setup A")
+			return func() {
+				events = append(events, "cleanup A")
+			}
+		})
+		UseEffect(func() Cleanup {
+			events = append(events, "setup B")
+			return func() {
+				events = append(events, "cleanup B")
+			}
+		})
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	if len(instance.effectSlots) != 0 || len(pendingEffects) != 0 {
+		t.Fatalf("failed render slots=%d pending=%d, want 0/0", len(instance.effectSlots), len(pendingEffects))
+	}
+	assertEffectEvents(t, events, nil)
+
+	fail = false
+	renderComponentInstance(instance)
+	if len(instance.effectSlots) != 2 || len(pendingEffects) != 2 {
+		t.Fatalf("successful retry slots=%d pending=%d, want 2/2", len(instance.effectSlots), len(pendingEffects))
+	}
+	flushPendingEffects()
+	deactivateComponent(instance)
+	assertEffectEvents(t, events, []string{"setup A", "setup B", "cleanup A", "cleanup B"})
+}
+
+func TestMultipleNewUnmountsCommitInOrder(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	instance := testComponentInstance("MultipleUnmounts", func() Node {
+		UseUnmount(func() {
+			events = append(events, "cleanup A")
+		})
+		UseUnmount(func() {
+			events = append(events, "cleanup B")
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	assertEffectEvents(t, events, nil)
+	if len(instance.unmountSlots) != 2 {
+		t.Fatalf("committed unmount slots = %d, want 2", len(instance.unmountSlots))
+	}
+	deactivateComponent(instance)
+	assertEffectEvents(t, events, []string{"cleanup A", "cleanup B"})
+}
+
+func TestMultipleNewUnmountsRollbackAndRetry(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	failed := testComponentInstance("MultipleUnmountFailure", func() Node {
+		UseUnmount(func() {
+			events = append(events, "failed cleanup A")
+		})
+		UseUnmount(func() {
+			events = append(events, "failed cleanup B")
+		})
+		panic("failed render")
+	}, nil)
+
+	renderComponentInstance(failed)
+	if len(failed.unmountSlots) != 0 {
+		t.Fatalf("failed render unmount slots = %d, want 0", len(failed.unmountSlots))
+	}
+	deactivateComponent(failed)
+	assertEffectEvents(t, events, nil)
+
+	retry := testComponentInstance("MultipleUnmountRetry", func() Node {
+		UseUnmount(func() {
+			events = append(events, "cleanup A")
+		})
+		UseUnmount(func() {
+			events = append(events, "cleanup B")
+		})
+		return Empty()
+	}, nil)
+	renderComponentInstance(retry)
+	deactivateComponent(retry)
+	assertEffectEvents(t, events, []string{"cleanup A", "cleanup B"})
+}
+
+func TestMultipleNewLifecycleHooksAppendAfterCommittedSlots(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	appendHooks := false
+	instance := testComponentInstance("AppendLifecycleHooks", func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "setup effect A")
+			return func() {
+				events = append(events, "cleanup effect A")
+			}
+		})
+		UseUnmount(func() {
+			events = append(events, "cleanup unmount A")
+		})
+		if appendHooks {
+			UseEffect(func() Cleanup {
+				events = append(events, "setup effect B")
+				return func() {
+					events = append(events, "cleanup effect B")
+				}
+			})
+			UseEffect(func() Cleanup {
+				events = append(events, "setup effect C")
+				return func() {
+					events = append(events, "cleanup effect C")
+				}
+			})
+			UseUnmount(func() {
+				events = append(events, "cleanup unmount B")
+			})
+			UseUnmount(func() {
+				events = append(events, "cleanup unmount C")
+			})
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	appendHooks = true
+	renderComponentInstance(instance)
+	if len(instance.effectSlots) != 3 || len(instance.unmountSlots) != 3 {
+		t.Fatalf("appended lifecycle slots effects=%d unmounts=%d, want 3/3",
+			len(instance.effectSlots), len(instance.unmountSlots))
+	}
+	flushPendingEffects()
+	deactivateComponent(instance)
+	assertEffectEvents(t, events, []string{
+		"setup effect A",
+		"setup effect B",
+		"setup effect C",
+		"cleanup effect A",
+		"cleanup effect B",
+		"cleanup effect C",
+		"cleanup unmount A",
+		"cleanup unmount B",
+		"cleanup unmount C",
+	})
+}
+
 func TestLifecycleHookTypeMismatchPanics(t *testing.T) {
 	resetEffectsForTest()
 	useMount := false

--- a/pkg/goframe/effects_test.go
+++ b/pkg/goframe/effects_test.go
@@ -288,6 +288,308 @@ func TestUseEffectUnsupportedDependencyPanics(t *testing.T) {
 	renderComponentInstance(instance)
 }
 
+func TestUseEffectChangedDepsRetryAfterFailedRender(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	dep := 1
+	label := "A"
+	fail := false
+	instance := testComponentInstance("EffectTransaction", func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return func() {
+				events = append(events, "cleanup "+committedLabel)
+			}
+		}, Deps(dep))
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	dep = 2
+	label = "B"
+	fail = true
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	assertEffectEvents(t, events, []string{"setup A"})
+
+	label = "C"
+	fail = false
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	deactivateComponent(instance)
+
+	assertEffectEvents(t, events, []string{
+		"setup A",
+		"cleanup A",
+		"setup C",
+		"cleanup C",
+	})
+}
+
+func TestUseEffectCommittedPendingStateSurvivesFailedRender(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	label := "A"
+	fail := false
+	instance := testComponentInstance("PendingEffectTransaction", func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return nil
+		})
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	if len(pendingEffects) != 1 {
+		t.Fatalf("pending effects after committed render = %d, want 1", len(pendingEffects))
+	}
+	label = "B"
+	fail = true
+	renderComponentInstance(instance)
+	if len(pendingEffects) != 1 {
+		t.Fatalf("pending effects after failed render = %d, want preserved queue entry", len(pendingEffects))
+	}
+
+	flushPendingEffects()
+	assertEffectEvents(t, events, []string{"setup A"})
+	if len(pendingEffects) != 0 {
+		t.Fatalf("pending effects after flush = %d, want 0", len(pendingEffects))
+	}
+}
+
+func TestUseEffectSuccessfulRerenderBeforeFlushUsesLatestCommittedClosure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	label := "A"
+	instance := testComponentInstance("CoalescedEffectTransaction", func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return nil
+		})
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	label = "B"
+	renderComponentInstance(instance)
+	if len(pendingEffects) != 1 {
+		t.Fatalf("pending effects before flush = %d, want one coalesced slot", len(pendingEffects))
+	}
+	flushPendingEffects()
+
+	assertEffectEvents(t, events, []string{"setup B"})
+}
+
+func TestUseEffectInitialFailedRenderQueuesNothing(t *testing.T) {
+	isolateLifecycleTestState(t)
+	setups := 0
+	fail := true
+	instance := testComponentInstance("InitialEffectTransaction", func() Node {
+		UseEffect(func() Cleanup {
+			setups++
+			return nil
+		})
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if setups != 0 || len(instance.effectSlots) != 0 || len(pendingEffects) != 0 {
+		t.Fatalf("failed initial render setups=%d slots=%d pending=%d, want 0/0/0",
+			setups, len(instance.effectSlots), len(pendingEffects))
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if setups != 1 || len(instance.effectSlots) != 1 {
+		t.Fatalf("successful retry setups=%d slots=%d, want 1/1", setups, len(instance.effectSlots))
+	}
+}
+
+func TestUseEffectEveryRenderFailedAttemptQueuesNothing(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	label := "A"
+	fail := false
+	instance := testComponentInstance("EveryRenderTransaction", func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return nil
+		}, EveryRender())
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	label = "B"
+	fail = true
+	renderComponentInstance(instance)
+	flushPendingEffects()
+
+	assertEffectEvents(t, events, []string{"setup A"})
+	if len(pendingEffects) != 0 {
+		t.Fatalf("pending EveryRender effects after failed attempt = %d, want 0", len(pendingEffects))
+	}
+}
+
+func TestUseUnmountFailedRenderPreservesCommittedCleanup(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	label := "A"
+	fail := false
+	instance := testComponentInstance("UnmountTransaction", func() Node {
+		committedLabel := label
+		UseUnmount(func() {
+			events = append(events, "cleanup "+committedLabel)
+		})
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	label = "B"
+	fail = true
+	renderComponentInstance(instance)
+	deactivateComponent(instance)
+
+	assertEffectEvents(t, events, []string{"cleanup A"})
+}
+
+func TestUseUnmountInitialFailedRenderCommitsNoCleanup(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	failed := testComponentInstance("InitialUnmountFailure", func() Node {
+		UseUnmount(func() {
+			events = append(events, "cleanup failed")
+		})
+		panic("failed render")
+	}, nil)
+
+	renderComponentInstance(failed)
+	if len(failed.unmountSlots) != 0 {
+		t.Fatalf("unmount slots after failed initial render = %d, want 0", len(failed.unmountSlots))
+	}
+	deactivateComponent(failed)
+	assertEffectEvents(t, events, nil)
+
+	fail := true
+	retry := testComponentInstance("InitialUnmountRetry", func() Node {
+		UseUnmount(func() {
+			events = append(events, "cleanup committed")
+		})
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+	renderComponentInstance(retry)
+	fail = false
+	renderComponentInstance(retry)
+	deactivateComponent(retry)
+	assertEffectEvents(t, events, []string{"cleanup committed"})
+}
+
+func TestLifecycleRollbackRunsBeforeInvariantRepanic(t *testing.T) {
+	isolateLifecycleTestState(t)
+	events := []string{}
+	dep := 1
+	label := "A"
+	panicInvariant := false
+	instance := testComponentInstance("InvariantLifecycleTransaction", func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return func() {
+				events = append(events, "cleanup "+committedLabel)
+			}
+		}, Deps(dep))
+		UseUnmount(func() {
+			events = append(events, "unmount "+committedLabel)
+		})
+		if panicInvariant {
+			UseEffect(func() Cleanup { return nil }, Deps(struct{}{}))
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	dep = 2
+	label = "B"
+	panicInvariant = true
+	assertPanic(t,
+		"goframe: unsupported effect dependency type; reduce complex values to string, id, version, or counter",
+		func() {
+			renderComponentInstance(instance)
+		})
+	if instance.lifecycleAttempt.active || len(instance.lifecycleAttempt.effects) != 0 || len(instance.lifecycleAttempt.unmounts) != 0 {
+		t.Fatalf("lifecycle attempt after invariant panic = %#v, want rolled back", instance.lifecycleAttempt)
+	}
+	if len(instance.effectSlots) != 1 || !depsEqual(instance.effectSlots[0].deps, Deps(1)) {
+		t.Fatalf("committed effect state changed after invariant panic: %#v", instance.effectSlots)
+	}
+
+	label = "C"
+	panicInvariant = false
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	deactivateComponent(instance)
+	assertEffectEvents(t, events, []string{
+		"setup A",
+		"cleanup A",
+		"setup C",
+		"cleanup C",
+		"unmount C",
+	})
+}
+
+func isolateLifecycleTestState(t *testing.T) {
+	t.Helper()
+	previousPending := pendingEffects
+	previousCurrent := currentComponent
+	previousFlushing := flushingEffects
+	pendingEffects = nil
+	currentComponent = nil
+	flushingEffects = false
+	t.Cleanup(func() {
+		pendingEffects = previousPending
+		currentComponent = previousCurrent
+		flushingEffects = previousFlushing
+	})
+}
+
+func assertEffectEvents(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("events = %#v, want %#v", got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("events = %#v, want %#v", got, want)
+		}
+	}
+}
+
 func resetEffectsForTest() {
 	pendingEffects = nil
 	currentComponent = nil

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -119,19 +119,6 @@ func nearestErrorBoundary(instance *componentInstance) *componentInstance {
 	return nil
 }
 
-func cancelPendingEffectsForRenderFailure(instance *componentInstance) {
-	if instance == nil {
-		return
-	}
-	for _, slot := range instance.effectSlots {
-		if slot == nil {
-			continue
-		}
-		slot.pending = false
-		slot.queued = false
-	}
-}
-
 func cancelPendingEffectsUnderBoundary(boundary *componentInstance) {
 	if boundary == nil {
 		return

--- a/pkg/goframe/resource.go
+++ b/pkg/goframe/resource.go
@@ -48,28 +48,39 @@ func UseResource[T any](key string, loader ResourceLoader[T]) (Resource[T], func
 	slot := useStateSlot[*resourceControl[T]](nil, "UseResource")
 	control := slot.get()
 	if control == nil {
-		control = newResourceControl[T](currentComponent, key, loader)
+		control = newResourceControl[T]()
 		slot.slot.value = control
 	}
-	control.owner = currentComponent
-	control.loader = loader
-	control.prepareKey(key)
+	attempt := requireLifecycleRenderAttempt(currentComponent)
+	snapshot, generation := control.prepareRender(attempt, currentComponent, key, loader)
 
-	generation := control.generation
 	UseEffect(func() Cleanup {
 		return control.start(key, generation)
 	}, Deps(key, generation))
 
-	return control.snapshot, control.reload
+	return snapshot, control.reload
 }
 
 type resourceControl[T any] struct {
+	committed  bool
 	owner      *componentInstance
 	key        string
 	generation int
 	loader     ResourceLoader[T]
 	snapshot   Resource[T]
 	current    *resourceRun[T]
+	pending    resourceRenderState[T]
+}
+
+type resourceRenderState[T any] struct {
+	attempt    *renderLifecycleAttempt
+	owner      *componentInstance
+	key        string
+	generation int
+	loader     ResourceLoader[T]
+	snapshot   Resource[T]
+	initial    bool
+	keyChanged bool
 }
 
 type resourceRun[T any] struct {
@@ -92,27 +103,73 @@ const (
 	resourceLoaderPanicError resourceInternalError = "goframe: resource loader panicked"
 )
 
-func newResourceControl[T any](owner *componentInstance, key string, loader ResourceLoader[T]) *resourceControl[T] {
+func newResourceControl[T any]() *resourceControl[T] {
 	return &resourceControl[T]{
-		owner:    owner,
-		key:      key,
-		loader:   loader,
 		snapshot: resourceLoading[T](),
 	}
 }
 
-func (control *resourceControl[T]) prepareKey(key string) {
-	if control.key == key {
+func (control *resourceControl[T]) prepareRender(
+	attempt *renderLifecycleAttempt,
+	owner *componentInstance,
+	key string,
+	loader ResourceLoader[T],
+) (Resource[T], int) {
+	if control.pending.attempt != nil {
+		panic("goframe: resource already participated in this render attempt")
+	}
+	pending := resourceRenderState[T]{
+		attempt:    attempt,
+		owner:      owner,
+		key:        control.key,
+		generation: control.generation,
+		loader:     loader,
+		snapshot:   control.snapshot,
+	}
+	if !control.committed {
+		pending.initial = true
+		pending.key = key
+		pending.snapshot = resourceLoading[T]()
+	} else if control.key != key {
+		pending.keyChanged = true
+		pending.key = key
+		pending.generation++
+		pending.snapshot = resourceLoading[T]()
+	}
+	control.pending = pending
+	attempt.participants = append(attempt.participants, control)
+	return pending.snapshot, pending.generation
+}
+
+func (control *resourceControl[T]) commitLifecycleRender(attempt *renderLifecycleAttempt) {
+	pending := control.pending
+	if pending.attempt != attempt {
 		return
 	}
-	control.invalidateCurrent()
-	control.key = key
-	control.generation++
-	control.snapshot = resourceLoading[T]()
+	control.owner = pending.owner
+	control.loader = pending.loader
+	if pending.initial {
+		control.committed = true
+		control.key = pending.key
+		control.generation = pending.generation
+		control.snapshot = pending.snapshot
+	} else if pending.keyChanged {
+		control.invalidateCurrent()
+		control.key = pending.key
+		control.generation = pending.generation
+		control.snapshot = pending.snapshot
+	}
+	control.pending = resourceRenderState[T]{}
+}
+
+func (control *resourceControl[T]) rollbackLifecycleRender(attempt *renderLifecycleAttempt) {
+	if control.pending.attempt == attempt {
+		control.pending = resourceRenderState[T]{}
+	}
 }
 
 func (control *resourceControl[T]) reload() {
-	if control == nil || control.owner == nil || !control.owner.active {
+	if control == nil || !control.committed || control.owner == nil || !control.owner.active {
 		return
 	}
 	control.invalidateCurrent()

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -855,6 +855,224 @@ func TestUseResourceNilLoaderPanics(t *testing.T) {
 	})
 }
 
+func TestUseResourceKeyRetryAfterFailedRender(t *testing.T) {
+	isolateLifecycleTestState(t)
+	loader := &resourceTestLoader{}
+	key := "a"
+	fail := false
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceKeyTransaction", func() Node {
+		resource, _ = UseResource(key, loader.load)
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.resolves[0]("ready-a")
+	renderComponentInstance(instance)
+	control := resourceControlForTest[string](t, instance)
+	if !resource.Ready() || resource.Value != "ready-a" {
+		t.Fatalf("resource before failed key render = %#v, want ready-a", resource)
+	}
+
+	key = "b"
+	fail = true
+	renderComponentInstance(instance)
+	if control.key != "a" || control.generation != 0 || !control.snapshot.Ready() || control.snapshot.Value != "ready-a" {
+		t.Fatalf("committed control after failed key render = key %q generation %d snapshot %#v, want committed a",
+			control.key, control.generation, control.snapshot)
+	}
+	if got := loader.starts; len(got) != 1 || got[0] != "a" {
+		t.Fatalf("loader starts after failed key render = %#v, want [a]", got)
+	}
+	if loader.cleanups != 0 {
+		t.Fatalf("loader cleanups after failed key render = %d, want 0", loader.cleanups)
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	if !resource.Loading() || control.key != "b" || control.generation != 1 {
+		t.Fatalf("resource/control after successful key retry = %#v key %q generation %d, want loading b/1",
+			resource, control.key, control.generation)
+	}
+	if len(loader.starts) != 1 || loader.cleanups != 0 {
+		t.Fatalf("before retry effect flush starts=%d cleanups=%d, want 1/0", len(loader.starts), loader.cleanups)
+	}
+	flushPendingEffects()
+	if got := loader.starts; len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("loader starts after successful key retry = %#v, want [a b]", got)
+	}
+	if loader.cleanups != 1 {
+		t.Fatalf("loader cleanups after successful key retry = %d, want 1", loader.cleanups)
+	}
+	loader.resolves[1]("ready-b")
+	renderComponentInstance(instance)
+	if !resource.Ready() || resource.Value != "ready-b" {
+		t.Fatalf("resource after retry resolve = %#v, want ready-b", resource)
+	}
+}
+
+func TestUseResourceFailedRenderPreservesCommittedRun(t *testing.T) {
+	isolateLifecycleTestState(t)
+	loader := &resourceTestLoader{}
+	key := "a"
+	fail := false
+	schedules := 0
+	var resource Resource[string]
+	instance := testComponentInstance("ResourceRunTransaction", func() Node {
+		resource, _ = UseResource(key, loader.load)
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	control := resourceControlForTest[string](t, instance)
+	committedRun := control.current
+	oldResolve := loader.resolves[0]
+	oldReject := loader.rejects[0]
+
+	key = "b"
+	fail = true
+	renderComponentInstance(instance)
+	if control.current != committedRun || !committedRun.active || control.key != "a" {
+		t.Fatalf("committed run after failed key render = current %p active %v key %q, want original active a",
+			control.current, committedRun.active, control.key)
+	}
+	oldResolve("ready-a")
+	if schedules != 1 || !control.snapshot.Ready() || control.snapshot.Value != "ready-a" {
+		t.Fatalf("old callback after failed render schedules=%d snapshot=%#v, want accepted ready-a",
+			schedules, control.snapshot)
+	}
+
+	key = "a"
+	fail = false
+	renderComponentInstance(instance)
+	if !resource.Ready() || resource.Value != "ready-a" {
+		t.Fatalf("resource after committed callback render = %#v, want ready-a", resource)
+	}
+	key = "b"
+	renderComponentInstance(instance)
+	if !resource.Loading() {
+		t.Fatalf("resource after committed key change = %#v, want loading", resource)
+	}
+	oldResolve("late-ready-a")
+	oldReject(errors.New("late-failed-a"))
+	if schedules != 1 || instance.dirty || !control.snapshot.Loading() {
+		t.Fatalf("stale callbacks after committed key change schedules=%d dirty=%v snapshot=%#v, want ignored",
+			schedules, instance.dirty, control.snapshot)
+	}
+	flushPendingEffects()
+}
+
+func TestUseResourceFailedLoaderReplacementIsNotCommitted(t *testing.T) {
+	isolateLifecycleTestState(t)
+	first := &resourceTestLoader{}
+	second := &resourceTestLoader{}
+	useSecond := false
+	fail := false
+	var reload func()
+	instance := testComponentInstance("ResourceLoaderTransaction", func() Node {
+		loader := first.load
+		if useSecond {
+			loader = second.load
+		}
+		_, reload = UseResource("same", loader)
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	useSecond = true
+	fail = true
+	renderComponentInstance(instance)
+
+	reload()
+	useSecond = false
+	fail = false
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if len(first.starts) != 2 || len(second.starts) != 0 {
+		t.Fatalf("starts after reload following failed replacement = first %d second %d, want 2/0",
+			len(first.starts), len(second.starts))
+	}
+
+	useSecond = true
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if len(first.starts) != 2 || len(second.starts) != 0 {
+		t.Fatalf("starts after successful same-key loader replacement = first %d second %d, want no restart",
+			len(first.starts), len(second.starts))
+	}
+	reload()
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if len(first.starts) != 2 || len(second.starts) != 1 {
+		t.Fatalf("starts after reload with committed replacement = first %d second %d, want 2/1",
+			len(first.starts), len(second.starts))
+	}
+}
+
+func TestUseResourceInitialFailedRenderStartsNoLoader(t *testing.T) {
+	isolateLifecycleTestState(t)
+	loader := &resourceTestLoader{}
+	fail := true
+	var resource Resource[string]
+	instance := testComponentInstance("InitialResourceTransaction", func() Node {
+		resource, _ = UseResource("initial", loader.load)
+		if fail {
+			panic("failed render")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	control := resourceControlForTest[string](t, instance)
+	if control.committed || control.owner != nil || control.loader != nil || control.key != "" || control.current != nil {
+		t.Fatalf("control after failed initial render = %#v, want no committed lifecycle state", control)
+	}
+	if control.pending.attempt != nil || len(instance.effectSlots) != 0 || len(loader.starts) != 0 {
+		t.Fatalf("failed initial resource pending=%#v effect slots=%d starts=%d, want cleared/0/0",
+			control.pending, len(instance.effectSlots), len(loader.starts))
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	if !resource.Loading() || !control.committed || control.key != "initial" || control.owner != instance {
+		t.Fatalf("resource/control after successful retry = %#v/%#v, want committed loading initial", resource, control)
+	}
+	if len(loader.starts) != 0 {
+		t.Fatalf("loader starts before retry effect flush = %d, want 0", len(loader.starts))
+	}
+	flushPendingEffects()
+	if got := loader.starts; len(got) != 1 || got[0] != "initial" {
+		t.Fatalf("loader starts after successful retry = %#v, want [initial]", got)
+	}
+}
+
+func resourceControlForTest[T any](t *testing.T, instance *componentInstance) *resourceControl[T] {
+	t.Helper()
+	if len(instance.stateSlots) == 0 {
+		t.Fatal("component has no resource state slot")
+	}
+	control, ok := instance.stateSlots[0].value.(*resourceControl[T])
+	if !ok || control == nil {
+		t.Fatalf("resource state slot = %#v, want *resourceControl", instance.stateSlots[0].value)
+	}
+	return control
+}
+
 func requireResourceEffectSlotCompleted(t *testing.T, instance *componentInstance) {
 	t.Helper()
 	if len(instance.effectSlots) != 1 {


### PR DESCRIPTION
## Summary

Makes effect, unmount, and resource lifecycle state transactional across
component renders.

A render that panics no longer commits speculative effect closures,
dependencies, unmount cleanups, or resource transitions. The last successful
render remains the source of committed lifecycle state.

## Changes

- Stages lifecycle updates until the component render completes successfully.
- Rolls back staged state before invariant repanics or ordinary render-error
  handling.
- Preserves previously committed and already queued effects after failed renders.
- Prevents failed renders from replacing committed `UseUnmount` cleanups.
- Keeps resource keys, loaders, snapshots, generations, active runs, and
  callbacks consistent across failed renders.
- Supports multiple staged effects and unmount cleanups in registration order.
- Compacts the transaction path so hook-free TinyGo applications do not retain
  unnecessary effect machinery.

## Validation

Includes focused and race-enabled coverage for:

- changed dependencies followed by failure and retry;
- successful rerenders before effect flush;
- initial and `EveryRender` failures;
- multiple staged lifecycle hooks;
- unmount cleanup commit and rollback;
- resource key and loader transitions;
- stale callback handling;
- invariant repanic ordering.

The full Go, debug-tag, race, vet, browser-smoke, documentation, artifact, and
module-path gates pass.

The complete Go 1.22.12 / TinyGo 0.41.1 size matrix passes without changing
budgets, workflows, compiler flags, or examples.

## Compatibility

This is an internal runtime correctness fix. It does not change the public API,
scheduler, state or reducer semantics, Error Boundary phases, dependency model,
or documented hook-order rules.