### PR TITLE
fix(runtime): serialize ARIA booleans as explicit tokens

### DIFF
--- a/pkg/goframe/props.go
+++ b/pkg/goframe/props.go
@@ -134,6 +134,15 @@ func normalizeAttributeName(name string) string {
 	}
 }
 
+func isARIAAttribute(name string) bool {
+	return len(name) > 5 &&
+		name[0]|0x20 == 'a' &&
+		name[1]|0x20 == 'r' &&
+		name[2]|0x20 == 'i' &&
+		name[3]|0x20 == 'a' &&
+		name[4] == '-'
+}
+
 func splitProps(props Props) (splitDOMProps, splitEventProps) {
 	if len(props) == 0 {
 		return nil, nil
@@ -143,6 +152,13 @@ func splitProps(props Props) (splitDOMProps, splitEventProps) {
 	var events splitEventProps
 	for name, value := range props {
 		if value == nil {
+			continue
+		}
+		if boolean, ok := value.(bool); ok && isARIAAttribute(name) {
+			if dom == nil {
+				dom = make(splitDOMProps, 0, len(props))
+			}
+			dom.set(name, domProp{value: strconv.FormatBool(boolean)})
 			continue
 		}
 		if boolean, ok := value.(bool); ok && !boolean {

--- a/pkg/goframe/props_test.go
+++ b/pkg/goframe/props_test.go
@@ -26,6 +26,7 @@ func TestSplitPropsContract(t *testing.T) {
 		"data-count":        42,
 		"data-ratio":        3.5,
 		"aria-expanded":     true,
+		"aria-hidden":       false,
 		"data-unsupported":  struct{ label string }{"unsupported"},
 		"data-bool-skipped": false,
 	})
@@ -41,7 +42,8 @@ func TestSplitPropsContract(t *testing.T) {
 		"disabled":         {boolean: true},
 		"data-count":       {value: "42"},
 		"data-ratio":       {value: "3.5"},
-		"aria-expanded":    {boolean: true},
+		"aria-expanded":    {value: "true"},
+		"aria-hidden":      {value: "false"},
 		"data-unsupported": {},
 	}
 	if len(dom) != len(wantDOM) {
@@ -69,6 +71,127 @@ func TestSplitPropsContract(t *testing.T) {
 	}
 	if _, exists := events.get("change"); exists {
 		t.Fatalf("events[change] should be absent")
+	}
+}
+
+func TestSplitPropsSerializesARIABooleanValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		prop  string
+		value bool
+		want  string
+	}{
+		{name: "expanded true", prop: "aria-expanded", value: true, want: "true"},
+		{name: "expanded false", prop: "aria-expanded", value: false, want: "false"},
+		{name: "hidden true", prop: "aria-hidden", value: true, want: "true"},
+		{name: "hidden false", prop: "aria-hidden", value: false, want: "false"},
+		{name: "invalid true", prop: "aria-invalid", value: true, want: "true"},
+		{name: "invalid false", prop: "aria-invalid", value: false, want: "false"},
+		{name: "upper prefix", prop: "ARIA-expanded", value: false, want: "false"},
+		{name: "title prefix", prop: "Aria-hidden", value: true, want: "true"},
+		{name: "mixed prefix", prop: "aRiA-invalid", value: false, want: "false"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dom, events := splitProps(Props{test.prop: test.value})
+			if len(dom) != 1 {
+				t.Fatalf("dom = %#v, want exactly one prop", dom)
+			}
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+			got, ok := dom.get(test.prop)
+			if !ok {
+				t.Fatalf("dom[%q] absent; dom = %#v", test.prop, dom)
+			}
+			if got != (domProp{value: test.want}) {
+				t.Fatalf("dom[%q] = %#v, want %#v", test.prop, got, domProp{value: test.want})
+			}
+			if got.boolean {
+				t.Fatalf("dom[%q].boolean = true, want false", test.prop)
+			}
+		})
+	}
+}
+
+func TestSplitPropsARIAPrefixBoundariesUseGenericBooleanSemantics(t *testing.T) {
+	for _, prop := range []string{"aria", "aria-", "ariax-expanded", "xaria-expanded"} {
+		t.Run(prop+" true", func(t *testing.T) {
+			dom, events := splitProps(Props{prop: true})
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+			if got, ok := dom.get(prop); !ok || got != (domProp{boolean: true}) {
+				t.Fatalf("dom[%q] = %#v, %v; want presence boolean", prop, got, ok)
+			}
+		})
+
+		t.Run(prop+" false", func(t *testing.T) {
+			dom, events := splitProps(Props{prop: false})
+			if len(dom) != 0 {
+				t.Fatalf("dom = %#v, want empty", dom)
+			}
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+		})
+	}
+}
+
+func TestSplitPropsPreservesNonARIABooleanSemantics(t *testing.T) {
+	for _, prop := range []string{"disabled", "checked", "selected", "hidden", "data-flag", "custom-flag"} {
+		t.Run(prop+" true", func(t *testing.T) {
+			dom, events := splitProps(Props{prop: true})
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+			if got, ok := dom.get(prop); !ok || got != (domProp{boolean: true}) {
+				t.Fatalf("dom[%q] = %#v, %v; want presence boolean", prop, got, ok)
+			}
+		})
+
+		t.Run(prop+" false", func(t *testing.T) {
+			dom, events := splitProps(Props{prop: false})
+			if len(dom) != 0 {
+				t.Fatalf("dom = %#v, want empty", dom)
+			}
+			if len(events) != 0 {
+				t.Fatalf("events = %#v, want empty", events)
+			}
+		})
+	}
+
+	dom, events := splitProps(Props{"OnChange": false})
+	if len(dom) != 0 || len(events) != 0 {
+		t.Fatalf("false event split = %#v, %#v; want empty", dom, events)
+	}
+}
+
+func TestSplitPropsPreservesNonBooleanARIAValues(t *testing.T) {
+	dom, events := splitProps(Props{
+		"aria-current":  "page",
+		"aria-checked":  "mixed",
+		"aria-rowindex": 3,
+		"aria-label":    "Save",
+	})
+
+	want := map[string]domProp{
+		"aria-current":  {value: "page"},
+		"aria-checked":  {value: "mixed"},
+		"aria-rowindex": {value: "3"},
+		"aria-label":    {value: "Save"},
+	}
+	if len(dom) != len(want) {
+		t.Fatalf("dom = %#v, want %d props", dom, len(want))
+	}
+	if len(events) != 0 {
+		t.Fatalf("events = %#v, want empty", events)
+	}
+	for name, wantProp := range want {
+		if got, ok := dom.get(name); !ok || got != wantProp {
+			t.Fatalf("dom[%q] = %#v, %v; want %#v, true", name, got, ok, wantProp)
+		}
 	}
 }
 

--- a/scripts/router-dashboard-browser-smoke.mjs
+++ b/scripts/router-dashboard-browser-smoke.mjs
@@ -138,6 +138,7 @@ try {
         hash: "#/issues/RD-2/edit",
         formTitle: "Billing dashboard needs clearer empty state",
         formDirty: "No local changes",
+        titleAriaInvalid: "false",
         resourceStatus: "ready",
         resourceAttempt: "2",
         boundaryFallback: false,
@@ -235,6 +236,7 @@ try {
         hash: "#/issues/RD-2/edit",
         formTitle: "Billing dashboard needs clearer empty state",
         formDirty: "No local changes",
+        titleAriaInvalid: "false",
         resourceStatus: "ready",
         resourceAttempt: "4",
         boundaryFallback: false,
@@ -249,6 +251,7 @@ try {
     assertState(await appState(client), {
         route: "edit",
         titleError: "Title is required.",
+        titleAriaInvalid: "true",
         formDirty: "Unsaved local changes",
         saved: false,
         resourceStatus: "ready",
@@ -265,6 +268,7 @@ try {
     assertState(await appState(client), {
         route: "edit",
         titleError: "",
+        titleAriaInvalid: "false",
         saved: true,
         resourceStatus: "ready",
         resourceAttempt: "4",
@@ -278,7 +282,8 @@ try {
         return state.formTitle === "Billing dashboard needs clearer empty state" &&
             state.formDirty === "No local changes" &&
             !state.saved &&
-            state.titleError === "";
+            state.titleError === "" &&
+            state.titleAriaInvalid === "false";
     }, "form reset");
     assertState(await appState(client), {
         route: "edit",
@@ -286,6 +291,7 @@ try {
         formDirty: "No local changes",
         saved: false,
         titleError: "",
+        titleAriaInvalid: "false",
         resourceStatus: "ready",
         resourceAttempt: "4",
         boundaryFallback: false,
@@ -338,6 +344,7 @@ async function appState(client) {
             formTitle: document.querySelector("[data-testid='rd-field-title']")?.value ?? "",
             formDirty: document.querySelector("[data-testid='rd-form-dirty']")?.textContent.trim() ?? "",
             titleError: document.querySelector("[data-testid='rd-field-error-title']")?.textContent.trim() ?? "",
+            titleAriaInvalid: document.querySelector("[data-testid='rd-field-title']")?.getAttribute("aria-invalid") ?? "<missing>",
             saved: Boolean(document.querySelector("[data-testid='rd-form-saved']")),
             notFoundPath: document.querySelector("[data-testid='rd-not-found-path']")?.textContent.trim() ?? "",
             resourceStatus: document.querySelector("[data-testid='rd-resource-status']")?.textContent.trim() ?? "",


### PR DESCRIPTION
## Summary

Serializes Go boolean values passed to `aria-*` attributes as explicit ARIA
tokens.

Previously, all boolean props used HTML presence-attribute semantics:

```text
true  → attribute=""
false → attribute removed
```

That behavior is correct for attributes such as `disabled`, `checked`, and
`selected`, but incorrect for ARIA states. ARIA boolean values now produce:

```text
true  → "true"
false → "false"
```

## Changes

- Recognizes non-empty `aria-*` names through a compact ASCII
  case-insensitive prefix check.
- Converts boolean ARIA values to ordinary string-backed DOM props.
- Retains false ARIA values instead of removing the attribute.
- Preserves existing behavior for HTML, `data-*`, custom, event, nil, and
  non-boolean ARIA props.
- Adds focused coverage for true and false values, mixed-case prefixes,
  prefix boundaries, and unaffected prop classes.
- Extends the router-dashboard browser smoke to verify explicit
  `aria-invalid` values throughout its existing validation flow.

## Validation

The change passes:

- repeated and race-enabled prop tests;
- full runtime, debug-tag, race, and vet suites;
- allocation benchmarks with unchanged allocation counts;
- focused and full browser smoke;
- repository, documentation, artifact, and module-path checks;
- the complete Go 1.22.12 / TinyGo 0.41.1 size matrix with unchanged budgets.

The pure runtime tests directly cover the new Go-boolean conversion path. The
existing browser flow verifies that explicit ARIA token values remain correct
through validation and reset transitions.

## Compatibility

This is an internal runtime correctness fix.

It does not change the public API, GOX, DOM bridge, event handling, HTML boolean
semantics, `data-*` or custom boolean behavior, dependencies, workflows,
compiler flags, or size budgets.