### PR TITLE
fix(goxc): materialize and watch go:embed inputs

### DIFF
--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -100,10 +100,11 @@ func buildApp(options buildOptions) (string, error) {
 	if err := validateWorkspaceRoot(layout); err != nil {
 		return "", err
 	}
-	entryPath, err := prepareBuildWorkspace(layout, manifest)
+	workspaceResult, err := prepareBuildWorkspaceResult(layout, manifest)
 	if err != nil {
 		return "", fmt.Errorf("prepare build workspace: %w", err)
 	}
+	entryPath := workspaceResult.EntryPath
 	outputPath := buildOutputPath(options, manifest, layout)
 	outputRoot := layout.BuildDir
 	if options.outDir != "" {

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -165,25 +165,49 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 	}
 
 	collector := newDevSnapshotCollector(layout.AppDir)
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		return resolveCurrentEmbedInputPlan(packageOptions{
+			appDir:    layout.AppDir,
+			compiler:  options.compiler,
+			workspace: options.workspace,
+			compress:  map[string]bool{},
+		})
+	}
 	server, err := newDevServer(layout.PackageDir, options.port, dependencies)
 	if err != nil {
 		return err
 	}
 
 	build := func(request devBuildRequest) error {
+		var attemptPlan embedInputPlan
+		haveAttemptPlan := false
 		err := dependencies.packageApp(packageOptions{
 			appDir:    layout.AppDir,
 			compiler:  options.compiler,
 			workspace: options.workspace,
 			compress:  map[string]bool{},
+			recordEmbedPlan: func(plan embedInputPlan) {
+				attemptPlan = plan
+				haveAttemptPlan = true
+			},
 		})
 		if err != nil {
+			if haveAttemptPlan {
+				collector.finishEmbedBuild(attemptPlan, false, err)
+			}
 			return err
 		}
 		if ctx.Err() != nil {
 			return nil
 		}
-		if _, err := server.activatePackage(); err != nil {
+		if _, err := server.activatePackageWithCommit(func() {
+			if haveAttemptPlan {
+				collector.finishEmbedBuild(attemptPlan, true)
+			}
+		}); err != nil {
+			if haveAttemptPlan {
+				collector.finishEmbedBuild(attemptPlan, false, err)
+			}
 			return err
 		}
 		if !server.started() {
@@ -195,14 +219,15 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 	}
 
 	runErr := runDevCoordinator(ctx, devCoordinatorConfig{
-		scan:         collector.collect,
-		build:        build,
-		serverErrors: server.errors(),
-		pollInterval: dependencies.pollInterval,
-		debounce:     dependencies.debounce,
-		stdout:       dependencies.stdout,
-		stderr:       dependencies.stderr,
-		hooks:        dependencies.hooks,
+		scan:              collector.collect,
+		build:             build,
+		serverErrors:      server.errors(),
+		pollInterval:      dependencies.pollInterval,
+		debounce:          dependencies.debounce,
+		stdout:            dependencies.stdout,
+		stderr:            dependencies.stderr,
+		hooks:             dependencies.hooks,
+		reconcileSnapshot: collector.reconcileEmbedSnapshot,
 	})
 	shutdownErr := server.shutdown()
 	if runErr != nil {
@@ -281,15 +306,22 @@ func newDevServer(packageDir string, port int, dependencies devDependencies) (*d
 }
 
 func (server *devServer) activatePackage() (uint64, error) {
+	return server.activatePackageWithCommit(nil)
+}
+
+func (server *devServer) activatePackageWithCommit(commit func()) (uint64, error) {
 	notify := server.started()
 	generation, err := server.generations.activatePackage(server.packageDir)
 	if err != nil {
 		return 0, err
 	}
-	server.reload.activate(generation, notify)
 	if server.hooks.GenerationActivated != nil {
 		server.hooks.GenerationActivated(generation)
 	}
+	if commit != nil {
+		commit()
+	}
+	server.reload.activate(generation, notify)
 	if notify && server.hooks.ReloadPublished != nil {
 		server.hooks.ReloadPublished(generation)
 	}
@@ -429,9 +461,19 @@ func diffDevSnapshots(previous, current devSnapshot) []string {
 }
 
 type devSnapshotCollector struct {
-	appDir     string
-	lastAssets devAssetWatchSpec
-	haveAssets bool
+	appDir           string
+	lastAssets       devAssetWatchSpec
+	haveAssets       bool
+	embedPlan        embedInputPlan
+	embedCandidate   embedInputPlan
+	haveCandidate    bool
+	embedRecovery    embedInputPlan
+	haveRecovery     bool
+	embedMembership  map[string]string
+	resolveEmbedPlan func() (embedInputPlan, error)
+	embedBuildOK     bool
+	haveEmbedOutcome bool
+	embedRecoveryErr error
 }
 
 type devAssetWatchSpec struct {
@@ -445,7 +487,10 @@ type devAssetDirectory struct {
 }
 
 func newDevSnapshotCollector(appDir string) *devSnapshotCollector {
-	return &devSnapshotCollector{appDir: appDir}
+	return &devSnapshotCollector{
+		appDir:          appDir,
+		embedMembership: map[string]string{},
+	}
 }
 
 func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
@@ -459,15 +504,19 @@ func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
 	if err := collector.collectModuleInputs(&snapshot); err != nil {
 		return snapshot, err
 	}
+	embedErr := collector.collectEmbedInputs(&snapshot)
+	if embedErr != nil && !devScanAllowsBuild(embedErr) {
+		return snapshot, embedErr
+	}
 
 	manifest, err := loadManifest(collector.appDir)
 	if err != nil {
-		return snapshot, collector.collectRetainedAssets(&snapshot, err)
+		return snapshot, collector.collectRetainedAssets(&snapshot, errors.Join(err, embedErr))
 	}
 	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
 	_, planErr := planPackageAssets(collector.appDir, manifest, wasmLogicalName, packageOptions{compress: map[string]bool{}})
 	if planErr != nil {
-		return snapshot, collector.collectRetainedAssets(&snapshot, planErr)
+		return snapshot, collector.collectRetainedAssets(&snapshot, errors.Join(planErr, embedErr))
 	}
 
 	spec, err := collector.assetWatchSpec(manifest)
@@ -479,7 +528,197 @@ func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
 	if err := collector.collectAssets(&snapshot, spec); err != nil {
 		return snapshot, err
 	}
+	if embedErr != nil {
+		return snapshot, embedErr
+	}
 	return snapshot, nil
+}
+
+const devEmbedSnapshotPrefix = "go:embed:"
+
+func (collector *devSnapshotCollector) collectEmbedInputs(snapshot *devSnapshot) error {
+	currentMembership, err := collector.currentEmbedMembership()
+	if err != nil {
+		return err
+	}
+	if collector.resolveEmbedPlan != nil && !stringMapsEqual(currentMembership, collector.embedMembership) {
+		candidate, resolveErr := collector.resolveEmbedPlan()
+		if resolveErr != nil {
+			collector.haveCandidate = false
+			if len(candidate.WatchRoots) > 0 {
+				collector.embedRecovery = candidate
+				collector.haveRecovery = true
+			}
+			collector.embedMembership = collector.mergedEmbedMembership(candidate)
+			collector.embedRecoveryErr = resolveErr
+			if collectErr := collector.collectEmbedPlan(snapshot, collector.embedPlan); collectErr != nil {
+				return collectErr
+			}
+			return devBuildableScanError{err: resolveErr}
+		}
+		collector.embedMembership = cloneStringMap(candidate.WatchMembership)
+		collector.embedRecoveryErr = nil
+		if embedInputPlansEqual(candidate, collector.embedPlan) {
+			collector.haveCandidate = false
+		} else {
+			collector.embedCandidate = candidate
+			collector.haveCandidate = true
+		}
+	}
+	plan := collector.embedPlan
+	if collector.haveCandidate {
+		plan = collector.embedCandidate
+	}
+	if err := collector.collectEmbedPlan(snapshot, plan); err != nil {
+		return err
+	}
+	if collector.haveCandidate {
+		return collector.collectOmittedCommittedEmbedInputs(snapshot, plan)
+	}
+	if collector.haveRecovery && collector.embedRecoveryErr != nil {
+		return devBuildableScanError{err: collector.embedRecoveryErr}
+	}
+	return nil
+}
+
+func (collector *devSnapshotCollector) collectEmbedPlan(snapshot *devSnapshot, plan embedInputPlan) error {
+	for _, input := range plan.Files {
+		if err := validatePathBelowRoot(collector.appDir, input.SourcePath, "watched embedded input", true); err != nil {
+			return err
+		}
+		fingerprint, err := collector.fileFingerprint(input.SourcePath, true)
+		if err != nil {
+			return err
+		}
+		snapshot.files[devEmbedSnapshotPrefix+input.DisplayPath] = fingerprint
+	}
+	return nil
+}
+
+func (collector *devSnapshotCollector) collectOmittedCommittedEmbedInputs(snapshot *devSnapshot, candidate embedInputPlan) error {
+	included := make(map[string]struct{}, len(candidate.Files))
+	for _, input := range candidate.Files {
+		included[input.DisplayPath] = struct{}{}
+	}
+	for _, input := range collector.embedPlan.Files {
+		if _, ok := included[input.DisplayPath]; ok {
+			continue
+		}
+		if err := validatePathBelowRoot(collector.appDir, input.SourcePath, "watched embedded input", true); err != nil {
+			return err
+		}
+		fingerprint, err := collector.fileFingerprint(input.SourcePath, true)
+		if err != nil {
+			return err
+		}
+		snapshot.files[devEmbedSnapshotPrefix+input.DisplayPath] = fingerprint
+	}
+	return nil
+}
+
+func (collector *devSnapshotCollector) currentEmbedMembership() (map[string]string, error) {
+	roots := map[string]struct{}{}
+	for _, root := range collector.embedPlan.WatchRoots {
+		roots[root] = struct{}{}
+	}
+	if collector.haveRecovery {
+		for _, root := range collector.embedRecovery.WatchRoots {
+			roots[root] = struct{}{}
+		}
+	}
+	ordered := make([]string, 0, len(roots))
+	for root := range roots {
+		ordered = append(ordered, root)
+	}
+	sort.Strings(ordered)
+	return embedWatchMembership(collector.appDir, ordered)
+}
+
+func (collector *devSnapshotCollector) finishEmbedBuild(plan embedInputPlan, succeeded bool, failures ...error) {
+	collector.embedBuildOK = succeeded
+	collector.haveEmbedOutcome = true
+	collector.haveCandidate = false
+	if succeeded && plan.Resolved {
+		collector.embedPlan = plan
+		collector.embedRecovery = embedInputPlan{}
+		collector.haveRecovery = false
+		collector.embedRecoveryErr = nil
+		collector.embedMembership = cloneStringMap(plan.WatchMembership)
+		return
+	}
+	if !plan.Resolved && len(plan.WatchRoots) > 0 {
+		collector.embedRecovery = plan
+		collector.haveRecovery = true
+		collector.embedMembership = collector.mergedEmbedMembership(plan)
+		if len(failures) > 0 {
+			collector.embedRecoveryErr = failures[0]
+		}
+	} else if plan.Resolved {
+		collector.embedRecovery = embedInputPlan{}
+		collector.haveRecovery = false
+		collector.embedRecoveryErr = nil
+		membership := map[string]string{}
+		for _, root := range collector.embedPlan.WatchRoots {
+			if fingerprint, ok := plan.WatchMembership[root]; ok {
+				membership[root] = fingerprint
+			} else if fingerprint, ok := collector.embedMembership[root]; ok {
+				membership[root] = fingerprint
+			} else if fingerprint, ok := collector.embedPlan.WatchMembership[root]; ok {
+				membership[root] = fingerprint
+			}
+		}
+		collector.embedMembership = membership
+	}
+}
+
+func (collector *devSnapshotCollector) reconcileEmbedSnapshot(snapshot devSnapshot) devSnapshot {
+	committed := make(map[string]embedInputFile, len(collector.embedPlan.Files))
+	for _, input := range collector.embedPlan.Files {
+		committed[devEmbedSnapshotPrefix+input.DisplayPath] = input
+	}
+	for path := range snapshot.files {
+		if !strings.HasPrefix(path, devEmbedSnapshotPrefix) {
+			continue
+		}
+		if _, ok := committed[path]; !ok || (collector.haveEmbedOutcome && collector.embedBuildOK) {
+			delete(snapshot.files, path)
+		}
+	}
+	if !collector.haveEmbedOutcome || collector.embedBuildOK {
+		for path, input := range committed {
+			snapshot.files[path] = input.Fingerprint
+		}
+	}
+	collector.haveEmbedOutcome = false
+	return snapshot
+}
+
+func (collector *devSnapshotCollector) mergedEmbedMembership(additional embedInputPlan) map[string]string {
+	merged := cloneStringMap(collector.embedPlan.WatchMembership)
+	for root, fingerprint := range additional.WatchMembership {
+		merged[root] = fingerprint
+	}
+	return merged
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
+func stringMapsEqual(first, second map[string]string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for key, value := range first {
+		if second[key] != value {
+			return false
+		}
+	}
+	return true
 }
 
 func (collector *devSnapshotCollector) collectRetainedAssets(snapshot *devSnapshot, scanErr error) error {
@@ -664,27 +903,34 @@ func (collector *devSnapshotCollector) collectAssetDirectory(snapshot *devSnapsh
 }
 
 func (collector *devSnapshotCollector) collectFile(snapshot *devSnapshot, file string, allowMissing bool) error {
+	fingerprint, err := collector.fileFingerprint(file, allowMissing)
+	if err != nil {
+		return err
+	}
+	snapshot.files[collector.displayPath(file)] = fingerprint
+	return nil
+}
+
+func (collector *devSnapshotCollector) fileFingerprint(file string, allowMissing bool) (string, error) {
 	info, err := os.Lstat(file)
 	if errors.Is(err, os.ErrNotExist) && allowMissing {
-		snapshot.files[collector.displayPath(file)] = "missing"
-		return nil
+		return "missing", nil
 	}
 	if err != nil {
-		return fmt.Errorf("inspect watched input %s: %w", file, err)
+		return "", fmt.Errorf("inspect watched input %s: %w", file, err)
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("watched input %s is a symlink; symlink paths are not supported", file)
+		return "", fmt.Errorf("watched input %s is a symlink; symlink paths are not supported", file)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("watched input %s is not a regular file", file)
+		return "", fmt.Errorf("watched input %s is not a regular file", file)
 	}
 	content, err := os.ReadFile(file)
 	if err != nil {
-		return fmt.Errorf("read watched input %s: %w", file, err)
+		return "", fmt.Errorf("read watched input %s: %w", file, err)
 	}
 	sum := sha256.Sum256(content)
-	snapshot.files[collector.displayPath(file)] = "sha256:" + hex.EncodeToString(sum[:])
-	return nil
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }
 
 func (collector *devSnapshotCollector) displayPath(file string) string {
@@ -696,14 +942,15 @@ func (collector *devSnapshotCollector) displayPath(file string) string {
 }
 
 type devCoordinatorConfig struct {
-	scan         func() (devSnapshot, error)
-	build        func(devBuildRequest) error
-	serverErrors <-chan error
-	pollInterval time.Duration
-	debounce     time.Duration
-	stdout       io.Writer
-	stderr       io.Writer
-	hooks        devHooks
+	scan              func() (devSnapshot, error)
+	build             func(devBuildRequest) error
+	serverErrors      <-chan error
+	pollInterval      time.Duration
+	debounce          time.Duration
+	stdout            io.Writer
+	stderr            io.Writer
+	hooks             devHooks
+	reconcileSnapshot func(devSnapshot) devSnapshot
 }
 
 type devBuildableScanError struct {
@@ -759,11 +1006,15 @@ func runDevCoordinator(ctx context.Context, config devCoordinatorConfig) error {
 		if initial {
 			changed = nil
 		}
-		return runDevBuild(config, devBuildRequest{
+		err := runDevBuild(config, devBuildRequest{
 			Number:  buildNumber,
 			Initial: initial,
 			Changed: changed,
 		})
+		if config.reconcileSnapshot != nil {
+			lastAttempted = config.reconcileSnapshot(lastAttempted)
+		}
+		return err
 	}
 	if devScanAllowsBuild(scanErr) {
 		if err := attemptBuild(initialSnapshot, nil); err != nil {

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -545,7 +545,7 @@ func (collector *devSnapshotCollector) collectEmbedInputs(snapshot *devSnapshot)
 		candidate, resolveErr := collector.resolveEmbedPlan()
 		if resolveErr != nil {
 			collector.haveCandidate = false
-			if len(candidate.WatchRoots) > 0 {
+			if len(candidate.Watches) > 0 {
 				collector.embedRecovery = candidate
 				collector.haveRecovery = true
 			}
@@ -617,20 +617,22 @@ func (collector *devSnapshotCollector) collectOmittedCommittedEmbedInputs(snapsh
 }
 
 func (collector *devSnapshotCollector) currentEmbedMembership() (map[string]string, error) {
-	roots := map[string]struct{}{}
-	for _, root := range collector.embedPlan.WatchRoots {
-		roots[root] = struct{}{}
+	watches := map[string]embedWatchSpec{}
+	for _, watch := range collector.embedPlan.Watches {
+		watches[embedWatchKey(watch)] = watch
 	}
 	if collector.haveRecovery {
-		for _, root := range collector.embedRecovery.WatchRoots {
-			roots[root] = struct{}{}
+		for _, watch := range collector.embedRecovery.Watches {
+			watches[embedWatchKey(watch)] = watch
 		}
 	}
-	ordered := make([]string, 0, len(roots))
-	for root := range roots {
-		ordered = append(ordered, root)
+	ordered := make([]embedWatchSpec, 0, len(watches))
+	for _, watch := range watches {
+		ordered = append(ordered, watch)
 	}
-	sort.Strings(ordered)
+	sort.Slice(ordered, func(first, second int) bool {
+		return embedWatchKey(ordered[first]) < embedWatchKey(ordered[second])
+	})
 	return embedWatchMembership(collector.appDir, ordered)
 }
 
@@ -646,7 +648,7 @@ func (collector *devSnapshotCollector) finishEmbedBuild(plan embedInputPlan, suc
 		collector.embedMembership = cloneStringMap(plan.WatchMembership)
 		return
 	}
-	if !plan.Resolved && len(plan.WatchRoots) > 0 {
+	if !plan.Resolved && len(plan.Watches) > 0 {
 		collector.embedRecovery = plan
 		collector.haveRecovery = true
 		collector.embedMembership = collector.mergedEmbedMembership(plan)
@@ -658,13 +660,14 @@ func (collector *devSnapshotCollector) finishEmbedBuild(plan embedInputPlan, suc
 		collector.haveRecovery = false
 		collector.embedRecoveryErr = nil
 		membership := map[string]string{}
-		for _, root := range collector.embedPlan.WatchRoots {
-			if fingerprint, ok := plan.WatchMembership[root]; ok {
-				membership[root] = fingerprint
-			} else if fingerprint, ok := collector.embedMembership[root]; ok {
-				membership[root] = fingerprint
-			} else if fingerprint, ok := collector.embedPlan.WatchMembership[root]; ok {
-				membership[root] = fingerprint
+		for _, watch := range collector.embedPlan.Watches {
+			key := embedWatchKey(watch)
+			if fingerprint, ok := plan.WatchMembership[key]; ok {
+				membership[key] = fingerprint
+			} else if fingerprint, ok := collector.embedMembership[key]; ok {
+				membership[key] = fingerprint
+			} else if fingerprint, ok := collector.embedPlan.WatchMembership[key]; ok {
+				membership[key] = fingerprint
 			}
 		}
 		collector.embedMembership = membership

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -156,6 +157,83 @@ func App() gf.Node {
 	writeTestFile(t, appDir, ".goframe/ignored.go", "package ignored\n")
 	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
 	writeTestFile(t, workspace, "tool-output.txt", "ignored\n")
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatalf("runDev() shutdown error: %v", err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
+
+func TestDevEmbedIntegrationRealWorkflow(t *testing.T) {
+	repositoryRoot, ok := findRepositoryRoot(".")
+	if !ok {
+		t.Fatal("repository root not found")
+	}
+	appDir := filepath.Join(t.TempDir(), "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeDevEmbedIntegrationApp(t, appDir, repositoryRoot)
+
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOFLAGS", "-mod=mod")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builds := make(chan devBuildEvent, 16)
+	serverURLs := make(chan string, 2)
+	generations := make(chan uint64, 8)
+	reloads := make(chan uint64, 8)
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) { generations <- generation }
+	dependencies.hooks.ReloadPublished = func(generation uint64) { reloads <- generation }
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{
+			appDir:    appDir,
+			compiler:  "go",
+			workspace: workspace,
+			port:      0,
+		}, dependencies)
+	}()
+
+	assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
+	serverURL := waitDevServerURL(t, serverURLs)
+	assertDevWASMContains(t, serverURL, "alpha")
+
+	writeTestFile(t, appDir, "message.txt", "beta")
+	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+	assertDevGenerationEvent(t, generations, 2)
+	assertDevGenerationEvent(t, reloads, 2)
+	assertDevWASMContains(t, serverURL, "beta")
+
+	writeTestFile(t, appDir, "extras/second.txt", "second")
+	assertDevEvent(t, waitDevEvent(t, builds), 3, false, false)
+	assertDevGenerationEvent(t, generations, 3)
+	assertDevGenerationEvent(t, reloads, 3)
+
+	writeTestFile(t, appDir, "extras/ignored.bin", "ignored")
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
+
+	if err := os.Remove(filepath.Join(appDir, "message.txt")); err != nil {
+		t.Fatal(err)
+	}
+	assertDevEvent(t, waitDevEvent(t, builds), 4, false, true)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
+	assertDevWASMContains(t, serverURL, "beta")
+
+	writeTestFile(t, appDir, "message.txt", "gamma")
+	assertDevEvent(t, waitDevEvent(t, builds), 5, false, false)
+	assertDevGenerationEvent(t, generations, 4)
+	assertDevGenerationEvent(t, reloads, 4)
+	assertDevWASMContains(t, serverURL, "gamma")
 	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
 
 	cancel()
@@ -578,6 +656,54 @@ func main() {
 	writeTestFile(t, appDir, "assets/message.txt", "initial asset")
 }
 
+func writeDevEmbedIntegrationApp(t *testing.T, appDir, repositoryRoot string) {
+	t.Helper()
+	writeTestFile(t, appDir, "go.mod", fmt.Sprintf(`module example.com/devembed
+
+go 1.22
+
+require %s v0.0.0
+
+replace %s => %s
+`, canonicalModulePath, canonicalModulePath, filepath.ToSlash(repositoryRoot)))
+	writeTestFile(t, appDir, manifestName, `{"name":"dev-embed","compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "main.go", `//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}
+`)
+	writeTestFile(t, appDir, "embedded.go", `package main
+
+import "embed"
+
+//go:embed message.txt
+var embeddedMessage string
+
+//go:embed extras/*.txt
+var embeddedExtras embed.FS
+`)
+	writeTestFile(t, appDir, "app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main><span id="embedded-value">{embeddedMessage}</span></main>
+}
+`)
+	writeTestFile(t, appDir, "message.txt", "alpha")
+	writeTestFile(t, appDir, "extras/base.txt", "base")
+	writeTestFile(t, appDir, "assets/index.html", `<!doctype html>
+<html><body><div id="root"></div><script src="wasm_exec.js"></script><script>fetch("bundle.wasm")</script></body></html>
+`)
+}
+
 func writeDevIntegrationGOX(t *testing.T, appDir, label string) {
 	t.Helper()
 	writeTestFile(t, appDir, "app.gox", fmt.Sprintf(`package main
@@ -677,6 +803,14 @@ func assertDevHTTPBody(t *testing.T, url, want string) {
 	t.Helper()
 	if got := readDevHTTPBody(t, url); got != want {
 		t.Fatalf("GET %s body = %q, want %q", url, got, want)
+	}
+}
+
+func assertDevWASMContains(t *testing.T, serverURL, want string) {
+	t.Helper()
+	body := []byte(readDevHTTPBody(t, serverURL+"/assets/bundle.wasm"))
+	if !bytes.Contains(body, []byte(want)) {
+		t.Fatalf("served WASM does not contain embedded value %q", want)
 	}
 }
 

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -205,6 +205,11 @@ func TestDevEmbedIntegrationRealWorkflow(t *testing.T) {
 	serverURL := waitDevServerURL(t, serverURLs)
 	assertDevWASMContains(t, serverURL, "alpha")
 
+	writeTestFile(t, appDir, "unrelated/deep/value.txt", "unrelated")
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
+
 	writeTestFile(t, appDir, "message.txt", "beta")
 	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
 	assertDevGenerationEvent(t, generations, 2)

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -319,6 +319,218 @@ func TestDevSnapshotExplicitAssetDirectoryRejectsNonDirectory(t *testing.T) {
 	}
 }
 
+func TestDevSnapshotWatchesCommittedEmbedContentOnly(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "templates/message.txt", "alpha")
+	writeTestFile(t, appDir, "notes.txt", "unrelated one")
+	collector := newDevSnapshotCollector(appDir)
+	plan := devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/message.txt")
+	collector.finishEmbedBuild(plan, true)
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatalf("initial collect() error: %v", err)
+	}
+	writeTestFile(t, appDir, "notes.txt", "unrelated two")
+	unrelated, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after unrelated edit: %v", err)
+	}
+	if !devSnapshotsEqual(initial, unrelated) {
+		t.Fatalf("unrelated file changed effective snapshot: %#v", diffDevSnapshots(initial, unrelated))
+	}
+
+	writeTestFile(t, appDir, "templates/message.txt", "beta")
+	changed, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after embedded edit: %v", err)
+	}
+	assertDevChangedPath(t, unrelated, changed, devEmbedSnapshotPrefix+"templates/message.txt")
+}
+
+func TestDevSnapshotRefreshesEmbedMembershipWithoutFalseBuilds(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "templates/one.txt", "one")
+	collector := newDevSnapshotCollector(appDir)
+	committed := devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/one.txt")
+	collector.finishEmbedBuild(committed, true)
+
+	resolved := committed
+	refreshes := 0
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		refreshes++
+		return resolved, nil
+	}
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestFile(t, appDir, "templates/ignored.bin", "ignored")
+	resolved = devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/one.txt")
+	unmatched, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after unmatched creation: %v", err)
+	}
+	if refreshes != 1 {
+		t.Fatalf("metadata refreshes = %d, want 1", refreshes)
+	}
+	if !devSnapshotsEqual(initial, unmatched) {
+		t.Fatalf("unmatched file changed effective snapshot: %#v", diffDevSnapshots(initial, unmatched))
+	}
+
+	writeTestFile(t, appDir, "templates/two.txt", "two")
+	resolved = devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/one.txt", "templates/two.txt")
+	matching, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after matching creation: %v", err)
+	}
+	if refreshes != 2 {
+		t.Fatalf("metadata refreshes = %d, want 2", refreshes)
+	}
+	assertDevChangedPath(t, unmatched, matching, devEmbedSnapshotPrefix+"templates/two.txt")
+
+	collector.finishEmbedBuild(resolved, false)
+	reconciled := collector.reconcileEmbedSnapshot(matching)
+	afterFailure, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after failed candidate build: %v", err)
+	}
+	if !devSnapshotsEqual(reconciled, afterFailure) {
+		t.Fatalf("failed build did not return to committed plan: %#v", diffDevSnapshots(reconciled, afterFailure))
+	}
+	if len(collector.embedPlan.Files) != 1 {
+		t.Fatalf("failed build published candidate plan: %#v", collector.embedPlan.Files)
+	}
+
+	collector.finishEmbedBuild(resolved, true)
+	reconciled = collector.reconcileEmbedSnapshot(afterFailure)
+	if _, ok := reconciled.files[devEmbedSnapshotPrefix+"templates/two.txt"]; !ok {
+		t.Fatalf("successful plan did not publish second input: %#v", reconciled.paths())
+	}
+}
+
+func TestDevSnapshotEmbedRemovalAndRestoration(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "message.txt", "alpha")
+	collector := newDevSnapshotCollector(appDir)
+	committed := devEmbedTestPlan(t, appDir, []string{"."}, "message.txt")
+	collector.finishEmbedBuild(committed, true)
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resolved embedInputPlan
+	var resolveErr error
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		return resolved, resolveErr
+	}
+	if err := os.Remove(filepath.Join(appDir, "message.txt")); err != nil {
+		t.Fatal(err)
+	}
+	resolved = devEmbedTestPlan(t, appDir, []string{"."})
+	resolved.Resolved = false
+	resolveErr = errors.New("pattern message.txt: no matching files found")
+	missing, err := collector.collect()
+	var buildable devBuildableScanError
+	if !errors.As(err, &buildable) || !strings.Contains(err.Error(), "no matching files") {
+		t.Fatalf("collect() removal error = %v, want buildable no-match error", err)
+	}
+	assertDevChangedPath(t, initial, missing, devEmbedSnapshotPrefix+"message.txt")
+	if got := missing.files[devEmbedSnapshotPrefix+"message.txt"]; got != "missing" {
+		t.Fatalf("removed embed fingerprint = %q, want missing", got)
+	}
+	collector.finishEmbedBuild(resolved, false)
+	missing = collector.reconcileEmbedSnapshot(missing)
+
+	writeTestFile(t, appDir, "message.txt", "gamma")
+	resolved = devEmbedTestPlan(t, appDir, []string{"."}, "message.txt")
+	resolveErr = nil
+	restored, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() restoration error: %v", err)
+	}
+	assertDevChangedPath(t, missing, restored, devEmbedSnapshotPrefix+"message.txt")
+	if collector.embedPlan.Files[0].Fingerprint != committed.Files[0].Fingerprint {
+		t.Fatal("restoration candidate changed the committed plan before a successful build")
+	}
+}
+
+func TestDevSnapshotEmbedPlanPublicationAndSymlinkSafety(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "internal/content/first.txt", "first")
+	writeTestFile(t, appDir, "internal/content/second.txt", "second")
+	collector := newDevSnapshotCollector(appDir)
+	first := devEmbedTestPlan(t, appDir, []string{"internal/content"}, "internal/content/first.txt")
+	second := devEmbedTestPlan(t, appDir, []string{"internal/content"}, "internal/content/second.txt")
+	collector.finishEmbedBuild(first, true)
+	collector.finishEmbedBuild(second, false)
+	if got := collector.embedPlan.Files[0].DisplayPath; got != "internal/content/first.txt" {
+		t.Fatalf("failed build published %q, want first plan", got)
+	}
+	collector.finishEmbedBuild(second, true)
+	if got := collector.embedPlan.Files[0].DisplayPath; got != "internal/content/second.txt" {
+		t.Fatalf("successful build retained %q, want second plan", got)
+	}
+
+	requireSymlinkSupport(t)
+	external := filepath.Join(t.TempDir(), "outside.txt")
+	writeTestFile(t, filepath.Dir(external), filepath.Base(external), "external secret")
+	local := filepath.Join(appDir, "internal", "content", "second.txt")
+	if err := os.Remove(local); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, local); err != nil {
+		t.Fatal(err)
+	}
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		return embedInputPlan{}, errors.New("symlinked embed input")
+	}
+	_, err := collector.collect()
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("collect() symlink error = %v", err)
+	}
+}
+
+func newDevEmbedTestApp(t *testing.T) string {
+	t.Helper()
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n\nfunc main() {}\n")
+	writeTestFile(t, appDir, indexHTMLAssetName, "<main>embed test</main>")
+	return appDir
+}
+
+func devEmbedTestPlan(t *testing.T, appDir string, roots []string, files ...string) embedInputPlan {
+	t.Helper()
+	collector := newDevSnapshotCollector(appDir)
+	plan := embedInputPlan{Resolved: true}
+	for _, root := range roots {
+		plan.WatchRoots = append(plan.WatchRoots, filepath.Join(appDir, filepath.FromSlash(root)))
+	}
+	for _, relative := range files {
+		path := filepath.Join(appDir, filepath.FromSlash(relative))
+		fingerprint, err := collector.fileFingerprint(path, true)
+		if err != nil {
+			t.Fatalf("fingerprint %s: %v", relative, err)
+		}
+		plan.Files = append(plan.Files, embedInputFile{
+			SourcePath:  path,
+			DisplayPath: filepath.ToSlash(relative),
+			Fingerprint: fingerprint,
+		})
+	}
+	sort.Slice(plan.Files, func(first, second int) bool {
+		return plan.Files[first].DisplayPath < plan.Files[second].DisplayPath
+	})
+	sort.Strings(plan.WatchRoots)
+	if err := populateEmbedWatchMembership(appDir, &plan); err != nil {
+		t.Fatalf("populate embed watch membership: %v", err)
+	}
+	return plan
+}
+
 func TestDevSnapshotUsesLastAssetsDuringMalformedManifest(t *testing.T) {
 	appDir := t.TempDir()
 	writeTestFile(t, appDir, manifestName, `{"compiler":"go","assets":"assets"}`)

--- a/cmd/goxc/dev_test.go
+++ b/cmd/goxc/dev_test.go
@@ -410,11 +410,81 @@ func TestDevSnapshotRefreshesEmbedMembershipWithoutFalseBuilds(t *testing.T) {
 	}
 }
 
+func TestDevSnapshotExactEmbedWatchAvoidsRecursiveRefresh(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "message.txt", "alpha")
+	exact := []embedWatchSpec{{Path: filepath.Join(appDir, "message.txt"), Kind: embedWatchExact}}
+	collector := newDevSnapshotCollector(appDir)
+	committed := devEmbedTestPlanWithWatches(t, appDir, exact, "message.txt")
+	collector.finishEmbedBuild(committed, true)
+	resolverCalls := 0
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		resolverCalls++
+		return devEmbedTestPlanWithWatches(t, appDir, exact, "message.txt"), nil
+	}
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, "unrelated/deep/value.txt", "unrelated")
+	unrelated, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after unrelated creation: %v", err)
+	}
+	if resolverCalls != 0 {
+		t.Fatalf("metadata resolver calls after unrelated creation = %d, want 0", resolverCalls)
+	}
+	if !devSnapshotsEqual(initial, unrelated) {
+		t.Fatalf("unrelated nested file changed exact embed snapshot: %#v", diffDevSnapshots(initial, unrelated))
+	}
+
+	writeTestFile(t, appDir, "message.txt", "beta")
+	contentChanged, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after exact content edit: %v", err)
+	}
+	if resolverCalls != 0 {
+		t.Fatalf("metadata resolver calls after content edit = %d, want 0", resolverCalls)
+	}
+	assertDevChangedPath(t, unrelated, contentChanged, devEmbedSnapshotPrefix+"message.txt")
+}
+
+func TestDevSnapshotNarrowEmbedDirectoryIgnoresSiblingMembership(t *testing.T) {
+	appDir := newDevEmbedTestApp(t)
+	writeTestFile(t, appDir, "templates/one.txt", "one")
+	collector := newDevSnapshotCollector(appDir)
+	committed := devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/one.txt")
+	collector.finishEmbedBuild(committed, true)
+	resolverCalls := 0
+	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		resolverCalls++
+		return devEmbedTestPlan(t, appDir, []string{"templates"}, "templates/one.txt"), nil
+	}
+
+	initial, err := collector.collect()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, appDir, "sibling/deep/value.txt", "unrelated")
+	after, err := collector.collect()
+	if err != nil {
+		t.Fatalf("collect() after sibling creation: %v", err)
+	}
+	if resolverCalls != 0 {
+		t.Fatalf("metadata resolver calls after sibling creation = %d, want 0", resolverCalls)
+	}
+	if !devSnapshotsEqual(initial, after) {
+		t.Fatalf("sibling directory changed narrow embed snapshot: %#v", diffDevSnapshots(initial, after))
+	}
+}
+
 func TestDevSnapshotEmbedRemovalAndRestoration(t *testing.T) {
 	appDir := newDevEmbedTestApp(t)
 	writeTestFile(t, appDir, "message.txt", "alpha")
 	collector := newDevSnapshotCollector(appDir)
-	committed := devEmbedTestPlan(t, appDir, []string{"."}, "message.txt")
+	exact := []embedWatchSpec{{Path: filepath.Join(appDir, "message.txt"), Kind: embedWatchExact}}
+	committed := devEmbedTestPlanWithWatches(t, appDir, exact, "message.txt")
 	collector.finishEmbedBuild(committed, true)
 	initial, err := collector.collect()
 	if err != nil {
@@ -423,13 +493,15 @@ func TestDevSnapshotEmbedRemovalAndRestoration(t *testing.T) {
 
 	var resolved embedInputPlan
 	var resolveErr error
+	resolverCalls := 0
 	collector.resolveEmbedPlan = func() (embedInputPlan, error) {
+		resolverCalls++
 		return resolved, resolveErr
 	}
 	if err := os.Remove(filepath.Join(appDir, "message.txt")); err != nil {
 		t.Fatal(err)
 	}
-	resolved = devEmbedTestPlan(t, appDir, []string{"."})
+	resolved = devEmbedTestPlanWithWatches(t, appDir, exact)
 	resolved.Resolved = false
 	resolveErr = errors.New("pattern message.txt: no matching files found")
 	missing, err := collector.collect()
@@ -441,11 +513,14 @@ func TestDevSnapshotEmbedRemovalAndRestoration(t *testing.T) {
 	if got := missing.files[devEmbedSnapshotPrefix+"message.txt"]; got != "missing" {
 		t.Fatalf("removed embed fingerprint = %q, want missing", got)
 	}
+	if resolverCalls != 1 {
+		t.Fatalf("metadata resolver calls after removal = %d, want 1", resolverCalls)
+	}
 	collector.finishEmbedBuild(resolved, false)
 	missing = collector.reconcileEmbedSnapshot(missing)
 
 	writeTestFile(t, appDir, "message.txt", "gamma")
-	resolved = devEmbedTestPlan(t, appDir, []string{"."}, "message.txt")
+	resolved = devEmbedTestPlanWithWatches(t, appDir, exact, "message.txt")
 	resolveErr = nil
 	restored, err := collector.collect()
 	if err != nil {
@@ -454,6 +529,9 @@ func TestDevSnapshotEmbedRemovalAndRestoration(t *testing.T) {
 	assertDevChangedPath(t, missing, restored, devEmbedSnapshotPrefix+"message.txt")
 	if collector.embedPlan.Files[0].Fingerprint != committed.Files[0].Fingerprint {
 		t.Fatal("restoration candidate changed the committed plan before a successful build")
+	}
+	if resolverCalls != 2 {
+		t.Fatalf("metadata resolver calls after restoration = %d, want 2", resolverCalls)
 	}
 }
 
@@ -504,11 +582,20 @@ func newDevEmbedTestApp(t *testing.T) string {
 
 func devEmbedTestPlan(t *testing.T, appDir string, roots []string, files ...string) embedInputPlan {
 	t.Helper()
-	collector := newDevSnapshotCollector(appDir)
-	plan := embedInputPlan{Resolved: true}
+	watches := make([]embedWatchSpec, 0, len(roots))
 	for _, root := range roots {
-		plan.WatchRoots = append(plan.WatchRoots, filepath.Join(appDir, filepath.FromSlash(root)))
+		watches = append(watches, embedWatchSpec{
+			Path: filepath.Join(appDir, filepath.FromSlash(root)),
+			Kind: embedWatchTree,
+		})
 	}
+	return devEmbedTestPlanWithWatches(t, appDir, watches, files...)
+}
+
+func devEmbedTestPlanWithWatches(t *testing.T, appDir string, watches []embedWatchSpec, files ...string) embedInputPlan {
+	t.Helper()
+	collector := newDevSnapshotCollector(appDir)
+	plan := embedInputPlan{Resolved: true, Watches: append([]embedWatchSpec(nil), watches...)}
 	for _, relative := range files {
 		path := filepath.Join(appDir, filepath.FromSlash(relative))
 		fingerprint, err := collector.fileFingerprint(path, true)
@@ -524,7 +611,9 @@ func devEmbedTestPlan(t *testing.T, appDir string, roots []string, files ...stri
 	sort.Slice(plan.Files, func(first, second int) bool {
 		return plan.Files[first].DisplayPath < plan.Files[second].DisplayPath
 	})
-	sort.Strings(plan.WatchRoots)
+	sort.Slice(plan.Watches, func(first, second int) bool {
+		return embedWatchKey(plan.Watches[first]) < embedWatchKey(plan.Watches[second])
+	})
 	if err := populateEmbedWatchMembership(appDir, &plan); err != nil {
 		t.Fatalf("populate embed watch membership: %v", err)
 	}

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -1,0 +1,425 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type embedInputPlan struct {
+	Files      []embedInputFile
+	WatchRoots []string
+	Resolved   bool
+}
+
+type embedInputFile struct {
+	SourcePath  string
+	DisplayPath string
+	Fingerprint string
+}
+
+type embedListPackage struct {
+	Dir           string
+	ImportPath    string
+	EmbedPatterns []string
+	EmbedFiles    []string
+	Error         *embedListError
+	DepsErrors    []embedListError
+}
+
+type embedListError struct {
+	Err string
+}
+
+type embedDiscoveryOverlay struct {
+	Replace map[string]string
+}
+
+type resolvedEmbedInput struct {
+	file        embedInputFile
+	destination string
+	copy        bool
+}
+
+func discoverAndMaterializeEmbedInputs(layout BuildLayout, appWorkDir, entryPath string) (embedInputPlan, error) {
+	overlayPath, replacements, cleanup, err := createEmbedDiscoveryOverlay(layout.AppDir, appWorkDir)
+	if err != nil {
+		return embedInputPlan{}, err
+	}
+	defer cleanup()
+
+	packages, listErr := listEmbedPackages(layout.Compiler, entryPath, overlayPath)
+	if listErr != nil && layout.Compiler == "tinygo" {
+		if partial, partialErr := listGoEmbedPackages(entryPath, overlayPath, true); partialErr == nil {
+			packages = partial
+		}
+	}
+	inputs, plan, planErr := resolveEmbedInputPlan(layout.AppDir, appWorkDir, replacements, packages)
+	if planErr != nil {
+		return plan, errors.Join(listErr, planErr)
+	}
+	if metadataErr := embedPackageMetadataError(packages); metadataErr != nil {
+		return plan, errors.Join(listErr, metadataErr)
+	}
+	if listErr != nil {
+		return plan, listErr
+	}
+	for _, input := range inputs {
+		if !input.copy {
+			continue
+		}
+		if err := mkdirAllBelowRoot(appWorkDir, filepath.Dir(input.destination), "embed destination directory"); err != nil {
+			return plan, err
+		}
+		if err := copyFile(input.file.SourcePath, input.destination); err != nil {
+			return plan, fmt.Errorf("copy embedded input %s: %w", input.file.DisplayPath, err)
+		}
+	}
+	plan.Resolved = true
+	return plan, nil
+}
+
+func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (string, map[string]string, func(), error) {
+	appDir, err := filepath.Abs(appDir)
+	if err != nil {
+		return "", nil, func() {}, fmt.Errorf("resolve embed source root: %w", err)
+	}
+	appWorkDir, err = filepath.Abs(appWorkDir)
+	if err != nil {
+		return "", nil, func() {}, fmt.Errorf("resolve embed workspace root: %w", err)
+	}
+	replacements := map[string]string{}
+	err = filepath.WalkDir(appDir, func(sourcePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("inspect embed candidate %s: %w", sourcePath, walkErr)
+		}
+		if sourcePath == appDir {
+			return nil
+		}
+		relative, err := filepath.Rel(appDir, sourcePath)
+		if err != nil {
+			return fmt.Errorf("resolve embed candidate %s: %w", sourcePath, err)
+		}
+		if shouldSkipEmbedCandidate(relative, entry) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			if sourcePath != appDir && nestedModuleBoundary(sourcePath) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() || strings.HasSuffix(sourcePath, ".gox.go") {
+			return nil
+		}
+		if err := validatePathBelowRoot(appDir, sourcePath, "embed candidate", false); err != nil {
+			return err
+		}
+		destination := filepath.Join(appWorkDir, relative)
+		if err := validatePathBelowRoot(appWorkDir, destination, "embed overlay destination", true); err != nil {
+			return err
+		}
+		if samePath(destination, filepath.Join(appWorkDir, "go.mod")) {
+			return nil
+		}
+		if _, err := os.Lstat(destination); err == nil {
+			return nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("inspect embed overlay destination %s: %w", destination, err)
+		}
+		replacements[destination] = sourcePath
+		return nil
+	})
+	if err != nil {
+		return "", nil, func() {}, err
+	}
+
+	temporary, err := os.CreateTemp("", "goxc-embed-overlay-*.json")
+	if err != nil {
+		return "", nil, func() {}, fmt.Errorf("create embed discovery overlay: %w", err)
+	}
+	overlayPath := temporary.Name()
+	cleanup := func() { _ = os.Remove(overlayPath) }
+	encoder := json.NewEncoder(temporary)
+	encodeErr := encoder.Encode(embedDiscoveryOverlay{Replace: replacements})
+	closeErr := temporary.Close()
+	if encodeErr != nil || closeErr != nil {
+		cleanup()
+		return "", nil, func() {}, fmt.Errorf("write embed discovery overlay: %w", errors.Join(encodeErr, closeErr))
+	}
+	return overlayPath, replacements, cleanup, nil
+}
+
+func shouldSkipEmbedCandidate(relative string, entry os.DirEntry) bool {
+	parts := strings.Split(filepath.ToSlash(relative), "/")
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case defaultWorkspaceName, "build", "dist", "node_modules", ".git", ".goxc-tmp":
+		return true
+	}
+	return false
+}
+
+func nestedModuleBoundary(directory string) bool {
+	info, err := os.Lstat(filepath.Join(directory, "go.mod"))
+	return err == nil && (info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0)
+}
+
+func listEmbedPackages(compiler, entryPath, overlayPath string) ([]embedListPackage, error) {
+	if compiler == "tinygo" {
+		return listTinyGoEmbedPackages(entryPath, overlayPath)
+	}
+	return listGoEmbedPackages(entryPath, overlayPath, false)
+}
+
+func listGoEmbedPackages(entryPath, overlayPath string, tinyGoTags bool) ([]embedListPackage, error) {
+	compilerPath, err := exec.LookPath("go")
+	if err != nil {
+		return nil, errors.New("Go compiler not found in PATH")
+	}
+	args := []string{
+		"list", "-deps", "-e",
+		"-json=Dir,ImportPath,GoFiles,EmbedPatterns,EmbedFiles,Error,DepsErrors",
+		"-buildvcs=false", "-overlay=" + overlayPath,
+	}
+	if tinyGoTags {
+		args = append(args, "-tags=tinygo")
+	}
+	args = append(args, ".")
+	command := exec.Command(compilerPath, args...)
+	command.Dir = entryPath
+	command.Env = append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0")
+	return runEmbedListCommand(command, "go list")
+}
+
+func listTinyGoEmbedPackages(entryPath, overlayPath string) ([]embedListPackage, error) {
+	compilerPath, err := exec.LookPath("tinygo")
+	if err != nil {
+		return nil, errors.New("TinyGo compiler not found in PATH; install TinyGo or use --compiler=go")
+	}
+	command := exec.Command(compilerPath, "list", "-target=wasm", "-deps", "-json", ".")
+	command.Dir = entryPath
+	flags := strings.TrimSpace(os.Getenv("GOFLAGS") + " -buildvcs=false " + strconv.Quote("-overlay="+overlayPath))
+	command.Env = setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", flags)
+	return runEmbedListCommand(command, "tinygo list")
+}
+
+func runEmbedListCommand(command *exec.Cmd, description string) ([]embedListPackage, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	runErr := command.Run()
+	packages, decodeErr := decodeEmbedListPackages(&stdout)
+	if decodeErr != nil {
+		return packages, fmt.Errorf("decode %s embed metadata: %w", description, decodeErr)
+	}
+	if runErr != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = runErr.Error()
+		}
+		return packages, fmt.Errorf("%s embed discovery failed: %s", description, detail)
+	}
+	return packages, nil
+}
+
+func decodeEmbedListPackages(reader io.Reader) ([]embedListPackage, error) {
+	decoder := json.NewDecoder(reader)
+	var packages []embedListPackage
+	for {
+		var packageInfo embedListPackage
+		err := decoder.Decode(&packageInfo)
+		if errors.Is(err, io.EOF) {
+			return packages, nil
+		}
+		if err != nil {
+			return packages, err
+		}
+		packages = append(packages, packageInfo)
+	}
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(environment)+1)
+	for _, item := range environment {
+		if !strings.HasPrefix(item, prefix) {
+			result = append(result, item)
+		}
+	}
+	return append(result, prefix+value)
+}
+
+func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]string, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {
+	inputsByDestination := map[string]resolvedEmbedInput{}
+	watchRoots := map[string]struct{}{}
+	for _, packageInfo := range packages {
+		packageRelative, ok, err := relativePathBelow(appWorkDir, packageInfo.Dir)
+		if err != nil {
+			return nil, embedInputPlan{}, err
+		}
+		if !ok {
+			continue
+		}
+		sourcePackageDir := filepath.Join(appDir, packageRelative)
+		for _, pattern := range packageInfo.EmbedPatterns {
+			root, err := embedPatternWatchRoot(appDir, sourcePackageDir, pattern)
+			if err != nil {
+				return nil, embedInputPlan{}, err
+			}
+			watchRoots[root] = struct{}{}
+		}
+		for _, embedFile := range packageInfo.EmbedFiles {
+			if filepath.IsAbs(filepath.FromSlash(embedFile)) {
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s must be package-relative", embedFile, packageInfo.ImportPath)
+			}
+			destination := filepath.Join(packageInfo.Dir, filepath.FromSlash(embedFile))
+			if err := validatePathBelowRoot(appWorkDir, destination, "embedded workspace input", true); err != nil {
+				return nil, embedInputPlan{}, err
+			}
+			source := replacements[destination]
+			needsCopy := source != ""
+			if source == "" {
+				source = filepath.Join(sourcePackageDir, filepath.FromSlash(embedFile))
+				if _, err := regularFileNoFollow(source, "embedded source input"); err != nil {
+					continue
+				}
+			}
+			if err := validatePathBelowRoot(appDir, source, "embedded source input", false); err != nil {
+				return nil, embedInputPlan{}, err
+			}
+			if _, err := regularFileNoFollow(source, "embedded source input"); err != nil {
+				return nil, embedInputPlan{}, err
+			}
+			content, err := os.ReadFile(source)
+			if err != nil {
+				return nil, embedInputPlan{}, fmt.Errorf("read embedded source input %s: %w", source, err)
+			}
+			displayPath, err := filepath.Rel(appDir, source)
+			if err != nil {
+				return nil, embedInputPlan{}, fmt.Errorf("resolve embedded source input %s: %w", source, err)
+			}
+			sum := sha256.Sum256(content)
+			inputsByDestination[destination] = resolvedEmbedInput{
+				file: embedInputFile{
+					SourcePath:  source,
+					DisplayPath: filepath.ToSlash(displayPath),
+					Fingerprint: "sha256:" + hex.EncodeToString(sum[:]),
+				},
+				destination: destination,
+				copy:        needsCopy,
+			}
+		}
+	}
+
+	destinations := make([]string, 0, len(inputsByDestination))
+	for destination := range inputsByDestination {
+		destinations = append(destinations, destination)
+	}
+	sort.Strings(destinations)
+	inputs := make([]resolvedEmbedInput, 0, len(destinations))
+	plan := embedInputPlan{}
+	for _, destination := range destinations {
+		input := inputsByDestination[destination]
+		inputs = append(inputs, input)
+		plan.Files = append(plan.Files, input.file)
+	}
+	for root := range watchRoots {
+		plan.WatchRoots = append(plan.WatchRoots, root)
+	}
+	sort.Strings(plan.WatchRoots)
+	return inputs, plan, nil
+}
+
+func relativePathBelow(root, target string) (string, bool, error) {
+	root, target, err := cleanRootAndTarget(root, target)
+	if err != nil {
+		return "", false, err
+	}
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve package path %s below %s: %w", target, root, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false, nil
+	}
+	return relative, true, nil
+}
+
+func embedPatternWatchRoot(appDir, sourcePackageDir, pattern string) (string, error) {
+	pattern = strings.TrimPrefix(pattern, "all:")
+	firstMeta := strings.IndexAny(pattern, "*?[")
+	rootRelative := ""
+	if firstMeta >= 0 {
+		prefix := strings.TrimSuffix(pattern[:firstMeta], "/")
+		rootRelative = path.Dir(prefix)
+		if strings.HasSuffix(pattern[:firstMeta], "/") {
+			rootRelative = prefix
+		}
+	} else {
+		candidate := filepath.Join(sourcePackageDir, filepath.FromSlash(pattern))
+		if info, err := os.Lstat(candidate); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+			rootRelative = pattern
+		} else {
+			rootRelative = path.Dir(pattern)
+		}
+	}
+	if rootRelative == "" || rootRelative == "." {
+		rootRelative = "."
+	}
+	root := filepath.Join(sourcePackageDir, filepath.FromSlash(rootRelative))
+	if err := validatePathBelowRoot(appDir, root, "embed pattern watch root", true); err != nil {
+		return "", err
+	}
+	return root, nil
+}
+
+func embedPackageMetadataError(packages []embedListPackage) error {
+	var failures []error
+	seen := map[string]struct{}{}
+	for _, packageInfo := range packages {
+		if packageInfo.Error != nil && packageInfo.Error.Err != "" {
+			message := packageInfo.Error.Err
+			if packageInfo.ImportPath != "" {
+				message = packageInfo.ImportPath + ": " + message
+			}
+			if _, ok := seen[message]; !ok {
+				seen[message] = struct{}{}
+				failures = append(failures, errors.New(message))
+			}
+		}
+		for _, dependencyError := range packageInfo.DepsErrors {
+			if dependencyError.Err == "" {
+				continue
+			}
+			if _, ok := seen[dependencyError.Err]; !ok {
+				seen[dependencyError.Err] = struct{}{}
+				failures = append(failures, errors.New(dependencyError.Err))
+			}
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	return fmt.Errorf("resolve go:embed inputs: %w", errors.Join(failures...))
+}

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -306,8 +306,10 @@ func listGoEmbedPackages(entryPath, overlayPath string, tinyGoTags bool) ([]embe
 	}
 	args = append(args, ".")
 	command := exec.Command(compilerPath, args...)
-	command.Dir = entryPath
-	command.Env = append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0")
+	environment := append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0")
+	if err := configureEmbedListCommand(command, entryPath, environment); err != nil {
+		return nil, err
+	}
 	return runEmbedListCommand(command, "go list")
 }
 
@@ -317,10 +319,23 @@ func listTinyGoEmbedPackages(entryPath, overlayPath string) ([]embedListPackage,
 		return nil, errors.New("TinyGo compiler not found in PATH; install TinyGo or use --compiler=go")
 	}
 	command := exec.Command(compilerPath, "list", "-target=wasm", "-deps", "-json", ".")
-	command.Dir = entryPath
 	flags := strings.TrimSpace(os.Getenv("GOFLAGS") + " -buildvcs=false " + strconv.Quote("-overlay="+overlayPath))
-	command.Env = setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", flags)
+	environment := setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", flags)
+	if err := configureEmbedListCommand(command, entryPath, environment); err != nil {
+		return nil, err
+	}
 	return runEmbedListCommand(command, "tinygo list")
+}
+
+func configureEmbedListCommand(command *exec.Cmd, entryPath string, environment []string) error {
+	lexicalEntryPath, err := filepath.Abs(entryPath)
+	if err != nil {
+		return fmt.Errorf("resolve embed discovery entry %s: %w", entryPath, err)
+	}
+	lexicalEntryPath = filepath.Clean(lexicalEntryPath)
+	command.Dir = lexicalEntryPath
+	command.Env = setEnvironmentValue(environment, "PWD", lexicalEntryPath)
+	return nil
 }
 
 func runEmbedListCommand(command *exec.Cmd, description string) ([]embedListPackage, error) {

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -60,9 +60,11 @@ type embedCandidate struct {
 	Kind       embedCandidateKind
 }
 
+type embedInputKey string
+
 type embedDiscoveryContext struct {
 	OverlayPath string
-	Candidates  map[string]embedCandidate
+	Candidates  map[embedInputKey]embedCandidate
 	Cleanup     func()
 }
 
@@ -74,8 +76,9 @@ const (
 )
 
 type embedWatchSpec struct {
-	Path string
-	Kind embedWatchKind
+	Path     string
+	Kind     embedWatchKind
+	Identity string
 }
 
 type resolvedEmbedInput struct {
@@ -137,7 +140,7 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryConte
 		return empty, fmt.Errorf("resolve embed workspace root: %w", err)
 	}
 	replacements := map[string]string{}
-	candidates := map[string]embedCandidate{}
+	candidates := map[embedInputKey]embedCandidate{}
 	unsafeSentinel := ""
 	cleanupTemporary := func() {
 		if unsafeSentinel != "" {
@@ -182,11 +185,15 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryConte
 			}
 			return nil
 		}
+		key, err := newEmbedInputKey(relative)
+		if err != nil {
+			return fmt.Errorf("resolve embed candidate %s: %w", sourcePath, err)
+		}
 		destination := filepath.Join(appWorkDir, relative)
 		if err := validatePathBelowRoot(appWorkDir, destination, "embed overlay destination", true); err != nil {
 			return err
 		}
-		destination, err = filepath.Abs(destination)
+		destination, err = canonicalPathForComparison(destination)
 		if err != nil {
 			return fmt.Errorf("resolve embed overlay destination %s: %w", destination, err)
 		}
@@ -209,9 +216,9 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryConte
 				return err
 			}
 		}
-		candidates[destination] = embedCandidate{SourcePath: sourcePath, Kind: kind}
+		candidates[key] = embedCandidate{SourcePath: sourcePath, Kind: kind}
 
-		if destination == filepath.Join(appWorkDir, "go.mod") {
+		if key == embedInputKey("go.mod") {
 			return nil
 		}
 		if kind != embedCandidateRegular {
@@ -362,7 +369,7 @@ func setEnvironmentValue(environment []string, key, value string) []string {
 	return append(result, prefix+value)
 }
 
-func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embedCandidate, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {
+func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[embedInputKey]embedCandidate, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {
 	appDir, err := filepath.Abs(appDir)
 	if err != nil {
 		return nil, embedInputPlan{}, fmt.Errorf("resolve embed source root: %w", err)
@@ -371,9 +378,8 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 	if err != nil {
 		return nil, embedInputPlan{}, fmt.Errorf("resolve embed workspace root: %w", err)
 	}
-	inputsByDestination := map[string]resolvedEmbedInput{}
+	inputsByKey := map[embedInputKey]resolvedEmbedInput{}
 	watches := map[string]embedWatchSpec{}
-	generatedGoMod := filepath.Join(appWorkDir, "go.mod")
 	for _, packageInfo := range packages {
 		packageRelative, ok, err := relativePathBelow(appWorkDir, packageInfo.Dir)
 		if err != nil {
@@ -394,7 +400,11 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 			if filepath.IsAbs(filepath.FromSlash(embedFile)) {
 				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s must be package-relative", embedFile, packageInfo.ImportPath)
 			}
-			destination := filepath.Join(packageInfo.Dir, filepath.FromSlash(embedFile))
+			key, err := newEmbedInputKey(filepath.Join(packageRelative, filepath.FromSlash(embedFile)))
+			if err != nil {
+				return nil, embedInputPlan{}, fmt.Errorf("resolve embedded input %q for %s: %w", embedFile, packageInfo.ImportPath, err)
+			}
+			destination := filepath.Join(appWorkDir, filepath.FromSlash(string(key)))
 			if err := validatePathBelowRoot(appWorkDir, destination, "embedded workspace input", true); err != nil {
 				return nil, embedInputPlan{}, err
 			}
@@ -402,13 +412,13 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 			if err != nil {
 				return nil, embedInputPlan{}, fmt.Errorf("resolve embedded workspace input %s: %w", destination, err)
 			}
-			if destination == generatedGoMod {
+			if key == embedInputKey("go.mod") {
 				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s collides with generated workspace state at %s; workspace go.mod is not authored embed content", embedFile, packageInfo.ImportPath, destination)
 			}
-			if strings.HasSuffix(filepath.ToSlash(destination), ".gox.go") {
+			if strings.HasSuffix(string(key), ".gox.go") {
 				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s resolves to workspace-generated GOX source at %s; generated workspace files are not authored embed content", embedFile, packageInfo.ImportPath, destination)
 			}
-			candidate, ok := candidates[destination]
+			candidate, ok := candidates[key]
 			if !ok {
 				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s at workspace destination %s has no valid authored backing file", embedFile, packageInfo.ImportPath, destination)
 			}
@@ -451,15 +461,11 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 			default:
 				return nil, embedInputPlan{}, fmt.Errorf("inspect embedded workspace destination %s: %w", destination, workspaceErr)
 			}
-			displayPath, err := filepath.Rel(appDir, source)
-			if err != nil {
-				return nil, embedInputPlan{}, fmt.Errorf("resolve embedded source input %s: %w", source, err)
-			}
 			sum := sha256.Sum256(content)
-			inputsByDestination[destination] = resolvedEmbedInput{
+			inputsByKey[key] = resolvedEmbedInput{
 				file: embedInputFile{
 					SourcePath:  source,
-					DisplayPath: filepath.ToSlash(displayPath),
+					DisplayPath: string(key),
 					Fingerprint: "sha256:" + hex.EncodeToString(sum[:]),
 				},
 				destination: destination,
@@ -468,15 +474,17 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 		}
 	}
 
-	destinations := make([]string, 0, len(inputsByDestination))
-	for destination := range inputsByDestination {
-		destinations = append(destinations, destination)
+	keys := make([]embedInputKey, 0, len(inputsByKey))
+	for key := range inputsByKey {
+		keys = append(keys, key)
 	}
-	sort.Strings(destinations)
-	inputs := make([]resolvedEmbedInput, 0, len(destinations))
+	sort.Slice(keys, func(first, second int) bool {
+		return keys[first] < keys[second]
+	})
+	inputs := make([]resolvedEmbedInput, 0, len(keys))
 	plan := embedInputPlan{}
-	for _, destination := range destinations {
-		input := inputsByDestination[destination]
+	for _, key := range keys {
+		input := inputsByKey[key]
 		inputs = append(inputs, input)
 		plan.Files = append(plan.Files, input.file)
 	}
@@ -490,18 +498,27 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embe
 }
 
 func relativePathBelow(root, target string) (string, bool, error) {
-	root, target, err := cleanRootAndTarget(root, target)
+	originalRoot, originalTarget := root, target
+	root, err := canonicalPathForComparison(root)
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf("resolve package root %s: %w", originalRoot, err)
 	}
-	relative, err := filepath.Rel(root, target)
+	target, err = canonicalPathForComparison(target)
 	if err != nil {
-		return "", false, fmt.Errorf("resolve package path %s below %s: %w", target, root, err)
+		return "", false, fmt.Errorf("resolve package path %s: %w", originalTarget, err)
 	}
-	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
-		return "", false, nil
+	return relativeCanonicalPathBelow(root, target, originalRoot, originalTarget)
+}
+
+func newEmbedInputKey(relative string) (embedInputKey, error) {
+	if relative == "" || filepath.IsAbs(relative) || filepath.VolumeName(relative) != "" {
+		return "", fmt.Errorf("embed input path %q must be relative", relative)
 	}
-	return relative, true, nil
+	cleaned := filepath.ToSlash(filepath.Clean(relative))
+	if cleaned == "" || cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") || path.IsAbs(cleaned) {
+		return "", fmt.Errorf("embed input path %q must stay inside the application workspace", relative)
+	}
+	return embedInputKey(cleaned), nil
 }
 
 func embedPatternWatchSpec(appDir, sourcePackageDir, pattern string) (embedWatchSpec, error) {
@@ -522,7 +539,7 @@ func embedPatternWatchSpec(appDir, sourcePackageDir, pattern string) (embedWatch
 		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return embedWatchSpec{}, fmt.Errorf("inspect embed pattern watch path %s: %w", candidate, err)
 		}
-		return embedWatchSpec{Path: candidate, Kind: kind}, nil
+		return newEmbedWatchSpec(appDir, candidate, kind)
 	}
 
 	rootRelative := ""
@@ -544,11 +561,69 @@ func embedPatternWatchSpec(appDir, sourcePackageDir, pattern string) (embedWatch
 	if err != nil {
 		return embedWatchSpec{}, fmt.Errorf("resolve embed pattern watch root %s: %w", root, err)
 	}
-	return embedWatchSpec{Path: root, Kind: embedWatchTree}, nil
+	return newEmbedWatchSpec(appDir, root, embedWatchTree)
 }
 
 func embedWatchKey(watch embedWatchSpec) string {
-	return strconv.Itoa(int(watch.Kind)) + ":" + watch.Path
+	identity := watch.Identity
+	if identity == "" {
+		identity = filepath.ToSlash(filepath.Clean(watch.Path))
+	}
+	return strconv.Itoa(int(watch.Kind)) + ":" + identity
+}
+
+func newEmbedWatchSpec(appDir, watchPath string, kind embedWatchKind) (embedWatchSpec, error) {
+	relative, inside, err := relativeEmbedWatchPathBelow(appDir, watchPath)
+	if err != nil {
+		return embedWatchSpec{}, err
+	}
+	if !inside {
+		return embedWatchSpec{}, fmt.Errorf("embed watch path %s must stay inside %s", watchPath, appDir)
+	}
+	identity := filepath.ToSlash(filepath.Clean(relative))
+	if identity == "" || identity == ".." || strings.HasPrefix(identity, "../") || path.IsAbs(identity) {
+		return embedWatchSpec{}, fmt.Errorf("embed watch path %s has invalid application-relative identity %q", watchPath, identity)
+	}
+	return embedWatchSpec{Path: watchPath, Kind: kind, Identity: identity}, nil
+}
+
+func relativeEmbedWatchPathBelow(root, target string) (string, bool, error) {
+	originalRoot, originalTarget := root, target
+	root, err := canonicalPathForComparison(root)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve embed watch root %s: %w", originalRoot, err)
+	}
+	info, lstatErr := os.Lstat(target)
+	if lstatErr == nil && info.Mode()&os.ModeSymlink != 0 {
+		parent, err := canonicalPathForComparison(filepath.Dir(target))
+		if err != nil {
+			return "", false, fmt.Errorf("resolve embed watch parent %s: %w", filepath.Dir(originalTarget), err)
+		}
+		target = filepath.Join(parent, filepath.Base(target))
+	} else {
+		if lstatErr != nil && !errors.Is(lstatErr, os.ErrNotExist) {
+			return "", false, fmt.Errorf("inspect embed watch path %s: %w", originalTarget, lstatErr)
+		}
+		target, err = canonicalPathForComparison(target)
+		if err != nil {
+			return "", false, fmt.Errorf("resolve embed watch path %s: %w", originalTarget, err)
+		}
+	}
+	return relativeCanonicalPathBelow(root, target, originalRoot, originalTarget)
+}
+
+func relativeCanonicalPathBelow(root, target, originalRoot, originalTarget string) (string, bool, error) {
+	if !strings.EqualFold(filepath.VolumeName(root), filepath.VolumeName(target)) {
+		return "", false, nil
+	}
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve package path %s below %s: %w", originalTarget, originalRoot, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false, nil
+	}
+	return relative, true, nil
 }
 
 func embedPackageMetadataError(packages []embedListPackage) error {
@@ -632,11 +707,15 @@ func embedWatchExactFingerprint(appDir, target string) (string, error) {
 }
 
 func validateEmbedWatchExactPath(appDir, target string) error {
-	_, inside, err := relativePathBelow(appDir, target)
+	root, target, err := cleanRootAndTarget(appDir, target)
 	if err != nil {
 		return err
 	}
-	if !inside {
+	relative, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("resolve exact embed watch path %s below %s: %w", target, root, err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("exact embed watch path %s must stay inside %s", target, appDir)
 	}
 	return validatePathBelowRoot(appDir, filepath.Dir(target), "exact embed watch parent", true)
@@ -714,7 +793,7 @@ func embedInputPlansEqual(first, second embedInputPlan) bool {
 		return false
 	}
 	for index := range first.Watches {
-		if first.Watches[index] != second.Watches[index] {
+		if embedWatchKey(first.Watches[index]) != embedWatchKey(second.Watches[index]) {
 			return false
 		}
 	}

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -189,14 +189,15 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryConte
 		if err != nil {
 			return fmt.Errorf("resolve embed candidate %s: %w", sourcePath, err)
 		}
-		destination := filepath.Join(appWorkDir, relative)
-		if err := validatePathBelowRoot(appWorkDir, destination, "embed overlay destination", true); err != nil {
+		overlayDestination := filepath.Join(appWorkDir, relative)
+		if err := validatePathBelowRoot(appWorkDir, overlayDestination, "embed overlay destination", true); err != nil {
 			return err
 		}
-		destination, err = canonicalPathForComparison(destination)
+		overlayDestination, err = filepath.Abs(overlayDestination)
 		if err != nil {
-			return fmt.Errorf("resolve embed overlay destination %s: %w", destination, err)
+			return fmt.Errorf("resolve embed overlay destination %s: %w", overlayDestination, err)
 		}
+		overlayDestination = filepath.Clean(overlayDestination)
 
 		kind := embedCandidateRegular
 		switch {
@@ -226,15 +227,15 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryConte
 			if err != nil {
 				return err
 			}
-			replacements[destination] = sentinel
+			replacements[overlayDestination] = sentinel
 			return nil
 		}
-		if _, err := os.Lstat(destination); err == nil {
+		if _, err := os.Lstat(overlayDestination); err == nil {
 			return nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("inspect embed overlay destination %s: %w", destination, err)
+			return fmt.Errorf("inspect embed overlay destination %s: %w", overlayDestination, err)
 		}
-		replacements[destination] = sourcePath
+		replacements[overlayDestination] = sourcePath
 		return nil
 	})
 	if err != nil {

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -19,7 +19,7 @@ import (
 
 type embedInputPlan struct {
 	Files           []embedInputFile
-	WatchRoots      []string
+	Watches         []embedWatchSpec
 	WatchMembership map[string]string
 	Resolved        bool
 }
@@ -47,6 +47,37 @@ type embedDiscoveryOverlay struct {
 	Replace map[string]string
 }
 
+type embedCandidateKind uint8
+
+const (
+	embedCandidateRegular embedCandidateKind = iota
+	embedCandidateSymlink
+	embedCandidateIrregular
+)
+
+type embedCandidate struct {
+	SourcePath string
+	Kind       embedCandidateKind
+}
+
+type embedDiscoveryContext struct {
+	OverlayPath string
+	Candidates  map[string]embedCandidate
+	Cleanup     func()
+}
+
+type embedWatchKind uint8
+
+const (
+	embedWatchExact embedWatchKind = iota
+	embedWatchTree
+)
+
+type embedWatchSpec struct {
+	Path string
+	Kind embedWatchKind
+}
+
 type resolvedEmbedInput struct {
 	file        embedInputFile
 	destination string
@@ -54,19 +85,19 @@ type resolvedEmbedInput struct {
 }
 
 func discoverAndMaterializeEmbedInputs(layout BuildLayout, appWorkDir, entryPath string) (embedInputPlan, error) {
-	overlayPath, replacements, cleanup, err := createEmbedDiscoveryOverlay(layout.AppDir, appWorkDir)
+	discovery, err := createEmbedDiscoveryOverlay(layout.AppDir, appWorkDir)
 	if err != nil {
 		return embedInputPlan{}, err
 	}
-	defer cleanup()
+	defer discovery.Cleanup()
 
-	packages, listErr := listEmbedPackages(layout.Compiler, entryPath, overlayPath)
+	packages, listErr := listEmbedPackages(layout.Compiler, entryPath, discovery.OverlayPath)
 	if listErr != nil && layout.Compiler == "tinygo" {
-		if partial, partialErr := listGoEmbedPackages(entryPath, overlayPath, true); partialErr == nil {
+		if partial, partialErr := listGoEmbedPackages(entryPath, discovery.OverlayPath, true); partialErr == nil {
 			packages = partial
 		}
 	}
-	inputs, plan, planErr := resolveEmbedInputPlan(layout.AppDir, appWorkDir, replacements, packages)
+	inputs, plan, planErr := resolveEmbedInputPlan(layout.AppDir, appWorkDir, discovery.Candidates, packages)
 	membershipErr := populateEmbedWatchMembership(layout.AppDir, &plan)
 	if planErr != nil {
 		return plan, errors.Join(listErr, planErr, membershipErr)
@@ -95,16 +126,39 @@ func discoverAndMaterializeEmbedInputs(layout BuildLayout, appWorkDir, entryPath
 	return plan, nil
 }
 
-func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (string, map[string]string, func(), error) {
+func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (embedDiscoveryContext, error) {
+	empty := embedDiscoveryContext{Cleanup: func() {}}
 	appDir, err := filepath.Abs(appDir)
 	if err != nil {
-		return "", nil, func() {}, fmt.Errorf("resolve embed source root: %w", err)
+		return empty, fmt.Errorf("resolve embed source root: %w", err)
 	}
 	appWorkDir, err = filepath.Abs(appWorkDir)
 	if err != nil {
-		return "", nil, func() {}, fmt.Errorf("resolve embed workspace root: %w", err)
+		return empty, fmt.Errorf("resolve embed workspace root: %w", err)
 	}
 	replacements := map[string]string{}
+	candidates := map[string]embedCandidate{}
+	unsafeSentinel := ""
+	cleanupTemporary := func() {
+		if unsafeSentinel != "" {
+			_ = os.Remove(unsafeSentinel)
+		}
+	}
+	ensureUnsafeSentinel := func() (string, error) {
+		if unsafeSentinel != "" {
+			return unsafeSentinel, nil
+		}
+		temporary, err := os.CreateTemp("", "goxc-embed-unsafe-*")
+		if err != nil {
+			return "", fmt.Errorf("create embed discovery sentinel: %w", err)
+		}
+		unsafeSentinel = temporary.Name()
+		if err := temporary.Close(); err != nil {
+			cleanupTemporary()
+			return "", fmt.Errorf("close embed discovery sentinel: %w", err)
+		}
+		return unsafeSentinel, nil
+	}
 	err = filepath.WalkDir(appDir, func(sourcePath string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return fmt.Errorf("inspect embed candidate %s: %w", sourcePath, walkErr)
@@ -122,26 +176,50 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (string, map[string]
 			}
 			return nil
 		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			return nil
-		}
 		if entry.IsDir() {
 			if sourcePath != appDir && nestedModuleBoundary(sourcePath) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		if !entry.Type().IsRegular() || strings.HasSuffix(sourcePath, ".gox.go") {
-			return nil
-		}
-		if err := validatePathBelowRoot(appDir, sourcePath, "embed candidate", false); err != nil {
-			return err
-		}
 		destination := filepath.Join(appWorkDir, relative)
 		if err := validatePathBelowRoot(appWorkDir, destination, "embed overlay destination", true); err != nil {
 			return err
 		}
-		if samePath(destination, filepath.Join(appWorkDir, "go.mod")) {
+		destination, err = filepath.Abs(destination)
+		if err != nil {
+			return fmt.Errorf("resolve embed overlay destination %s: %w", destination, err)
+		}
+
+		kind := embedCandidateRegular
+		switch {
+		case entry.Type()&os.ModeSymlink != 0:
+			kind = embedCandidateSymlink
+		default:
+			info, err := entry.Info()
+			if err != nil {
+				return fmt.Errorf("inspect embed candidate %s: %w", sourcePath, err)
+			}
+			if !info.Mode().IsRegular() {
+				kind = embedCandidateIrregular
+			}
+		}
+		if kind == embedCandidateRegular {
+			if err := validatePathBelowRoot(appDir, sourcePath, "embed candidate", false); err != nil {
+				return err
+			}
+		}
+		candidates[destination] = embedCandidate{SourcePath: sourcePath, Kind: kind}
+
+		if destination == filepath.Join(appWorkDir, "go.mod") {
+			return nil
+		}
+		if kind != embedCandidateRegular {
+			sentinel, err := ensureUnsafeSentinel()
+			if err != nil {
+				return err
+			}
+			replacements[destination] = sentinel
 			return nil
 		}
 		if _, err := os.Lstat(destination); err == nil {
@@ -153,23 +231,32 @@ func createEmbedDiscoveryOverlay(appDir, appWorkDir string) (string, map[string]
 		return nil
 	})
 	if err != nil {
-		return "", nil, func() {}, err
+		cleanupTemporary()
+		return empty, err
 	}
 
 	temporary, err := os.CreateTemp("", "goxc-embed-overlay-*.json")
 	if err != nil {
-		return "", nil, func() {}, fmt.Errorf("create embed discovery overlay: %w", err)
+		cleanupTemporary()
+		return empty, fmt.Errorf("create embed discovery overlay: %w", err)
 	}
 	overlayPath := temporary.Name()
-	cleanup := func() { _ = os.Remove(overlayPath) }
+	cleanup := func() {
+		_ = os.Remove(overlayPath)
+		cleanupTemporary()
+	}
 	encoder := json.NewEncoder(temporary)
 	encodeErr := encoder.Encode(embedDiscoveryOverlay{Replace: replacements})
 	closeErr := temporary.Close()
 	if encodeErr != nil || closeErr != nil {
 		cleanup()
-		return "", nil, func() {}, fmt.Errorf("write embed discovery overlay: %w", errors.Join(encodeErr, closeErr))
+		return empty, fmt.Errorf("write embed discovery overlay: %w", errors.Join(encodeErr, closeErr))
 	}
-	return overlayPath, replacements, cleanup, nil
+	return embedDiscoveryContext{
+		OverlayPath: overlayPath,
+		Candidates:  candidates,
+		Cleanup:     cleanup,
+	}, nil
 }
 
 func shouldSkipEmbedCandidate(relative string, entry os.DirEntry) bool {
@@ -275,9 +362,18 @@ func setEnvironmentValue(environment []string, key, value string) []string {
 	return append(result, prefix+value)
 }
 
-func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]string, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {
+func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[string]embedCandidate, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {
+	appDir, err := filepath.Abs(appDir)
+	if err != nil {
+		return nil, embedInputPlan{}, fmt.Errorf("resolve embed source root: %w", err)
+	}
+	appWorkDir, err = filepath.Abs(appWorkDir)
+	if err != nil {
+		return nil, embedInputPlan{}, fmt.Errorf("resolve embed workspace root: %w", err)
+	}
 	inputsByDestination := map[string]resolvedEmbedInput{}
-	watchRoots := map[string]struct{}{}
+	watches := map[string]embedWatchSpec{}
+	generatedGoMod := filepath.Join(appWorkDir, "go.mod")
 	for _, packageInfo := range packages {
 		packageRelative, ok, err := relativePathBelow(appWorkDir, packageInfo.Dir)
 		if err != nil {
@@ -288,11 +384,11 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]st
 		}
 		sourcePackageDir := filepath.Join(appDir, packageRelative)
 		for _, pattern := range packageInfo.EmbedPatterns {
-			root, err := embedPatternWatchRoot(appDir, sourcePackageDir, pattern)
+			watch, err := embedPatternWatchSpec(appDir, sourcePackageDir, pattern)
 			if err != nil {
 				return nil, embedInputPlan{}, err
 			}
-			watchRoots[root] = struct{}{}
+			watches[embedWatchKey(watch)] = watch
 		}
 		for _, embedFile := range packageInfo.EmbedFiles {
 			if filepath.IsAbs(filepath.FromSlash(embedFile)) {
@@ -302,13 +398,29 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]st
 			if err := validatePathBelowRoot(appWorkDir, destination, "embedded workspace input", true); err != nil {
 				return nil, embedInputPlan{}, err
 			}
-			source := replacements[destination]
-			needsCopy := source != ""
-			if source == "" {
-				source = filepath.Join(sourcePackageDir, filepath.FromSlash(embedFile))
-				if _, err := regularFileNoFollow(source, "embedded source input"); err != nil {
-					continue
-				}
+			destination, err = filepath.Abs(destination)
+			if err != nil {
+				return nil, embedInputPlan{}, fmt.Errorf("resolve embedded workspace input %s: %w", destination, err)
+			}
+			if destination == generatedGoMod {
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s collides with generated workspace state at %s; workspace go.mod is not authored embed content", embedFile, packageInfo.ImportPath, destination)
+			}
+			if strings.HasSuffix(filepath.ToSlash(destination), ".gox.go") {
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s resolves to workspace-generated GOX source at %s; generated workspace files are not authored embed content", embedFile, packageInfo.ImportPath, destination)
+			}
+			candidate, ok := candidates[destination]
+			if !ok {
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s at workspace destination %s has no valid authored backing file", embedFile, packageInfo.ImportPath, destination)
+			}
+			source := candidate.SourcePath
+			switch candidate.Kind {
+			case embedCandidateSymlink:
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s resolves to symlinked authored input %s; symlink embed inputs are not supported", embedFile, packageInfo.ImportPath, source)
+			case embedCandidateIrregular:
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s resolves to irregular authored input %s; embed inputs must be regular files", embedFile, packageInfo.ImportPath, source)
+			case embedCandidateRegular:
+			default:
+				return nil, embedInputPlan{}, fmt.Errorf("embedded input %q for %s has unknown authored provenance at %s", embedFile, packageInfo.ImportPath, source)
 			}
 			if err := validatePathBelowRoot(appDir, source, "embedded source input", false); err != nil {
 				return nil, embedInputPlan{}, err
@@ -319,6 +431,25 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]st
 			content, err := os.ReadFile(source)
 			if err != nil {
 				return nil, embedInputPlan{}, fmt.Errorf("read embedded source input %s: %w", source, err)
+			}
+			needsCopy := true
+			workspaceInfo, workspaceErr := os.Lstat(destination)
+			switch {
+			case workspaceErr == nil:
+				if workspaceInfo.Mode()&os.ModeSymlink != 0 || !workspaceInfo.Mode().IsRegular() {
+					return nil, embedInputPlan{}, fmt.Errorf("embedded workspace destination %s for %q is not a regular authored copy", destination, embedFile)
+				}
+				workspaceContent, err := os.ReadFile(destination)
+				if err != nil {
+					return nil, embedInputPlan{}, fmt.Errorf("read embedded workspace destination %s: %w", destination, err)
+				}
+				if !bytes.Equal(workspaceContent, content) {
+					return nil, embedInputPlan{}, fmt.Errorf("embedded workspace destination %s for %q does not match authored input %s", destination, embedFile, source)
+				}
+				needsCopy = false
+			case errors.Is(workspaceErr, os.ErrNotExist):
+			default:
+				return nil, embedInputPlan{}, fmt.Errorf("inspect embedded workspace destination %s: %w", destination, workspaceErr)
 			}
 			displayPath, err := filepath.Rel(appDir, source)
 			if err != nil {
@@ -349,10 +480,12 @@ func resolveEmbedInputPlan(appDir, appWorkDir string, replacements map[string]st
 		inputs = append(inputs, input)
 		plan.Files = append(plan.Files, input.file)
 	}
-	for root := range watchRoots {
-		plan.WatchRoots = append(plan.WatchRoots, root)
+	for _, watch := range watches {
+		plan.Watches = append(plan.Watches, watch)
 	}
-	sort.Strings(plan.WatchRoots)
+	sort.Slice(plan.Watches, func(first, second int) bool {
+		return embedWatchKey(plan.Watches[first]) < embedWatchKey(plan.Watches[second])
+	})
 	return inputs, plan, nil
 }
 
@@ -371,9 +504,27 @@ func relativePathBelow(root, target string) (string, bool, error) {
 	return relative, true, nil
 }
 
-func embedPatternWatchRoot(appDir, sourcePackageDir, pattern string) (string, error) {
+func embedPatternWatchSpec(appDir, sourcePackageDir, pattern string) (embedWatchSpec, error) {
 	pattern = strings.TrimPrefix(pattern, "all:")
 	firstMeta := strings.IndexAny(pattern, "*?[")
+	if firstMeta < 0 {
+		candidate := filepath.Join(sourcePackageDir, filepath.FromSlash(pattern))
+		if err := validateEmbedWatchExactPath(appDir, candidate); err != nil {
+			return embedWatchSpec{}, err
+		}
+		candidate, err := filepath.Abs(candidate)
+		if err != nil {
+			return embedWatchSpec{}, fmt.Errorf("resolve embed pattern watch path %s: %w", candidate, err)
+		}
+		kind := embedWatchExact
+		if info, err := os.Lstat(candidate); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+			kind = embedWatchTree
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return embedWatchSpec{}, fmt.Errorf("inspect embed pattern watch path %s: %w", candidate, err)
+		}
+		return embedWatchSpec{Path: candidate, Kind: kind}, nil
+	}
+
 	rootRelative := ""
 	if firstMeta >= 0 {
 		prefix := strings.TrimSuffix(pattern[:firstMeta], "/")
@@ -381,22 +532,23 @@ func embedPatternWatchRoot(appDir, sourcePackageDir, pattern string) (string, er
 		if strings.HasSuffix(pattern[:firstMeta], "/") {
 			rootRelative = prefix
 		}
-	} else {
-		candidate := filepath.Join(sourcePackageDir, filepath.FromSlash(pattern))
-		if info, err := os.Lstat(candidate); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
-			rootRelative = pattern
-		} else {
-			rootRelative = path.Dir(pattern)
-		}
 	}
 	if rootRelative == "" || rootRelative == "." {
 		rootRelative = "."
 	}
 	root := filepath.Join(sourcePackageDir, filepath.FromSlash(rootRelative))
 	if err := validatePathBelowRoot(appDir, root, "embed pattern watch root", true); err != nil {
-		return "", err
+		return embedWatchSpec{}, err
 	}
-	return root, nil
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return embedWatchSpec{}, fmt.Errorf("resolve embed pattern watch root %s: %w", root, err)
+	}
+	return embedWatchSpec{Path: root, Kind: embedWatchTree}, nil
+}
+
+func embedWatchKey(watch embedWatchSpec) string {
+	return strconv.Itoa(int(watch.Kind)) + ":" + watch.Path
 }
 
 func embedPackageMetadataError(packages []embedListPackage) error {
@@ -430,24 +582,67 @@ func embedPackageMetadataError(packages []embedListPackage) error {
 }
 
 func populateEmbedWatchMembership(appDir string, plan *embedInputPlan) error {
-	membership, err := embedWatchMembership(appDir, plan.WatchRoots)
+	membership, err := embedWatchMembership(appDir, plan.Watches)
 	plan.WatchMembership = membership
 	return err
 }
 
-func embedWatchMembership(appDir string, roots []string) (map[string]string, error) {
-	membership := make(map[string]string, len(roots))
-	for _, root := range roots {
-		fingerprint, err := embedWatchRootFingerprint(appDir, root)
+func embedWatchMembership(appDir string, watches []embedWatchSpec) (map[string]string, error) {
+	membership := make(map[string]string, len(watches))
+	for _, watch := range watches {
+		var fingerprint string
+		var err error
+		switch watch.Kind {
+		case embedWatchExact:
+			fingerprint, err = embedWatchExactFingerprint(appDir, watch.Path)
+		case embedWatchTree:
+			fingerprint, err = embedWatchTreeFingerprint(appDir, watch.Path)
+		default:
+			err = fmt.Errorf("embed watch path %s has unknown kind %d", watch.Path, watch.Kind)
+		}
 		if err != nil {
 			return membership, err
 		}
-		membership[root] = fingerprint
+		membership[embedWatchKey(watch)] = fingerprint
 	}
 	return membership, nil
 }
 
-func embedWatchRootFingerprint(appDir, root string) (string, error) {
+func embedWatchExactFingerprint(appDir, target string) (string, error) {
+	if err := validateEmbedWatchExactPath(appDir, target); err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return "missing", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect exact embed watch path %s: %w", target, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "symlink", nil
+	}
+	if info.Mode().IsRegular() {
+		return "regular", nil
+	}
+	if info.IsDir() {
+		return "directory", nil
+	}
+	return "other", nil
+}
+
+func validateEmbedWatchExactPath(appDir, target string) error {
+	_, inside, err := relativePathBelow(appDir, target)
+	if err != nil {
+		return err
+	}
+	if !inside {
+		return fmt.Errorf("exact embed watch path %s must stay inside %s", target, appDir)
+	}
+	return validatePathBelowRoot(appDir, filepath.Dir(target), "exact embed watch parent", true)
+}
+
+func embedWatchTreeFingerprint(appDir, root string) (string, error) {
 	if err := validatePathBelowRoot(appDir, root, "embed watch root", true); err != nil {
 		return "", err
 	}
@@ -512,6 +707,14 @@ func embedInputPlansEqual(first, second embedInputPlan) bool {
 	for index := range first.Files {
 		if first.Files[index].DisplayPath != second.Files[index].DisplayPath ||
 			first.Files[index].Fingerprint != second.Files[index].Fingerprint {
+			return false
+		}
+	}
+	if len(first.Watches) != len(second.Watches) {
+		return false
+	}
+	for index := range first.Watches {
+		if first.Watches[index] != second.Watches[index] {
 			return false
 		}
 	}

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -18,9 +18,10 @@ import (
 )
 
 type embedInputPlan struct {
-	Files      []embedInputFile
-	WatchRoots []string
-	Resolved   bool
+	Files           []embedInputFile
+	WatchRoots      []string
+	WatchMembership map[string]string
+	Resolved        bool
 }
 
 type embedInputFile struct {
@@ -66,14 +67,18 @@ func discoverAndMaterializeEmbedInputs(layout BuildLayout, appWorkDir, entryPath
 		}
 	}
 	inputs, plan, planErr := resolveEmbedInputPlan(layout.AppDir, appWorkDir, replacements, packages)
+	membershipErr := populateEmbedWatchMembership(layout.AppDir, &plan)
 	if planErr != nil {
-		return plan, errors.Join(listErr, planErr)
+		return plan, errors.Join(listErr, planErr, membershipErr)
 	}
 	if metadataErr := embedPackageMetadataError(packages); metadataErr != nil {
-		return plan, errors.Join(listErr, metadataErr)
+		return plan, errors.Join(listErr, metadataErr, membershipErr)
 	}
 	if listErr != nil {
-		return plan, listErr
+		return plan, errors.Join(listErr, membershipErr)
+	}
+	if membershipErr != nil {
+		return plan, membershipErr
 	}
 	for _, input := range inputs {
 		if !input.copy {
@@ -422,4 +427,118 @@ func embedPackageMetadataError(packages []embedListPackage) error {
 		return nil
 	}
 	return fmt.Errorf("resolve go:embed inputs: %w", errors.Join(failures...))
+}
+
+func populateEmbedWatchMembership(appDir string, plan *embedInputPlan) error {
+	membership, err := embedWatchMembership(appDir, plan.WatchRoots)
+	plan.WatchMembership = membership
+	return err
+}
+
+func embedWatchMembership(appDir string, roots []string) (map[string]string, error) {
+	membership := make(map[string]string, len(roots))
+	for _, root := range roots {
+		fingerprint, err := embedWatchRootFingerprint(appDir, root)
+		if err != nil {
+			return membership, err
+		}
+		membership[root] = fingerprint
+	}
+	return membership, nil
+}
+
+func embedWatchRootFingerprint(appDir, root string) (string, error) {
+	if err := validatePathBelowRoot(appDir, root, "embed watch root", true); err != nil {
+		return "", err
+	}
+	info, err := os.Lstat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return "missing", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("inspect embed watch root %s: %w", root, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("embed watch root %s is a symlink; symlink paths are not supported", root)
+	}
+	if !info.IsDir() {
+		return "not-directory:" + info.Mode().Type().String(), nil
+	}
+	hash := sha256.New()
+	err = filepath.WalkDir(root, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("inspect embed watch input %s: %w", current, walkErr)
+		}
+		if current != root {
+			relativeToApp, err := filepath.Rel(appDir, current)
+			if err != nil {
+				return fmt.Errorf("resolve embed watch input %s: %w", current, err)
+			}
+			if shouldSkipEmbedCandidate(relativeToApp, entry) {
+				if entry.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+		relative, err := filepath.Rel(root, current)
+		if err != nil {
+			return fmt.Errorf("resolve embed watch input %s: %w", current, err)
+		}
+		kind := entry.Type().String()
+		if entry.IsDir() {
+			kind = "directory"
+		} else if entry.Type().IsRegular() {
+			kind = "file"
+		} else if entry.Type()&os.ModeSymlink != 0 {
+			kind = "symlink"
+		}
+		_, _ = fmt.Fprintf(hash, "%s\x00%s\n", filepath.ToSlash(relative), kind)
+		if current != root && entry.IsDir() && nestedModuleBoundary(current) {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func embedInputPlansEqual(first, second embedInputPlan) bool {
+	if len(first.Files) != len(second.Files) {
+		return false
+	}
+	for index := range first.Files {
+		if first.Files[index].DisplayPath != second.Files[index].DisplayPath ||
+			first.Files[index].Fingerprint != second.Files[index].Fingerprint {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveCurrentEmbedInputPlan(options packageOptions) (embedInputPlan, error) {
+	manifest, err := loadManifest(options.appDir)
+	if err != nil {
+		return embedInputPlan{}, err
+	}
+	compiler := options.compiler
+	if compiler == "" {
+		compiler = manifest.Compiler
+	}
+	if err := validateCompiler(compiler); err != nil {
+		return embedInputPlan{}, err
+	}
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    options.appDir,
+		compiler:  compiler,
+		profile:   packageProfile(options.assetHash, options.preload, options.compress),
+		workspace: options.workspace,
+	})
+	if err != nil {
+		return embedInputPlan{}, err
+	}
+	result, err := prepareBuildWorkspaceResult(layout, manifest)
+	return result.EmbedPlan, err
 }

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -234,6 +235,321 @@ func main() { _ = external.Message }
 	}
 }
 
+func TestEmbedInputPlanResolvesPhysicalWorkspaceAlias(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	workspaceParent := filepath.Join(root, "physical")
+	workspaceRoot := filepath.Join(workspaceParent, "workspace")
+	workspaceAliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(workspaceAliasParent, "workspace")
+	writeTestFile(t, appDir, "message.txt", "authored")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(workspaceParent, workspaceAliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery, err := createEmbedDiscoveryOverlay(appDir, workspaceAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Cleanup()
+	_, plan, err := resolveEmbedInputPlan(appDir, workspaceAlias, discovery.Candidates, []embedListPackage{{
+		Dir:        workspaceRoot,
+		ImportPath: "example.com/alias",
+		EmbedFiles: []string{"message.txt"},
+	}})
+	if err != nil {
+		t.Fatalf("resolveEmbedInputPlan() error: %v", err)
+	}
+	if got, want := embedPlanPaths(plan), []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	if got := plan.Files[0].SourcePath; got != filepath.Join(appDir, "message.txt") {
+		t.Fatalf("authored source = %q, want app-local message.txt", got)
+	}
+}
+
+func TestEmbedDiscoveryOverlayUsesPhysicalWorkspacePath(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	workspaceParent := filepath.Join(root, "physical")
+	workspaceRoot := filepath.Join(workspaceParent, "workspace")
+	workspaceAliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(workspaceAliasParent, "workspace")
+	writeTestFile(t, appDir, "message.txt", "authored")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(workspaceParent, workspaceAliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery, err := createEmbedDiscoveryOverlay(appDir, workspaceAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Cleanup()
+	content, err := os.ReadFile(discovery.OverlayPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var overlay embedDiscoveryOverlay
+	if err := json.Unmarshal(content, &overlay); err != nil {
+		t.Fatal(err)
+	}
+	want, err := canonicalPathForComparison(filepath.Join(workspaceRoot, "message.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := overlay.Replace[want]; got != filepath.Join(appDir, "message.txt") {
+		t.Fatalf("physical overlay replacement = %q, want authored message.txt; replacements=%#v", got, overlay.Replace)
+	}
+}
+
+func TestEmbedInputKeysPreservePhysicalApplicationAliasIdentity(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	physicalParent := filepath.Join(root, "physical")
+	appDir := filepath.Join(physicalParent, "app")
+	aliasParent := filepath.Join(root, "physical-alias")
+	appAlias := filepath.Join(aliasParent, "app")
+	source := filepath.Join(appDir, "internal", "content", "payload.txt")
+	writeTestFile(t, appDir, "internal/content/payload.txt", "payload")
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	realRelative, inside, err := relativePathBelow(appDir, source)
+	if err != nil || !inside {
+		t.Fatalf("real source relation = %q, inside=%v, err=%v", realRelative, inside, err)
+	}
+	aliasRelative, inside, err := relativePathBelow(appAlias, source)
+	if err != nil || !inside {
+		t.Fatalf("aliased source relation = %q, inside=%v, err=%v", aliasRelative, inside, err)
+	}
+	realKey, err := newEmbedInputKey(realRelative)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasKey, err := newEmbedInputKey(aliasRelative)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if realKey != aliasKey || realKey != embedInputKey("internal/content/payload.txt") {
+		t.Fatalf("physical alias keys = %q and %q", realKey, aliasKey)
+	}
+	if err := validatePathBelowRoot(appDir, source, "embedded source input", false); err != nil {
+		t.Fatalf("validate physical authored source: %v", err)
+	}
+}
+
+func TestEmbedInputPlanResolvesMissingWorkspaceTail(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	workspaceParent := filepath.Join(root, "workspace")
+	appWorkDir := filepath.Join(workspaceParent, "missing-app")
+	source := filepath.Join(appDir, "cmd", "app", "message.txt")
+	writeTestFile(t, appDir, "cmd/app/message.txt", "payload")
+	if err := os.MkdirAll(workspaceParent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	inputs, plan, err := resolveEmbedInputPlan(appDir, appWorkDir, map[embedInputKey]embedCandidate{
+		"cmd/app/message.txt": {SourcePath: source, Kind: embedCandidateRegular},
+	}, []embedListPackage{{
+		Dir:        filepath.Join(appWorkDir, "cmd", "app"),
+		ImportPath: "example.com/missing/cmd/app",
+		EmbedFiles: []string{"message.txt"},
+	}})
+	if err != nil {
+		t.Fatalf("resolveEmbedInputPlan() error: %v", err)
+	}
+	if got, want := embedPlanPaths(plan), []string{"cmd/app/message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	if len(inputs) != 1 || !inputs[0].copy || inputs[0].destination != filepath.Join(appWorkDir, "cmd", "app", "message.txt") {
+		t.Fatalf("missing-tail input = %+v", inputs)
+	}
+}
+
+func TestEmbedDiscoveryCandidatesUseDistinctRelativeKeys(t *testing.T) {
+	appDir := t.TempDir()
+	appWorkDir := t.TempDir()
+	writeTestFile(t, appDir, "first/payload.txt", "first")
+	writeTestFile(t, appDir, "second/payload.txt", "second")
+	discovery, err := createEmbedDiscoveryOverlay(appDir, appWorkDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Cleanup()
+	if len(discovery.Candidates) != 2 {
+		t.Fatalf("candidate count = %d, want 2", len(discovery.Candidates))
+	}
+	for _, key := range []embedInputKey{"first/payload.txt", "second/payload.txt"} {
+		if _, ok := discovery.Candidates[key]; !ok {
+			t.Fatalf("candidate key %q missing: %#v", key, discovery.Candidates)
+		}
+	}
+}
+
+func TestEmbedInputPlanFiltersPhysicalPackageOutsideWorkspace(t *testing.T) {
+	appDir := t.TempDir()
+	appWorkDir := t.TempDir()
+	externalPackage := filepath.Join(t.TempDir(), "external")
+	if err := os.MkdirAll(externalPackage, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	inputs, plan, err := resolveEmbedInputPlan(appDir, appWorkDir, nil, []embedListPackage{{
+		Dir:           externalPackage,
+		ImportPath:    "example.com/external",
+		EmbedPatterns: []string{"payload.txt"},
+		EmbedFiles:    []string{"payload.txt"},
+	}})
+	if err != nil {
+		t.Fatalf("resolveEmbedInputPlan() error: %v", err)
+	}
+	if len(inputs) != 0 || len(plan.Files) != 0 || len(plan.Watches) != 0 {
+		t.Fatalf("external package entered embed plan: inputs=%#v plan=%#v", inputs, plan)
+	}
+}
+
+func TestEmbedInputPlanFiltersPackageOnDifferentWindowsVolume(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows volume identity regression")
+	}
+	if relative, inside, err := relativeCanonicalPathBelow(
+		`C:\workspace\app`,
+		`D:\repository\pkg\goframe`,
+		`C:\workspace\app`,
+		`D:\repository\pkg\goframe`,
+	); err != nil || inside || relative != "" {
+		t.Fatalf("different-volume relation = %q, inside=%v, err=%v", relative, inside, err)
+	}
+
+	repositoryRoot, ok := findRepositoryRoot(".")
+	if !ok {
+		t.Fatal("repository root not found")
+	}
+	appDir := t.TempDir()
+	appWorkDir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(appWorkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	externalPackage := filepath.Join(repositoryRoot, "pkg", "goframe")
+	if strings.EqualFold(filepath.VolumeName(appWorkDir), filepath.VolumeName(externalPackage)) {
+		return
+	}
+	_, plan, err := resolveEmbedInputPlan(appDir, appWorkDir, nil, []embedListPackage{{
+		Dir:        externalPackage,
+		ImportPath: canonicalModulePath + "/pkg/goframe",
+	}})
+	if err != nil {
+		t.Fatalf("different-volume external package error: %v", err)
+	}
+	if len(plan.Files) != 0 || len(plan.Watches) != 0 {
+		t.Fatalf("different-volume external package entered plan: %#v", plan)
+	}
+}
+
+func TestEmbedInputPlanRejectsReservedWorkspaceInputsThroughAlias(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	workspaceParent := filepath.Join(root, "physical")
+	workspaceRoot := filepath.Join(workspaceParent, "workspace")
+	aliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, "cmd", "app"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(workspaceParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name       string
+		packageDir string
+		embedFile  string
+		want       string
+	}{
+		{name: "go.mod", packageDir: workspaceRoot, embedFile: "go.mod", want: "workspace go.mod"},
+		{name: "generated GOX", packageDir: filepath.Join(workspaceRoot, "cmd", "app"), embedFile: "app.gox.go", want: "workspace-generated GOX source"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := resolveEmbedInputPlan(appDir, workspaceAlias, nil, []embedListPackage{{
+				Dir:        test.packageDir,
+				ImportPath: "example.com/reserved",
+				EmbedFiles: []string{test.embedFile},
+			}})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("resolveEmbedInputPlan() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestEmbedWatchIdentityDeduplicatesPhysicalAliases(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	physicalParent := filepath.Join(root, "physical")
+	appDir := filepath.Join(physicalParent, "app")
+	aliasParent := filepath.Join(root, "physical-alias")
+	appAlias := filepath.Join(aliasParent, "app")
+	writeTestFile(t, appDir, "message.txt", "payload")
+	writeTestFile(t, appDir, "templates/page.html", "page")
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+
+	realWatch, err := embedPatternWatchSpec(appDir, appDir, "message.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasWatch, err := embedPatternWatchSpec(appAlias, appAlias, "message.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if embedWatchKey(realWatch) != embedWatchKey(aliasWatch) {
+		t.Fatalf("equivalent watch keys = %q and %q", embedWatchKey(realWatch), embedWatchKey(aliasWatch))
+	}
+	watches := map[string]embedWatchSpec{
+		embedWatchKey(realWatch):  realWatch,
+		embedWatchKey(aliasWatch): aliasWatch,
+	}
+	if len(watches) != 1 {
+		t.Fatalf("deduplicated watch count = %d, want 1", len(watches))
+	}
+	realTreeWatch, err := embedPatternWatchSpec(appDir, appDir, "templates/*.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasTreeWatch, err := embedPatternWatchSpec(appAlias, appAlias, "templates/*.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if embedWatchKey(realTreeWatch) != embedWatchKey(aliasTreeWatch) {
+		t.Fatalf("equivalent tree watch keys = %q and %q", embedWatchKey(realTreeWatch), embedWatchKey(aliasTreeWatch))
+	}
+	treeWatches := map[string]embedWatchSpec{
+		embedWatchKey(realTreeWatch):  realTreeWatch,
+		embedWatchKey(aliasTreeWatch): aliasTreeWatch,
+	}
+	if len(treeWatches) != 1 {
+		t.Fatalf("deduplicated tree watch count = %d, want 1", len(treeWatches))
+	}
+	exactTreePath, err := newEmbedWatchSpec(appDir, realTreeWatch.Path, embedWatchExact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if embedWatchKey(exactTreePath) == embedWatchKey(realTreeWatch) {
+		t.Fatal("exact and tree watches collapsed to one identity")
+	}
+}
+
 func TestEmbedWorkspaceBuildsRootAndInternalPackageInputs(t *testing.T) {
 	t.Run("root package", func(t *testing.T) {
 		appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "root payload"})
@@ -352,8 +668,7 @@ func TestEmbedMaterializationRejectsUnsafeInputs(t *testing.T) {
 	t.Run("destination traversal", func(t *testing.T) {
 		appDir := t.TempDir()
 		appWorkDir := t.TempDir()
-		outside := filepath.Join(filepath.Dir(appWorkDir), "escape.txt")
-		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]embedCandidate{outside: {
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[embedInputKey]embedCandidate{"escape.txt": {
 			SourcePath: filepath.Join(appDir, "source.txt"),
 			Kind:       embedCandidateRegular,
 		}}, []embedListPackage{{
@@ -405,7 +720,7 @@ func TestEmbedDiscoveryPreservesUnsafeCandidateProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	destination := filepath.Join(appWorkDir, "link.txt")
-	candidate, ok := discovery.Candidates[destination]
+	candidate, ok := discovery.Candidates["link.txt"]
 	if !ok {
 		discovery.Cleanup()
 		t.Fatalf("symlink candidate missing for %s", destination)
@@ -561,9 +876,8 @@ func TestEmbedMaterializationRejectsIrregularPatternCandidate(t *testing.T) {
 	t.Run("candidate validation", func(t *testing.T) {
 		appDir := t.TempDir()
 		appWorkDir := t.TempDir()
-		destination := filepath.Join(appWorkDir, "payload.irregular")
-		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]embedCandidate{
-			destination: {SourcePath: filepath.Join(appDir, "payload.irregular"), Kind: embedCandidateIrregular},
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[embedInputKey]embedCandidate{
+			"payload.irregular": {SourcePath: filepath.Join(appDir, "payload.irregular"), Kind: embedCandidateIrregular},
 		}, []embedListPackage{{
 			Dir:        appWorkDir,
 			ImportPath: "example.com/irregular",

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -350,7 +353,10 @@ func TestEmbedMaterializationRejectsUnsafeInputs(t *testing.T) {
 		appDir := t.TempDir()
 		appWorkDir := t.TempDir()
 		outside := filepath.Join(filepath.Dir(appWorkDir), "escape.txt")
-		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]string{outside: filepath.Join(appDir, "source.txt")}, []embedListPackage{{
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]embedCandidate{outside: {
+			SourcePath: filepath.Join(appDir, "source.txt"),
+			Kind:       embedCandidateRegular,
+		}}, []embedListPackage{{
 			Dir:        appWorkDir,
 			ImportPath: "example.com/app",
 			EmbedFiles: []string{"../escape.txt"},
@@ -376,6 +382,337 @@ func TestEmbedMaterializationRejectsUnsafeInputs(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestEmbedDiscoveryPreservesUnsafeCandidateProvenance(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	appWorkDir := filepath.Join(root, "work")
+	writeTestFile(t, appDir, "main.go", embedFSSource("*"))
+	if err := os.MkdirAll(appWorkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(root, "external.txt")
+	writeTestFile(t, root, "external.txt", "external-secret")
+	link := filepath.Join(appDir, "link.txt")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+
+	discovery, err := createEmbedDiscoveryOverlay(appDir, appWorkDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := filepath.Join(appWorkDir, "link.txt")
+	candidate, ok := discovery.Candidates[destination]
+	if !ok {
+		discovery.Cleanup()
+		t.Fatalf("symlink candidate missing for %s", destination)
+	}
+	if candidate.Kind != embedCandidateSymlink || candidate.SourcePath != link {
+		discovery.Cleanup()
+		t.Fatalf("symlink candidate = %+v", candidate)
+	}
+	overlayContent, err := os.ReadFile(discovery.OverlayPath)
+	if err != nil {
+		discovery.Cleanup()
+		t.Fatal(err)
+	}
+	var overlay embedDiscoveryOverlay
+	if err := json.Unmarshal(overlayContent, &overlay); err != nil {
+		discovery.Cleanup()
+		t.Fatal(err)
+	}
+	sentinel := overlay.Replace[destination]
+	if sentinel == "" || sentinel == external || sentinel == link {
+		discovery.Cleanup()
+		t.Fatalf("unsafe overlay backing = %q", sentinel)
+	}
+	if _, inside, err := relativePathBelow(appDir, sentinel); err != nil || inside {
+		discovery.Cleanup()
+		t.Fatalf("sentinel %q is inside app: inside=%v err=%v", sentinel, inside, err)
+	}
+	if content, err := os.ReadFile(sentinel); err != nil || len(content) != 0 {
+		discovery.Cleanup()
+		t.Fatalf("sentinel content = %q, err=%v", content, err)
+	}
+
+	discovery.Cleanup()
+	for _, temporary := range []string{discovery.OverlayPath, sentinel} {
+		if _, err := os.Lstat(temporary); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("temporary discovery file %s remained: %v", temporary, err)
+		}
+	}
+}
+
+func TestEmbedMaterializationRejectsUnsafePatternCandidates(t *testing.T) {
+	requireSymlinkSupport(t)
+	tests := []struct {
+		name       string
+		pattern    string
+		link       string
+		additional map[string]string
+	}{
+		{
+			name:       "broad root pattern",
+			pattern:    "*",
+			link:       "link.txt",
+			additional: map[string]string{"regular.txt": "regular"},
+		},
+		{
+			name:       "directory pattern with nested symlink",
+			pattern:    "templates",
+			link:       "templates/link.txt",
+			additional: map[string]string{"templates/visible.txt": "visible"},
+		},
+		{
+			name:       "all directory pattern",
+			pattern:    "all:templates",
+			link:       "templates/link.txt",
+			additional: map[string]string{"templates/visible.txt": "visible"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			appDir := filepath.Join(root, "app")
+			packageDir := filepath.Join(appDir, "cmd", "app")
+			writeTestFile(t, appDir, "go.mod", "module example.com/unsafeembed\n\ngo 1.22\n")
+			writeTestFile(t, packageDir, "main.go", embedFSSource(test.pattern))
+			for relative, content := range test.additional {
+				writeTestFile(t, packageDir, relative, content)
+			}
+			external := filepath.Join(root, "external.txt")
+			writeTestFile(t, root, "external.txt", "external-secret")
+			link := filepath.Join(packageDir, filepath.FromSlash(test.link))
+			if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(external, link); err != nil {
+				t.Fatal(err)
+			}
+			layout := newEmbedTestLayout(t, appDir, "go", "")
+			_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "cmd/app"))
+			if err == nil || !strings.Contains(err.Error(), "symlinked authored input") || !strings.Contains(err.Error(), test.link) {
+				t.Fatalf("prepareBuildWorkspaceResult() error = %v, want selected symlink rejection", err)
+			}
+			if workspaceContainsBytes(t, layout.WorkDir, "external-secret") {
+				t.Fatal("external symlink target bytes entered the workspace")
+			}
+		})
+	}
+}
+
+func TestEmbedMaterializationIgnoresUnselectedUnsafeCandidate(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	packageDir := filepath.Join(appDir, "cmd", "app")
+	writeTestFile(t, appDir, "go.mod", "module example.com/unselectedembed\n\ngo 1.22\n")
+	writeTestFile(t, packageDir, "main.go", embedStringSource("regular.txt"))
+	writeTestFile(t, packageDir, "regular.txt", "regular")
+	external := filepath.Join(root, "external.txt")
+	writeTestFile(t, root, "external.txt", "external-secret")
+	if err := os.Symlink(external, filepath.Join(packageDir, "unselected.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "cmd/app"))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"cmd/app/regular.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	if workspaceContainsBytes(t, layout.WorkDir, "external-secret") {
+		t.Fatal("unselected symlink target bytes entered the workspace")
+	}
+}
+
+func TestEmbedMaterializationRejectsIrregularPatternCandidate(t *testing.T) {
+	t.Run("real socket", func(t *testing.T) {
+		root, err := os.MkdirTemp("", "ge-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(root) })
+		appDir := filepath.Join(root, "app")
+		packageDir := filepath.Join(appDir, "cmd", "app")
+		writeTestFile(t, appDir, "go.mod", "module example.com/irregularembed\n\ngo 1.22\n")
+		writeTestFile(t, packageDir, "main.go", embedFSSource("*"))
+		writeTestFile(t, packageDir, "regular.txt", "regular")
+		socketPath := filepath.Join(packageDir, "payload.sock")
+		listener, err := net.Listen("unix", socketPath)
+		if err != nil {
+			t.Skipf("Unix-domain socket creation is unavailable: %v", err)
+		}
+		defer listener.Close()
+
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err = prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "cmd/app"))
+		if err == nil || !strings.Contains(err.Error(), "irregular authored input") || !strings.Contains(err.Error(), "payload.sock") {
+			t.Fatalf("prepareBuildWorkspaceResult() error = %v, want irregular input rejection", err)
+		}
+	})
+
+	t.Run("candidate validation", func(t *testing.T) {
+		appDir := t.TempDir()
+		appWorkDir := t.TempDir()
+		destination := filepath.Join(appWorkDir, "payload.irregular")
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]embedCandidate{
+			destination: {SourcePath: filepath.Join(appDir, "payload.irregular"), Kind: embedCandidateIrregular},
+		}, []embedListPackage{{
+			Dir:        appWorkDir,
+			ImportPath: "example.com/irregular",
+			EmbedFiles: []string{"payload.irregular"},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "irregular authored input") {
+			t.Fatalf("resolveEmbedInputPlan() error = %v, want irregular candidate rejection", err)
+		}
+	})
+}
+
+func TestEmbedMaterializationRejectsWorkspaceOnlyInputs(t *testing.T) {
+	t.Run("missing authored go.mod", func(t *testing.T) {
+		appDir := t.TempDir()
+		writeTestFile(t, appDir, "main.go", embedStringSource("go.mod"))
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+		if err == nil || !strings.Contains(err.Error(), "collides with generated workspace state") {
+			t.Fatalf("prepareBuildWorkspaceResult() error = %v, want workspace go.mod rejection", err)
+		}
+	})
+
+	t.Run("authored go.mod collision", func(t *testing.T) {
+		appDir := newEmbedTestApp(t, embedStringSource("go.mod"), nil)
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+		if err == nil || !strings.Contains(err.Error(), "workspace go.mod is not authored embed content") {
+			t.Fatalf("prepareBuildWorkspaceResult() error = %v, want transformed go.mod rejection", err)
+		}
+	})
+
+	t.Run("generated GOX output", func(t *testing.T) {
+		repositoryRoot, ok := findRepositoryRoot(".")
+		if !ok {
+			t.Fatal("repository root not found")
+		}
+		appDir := t.TempDir()
+		writeTestFile(t, appDir, "go.mod", "module example.com/generatedembed\n\ngo 1.22\n\nrequire "+canonicalModulePath+" v0.0.0\n\nreplace "+canonicalModulePath+" => "+filepath.ToSlash(repositoryRoot)+"\n")
+		writeTestFile(t, appDir, "cmd/app/main.go", embedFSSource("*"))
+		writeTestFile(t, appDir, "cmd/app/app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node { return <p>generated</p> }
+`)
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "cmd/app"))
+		if err == nil || !strings.Contains(err.Error(), ".gox.go") || !strings.Contains(err.Error(), "workspace-generated GOX source") {
+			t.Fatalf("prepareBuildWorkspaceResult() error = %v, want generated GOX rejection", err)
+		}
+	})
+
+	t.Run("synthetic missing provenance", func(t *testing.T) {
+		appDir := t.TempDir()
+		appWorkDir := t.TempDir()
+		writeTestFile(t, appWorkDir, "workspace-only.txt", "generated")
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, nil, []embedListPackage{{
+			Dir:        appWorkDir,
+			ImportPath: "example.com/workspace-only",
+			EmbedFiles: []string{"workspace-only.txt"},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "has no valid authored backing file") {
+			t.Fatalf("resolveEmbedInputPlan() error = %v, want missing provenance", err)
+		}
+	})
+}
+
+func TestEmbedMaterializationAcceptsAuthoredGoFileProvenance(t *testing.T) {
+	appDir := newEmbedTestApp(t, embedStringSource("payload.go"), map[string]string{
+		"payload.go": "package main\n\nconst authoredPayload = true\n",
+	})
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"payload.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "payload.go"), "package main\n\nconst authoredPayload = true\n")
+}
+
+func TestEmbedPatternWatchBoundaries(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "message.txt", "message")
+	writeTestFile(t, appDir, "config/app.json", "{}")
+	writeTestFile(t, appDir, "templates/one.txt", "one")
+	tests := []struct {
+		pattern string
+		kind    embedWatchKind
+		path    string
+	}{
+		{pattern: "message.txt", kind: embedWatchExact, path: "message.txt"},
+		{pattern: "config/app.json", kind: embedWatchExact, path: "config/app.json"},
+		{pattern: "missing.txt", kind: embedWatchExact, path: "missing.txt"},
+		{pattern: "templates", kind: embedWatchTree, path: "templates"},
+		{pattern: "templates/*.txt", kind: embedWatchTree, path: "templates"},
+		{pattern: "*", kind: embedWatchTree, path: "."},
+	}
+	for _, test := range tests {
+		t.Run(test.pattern, func(t *testing.T) {
+			watch, err := embedPatternWatchSpec(appDir, appDir, test.pattern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if watch.Kind != test.kind || watch.Path != filepath.Join(appDir, filepath.FromSlash(test.path)) {
+				t.Fatalf("watch = %+v, want kind=%d path=%s", watch, test.kind, test.path)
+			}
+		})
+	}
+}
+
+func TestEmbedExactWatchFingerprintTracksOnlyPathType(t *testing.T) {
+	requireSymlinkSupport(t)
+	appDir := t.TempDir()
+	target := filepath.Join(appDir, "message.txt")
+	if got, err := embedWatchExactFingerprint(appDir, target); err != nil || got != "missing" {
+		t.Fatalf("missing fingerprint = %q, err=%v", got, err)
+	}
+	writeTestFile(t, appDir, "message.txt", "first")
+	first, err := embedWatchExactFingerprint(appDir, target)
+	if err != nil || first != "regular" {
+		t.Fatalf("regular fingerprint = %q, err=%v", first, err)
+	}
+	writeTestFile(t, appDir, "message.txt", "second")
+	second, err := embedWatchExactFingerprint(appDir, target)
+	if err != nil || second != first {
+		t.Fatalf("content-only fingerprint = %q, want %q, err=%v", second, first, err)
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := embedWatchExactFingerprint(appDir, target); err != nil || got != "directory" {
+		t.Fatalf("directory fingerprint = %q, err=%v", got, err)
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(t.TempDir(), "external.txt")
+	writeTestFile(t, filepath.Dir(external), filepath.Base(external), "external")
+	if err := os.Symlink(external, target); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := embedWatchExactFingerprint(appDir, target); err != nil || got != "symlink" {
+		t.Fatalf("symlink fingerprint = %q, err=%v", got, err)
+	}
 }
 
 func TestEmbedMaterializationDoesNotCopyUnrelatedFiles(t *testing.T) {

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -354,7 +354,11 @@ func main() { _ = message }
 		t.Fatal(err)
 	}
 	defer discovery.Cleanup()
-	t.Setenv("PWD", workspaceAlias)
+	stalePWD := filepath.Join(root, "unrelated-pwd")
+	if err := os.MkdirAll(stalePWD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PWD", stalePWD)
 	packages, err := listGoEmbedPackages(workspaceAlias, discovery.OverlayPath, false)
 	if err != nil {
 		t.Fatalf("listGoEmbedPackages() error: %v", err)
@@ -387,6 +391,197 @@ func main() { _ = message }
 	}
 }
 
+func TestEmbedDiscoveryTinyGoUsesLexicalWorkspaceAliasIntegration(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("TinyGo is not available")
+	}
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	physicalParent := filepath.Join(root, "physical")
+	workspaceRoot := filepath.Join(physicalParent, "workspace")
+	aliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	source := `package main
+
+import _ "embed"
+
+//go:embed message.txt
+var message string
+
+func main() { _ = message }
+`
+	writeTestFile(t, appDir, "go.mod", "module example.com/lexical-tinygo-overlay\n\ngo 1.22\n")
+	writeTestFile(t, appDir, "main.go", source)
+	writeTestFile(t, appDir, "message.txt", "authored")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, workspaceRoot, "go.mod", "module example.com/lexical-tinygo-overlay\n\ngo 1.22\n")
+	writeTestFile(t, workspaceRoot, "main.go", source)
+
+	discovery, err := createEmbedDiscoveryOverlay(appDir, workspaceAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Cleanup()
+	stalePWD := filepath.Join(root, "unrelated-pwd")
+	if err := os.MkdirAll(stalePWD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PWD", stalePWD)
+	packages, err := listTinyGoEmbedPackages(workspaceAlias, discovery.OverlayPath)
+	if err != nil {
+		t.Fatalf("listTinyGoEmbedPackages() error: %v", err)
+	}
+	if err := embedPackageMetadataError(packages); err != nil {
+		t.Fatalf("embedPackageMetadataError() error: %v", err)
+	}
+	var discovered *embedListPackage
+	for index := range packages {
+		if packages[index].ImportPath == "example.com/lexical-tinygo-overlay" {
+			discovered = &packages[index]
+			break
+		}
+	}
+	if discovered == nil {
+		t.Fatalf("root package missing from tinygo list output: %#v", packages)
+	}
+	if got, want := discovered.EmbedPatterns, []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("EmbedPatterns = %#v, want %#v", got, want)
+	}
+	if got, want := discovered.EmbedFiles, []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("EmbedFiles = %#v, want %#v", got, want)
+	}
+	_, plan, err := resolveEmbedInputPlan(appDir, workspaceAlias, discovery.Candidates, packages)
+	if err != nil {
+		t.Fatalf("resolveEmbedInputPlan() error: %v", err)
+	}
+	if got, want := embedPlanPaths(plan), []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+}
+
+func TestEmbedDiscoveryUsesOrdinaryWorkspaceWithStalePWD(t *testing.T) {
+	appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "ordinary workspace"})
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	stalePWD := t.TempDir()
+	t.Setenv("PWD", stalePWD)
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "message.txt"), "ordinary workspace")
+}
+
+func TestEmbedListCommandPreservesLexicalWorkingDirectory(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	physicalEntryPath := filepath.Join(root, "physical", "entry")
+	aliasParent := filepath.Join(root, "physical-alias")
+	lexicalEntryPath := filepath.Join(aliasParent, "entry")
+	if err := os.MkdirAll(physicalEntryPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "physical"), aliasParent); err != nil {
+		t.Fatal(err)
+	}
+	stalePWD := filepath.Join(root, "stale-pwd")
+	parentPWD := filepath.Join(root, "parent-pwd")
+	if err := os.MkdirAll(stalePWD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(parentPWD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PWD", parentPWD)
+	want, err := filepath.Abs(lexicalEntryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = filepath.Clean(want)
+	physical, err := canonicalPathForComparison(lexicalEntryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if physical == want {
+		t.Fatalf("test alias did not preserve a distinct lexical path: %q", want)
+	}
+
+	for _, test := range []struct {
+		name        string
+		environment func() []string
+		wantValues  []string
+	}{
+		{
+			name: "go",
+			environment: func() []string {
+				return append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0", "PWD="+stalePWD)
+			},
+			wantValues: []string{"GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0"},
+		},
+		{
+			name: "tinygo",
+			environment: func() []string {
+				environment := setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", "-buildvcs=false -overlay=overlay.json")
+				return append(environment, "PWD="+stalePWD)
+			},
+			wantValues: []string{"GOFLAGS=-buildvcs=false -overlay=overlay.json"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			command := &exec.Cmd{}
+			if err := configureEmbedListCommand(command, lexicalEntryPath, test.environment()); err != nil {
+				t.Fatalf("configureEmbedListCommand() error: %v", err)
+			}
+			if command.Dir != want {
+				t.Fatalf("command.Dir = %q, want lexical path %q", command.Dir, want)
+			}
+			pwdCount := 0
+			for _, item := range command.Env {
+				if strings.HasPrefix(item, "PWD=") {
+					pwdCount++
+					if item != "PWD="+want {
+						t.Fatalf("command PWD = %q, want %q", item, "PWD="+want)
+					}
+				}
+				if item == "PWD="+stalePWD {
+					t.Fatalf("stale PWD remained in command environment: %#v", command.Env)
+				}
+			}
+			if pwdCount != 1 {
+				t.Fatalf("command environment contains %d PWD entries, want 1: %#v", pwdCount, command.Env)
+			}
+			for _, wantValue := range test.wantValues {
+				if !stringSliceContains(command.Env, wantValue) {
+					t.Fatalf("command environment lost %q: %#v", wantValue, command.Env)
+				}
+			}
+			if command.Dir == physical {
+				t.Fatalf("command directory was physically canonicalized to %q", physical)
+			}
+			if got := os.Getenv("PWD"); got != parentPWD {
+				t.Fatalf("parent PWD = %q, want unchanged %q", got, parentPWD)
+			}
+		})
+	}
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestEmbedWorkspacePreparesThroughExternalWorkspaceAlias(t *testing.T) {
 	requireSymlinkSupport(t)
 	root := t.TempDir()
@@ -402,7 +597,11 @@ func TestEmbedWorkspacePreparesThroughExternalWorkspaceAlias(t *testing.T) {
 		t.Fatal(err)
 	}
 	layout := newEmbedTestLayout(t, appDir, "go", workspaceAlias)
-	t.Setenv("PWD", layout.WorkDir)
+	stalePWD := filepath.Join(root, "unrelated-pwd")
+	if err := os.MkdirAll(stalePWD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PWD", stalePWD)
 	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
 	if err != nil {
 		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestEmbedMaterializationUsesGoToolSemantics(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		files   map[string]string
+		want    []string
+		absent  []string
+		wantErr string
+	}{
+		{
+			name:   "single file",
+			source: embedStringSource("message.txt"),
+			files:  map[string]string{"message.txt": "hello"},
+			want:   []string{"message.txt"},
+		},
+		{
+			name:   "multiple patterns",
+			source: embedFSSource("templates/*.txt config/app.json"),
+			files: map[string]string{
+				"templates/first.txt":  "first",
+				"templates/second.txt": "second",
+				"templates/skip.html":  "skip",
+				"config/app.json":      `{}`,
+			},
+			want:   []string{"config/app.json", "templates/first.txt", "templates/second.txt"},
+			absent: []string{"templates/skip.html"},
+		},
+		{
+			name: "repeated directives",
+			source: `package main
+
+import "embed"
+
+//go:embed first.txt
+//go:embed second.txt
+var files embed.FS
+
+func main() { _ = files }
+`,
+			files: map[string]string{"first.txt": "first", "second.txt": "second"},
+			want:  []string{"first.txt", "second.txt"},
+		},
+		{
+			name:   "quoted filename",
+			source: embedStringSource(`"hello world.txt"`),
+			files:  map[string]string{"hello world.txt": "hello"},
+			want:   []string{"hello world.txt"},
+		},
+		{
+			name:   "directory default exclusions",
+			source: embedFSSource("templates"),
+			files: map[string]string{
+				"templates/visible.txt":        "visible",
+				"templates/nested/data.txt":    "nested",
+				"templates/.hidden.txt":        "hidden",
+				"templates/_private.txt":       "private",
+				"templates/nested/.hidden.txt": "nested hidden",
+			},
+			want: []string{"templates/nested/data.txt", "templates/visible.txt"},
+			absent: []string{
+				"templates/.hidden.txt",
+				"templates/_private.txt",
+				"templates/nested/.hidden.txt",
+			},
+		},
+		{
+			name:   "all directory includes hidden names",
+			source: embedFSSource("all:templates"),
+			files: map[string]string{
+				"templates/visible.txt":  "visible",
+				"templates/.hidden.txt":  "hidden",
+				"templates/_private.txt": "private",
+			},
+			want: []string{"templates/.hidden.txt", "templates/_private.txt", "templates/visible.txt"},
+		},
+		{
+			name:   "overlapping patterns deduplicate",
+			source: embedFSSource("templates/*.txt templates/one.txt"),
+			files:  map[string]string{"templates/one.txt": "one", "templates/two.txt": "two"},
+			want:   []string{"templates/one.txt", "templates/two.txt"},
+		},
+		{
+			name:    "no match",
+			source:  embedStringSource("missing.txt"),
+			wantErr: "pattern missing.txt: no matching files found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			appDir := newEmbedTestApp(t, test.source, test.files)
+			layout := newEmbedTestLayout(t, appDir, "go", "")
+			result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("prepareBuildWorkspaceResult() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+			}
+			got := embedPlanPaths(result.EmbedPlan)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("embed plan = %#v, want %#v", got, test.want)
+			}
+			for _, relative := range test.want {
+				workspacePath := filepath.Join(layout.WorkDir, filepath.FromSlash(relative))
+				gotContent, readErr := os.ReadFile(workspacePath)
+				if readErr != nil {
+					t.Fatalf("read materialized %s: %v", relative, readErr)
+				}
+				if string(gotContent) != test.files[relative] {
+					t.Fatalf("materialized %s = %q, want %q", relative, gotContent, test.files[relative])
+				}
+			}
+			for _, relative := range test.absent {
+				if _, statErr := os.Stat(filepath.Join(layout.WorkDir, filepath.FromSlash(relative))); !os.IsNotExist(statErr) {
+					t.Fatalf("unmatched input %s was materialized: %v", relative, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestEmbedDiscoveryUsesBrowserBuildConstraints(t *testing.T) {
+	appDir := newEmbedTestApp(t, `package main
+
+func main() {}
+`, map[string]string{
+		"active.txt": "active",
+	})
+	writeTestFile(t, appDir, "browser.go", `//go:build js && wasm
+
+package main
+
+import _ "embed"
+
+//go:embed active.txt
+var active string
+`)
+	writeTestFile(t, appDir, "host.go", `//go:build linux
+
+package main
+
+import _ "embed"
+
+//go:embed missing-host.txt
+var host string
+`)
+
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"active.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+}
+
+func TestEmbedDiscoveryUsesTinyGoBuildConstraint(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("TinyGo is not available")
+	}
+	appDir := newEmbedTestApp(t, `package main
+
+func main() {}
+`, map[string]string{"tiny.txt": "tiny"})
+	writeTestFile(t, appDir, "tiny.go", `//go:build tinygo
+
+package main
+
+import _ "embed"
+
+//go:embed tiny.txt
+var tiny string
+`)
+	layout := newEmbedTestLayout(t, appDir, "tinygo", "")
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("tinygo", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"tiny.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+}
+
+func TestEmbedDiscoveryFiltersExternalDependencyInputs(t *testing.T) {
+	root := t.TempDir()
+	externalDir := filepath.Join(root, "external")
+	writeTestFile(t, externalDir, "go.mod", "module example.com/external\n\ngo 1.22\n")
+	writeTestFile(t, externalDir, "content.go", `package external
+
+import _ "embed"
+
+//go:embed external.txt
+var Message string
+`)
+	writeTestFile(t, externalDir, "external.txt", "external-secret")
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, appDir, "go.mod", "module example.com/app\n\ngo 1.22\n\nrequire example.com/external v0.0.0\n\nreplace example.com/external => ../external\n")
+	writeTestFile(t, appDir, "main.go", `package main
+
+import "example.com/external"
+
+func main() { _ = external.Message }
+`)
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if len(result.EmbedPlan.Files) != 0 {
+		t.Fatalf("external embed files entered local plan: %#v", result.EmbedPlan.Files)
+	}
+	if matches, err := filepath.Glob(filepath.Join(layout.WorkDir, "**", "external.txt")); err != nil || len(matches) != 0 {
+		t.Fatalf("external embed file materialized: matches=%#v err=%v", matches, err)
+	}
+}
+
+func TestEmbedWorkspaceBuildsRootAndInternalPackageInputs(t *testing.T) {
+	t.Run("root package", func(t *testing.T) {
+		appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "root payload"})
+		output, err := buildApp(buildOptions{appDir: appDir, compiler: "go"})
+		if err != nil {
+			t.Fatalf("buildApp() error: %v", err)
+		}
+		if _, err := os.Stat(output); err != nil {
+			t.Fatalf("built output missing: %v", err)
+		}
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "message.txt"), "root payload")
+	})
+
+	t.Run("child entry with generated GOX dependency", func(t *testing.T) {
+		appDir := t.TempDir()
+		writeTestFile(t, appDir, "go.mod", "module example.com/multiembed\n\ngo 1.22\n")
+		writeTestFile(t, appDir, "cmd/app/main.go", "package main\n\nfunc main() {}\n")
+		writeTestFile(t, appDir, "cmd/app/app.gox", `package main
+
+import (
+	"example.com/multiembed/internal/content"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func App() gf.Node {
+	return <p>{content.Message}</p>
+}
+`)
+		writeTestFile(t, appDir, "internal/content/content.go", `package content
+
+import _ "embed"
+
+//go:embed payload.txt
+var Message string
+`)
+		writeTestFile(t, appDir, "internal/content/payload.txt", "internal payload")
+		writeTestFile(t, appDir, manifestName, `{"entry":"cmd/app","compiler":"go"}`)
+		output, err := buildApp(buildOptions{appDir: appDir, compiler: "go"})
+		if err != nil {
+			t.Fatalf("buildApp() error: %v", err)
+		}
+		if _, err := os.Stat(output); err != nil {
+			t.Fatalf("built output missing: %v", err)
+		}
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "internal", "content", "payload.txt"), "internal payload")
+	})
+}
+
+func TestEmbedWorkspaceSupportsExternalWorkspace(t *testing.T) {
+	appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "external workspace"})
+	externalBase := t.TempDir()
+	output, err := buildApp(buildOptions{appDir: appDir, compiler: "go", workspace: externalBase})
+	if err != nil {
+		t.Fatalf("buildApp() error: %v", err)
+	}
+	if _, err := os.Stat(output); err != nil {
+		t.Fatalf("built output missing: %v", err)
+	}
+	layout := newEmbedTestLayout(t, appDir, "go", externalBase)
+	assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "message.txt"), "external workspace")
+	if matches, err := filepath.Glob(filepath.Join(layout.WorkspaceRoot, "**", "goxc-embed-overlay-*.json")); err != nil || len(matches) != 0 {
+		t.Fatalf("temporary overlay leaked into workspace: matches=%#v err=%v", matches, err)
+	}
+}
+
+func TestEmbedWorkspaceBuildsWithTinyGo(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("TinyGo is not available")
+	}
+	t.Setenv("GOFLAGS", strings.TrimSpace(os.Getenv("GOFLAGS")+" -buildvcs=false"))
+	appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "tinygo payload"})
+	output, err := buildApp(buildOptions{appDir: appDir, compiler: "tinygo"})
+	if err != nil {
+		t.Fatalf("buildApp() error: %v", err)
+	}
+	if _, err := os.Stat(output); err != nil {
+		t.Fatalf("built output missing: %v", err)
+	}
+	layout := newEmbedTestLayout(t, appDir, "tinygo", "")
+	assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "message.txt"), "tinygo payload")
+}
+
+func TestEmbedMaterializationRejectsUnsafeInputs(t *testing.T) {
+	t.Run("symlinked file", func(t *testing.T) {
+		appDir := newEmbedTestApp(t, embedStringSource("message.txt"), nil)
+		external := filepath.Join(t.TempDir(), "outside.txt")
+		writeTestFile(t, filepath.Dir(external), filepath.Base(external), "outside-secret")
+		if err := os.Symlink(external, filepath.Join(appDir, "message.txt")); err != nil {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+		if err == nil {
+			t.Fatal("prepareBuildWorkspaceResult() succeeded for symlinked embedded input")
+		}
+		if content, readErr := os.ReadFile(filepath.Join(layout.WorkDir, "message.txt")); readErr == nil && string(content) == "outside-secret" {
+			t.Fatal("external symlink target was copied")
+		}
+	})
+
+	t.Run("symlinked directory", func(t *testing.T) {
+		appDir := newEmbedTestApp(t, embedFSSource("templates"), nil)
+		external := t.TempDir()
+		writeTestFile(t, external, "outside.txt", "outside-secret")
+		if err := os.Symlink(external, filepath.Join(appDir, "templates")); err != nil {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		if _, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", ".")); err == nil {
+			t.Fatal("prepareBuildWorkspaceResult() succeeded for symlinked embedded directory")
+		}
+	})
+
+	t.Run("destination traversal", func(t *testing.T) {
+		appDir := t.TempDir()
+		appWorkDir := t.TempDir()
+		outside := filepath.Join(filepath.Dir(appWorkDir), "escape.txt")
+		_, _, err := resolveEmbedInputPlan(appDir, appWorkDir, map[string]string{outside: filepath.Join(appDir, "source.txt")}, []embedListPackage{{
+			Dir:        appWorkDir,
+			ImportPath: "example.com/app",
+			EmbedFiles: []string{"../escape.txt"},
+		}})
+		if err == nil || !strings.Contains(err.Error(), "must stay inside") {
+			t.Fatalf("resolveEmbedInputPlan() error = %v, want workspace escape", err)
+		}
+	})
+
+	t.Run("nested module and tool output", func(t *testing.T) {
+		appDir := newEmbedTestApp(t, embedFSSource("nested .goframe"), nil)
+		writeTestFile(t, appDir, "nested/go.mod", "module example.com/nested\n\ngo 1.22\n")
+		writeTestFile(t, appDir, "nested/secret.txt", "nested-secret")
+		writeTestFile(t, appDir, ".goframe/secret.txt", "tool-secret")
+		layout := newEmbedTestLayout(t, appDir, "go", "")
+		_, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+		if err == nil {
+			t.Fatal("prepareBuildWorkspaceResult() succeeded for excluded embed trees")
+		}
+		for _, secret := range []string{"nested-secret", "tool-secret"} {
+			if workspaceContainsBytes(t, layout.WorkDir, secret) {
+				t.Fatalf("workspace contains excluded bytes %q", secret)
+			}
+		}
+	})
+}
+
+func TestEmbedMaterializationDoesNotCopyUnrelatedFiles(t *testing.T) {
+	appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{
+		"message.txt": "included",
+		"secret.txt":  "sensitive-unrelated-bytes",
+	})
+	layout := newEmbedTestLayout(t, appDir, "go", "")
+	if _, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", ".")); err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(layout.WorkDir, "secret.txt")); !os.IsNotExist(err) {
+		t.Fatalf("unrelated file was copied: %v", err)
+	}
+}
+
+func newEmbedTestApp(t *testing.T, source string, files map[string]string) string {
+	t.Helper()
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "go.mod", "module example.com/embedapp\n\ngo 1.22\n")
+	writeTestFile(t, appDir, "main.go", source)
+	for relative, content := range files {
+		writeTestFile(t, appDir, relative, content)
+	}
+	return appDir
+}
+
+func newEmbedTestLayout(t *testing.T, appDir, compiler, workspace string) BuildLayout {
+	t.Helper()
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir, compiler: compiler, workspace: workspace})
+	if err != nil {
+		t.Fatalf("newBuildLayout() error: %v", err)
+	}
+	return layout
+}
+
+func defaultEmbedManifest(compiler, entry string) projectManifest {
+	return projectManifest{
+		Name:     "embed-test",
+		Entry:    entry,
+		Compiler: compiler,
+		WASM:     "bundle.wasm",
+		Assets:   autoManifestAssets(),
+	}
+}
+
+func embedStringSource(pattern string) string {
+	return `package main
+
+import _ "embed"
+
+//go:embed ` + pattern + `
+var payload string
+
+func main() { _ = payload }
+`
+}
+
+func embedFSSource(pattern string) string {
+	return `package main
+
+import "embed"
+
+//go:embed ` + pattern + `
+var payload embed.FS
+
+func main() { _ = payload }
+`
+}
+
+func embedPlanPaths(plan embedInputPlan) []string {
+	paths := make([]string, 0, len(plan.Files))
+	for _, file := range plan.Files {
+		paths = append(paths, file.DisplayPath)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func assertEmbedFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(content) != want {
+		t.Fatalf("%s = %q, want %q", path, content, want)
+	}
+}
+
+func workspaceContainsBytes(t *testing.T, root, value string) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(root, func(current string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(current)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(string(content), value) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("inspect workspace: %v", err)
+	}
+	return found
+}

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -272,7 +272,7 @@ func TestEmbedInputPlanResolvesPhysicalWorkspaceAlias(t *testing.T) {
 	}
 }
 
-func TestEmbedDiscoveryOverlayUsesPhysicalWorkspacePath(t *testing.T) {
+func TestEmbedDiscoveryOverlayPreservesLexicalWorkspacePath(t *testing.T) {
 	requireSymlinkSupport(t)
 	root := t.TempDir()
 	appDir := filepath.Join(root, "app")
@@ -301,12 +301,121 @@ func TestEmbedDiscoveryOverlayUsesPhysicalWorkspacePath(t *testing.T) {
 	if err := json.Unmarshal(content, &overlay); err != nil {
 		t.Fatal(err)
 	}
-	want, err := canonicalPathForComparison(filepath.Join(workspaceRoot, "message.txt"))
+	want, err := filepath.Abs(filepath.Join(workspaceAlias, "message.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	want = filepath.Clean(want)
 	if got := overlay.Replace[want]; got != filepath.Join(appDir, "message.txt") {
-		t.Fatalf("physical overlay replacement = %q, want authored message.txt; replacements=%#v", got, overlay.Replace)
+		t.Fatalf("lexical overlay replacement = %q, want authored message.txt; replacements=%#v", got, overlay.Replace)
+	}
+	physical, err := canonicalPathForComparison(filepath.Join(workspaceRoot, "message.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if physical != want {
+		if _, ok := overlay.Replace[physical]; ok {
+			t.Fatalf("overlay retained physical replacement key %q: %#v", physical, overlay.Replace)
+		}
+	}
+}
+
+func TestEmbedDiscoveryOverlayUsesLexicalWorkspaceAliasIntegration(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	physicalParent := filepath.Join(root, "physical")
+	workspaceRoot := filepath.Join(physicalParent, "workspace")
+	aliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	source := `package main
+
+import _ "embed"
+
+//go:embed message.txt
+var message string
+
+func main() { _ = message }
+`
+	writeTestFile(t, appDir, "go.mod", "module example.com/lexical-overlay\n\ngo 1.22\n")
+	writeTestFile(t, appDir, "main.go", source)
+	writeTestFile(t, appDir, "message.txt", "authored")
+	if err := os.MkdirAll(workspaceRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, workspaceRoot, "go.mod", "module example.com/lexical-overlay\n\ngo 1.22\n")
+	writeTestFile(t, workspaceRoot, "main.go", source)
+
+	discovery, err := createEmbedDiscoveryOverlay(appDir, workspaceAlias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discovery.Cleanup()
+	t.Setenv("PWD", workspaceAlias)
+	packages, err := listGoEmbedPackages(workspaceAlias, discovery.OverlayPath, false)
+	if err != nil {
+		t.Fatalf("listGoEmbedPackages() error: %v", err)
+	}
+	if err := embedPackageMetadataError(packages); err != nil {
+		t.Fatalf("embedPackageMetadataError() error: %v", err)
+	}
+	var discovered *embedListPackage
+	for index := range packages {
+		if packages[index].ImportPath == "example.com/lexical-overlay" {
+			discovered = &packages[index]
+			break
+		}
+	}
+	if discovered == nil {
+		t.Fatalf("root package missing from go list output: %#v", packages)
+	}
+	if got, want := discovered.EmbedPatterns, []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("EmbedPatterns = %#v, want %#v", got, want)
+	}
+	if got, want := discovered.EmbedFiles, []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("EmbedFiles = %#v, want %#v", got, want)
+	}
+	_, plan, err := resolveEmbedInputPlan(appDir, workspaceAlias, discovery.Candidates, packages)
+	if err != nil {
+		t.Fatalf("resolveEmbedInputPlan() error: %v", err)
+	}
+	if got, want := embedPlanPaths(plan), []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+}
+
+func TestEmbedWorkspacePreparesThroughExternalWorkspaceAlias(t *testing.T) {
+	requireSymlinkSupport(t)
+	root := t.TempDir()
+	appDir := newEmbedTestApp(t, embedStringSource("message.txt"), map[string]string{"message.txt": "external workspace"})
+	physicalParent := filepath.Join(root, "physical")
+	physicalWorkspace := filepath.Join(physicalParent, "workspace")
+	aliasParent := filepath.Join(root, "physical-alias")
+	workspaceAlias := filepath.Join(aliasParent, "workspace")
+	if err := os.MkdirAll(physicalWorkspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalParent, aliasParent); err != nil {
+		t.Fatal(err)
+	}
+	layout := newEmbedTestLayout(t, appDir, "go", workspaceAlias)
+	t.Setenv("PWD", layout.WorkDir)
+	result, err := prepareBuildWorkspaceResult(layout, defaultEmbedManifest("go", "."))
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResult() error: %v", err)
+	}
+	if !result.EmbedPlan.Resolved {
+		t.Fatal("embed plan was not resolved")
+	}
+	if got, want := embedPlanPaths(result.EmbedPlan), []string{"message.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("embed plan = %#v, want %#v", got, want)
+	}
+	assertEmbedFileContent(t, filepath.Join(layout.WorkDir, "message.txt"), "external workspace")
+	if matches, err := filepath.Glob(filepath.Join(layout.WorkspaceRoot, "goxc-embed-*.json")); err != nil || len(matches) != 0 {
+		t.Fatalf("temporary overlay leaked into workspace: matches=%#v err=%v", matches, err)
 	}
 }
 
@@ -703,9 +812,14 @@ func TestEmbedDiscoveryPreservesUnsafeCandidateProvenance(t *testing.T) {
 	requireSymlinkSupport(t)
 	root := t.TempDir()
 	appDir := filepath.Join(root, "app")
-	appWorkDir := filepath.Join(root, "work")
+	physicalWorkspace := filepath.Join(root, "physical-workspace")
+	workspaceAlias := filepath.Join(root, "workspace-alias")
+	appWorkDir := filepath.Join(workspaceAlias, "work")
 	writeTestFile(t, appDir, "main.go", embedFSSource("*"))
-	if err := os.MkdirAll(appWorkDir, 0o755); err != nil {
+	if err := os.MkdirAll(physicalWorkspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(physicalWorkspace, workspaceAlias); err != nil {
 		t.Fatal(err)
 	}
 	external := filepath.Join(root, "external.txt")
@@ -743,6 +857,17 @@ func TestEmbedDiscoveryPreservesUnsafeCandidateProvenance(t *testing.T) {
 	if sentinel == "" || sentinel == external || sentinel == link {
 		discovery.Cleanup()
 		t.Fatalf("unsafe overlay backing = %q", sentinel)
+	}
+	physicalDestination, err := canonicalPathForComparison(destination)
+	if err != nil {
+		discovery.Cleanup()
+		t.Fatal(err)
+	}
+	if physicalDestination != destination {
+		if _, ok := overlay.Replace[physicalDestination]; ok {
+			discovery.Cleanup()
+			t.Fatalf("unsafe overlay retained physical replacement key %q: %#v", physicalDestination, overlay.Replace)
+		}
 	}
 	if _, inside, err := relativePathBelow(appDir, sentinel); err != nil || inside {
 		discovery.Cleanup()

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -32,13 +32,14 @@ const (
 )
 
 type packageOptions struct {
-	appDir    string
-	compiler  string
-	outDir    string
-	workspace string
-	compress  map[string]bool
-	assetHash bool
-	preload   bool
+	appDir          string
+	compiler        string
+	outDir          string
+	workspace       string
+	compress        map[string]bool
+	assetHash       bool
+	preload         bool
+	recordEmbedPlan func(embedInputPlan)
 }
 
 type packageAssetPlan struct {
@@ -223,10 +224,14 @@ func packageApp(options packageOptions) error {
 	} else if err := validatePathBelowRoot(layout.WorkspaceRoot, options.outDir, "package output directory", true); err != nil {
 		return err
 	}
-	entryPath, err := prepareBuildWorkspace(layout, manifest)
+	workspaceResult, err := prepareBuildWorkspaceResult(layout, manifest)
+	if options.recordEmbedPlan != nil {
+		options.recordEmbedPlan(workspaceResult.EmbedPlan)
+	}
 	if err != nil {
 		return fmt.Errorf("prepare package workspace: %w", err)
 	}
+	entryPath := workspaceResult.EntryPath
 
 	tempDir, err := os.MkdirTemp("", "goxc-package-*")
 	if err != nil {

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -145,7 +145,10 @@ func copyAuthoredGoFiles(sourceRoot, destinationRoot string) error {
 			return nil
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("source path %s is a symlink; symlinked source files are not supported", sourcePath)
+			if filepath.Ext(sourcePath) == ".go" && !strings.HasSuffix(sourcePath, ".gox.go") {
+				return fmt.Errorf("source path %s is a symlink; symlinked source files are not supported", sourcePath)
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			return nil
@@ -335,7 +338,10 @@ func findGOXFiles(path string) ([]string, error) {
 			return nil
 		}
 		if entry.Type()&os.ModeSymlink != 0 {
-			return fmt.Errorf("GOX source path %s is a symlink; symlinked source files are not supported", current)
+			if filepath.Ext(current) == ".gox" {
+				return fmt.Errorf("GOX source path %s is a symlink; symlinked source files are not supported", current)
+			}
+			return nil
 		}
 		if !entry.IsDir() && filepath.Ext(current) == ".gox" {
 			files = append(files, current)

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -16,40 +16,56 @@ var (
 )
 
 func prepareBuildWorkspace(layout BuildLayout, manifest projectManifest) (string, error) {
+	result, err := prepareBuildWorkspaceResult(layout, manifest)
+	return result.EntryPath, err
+}
+
+type buildWorkspaceResult struct {
+	EntryPath string
+	EmbedPlan embedInputPlan
+}
+
+func prepareBuildWorkspaceResult(layout BuildLayout, manifest projectManifest) (buildWorkspaceResult, error) {
+	var result buildWorkspaceResult
 	if err := validateWorkspaceRoot(layout); err != nil {
-		return "", err
+		return result, err
 	}
 	entry, err := resolveEntryPackageDir(layout.AppDir, manifest.Entry)
 	if err != nil {
-		return "", err
+		return result, err
 	}
 	if err := validatePathBelowRoot(layout.WorkspaceRoot, layout.WorkDir, "workspace work directory", true); err != nil {
-		return "", err
+		return result, err
 	}
 	if err := refreshDirectory(layout.WorkDir); err != nil {
-		return "", err
+		return result, err
 	}
 	config := workspaceModuleConfigForApp(layout.AppDir)
 	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
 	if err := copyAuthoredGoFiles(layout.AppDir, appWorkDir); err != nil {
-		return "", err
+		return result, err
 	}
 	if err := generateIntoDirectory(layout.AppDir, appWorkDir, false); err != nil {
-		return "", err
+		return result, err
 	}
 	if config.CopyGoframeRuntime {
 		if err := copyGoframeRuntimePackage(layout.WorkDir, config.ModuleRoot); err != nil {
-			return "", err
+			return result, err
 		}
 	}
 	if err := writeWorkspaceGoMod(layout.WorkDir, layout.AppDir); err != nil {
-		return "", err
+		return result, err
 	}
 	entryRelative, err := filepath.Rel(layout.AppDir, entry)
 	if err != nil {
-		return "", fmt.Errorf("resolve entry workspace path: %w", err)
+		return result, fmt.Errorf("resolve entry workspace path: %w", err)
 	}
-	return filepath.Join(appWorkDir, entryRelative), nil
+	result.EntryPath = filepath.Join(appWorkDir, entryRelative)
+	result.EmbedPlan, err = discoverAndMaterializeEmbedInputs(layout, appWorkDir, result.EntryPath)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 func resolveEntryPackageDir(appDir, entry string) (string, error) {

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -36,6 +36,8 @@ const counters = {
     reloadEventsPublished: 0,
     catchUpReloads: 0,
     previousProcessCatchUpReloads: 0,
+    embedReloads: 0,
+    embedFailedAttempts: 0,
     publicationProbeBatches: 0,
     completeResponsesDuringBuild: 0,
     oldGenerationIndexResponses: 0,
@@ -92,7 +94,7 @@ try {
     client1 = await connect(initialTarget.webSocketDebuggerUrl);
     await prepareClient(client1);
     await navigate(client1, `${serverURL}/?smoke=initial`);
-    const initial = await waitForPageState(client1, { gox: "gox-initial", go: "go-initial", index: "index-initial" });
+    const initial = await waitForPageState(client1, { gox: "gox-initial", go: "go-initial", index: "index-initial", embedded: "embed-alpha" });
     assert(initial.pageLoads === 1, `initial page loads = ${initial.pageLoads}, want 1`);
     assert(initial.generation === 1, `initial generation = ${initial.generation}, want 1`);
     assert(/^[0-9a-f]{32}$/.test(initial.instance), `initial process instance = ${JSON.stringify(initial.instance)}, want a 32-character hex token`);
@@ -149,7 +151,6 @@ try {
     const burstStart = lines.length;
     for (const value of ["burst-one", "burst-two", "burst-final"]) {
         await writeGOX(value);
-        await wait(20);
     }
     await waitForBuild(nextBuild, "succeeded", burstStart);
     await assertSuccessfulReload(client1, burstBaseline, { gox: "burst-final", go: "go-rebuild", index: "index-rebuild" }, ++activeGeneration);
@@ -182,6 +183,47 @@ try {
     recordSuccessfulReload();
     nextBuild++;
     console.log("failed build recovery reload: ok");
+
+    const embedBaseline = await pageState(client1);
+    await writeEmbeddedMessage("embed-beta");
+    await waitForBuild(nextBuild, "succeeded");
+    await assertSuccessfulReload(client1, embedBaseline, {
+        gox: "recovered",
+        go: "go-rebuild",
+        index: "index-rebuild",
+        embedded: "embed-beta",
+    }, ++activeGeneration);
+    counters.embedReloads++;
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("embedded payload reload: ok");
+
+    const removedEmbedBaseline = await pageState(client1);
+    await rm(join(appDir, "embedded-message.txt"));
+    await waitForBuild(nextBuild, "failed");
+    counters.failedPackageAttempts++;
+    counters.embedFailedAttempts++;
+    nextBuild++;
+    await wait(250);
+    const afterEmbedRemoval = await pageState(client1);
+    assert(afterEmbedRemoval.pageLoads === removedEmbedBaseline.pageLoads
+        && afterEmbedRemoval.reloadEvents === removedEmbedBaseline.reloadEvents,
+        `removed embedded payload reloaded the browser: ${JSON.stringify({ removedEmbedBaseline, afterEmbedRemoval })}`);
+    assert(afterEmbedRemoval.embedded === "embed-beta", `removed embedded payload changed the active page: ${JSON.stringify(afterEmbedRemoval)}`);
+    console.log("embedded payload removal preservation: ok");
+
+    await writeEmbeddedMessage("embed-gamma");
+    await waitForBuild(nextBuild, "succeeded");
+    await assertSuccessfulReload(client1, afterEmbedRemoval, {
+        gox: "recovered",
+        go: "go-rebuild",
+        index: "index-rebuild",
+        embedded: "embed-gamma",
+    }, ++activeGeneration);
+    counters.embedReloads++;
+    recordSuccessfulReload();
+    nextBuild++;
+    console.log("embedded payload recovery reload: ok");
 
     const secondTarget = await client1.call("Target.createTarget", { url: "about:blank" });
     const target = await waitForTarget(debugPort, secondTarget.targetId);
@@ -298,6 +340,8 @@ try {
     console.log(`reload events received by client 2: ${client2Final.reloadEvents}`);
     console.log(`catch-up reloads: ${counters.catchUpReloads}`);
     console.log(`previous-process catch-up reloads: ${counters.previousProcessCatchUpReloads}`);
+    console.log(`embedded payload reloads: ${counters.embedReloads}`);
+    console.log(`embedded payload failed attempts: ${counters.embedFailedAttempts}`);
     console.log("connected subscribers at shutdown: 0");
     console.log(`publication probe batches: ${counters.publicationProbeBatches}`);
     console.log(`complete responses during rebuild: ${counters.completeResponsesDuringBuild}`);
@@ -334,17 +378,23 @@ async function writeApplication(gox, go, index) {
     await writeFile(join(appDir, "goframe.json"), `{"name":"dev-reload-smoke","entry":".","compiler":"go","assets":"assets"}\n`);
     await writeFile(join(appDir, "main.go"), `//go:build js && wasm\n\npackage main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc main() {\n    done := make(chan struct{})\n    gf.Mount("root", App)\n    <-done\n}\n`);
     await writeGoMessage(go);
+    await writeFile(join(appDir, "embedded.go"), `package main\n\nimport _ "embed"\n\n//go:embed embedded-message.txt\nvar embeddedMessage string\n`);
+    await writeEmbeddedMessage("embed-alpha");
     await writeGOX(gox);
     await writeIndex(index);
     await writeFile(join(appDir, "assets", "marker.txt"), "complete asset\n");
 }
 
 async function writeGOX(value) {
-    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span></main>\n}\n`);
+    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span><span id="embedded-value">{embeddedMessage}</span></main>\n}\n`);
 }
 
 async function writeGoMessage(value) {
     await writeFile(join(appDir, "message.go"), `package main\n\nfunc message() string { return ${JSON.stringify(value)} }\n`);
+}
+
+async function writeEmbeddedMessage(value) {
+    await writeFile(join(appDir, "embedded-message.txt"), value);
 }
 
 async function writeIndex(value) {
@@ -408,6 +458,7 @@ async function pageState(client) {
             readyState: document.readyState,
             gox: document.querySelector("#gox-version")?.textContent || "",
             go: document.querySelector("#go-version")?.textContent || "",
+            embedded: document.querySelector("#embedded-value")?.textContent || "",
             index: document.querySelector("#index-version")?.textContent || "",
             pageLoads: Number(sessionStorage.getItem("goframe-dev-page-loads") || "0"),
             reloadEvents: Number(sessionStorage.getItem("goframe-dev-reload-events") || "0"),


### PR DESCRIPTION
## Summary

Adds `//go:embed` support to isolated `goxc` workspaces and the watched
development loop.

Previously, authored Go files were copied into the hidden workspace without
their embedded payloads. This caused valid builds to fail and prevented
payload-only changes from triggering `goxc dev` rebuilds.

## Changes

- Uses Go and TinyGo package metadata as the source of truth for effective
  `EmbedPatterns` and `EmbedFiles`.
- Materializes only selected authored embed inputs into the hidden workspace.
- Supports root, internal-package, child-entry, multi-package GOX, and external
  workspace layouts.
- Preserves standard pattern behavior for files, globs, directories, repeated
  directives, quoted names, and `all:`.
- Tracks embedded file contents and pattern membership in `goxc dev`.
- Rebuilds and reloads after effective payload changes, additions, removals, and
  restorations.
- Preserves the last successful package generation and publishes no reload after
  failed embed builds.
- Uses exact-path watches for literal files and bounded tree watches for
  directories and globs.
- Rejects selected symlinks, irregular files, workspace-only inputs, generated
  `go.mod`, and generated `.gox.go` files without following external targets.
- Keeps discovery overlays and unsafe sentinels temporary and outside authored
  application state.

## Validation

The change includes focused, repeated, race-enabled, integration, and browser
coverage for:

- single, multiple, repeated, quoted, directory, glob, and `all:` patterns;
- browser and TinyGo build constraints;
- internal packages, generated GOX imports, child entries, and external
  workspaces;
- payload edits, matching-file creation, removal, failed rebuilds, and recovery;
- unrelated-file suppression and exact-watch polling boundaries;
- broad-pattern symlinks, irregular files, missing provenance, and generated
  workspace collisions.

The full Go, debug-tag, race, vet, browser-smoke, documentation, artifact, and
module-path checks pass.

The complete Go 1.22.12 / TinyGo 0.41.1 example matrix remains byte-identical,
with no runtime, workflow, dependency, or size-budget changes.

## Compatibility and limits

This is an internal `goxc` correctness change. It does not change the public
framework API, GOX language, manifest schema, package metadata schema, runtime,
or packaged application format.

Embed inputs must be authored regular files inside the materialized application
tree. Workspace-generated `go.mod` and `.gox.go` files are intentionally
rejected as embed payloads, so root-level patterns that select reserved workspace
state fail closed rather than embedding transformed or generated bytes.