### PR TITLE
fix(goxc): isolate compiler subprocess environments

### DIFF
--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -199,10 +199,14 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 			entryArg,
 		)
 	}
-	command.Dir = commandDir
-	command.Env = compilerEnvironment(compiler)
-	if compiler == "go" {
-		command.Env = append(command.Env, "GOOS=js", "GOARCH=wasm")
+	if err := configureWorkspaceCompilerCommand(command, compilerEnvironmentOptions{
+		Compiler:         compiler,
+		Invocation:       compilerInvocationBuild,
+		WorkingDirectory: commandDir,
+		GoFlags:          workspaceCompilerBaseGoFlags,
+		StandardGoTarget: compiler == "go",
+	}); err != nil {
+		return err
 	}
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
@@ -213,20 +217,6 @@ func compileWASM(compiler, entryPath, outputPath string) error {
 		return err
 	}
 	return nil
-}
-
-func compilerEnvironment(compiler string) []string {
-	environment := os.Environ()
-	if compiler != "tinygo" || os.Getenv("XDG_CACHE_HOME") != "" {
-		return environment
-	}
-	if goCache := os.Getenv("GOCACHE"); goCache != "" {
-		cache := filepath.Join(filepath.Dir(goCache), "goxc-xdg-cache")
-		if err := os.MkdirAll(cache, 0o755); err == nil {
-			environment = append(environment, "XDG_CACHE_HOME="+cache)
-		}
-	}
-	return environment
 }
 
 func validateCompiler(compiler string) error {

--- a/cmd/goxc/build_external_module_test.go
+++ b/cmd/goxc/build_external_module_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestBuildAppSupportsExternalModuleComponentPackage(t *testing.T) {
+func TestExternalModuleEnvironmentIsolation(t *testing.T) {
 	root := t.TempDir()
 	appDir := filepath.Join(root, "app")
 	uiDir := filepath.Join(root, "ui")
@@ -45,10 +45,8 @@ func App() gf.Node {
 }
 `)
 
-	t.Setenv("GOPROXY", "off")
-	t.Setenv("GOSUMDB", "off")
-	t.Setenv("GOWORK", "off")
-	t.Setenv("GOFLAGS", "-mod=mod")
+	workPath, workContent := writeHostileParentWorkspace(t, root)
+	setHostileCompilerWorkflowEnvironment(t, workPath, "-mod=vendor")
 
 	workspaceBase := filepath.Join(t.TempDir(), "workspace")
 	outputPath, err := buildApp(buildOptions{
@@ -103,6 +101,7 @@ func App() gf.Node {
 		t.Fatalf("external dependency GOX source was generated next to dependency source: %v", err)
 	}
 	assertWorkspaceDoesNotContainGeneratedExternalGOX(t, layout.WorkDir)
+	assertTestFileUnchanged(t, workPath, workContent)
 }
 
 func assertWorkspaceDoesNotContainGeneratedExternalGOX(t *testing.T, workDir string) {

--- a/cmd/goxc/compiler_env.go
+++ b/cmd/goxc/compiler_env.go
@@ -62,10 +62,7 @@ func workspaceCompilerEnvironmentFrom(base []string, options compilerEnvironment
 
 	environment := append([]string(nil), base...)
 	if options.Compiler == "tinygo" {
-		environment, err = withTinyGoCacheFallback(environment)
-		if err != nil {
-			return nil, "", compilerEnvironmentError(options, "XDG_CACHE_HOME", err)
-		}
+		environment = withTinyGoCacheFallback(environment)
 	}
 
 	controlled := []string{"PWD", "GOWORK", "GO111MODULE", "GOFLAGS", "GOOS", "GOARCH", "CGO_ENABLED"}
@@ -105,19 +102,19 @@ func compilerEnvironmentError(options compilerEnvironmentOptions, key string, er
 	return fmt.Errorf("prepare %s %s compiler environment for %s: %s: %w", compiler, invocation, directory, key, err)
 }
 
-func withTinyGoCacheFallback(environment []string) ([]string, error) {
+func withTinyGoCacheFallback(environment []string) []string {
 	if value, ok := environmentValue(environment, "XDG_CACHE_HOME"); ok && value != "" {
-		return environment, nil
+		return environment
 	}
 	goCache, ok := environmentValue(environment, "GOCACHE")
 	if !ok || goCache == "" {
-		return environment, nil
+		return environment
 	}
 	cache := filepath.Join(filepath.Dir(goCache), "goxc-xdg-cache")
 	if err := os.MkdirAll(cache, 0o755); err != nil {
-		return nil, fmt.Errorf("create TinyGo cache fallback %s: %w", cache, err)
+		return environment
 	}
-	return setEnvironmentValue(environment, "XDG_CACHE_HOME", cache), nil
+	return setEnvironmentValue(environment, "XDG_CACHE_HOME", cache)
 }
 
 func removeEnvironmentKeys(environment []string, keys []string) []string {

--- a/cmd/goxc/compiler_env.go
+++ b/cmd/goxc/compiler_env.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type compilerInvocationKind string
+
+const (
+	compilerInvocationBuild          compilerInvocationKind = "build"
+	compilerInvocationEmbedDiscovery compilerInvocationKind = "embed discovery"
+	workspaceCompilerBaseGoFlags                            = "-buildvcs=false"
+)
+
+type compilerEnvironmentOptions struct {
+	Compiler         string
+	Invocation       compilerInvocationKind
+	WorkingDirectory string
+	GoFlags          string
+	StandardGoTarget bool
+}
+
+type compilerEnvironmentValue struct {
+	key   string
+	value string
+}
+
+func configureWorkspaceCompilerCommand(command *exec.Cmd, options compilerEnvironmentOptions) error {
+	environment, directory, err := workspaceCompilerEnvironment(options)
+	if err != nil {
+		return err
+	}
+	command.Dir = directory
+	command.Env = environment
+	return nil
+}
+
+func workspaceCompilerEnvironment(options compilerEnvironmentOptions) ([]string, string, error) {
+	return workspaceCompilerEnvironmentFrom(os.Environ(), options)
+}
+
+func workspaceCompilerEnvironmentFrom(base []string, options compilerEnvironmentOptions) ([]string, string, error) {
+	if options.Compiler != "go" && options.Compiler != "tinygo" {
+		return nil, "", compilerEnvironmentError(options, "compiler", fmt.Errorf("unsupported compiler %q", options.Compiler))
+	}
+	if options.Invocation == "" {
+		return nil, "", compilerEnvironmentError(options, "invocation", fmt.Errorf("invocation kind is required"))
+	}
+	directory, err := filepath.Abs(options.WorkingDirectory)
+	if err != nil {
+		return nil, "", compilerEnvironmentError(options, "PWD", err)
+	}
+	directory = filepath.Clean(directory)
+	if strings.TrimSpace(options.GoFlags) == "" {
+		return nil, "", compilerEnvironmentError(options, "GOFLAGS", fmt.Errorf("an explicit non-empty owned value is required to override GOENV defaults"))
+	}
+
+	environment := append([]string(nil), base...)
+	if options.Compiler == "tinygo" {
+		environment, err = withTinyGoCacheFallback(environment)
+		if err != nil {
+			return nil, "", compilerEnvironmentError(options, "XDG_CACHE_HOME", err)
+		}
+	}
+
+	controlled := []string{"PWD", "GOWORK", "GO111MODULE", "GOFLAGS", "GOOS", "GOARCH", "CGO_ENABLED"}
+	environment = removeEnvironmentKeys(environment, controlled)
+	values := []compilerEnvironmentValue{
+		{key: "PWD", value: directory},
+		{key: "GOWORK", value: "off"},
+		{key: "GO111MODULE", value: "on"},
+		{key: "GOFLAGS", value: options.GoFlags},
+	}
+	if options.StandardGoTarget {
+		values = append(values,
+			compilerEnvironmentValue{key: "GOOS", value: "js"},
+			compilerEnvironmentValue{key: "GOARCH", value: "wasm"},
+			compilerEnvironmentValue{key: "CGO_ENABLED", value: "0"},
+		)
+	}
+	for _, value := range values {
+		environment = append(environment, value.key+"="+value.value)
+	}
+	return environment, directory, nil
+}
+
+func compilerEnvironmentError(options compilerEnvironmentOptions, key string, err error) error {
+	directory := options.WorkingDirectory
+	if directory == "" {
+		directory = "."
+	}
+	invocation := options.Invocation
+	if invocation == "" {
+		invocation = "unknown"
+	}
+	compiler := options.Compiler
+	if compiler == "" {
+		compiler = "unknown"
+	}
+	return fmt.Errorf("prepare %s %s compiler environment for %s: %s: %w", compiler, invocation, directory, key, err)
+}
+
+func withTinyGoCacheFallback(environment []string) ([]string, error) {
+	if value, ok := environmentValue(environment, "XDG_CACHE_HOME"); ok && value != "" {
+		return environment, nil
+	}
+	goCache, ok := environmentValue(environment, "GOCACHE")
+	if !ok || goCache == "" {
+		return environment, nil
+	}
+	cache := filepath.Join(filepath.Dir(goCache), "goxc-xdg-cache")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		return nil, fmt.Errorf("create TinyGo cache fallback %s: %w", cache, err)
+	}
+	return setEnvironmentValue(environment, "XDG_CACHE_HOME", cache), nil
+}
+
+func removeEnvironmentKeys(environment []string, keys []string) []string {
+	result := make([]string, 0, len(environment))
+	for _, item := range environment {
+		key, _, ok := strings.Cut(item, "=")
+		if !ok || !environmentKeyIn(key, keys) {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	result := removeEnvironmentKeys(environment, []string{key})
+	return append(result, key+"="+value)
+}
+
+func environmentValue(environment []string, key string) (string, bool) {
+	for index := len(environment) - 1; index >= 0; index-- {
+		itemKey, value, ok := strings.Cut(environment[index], "=")
+		if ok && environmentKeysEqual(itemKey, key) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func environmentKeyIn(key string, keys []string) bool {
+	for _, candidate := range keys {
+		if environmentKeysEqual(key, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func environmentKeysEqual(first, second string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(first, second)
+	}
+	return first == second
+}

--- a/cmd/goxc/compiler_env_test.go
+++ b/cmd/goxc/compiler_env_test.go
@@ -179,19 +179,270 @@ func TestCompilerEnvironmentContract(t *testing.T) {
 	}
 }
 
+func TestTinyGoCacheFallbackFailureIsBestEffort(t *testing.T) {
+	root := t.TempDir()
+	blockingPath := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(blockingPath, []byte("blocking file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	goCache := filepath.Join(blockingPath, "go-build")
+	workingDirectory := filepath.Join(root, "working", "..", "app")
+	base := []string{
+		"GOCACHE=" + goCache,
+		"SENTINEL=preserved",
+		"PWD=stale",
+		"GOWORK=parent.work",
+		"GO111MODULE=off",
+		"GOFLAGS=-mod=vendor",
+		"GOOS=linux",
+		"GOARCH=amd64",
+		"CGO_ENABLED=1",
+	}
+	wantBase := append([]string(nil), base...)
+	t.Setenv("GOCACHE", "parent-cache")
+	t.Setenv("XDG_CACHE_HOME", "parent-xdg-cache")
+
+	tests := []struct {
+		name       string
+		invocation compilerInvocationKind
+		goFlags    string
+	}{
+		{
+			name:       "build",
+			invocation: compilerInvocationBuild,
+			goFlags:    workspaceCompilerBaseGoFlags,
+		},
+		{
+			name:       "embed discovery",
+			invocation: compilerInvocationEmbedDiscovery,
+			goFlags: workspaceCompilerBaseGoFlags + " " + strconv.Quote(
+				"-overlay="+filepath.Join(root, "overlay with spaces.json"),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			environment, directory, err := workspaceCompilerEnvironmentFrom(base, compilerEnvironmentOptions{
+				Compiler:         "tinygo",
+				Invocation:       test.invocation,
+				WorkingDirectory: workingDirectory,
+				GoFlags:          test.goFlags,
+			})
+			if err != nil {
+				t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+			}
+
+			wantDirectory, err := filepath.Abs(workingDirectory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantDirectory = filepath.Clean(wantDirectory)
+			if directory != wantDirectory {
+				t.Fatalf("directory = %q, want %q", directory, wantDirectory)
+			}
+			for key, want := range map[string]string{
+				"GOCACHE":     goCache,
+				"SENTINEL":    "preserved",
+				"PWD":         wantDirectory,
+				"GOWORK":      "off",
+				"GO111MODULE": "on",
+				"GOFLAGS":     test.goFlags,
+			} {
+				assertCompilerEnvironmentValue(t, environment, key, want)
+			}
+			if count := countCompilerEnvironmentKey(environment, "XDG_CACHE_HOME"); count != 0 {
+				t.Fatalf("environment contains %d XDG_CACHE_HOME values, want 0: %#v", count, environment)
+			}
+			for _, key := range []string{"GOOS", "GOARCH", "CGO_ENABLED"} {
+				if count := countCompilerEnvironmentKey(environment, key); count != 0 {
+					t.Fatalf("TinyGo environment retained %s: %#v", key, environment)
+				}
+			}
+			if !reflect.DeepEqual(base, wantBase) {
+				t.Fatalf("input environment mutated:\ngot  %#v\nwant %#v", base, wantBase)
+			}
+			if got := os.Getenv("GOCACHE"); got != "parent-cache" {
+				t.Fatalf("parent GOCACHE = %q", got)
+			}
+			if got := os.Getenv("XDG_CACHE_HOME"); got != "parent-xdg-cache" {
+				t.Fatalf("parent XDG_CACHE_HOME = %q", got)
+			}
+		})
+	}
+}
+
+func TestTinyGoCacheFallbackSuccess(t *testing.T) {
+	root := t.TempDir()
+	goCache := filepath.Join(root, "go-build")
+	environment, _, err := workspaceCompilerEnvironmentFrom([]string{
+		"GOCACHE=" + goCache,
+		"SENTINEL=preserved",
+		"PWD=stale",
+		"GOWORK=parent.work",
+		"GOFLAGS=-mod=vendor",
+		"GOOS=linux",
+		"GOARCH=amd64",
+		"CGO_ENABLED=1",
+	}, compilerEnvironmentOptions{
+		Compiler:         "tinygo",
+		Invocation:       compilerInvocationBuild,
+		WorkingDirectory: filepath.Join(root, "app"),
+		GoFlags:          workspaceCompilerBaseGoFlags,
+	})
+	if err != nil {
+		t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+	}
+
+	fallback := filepath.Join(root, "goxc-xdg-cache")
+	info, err := os.Stat(fallback)
+	if err != nil {
+		t.Fatalf("stat TinyGo cache fallback: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("TinyGo cache fallback mode = %s, want directory", info.Mode())
+	}
+	assertCompilerEnvironmentValue(t, environment, "XDG_CACHE_HOME", fallback)
+	assertCompilerEnvironmentValue(t, environment, "GOCACHE", goCache)
+	assertCompilerEnvironmentValue(t, environment, "GOWORK", "off")
+	assertCompilerEnvironmentValue(t, environment, "GOFLAGS", workspaceCompilerBaseGoFlags)
+}
+
+func TestTinyGoCacheFallbackPreservesExistingValue(t *testing.T) {
+	root := t.TempDir()
+	blockingPath := filepath.Join(root, "not-a-directory")
+	if err := os.WriteFile(blockingPath, []byte("blocking file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	customCache := filepath.Join(root, "custom-cache")
+	environment, _, err := workspaceCompilerEnvironmentFrom([]string{
+		"XDG_CACHE_HOME=" + customCache,
+		"GOCACHE=" + filepath.Join(blockingPath, "go-build"),
+	}, compilerEnvironmentOptions{
+		Compiler:         "tinygo",
+		Invocation:       compilerInvocationBuild,
+		WorkingDirectory: filepath.Join(root, "app"),
+		GoFlags:          workspaceCompilerBaseGoFlags,
+	})
+	if err != nil {
+		t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+	}
+	assertCompilerEnvironmentValue(t, environment, "XDG_CACHE_HOME", customCache)
+}
+
+func TestTinyGoCacheFallbackEmptyValue(t *testing.T) {
+	t.Run("successful fallback replaces empty value", func(t *testing.T) {
+		root := t.TempDir()
+		goCache := filepath.Join(root, "go-build")
+		environment, _, err := workspaceCompilerEnvironmentFrom([]string{
+			"XDG_CACHE_HOME=",
+			"GOCACHE=" + goCache,
+		}, compilerEnvironmentOptions{
+			Compiler:         "tinygo",
+			Invocation:       compilerInvocationBuild,
+			WorkingDirectory: filepath.Join(root, "app"),
+			GoFlags:          workspaceCompilerBaseGoFlags,
+		})
+		if err != nil {
+			t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+		}
+		assertCompilerEnvironmentValue(t, environment, "XDG_CACHE_HOME", filepath.Join(root, "goxc-xdg-cache"))
+	})
+
+	t.Run("failed fallback preserves empty value", func(t *testing.T) {
+		root := t.TempDir()
+		blockingPath := filepath.Join(root, "not-a-directory")
+		if err := os.WriteFile(blockingPath, []byte("blocking file"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		environment, _, err := workspaceCompilerEnvironmentFrom([]string{
+			"XDG_CACHE_HOME=",
+			"GOCACHE=" + filepath.Join(blockingPath, "go-build"),
+		}, compilerEnvironmentOptions{
+			Compiler:         "tinygo",
+			Invocation:       compilerInvocationBuild,
+			WorkingDirectory: filepath.Join(root, "app"),
+			GoFlags:          workspaceCompilerBaseGoFlags,
+		})
+		if err != nil {
+			t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+		}
+		assertCompilerEnvironmentValue(t, environment, "XDG_CACHE_HOME", "")
+	})
+}
+
+func TestTinyGoCacheFallbackWithoutGoCacheLeavesXDGUnset(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		base []string
+	}{
+		{name: "missing", base: []string{"SENTINEL=preserved"}},
+		{name: "empty", base: []string{"GOCACHE=", "SENTINEL=preserved"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			environment, _, err := workspaceCompilerEnvironmentFrom(test.base, compilerEnvironmentOptions{
+				Compiler:         "tinygo",
+				Invocation:       compilerInvocationBuild,
+				WorkingDirectory: t.TempDir(),
+				GoFlags:          workspaceCompilerBaseGoFlags,
+			})
+			if err != nil {
+				t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+			}
+			if count := countCompilerEnvironmentKey(environment, "XDG_CACHE_HOME"); count != 0 {
+				t.Fatalf("environment contains %d XDG_CACHE_HOME values, want 0: %#v", count, environment)
+			}
+			assertCompilerEnvironmentValue(t, environment, "SENTINEL", "preserved")
+		})
+	}
+}
+
 func TestCompilerEnvironmentErrorIdentifiesBoundary(t *testing.T) {
 	directory := t.TempDir()
-	_, _, err := workspaceCompilerEnvironmentFrom(nil, compilerEnvironmentOptions{
-		Compiler: "tinygo", Invocation: compilerInvocationBuild,
-		WorkingDirectory: directory,
-	})
-	if err == nil {
-		t.Fatal("workspaceCompilerEnvironmentFrom() succeeded without owned GOFLAGS")
+	tests := []struct {
+		name    string
+		options compilerEnvironmentOptions
+		want    []string
+	}{
+		{
+			name: "unsupported compiler",
+			options: compilerEnvironmentOptions{
+				Compiler: "other", Invocation: compilerInvocationBuild,
+				WorkingDirectory: directory, GoFlags: workspaceCompilerBaseGoFlags,
+			},
+			want: []string{"other", "build", "compiler", directory},
+		},
+		{
+			name: "missing invocation",
+			options: compilerEnvironmentOptions{
+				Compiler: "tinygo", WorkingDirectory: directory,
+				GoFlags: workspaceCompilerBaseGoFlags,
+			},
+			want: []string{"tinygo", "unknown", "invocation", directory},
+		},
+		{
+			name: "empty owned GOFLAGS",
+			options: compilerEnvironmentOptions{
+				Compiler: "tinygo", Invocation: compilerInvocationBuild,
+				WorkingDirectory: directory,
+			},
+			want: []string{"tinygo", "build", "GOFLAGS", directory},
+		},
 	}
-	for _, want := range []string{"tinygo", "build", "GOFLAGS", directory} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error %q does not contain %q", err, want)
-		}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := workspaceCompilerEnvironmentFrom(nil, test.options)
+			if err == nil {
+				t.Fatal("workspaceCompilerEnvironmentFrom() succeeded")
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not contain %q", err, want)
+				}
+			}
+		})
 	}
 }
 

--- a/cmd/goxc/compiler_env_test.go
+++ b/cmd/goxc/compiler_env_test.go
@@ -1,0 +1,334 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCompilerEnvironmentContract(t *testing.T) {
+	root := t.TempDir()
+	workingDirectory := filepath.Join(root, "lexical", "..", "lexical", "app")
+	base := []string{
+		"PATH=tool-path",
+		"HOME=home-value",
+		"GOROOT=go-root-value",
+		"GOPATH=go-path-value",
+		"GOCACHE=go-cache-value",
+		"GOPROXY=proxy-value",
+		"GOMODCACHE=module-cache-value",
+		"GONOPROXY=no-proxy-value",
+		"GOPRIVATE=private-value",
+		"GONOSUMDB=no-sum-value",
+		"GOSUMDB=sum-value",
+		"GOINSECURE=insecure-value",
+		"GOVCS=vcs-value",
+		"GOTOOLCHAIN=toolchain-value",
+		"GOENV=user-goenv-value",
+		"GODEBUG=debug-value",
+		"GOEXPERIMENT=experiment-value",
+		"GOWASM=wasm-value",
+		"XDG_CACHE_HOME=tinygo-cache-value",
+		"TMPDIR=tmpdir-value",
+		"TMP=tmp-value",
+		"TEMP=temp-value",
+		"SSL_CERT_FILE=cert-file-value",
+		"SSL_CERT_DIR=cert-dir-value",
+		"GIT_CONFIG_GLOBAL=git-config-value",
+		"SSH_AUTH_SOCK=ssh-value",
+		"SENTINEL=preserved-value",
+		"PWD=stale-one",
+		"PWD=stale-two",
+		"GOWORK=parent.work",
+		"GOWORK=other.work",
+		"GO111MODULE=off",
+		"GOFLAGS=-mod=vendor",
+		"GOFLAGS=-tags=goxc_hostile",
+		"GOOS=linux",
+		"GOARCH=amd64",
+		"CGO_ENABLED=1",
+	}
+	wantBase := append([]string(nil), base...)
+	t.Setenv("GOWORK", "parent-process-work")
+	t.Setenv("GOFLAGS", "parent-process-flags")
+	t.Setenv("PWD", "parent-process-pwd")
+
+	tests := []struct {
+		name       string
+		options    compilerEnvironmentOptions
+		wantTarget bool
+	}{
+		{
+			name: "Go build",
+			options: compilerEnvironmentOptions{
+				Compiler: "go", Invocation: compilerInvocationBuild,
+				WorkingDirectory: workingDirectory, GoFlags: workspaceCompilerBaseGoFlags,
+				StandardGoTarget: true,
+			},
+			wantTarget: true,
+		},
+		{
+			name: "Go embed discovery",
+			options: compilerEnvironmentOptions{
+				Compiler: "go", Invocation: compilerInvocationEmbedDiscovery,
+				WorkingDirectory: workingDirectory, GoFlags: workspaceCompilerBaseGoFlags,
+				StandardGoTarget: true,
+			},
+			wantTarget: true,
+		},
+		{
+			name: "TinyGo build",
+			options: compilerEnvironmentOptions{
+				Compiler: "tinygo", Invocation: compilerInvocationBuild,
+				WorkingDirectory: workingDirectory, GoFlags: workspaceCompilerBaseGoFlags,
+			},
+		},
+		{
+			name: "TinyGo embed discovery",
+			options: compilerEnvironmentOptions{
+				Compiler: "tinygo", Invocation: compilerInvocationEmbedDiscovery,
+				WorkingDirectory: workingDirectory,
+				GoFlags:          workspaceCompilerBaseGoFlags + " " + strconv.Quote("-overlay="+filepath.Join(root, "overlay with spaces.json")),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			environment, directory, err := workspaceCompilerEnvironmentFrom(base, test.options)
+			if err != nil {
+				t.Fatalf("workspaceCompilerEnvironmentFrom() error: %v", err)
+			}
+			wantDirectory, err := filepath.Abs(workingDirectory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantDirectory = filepath.Clean(wantDirectory)
+			if directory != wantDirectory {
+				t.Fatalf("directory = %q, want lexical %q", directory, wantDirectory)
+			}
+			for key, want := range map[string]string{
+				"PWD": directory, "GOWORK": "off", "GO111MODULE": "on", "GOFLAGS": test.options.GoFlags,
+			} {
+				assertCompilerEnvironmentValue(t, environment, key, want)
+			}
+			if test.wantTarget {
+				assertCompilerEnvironmentValue(t, environment, "GOOS", "js")
+				assertCompilerEnvironmentValue(t, environment, "GOARCH", "wasm")
+				assertCompilerEnvironmentValue(t, environment, "CGO_ENABLED", "0")
+			} else {
+				for _, key := range []string{"GOOS", "GOARCH", "CGO_ENABLED"} {
+					if countCompilerEnvironmentKey(environment, key) != 0 {
+						t.Fatalf("TinyGo environment retained %s: %#v", key, environment)
+					}
+				}
+			}
+			for _, want := range []string{
+				"PATH=tool-path",
+				"HOME=home-value",
+				"GOROOT=go-root-value",
+				"GOPATH=go-path-value",
+				"GOCACHE=go-cache-value",
+				"GOPROXY=proxy-value",
+				"GOMODCACHE=module-cache-value",
+				"GONOPROXY=no-proxy-value",
+				"GOPRIVATE=private-value",
+				"GONOSUMDB=no-sum-value",
+				"GOSUMDB=sum-value",
+				"GOINSECURE=insecure-value",
+				"GOVCS=vcs-value",
+				"GOTOOLCHAIN=toolchain-value",
+				"GOENV=user-goenv-value",
+				"GODEBUG=debug-value",
+				"GOEXPERIMENT=experiment-value",
+				"GOWASM=wasm-value",
+				"XDG_CACHE_HOME=tinygo-cache-value",
+				"TMPDIR=tmpdir-value",
+				"TMP=tmp-value",
+				"TEMP=temp-value",
+				"SSL_CERT_FILE=cert-file-value",
+				"SSL_CERT_DIR=cert-dir-value",
+				"GIT_CONFIG_GLOBAL=git-config-value",
+				"SSH_AUTH_SOCK=ssh-value",
+				"SENTINEL=preserved-value",
+			} {
+				if !stringSliceContains(environment, want) {
+					t.Fatalf("environment lost %q: %#v", want, environment)
+				}
+			}
+			if !reflect.DeepEqual(base, wantBase) {
+				t.Fatalf("input environment mutated:\ngot  %#v\nwant %#v", base, wantBase)
+			}
+		})
+	}
+
+	if got := os.Getenv("GOWORK"); got != "parent-process-work" {
+		t.Fatalf("parent GOWORK = %q", got)
+	}
+	if got := os.Getenv("GOFLAGS"); got != "parent-process-flags" {
+		t.Fatalf("parent GOFLAGS = %q", got)
+	}
+	if got := os.Getenv("PWD"); got != "parent-process-pwd" {
+		t.Fatalf("parent PWD = %q", got)
+	}
+}
+
+func TestCompilerEnvironmentErrorIdentifiesBoundary(t *testing.T) {
+	directory := t.TempDir()
+	_, _, err := workspaceCompilerEnvironmentFrom(nil, compilerEnvironmentOptions{
+		Compiler: "tinygo", Invocation: compilerInvocationBuild,
+		WorkingDirectory: directory,
+	})
+	if err == nil {
+		t.Fatal("workspaceCompilerEnvironmentFrom() succeeded without owned GOFLAGS")
+	}
+	for _, want := range []string{"tinygo", "build", "GOFLAGS", directory} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestAmbientGoWorkIsolation(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		explicit bool
+	}{
+		{name: "auto"},
+		{name: "explicit", explicit: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			appDir := filepath.Join(root, "app")
+			writeCompilerEnvironmentTestApp(t, appDir, "")
+			writeTestFile(t, root, "host/go.mod", "module example.com/host\n\ngo 1.22\n")
+			workContent := "go 1.22\n\nuse ./host\n"
+			writeTestFile(t, root, "go.work", workContent)
+			workPath := filepath.Join(root, "go.work")
+			if test.explicit {
+				t.Setenv("GOWORK", workPath)
+			} else {
+				t.Setenv("GOWORK", "")
+			}
+			setOfflineCompilerTestEnvironment(t)
+
+			output, err := buildApp(buildOptions{appDir: appDir, compiler: "go"})
+			if err != nil {
+				t.Fatalf("buildApp() error below parent go.work: %v", err)
+			}
+			assertNonEmptyCompilerOutput(t, output)
+			content, err := os.ReadFile(workPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != workContent {
+				t.Fatalf("parent go.work changed:\n%s", content)
+			}
+		})
+	}
+}
+
+func TestAmbientGoFlagsIsolation(t *testing.T) {
+	tests := []struct {
+		name    string
+		goFlags func(root string) string
+		hostile bool
+	}{
+		{name: "vendor", goFlags: func(string) string { return "-mod=vendor" }},
+		{name: "modfile", goFlags: func(root string) string { return "-modfile=" + filepath.Join(root, "poison.mod") }},
+		{name: "overlay", goFlags: func(root string) string { return "-overlay=" + filepath.Join(root, "missing-overlay.json") }},
+		{name: "tags", goFlags: func(string) string { return "-tags=goxc_hostile" }, hostile: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			appDir := filepath.Join(root, "app")
+			writeCompilerEnvironmentTestApp(t, appDir, "")
+			if test.name == "modfile" {
+				writeTestFile(t, root, "poison.mod", "module poison.invalid\n\ngo 1.22\n\nrequire broken\n")
+			}
+			if test.hostile {
+				writeTestFile(t, appDir, "hostile.go", "//go:build goxc_hostile\n\npackage main\n\nvar _ = missingHostileSymbol\n")
+			}
+			t.Setenv("GOWORK", "off")
+			t.Setenv("GOFLAGS", test.goFlags(root))
+			setOfflineCompilerTestEnvironment(t)
+
+			output, err := buildApp(buildOptions{appDir: appDir, compiler: "go"})
+			if err != nil {
+				t.Fatalf("buildApp() error with ambient GOFLAGS=%q: %v", test.goFlags(root), err)
+			}
+			assertNonEmptyCompilerOutput(t, output)
+		})
+	}
+}
+
+func writeCompilerEnvironmentTestApp(t *testing.T, appDir, extraMain string) {
+	t.Helper()
+	writeTestFile(t, appDir, "go.mod", "module example.com/compiler-environment\n\ngo 1.22\n")
+	writeTestFile(t, appDir, manifestName, `{"name":"compiler-environment","compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n\nfunc main() {}\n"+extraMain)
+}
+
+func setOfflineCompilerTestEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOENV", "off")
+}
+
+func assertNonEmptyCompilerOutput(t *testing.T, output string) {
+	t.Helper()
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatalf("build output missing: %v", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		t.Fatalf("build output = mode %s size %d", info.Mode(), info.Size())
+	}
+}
+
+func assertCompilerEnvironmentValue(t *testing.T, environment []string, key, want string) {
+	t.Helper()
+	if count := countCompilerEnvironmentKey(environment, key); count != 1 {
+		t.Fatalf("environment contains %d %s values, want 1: %#v", count, key, environment)
+	}
+	if got, ok := environmentValue(environment, key); !ok || got != want {
+		t.Fatalf("environment %s = %q, present=%v, want %q", key, got, ok, want)
+	}
+}
+
+func countCompilerEnvironmentKey(environment []string, key string) int {
+	count := 0
+	for _, item := range environment {
+		itemKey, _, ok := strings.Cut(item, "=")
+		if ok && environmentKeysEqual(itemKey, key) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestCompilerEnvironmentWindowsKeyIdentity(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows environment keys are case-insensitive")
+	}
+	environment, _, err := workspaceCompilerEnvironmentFrom([]string{
+		"Path=one", "pwd=stale", "GoWork=parent", "goflags=-mod=vendor", "XDG_CACHE_HOME=cache",
+	}, compilerEnvironmentOptions{
+		Compiler: "tinygo", Invocation: compilerInvocationBuild,
+		WorkingDirectory: t.TempDir(), GoFlags: workspaceCompilerBaseGoFlags,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"PWD", "GOWORK", "GOFLAGS"} {
+		if count := countCompilerEnvironmentKey(environment, key); count != 1 {
+			t.Fatalf("case-insensitive %s count = %d: %#v", key, count, environment)
+		}
+	}
+}

--- a/cmd/goxc/compiler_env_test.go
+++ b/cmd/goxc/compiler_env_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -330,5 +332,125 @@ func TestCompilerEnvironmentWindowsKeyIdentity(t *testing.T) {
 		if count := countCompilerEnvironmentKey(environment, key); count != 1 {
 			t.Fatalf("case-insensitive %s count = %d: %#v", key, count, environment)
 		}
+	}
+}
+
+func TestCompilerEnvironmentIgnoresPersistentGoFlags(t *testing.T) {
+	compilers := []string{"go"}
+	if _, err := exec.LookPath("tinygo"); err == nil {
+		compilers = append(compilers, "tinygo")
+	}
+	for _, compiler := range compilers {
+		t.Run(compiler, func(t *testing.T) {
+			root := t.TempDir()
+			appDir := filepath.Join(root, "app")
+			writeCompilerEnvironmentTestApp(t, appDir, "")
+			goEnvPath := filepath.Join(root, "go-env")
+			goEnvContent := "GOFLAGS=-mod=vendor\n"
+			if err := os.WriteFile(goEnvPath, []byte(goEnvContent), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			t.Setenv("GOENV", goEnvPath)
+			unsetCompilerEnvironmentForTest(t, "GOFLAGS")
+			t.Setenv("GOWORK", "off")
+			t.Setenv("GOPROXY", "off")
+			t.Setenv("GOSUMDB", "off")
+
+			output, err := buildApp(buildOptions{appDir: appDir, compiler: compiler})
+			if err != nil {
+				t.Fatalf("buildApp() with GOENV-persisted GOFLAGS using %s: %v", compiler, err)
+			}
+			assertNonEmptyCompilerOutput(t, output)
+			assertTestFileUnchanged(t, goEnvPath, goEnvContent)
+		})
+	}
+}
+
+func TestPackageEnvironmentIsolation(t *testing.T) {
+	compilers := []string{"go"}
+	if _, err := exec.LookPath("tinygo"); err == nil {
+		compilers = append(compilers, "tinygo")
+	}
+	for _, compiler := range compilers {
+		t.Run(compiler, func(t *testing.T) {
+			root := t.TempDir()
+			appDir := filepath.Join(root, "app")
+			writeCompilerEnvironmentTestApp(t, appDir, "")
+			workPath, workContent := writeHostileParentWorkspace(t, root)
+			setHostileCompilerWorkflowEnvironment(t, workPath, "-mod=vendor")
+
+			outDir := filepath.Join(t.TempDir(), "package")
+			err := packageApp(packageOptions{
+				appDir: appDir, compiler: compiler, outDir: outDir,
+				workspace: filepath.Join(t.TempDir(), "workspace"),
+				compress:  map[string]bool{},
+			})
+			if err != nil {
+				t.Fatalf("packageApp() with hostile environment using %s: %v", compiler, err)
+			}
+
+			metadataContent, err := os.ReadFile(filepath.Join(outDir, packageMetadataName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var metadata packageMetadata
+			if err := json.Unmarshal(metadataContent, &metadata); err != nil {
+				t.Fatalf("decode package metadata: %v", err)
+			}
+			if metadata.Compiler != compiler || metadata.Entrypoints.WASM == "" {
+				t.Fatalf("package metadata = %+v, want compiler %q and WASM entrypoint", metadata, compiler)
+			}
+			wasmPath := filepath.Join(outDir, filepath.FromSlash(metadata.Entrypoints.WASM))
+			assertNonEmptyCompilerOutput(t, wasmPath)
+			assertTestFileUnchanged(t, workPath, workContent)
+		})
+	}
+}
+
+func writeHostileParentWorkspace(t *testing.T, root string) (string, string) {
+	t.Helper()
+	writeTestFile(t, root, "host/go.mod", "module example.com/host\n\ngo 1.22\n")
+	content := "go 1.22\n\nuse ./host\n"
+	writeTestFile(t, root, "go.work", content)
+	return filepath.Join(root, "go.work"), content
+}
+
+func setHostileCompilerWorkflowEnvironment(t *testing.T, workPath, goFlags string) {
+	t.Helper()
+	t.Setenv("GOWORK", workPath)
+	t.Setenv("GOFLAGS", goFlags)
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOPROXY", "off")
+	t.Setenv("GOSUMDB", "off")
+}
+
+func unsetCompilerEnvironmentForTest(t *testing.T, key string) {
+	t.Helper()
+	value, present := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		var err error
+		if present {
+			err = os.Setenv(key, value)
+		} else {
+			err = os.Unsetenv(key)
+		}
+		if err != nil {
+			t.Errorf("restore %s: %v", key, err)
+		}
+	})
+}
+
+func assertTestFileUnchanged(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != want {
+		t.Fatalf("%s changed:\ngot  %q\nwant %q", path, content, want)
 	}
 }

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -166,6 +166,58 @@ func App() gf.Node {
 	waitDevListenerClosed(t, serverURL)
 }
 
+func TestDevEnvironmentIsolationRealWorkflow(t *testing.T) {
+	repositoryRoot, ok := findRepositoryRoot(".")
+	if !ok {
+		t.Fatal("repository root not found")
+	}
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeDevIntegrationApp(t, appDir, repositoryRoot, "environment-isolation")
+	workPath, workContent := writeHostileParentWorkspace(t, root)
+	setHostileCompilerWorkflowEnvironment(t, workPath, "-mod=vendor")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builds := make(chan devBuildEvent, 8)
+	serverURLs := make(chan string, 1)
+	generations := make(chan uint64, 4)
+	reloads := make(chan uint64, 4)
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) {
+		generations <- generation
+	}
+	dependencies.hooks.ReloadPublished = func(generation uint64) {
+		reloads <- generation
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{
+			appDir: appDir, compiler: "go", workspace: workspace, port: 0,
+		}, dependencies)
+	}()
+
+	assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
+	serverURL := waitDevServerURL(t, serverURLs)
+	assertDevHTTPContains(t, serverURL+"/", "GoFrame dev integration")
+
+	writeTestFile(t, appDir, "message.go", "package main\n\nfunc message() string { return \"isolated rebuild\" }\n")
+	assertDevEvent(t, waitDevEvent(t, builds), 2, false, false)
+	assertDevGenerationEvent(t, generations, 2)
+	assertDevGenerationEvent(t, reloads, 2)
+	assertNoDevEvent(t, builds, 3*devIntegrationDebounce)
+	assertTestFileUnchanged(t, workPath, workContent)
+
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatalf("runDev() shutdown error: %v", err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
+
 func TestDevEmbedIntegrationRealWorkflow(t *testing.T) {
 	repositoryRoot, ok := findRepositoryRoot(".")
 	if !ok {

--- a/cmd/goxc/embed.go
+++ b/cmd/goxc/embed.go
@@ -306,8 +306,7 @@ func listGoEmbedPackages(entryPath, overlayPath string, tinyGoTags bool) ([]embe
 	}
 	args = append(args, ".")
 	command := exec.Command(compilerPath, args...)
-	environment := append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0")
-	if err := configureEmbedListCommand(command, entryPath, environment); err != nil {
+	if err := configureEmbedListCommand(command, "go", entryPath, workspaceCompilerBaseGoFlags); err != nil {
 		return nil, err
 	}
 	return runEmbedListCommand(command, "go list")
@@ -319,23 +318,21 @@ func listTinyGoEmbedPackages(entryPath, overlayPath string) ([]embedListPackage,
 		return nil, errors.New("TinyGo compiler not found in PATH; install TinyGo or use --compiler=go")
 	}
 	command := exec.Command(compilerPath, "list", "-target=wasm", "-deps", "-json", ".")
-	flags := strings.TrimSpace(os.Getenv("GOFLAGS") + " -buildvcs=false " + strconv.Quote("-overlay="+overlayPath))
-	environment := setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", flags)
-	if err := configureEmbedListCommand(command, entryPath, environment); err != nil {
+	flags := workspaceCompilerBaseGoFlags + " " + strconv.Quote("-overlay="+overlayPath)
+	if err := configureEmbedListCommand(command, "tinygo", entryPath, flags); err != nil {
 		return nil, err
 	}
 	return runEmbedListCommand(command, "tinygo list")
 }
 
-func configureEmbedListCommand(command *exec.Cmd, entryPath string, environment []string) error {
-	lexicalEntryPath, err := filepath.Abs(entryPath)
-	if err != nil {
-		return fmt.Errorf("resolve embed discovery entry %s: %w", entryPath, err)
-	}
-	lexicalEntryPath = filepath.Clean(lexicalEntryPath)
-	command.Dir = lexicalEntryPath
-	command.Env = setEnvironmentValue(environment, "PWD", lexicalEntryPath)
-	return nil
+func configureEmbedListCommand(command *exec.Cmd, compiler, entryPath, goFlags string) error {
+	return configureWorkspaceCompilerCommand(command, compilerEnvironmentOptions{
+		Compiler:         compiler,
+		Invocation:       compilerInvocationEmbedDiscovery,
+		WorkingDirectory: entryPath,
+		GoFlags:          goFlags,
+		StandardGoTarget: compiler == "go",
+	})
 }
 
 func runEmbedListCommand(command *exec.Cmd, description string) ([]embedListPackage, error) {
@@ -372,17 +369,6 @@ func decodeEmbedListPackages(reader io.Reader) ([]embedListPackage, error) {
 		}
 		packages = append(packages, packageInfo)
 	}
-}
-
-func setEnvironmentValue(environment []string, key, value string) []string {
-	prefix := key + "="
-	result := make([]string, 0, len(environment)+1)
-	for _, item := range environment {
-		if !strings.HasPrefix(item, prefix) {
-			result = append(result, item)
-		}
-	}
-	return append(result, prefix+value)
 }
 
 func resolveEmbedInputPlan(appDir, appWorkDir string, candidates map[embedInputKey]embedCandidate, packages []embedListPackage) ([]resolvedEmbedInput, embedInputPlan, error) {

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -493,14 +493,9 @@ func TestEmbedListCommandPreservesLexicalWorkingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	stalePWD := filepath.Join(root, "stale-pwd")
-	parentPWD := filepath.Join(root, "parent-pwd")
 	if err := os.MkdirAll(stalePWD, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(parentPWD, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PWD", parentPWD)
 	want, err := filepath.Abs(lexicalEntryPath)
 	if err != nil {
 		t.Fatal(err)
@@ -515,29 +510,28 @@ func TestEmbedListCommandPreservesLexicalWorkingDirectory(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name        string
-		environment func() []string
-		wantValues  []string
+		name       string
+		compiler   string
+		goFlags    string
+		wantValues []string
 	}{
 		{
-			name: "go",
-			environment: func() []string {
-				return append(compilerEnvironment("go"), "GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0", "PWD="+stalePWD)
-			},
+			name:       "go",
+			compiler:   "go",
+			goFlags:    workspaceCompilerBaseGoFlags,
 			wantValues: []string{"GOOS=js", "GOARCH=wasm", "CGO_ENABLED=0"},
 		},
 		{
-			name: "tinygo",
-			environment: func() []string {
-				environment := setEnvironmentValue(compilerEnvironment("tinygo"), "GOFLAGS", "-buildvcs=false -overlay=overlay.json")
-				return append(environment, "PWD="+stalePWD)
-			},
+			name:       "tinygo",
+			compiler:   "tinygo",
+			goFlags:    "-buildvcs=false -overlay=overlay.json",
 			wantValues: []string{"GOFLAGS=-buildvcs=false -overlay=overlay.json"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			command := &exec.Cmd{}
-			if err := configureEmbedListCommand(command, lexicalEntryPath, test.environment()); err != nil {
+			t.Setenv("PWD", stalePWD)
+			if err := configureEmbedListCommand(command, test.compiler, lexicalEntryPath, test.goFlags); err != nil {
 				t.Fatalf("configureEmbedListCommand() error: %v", err)
 			}
 			if command.Dir != want {
@@ -566,8 +560,8 @@ func TestEmbedListCommandPreservesLexicalWorkingDirectory(t *testing.T) {
 			if command.Dir == physical {
 				t.Fatalf("command directory was physically canonicalized to %q", physical)
 			}
-			if got := os.Getenv("PWD"); got != parentPWD {
-				t.Fatalf("parent PWD = %q, want unchanged %q", got, parentPWD)
+			if got := os.Getenv("PWD"); got != stalePWD {
+				t.Fatalf("parent PWD = %q, want unchanged %q", got, stalePWD)
 			}
 		})
 	}

--- a/cmd/goxc/embed_test.go
+++ b/cmd/goxc/embed_test.go
@@ -202,6 +202,39 @@ var tiny string
 	}
 }
 
+func TestEmbedEnvironmentIsolation(t *testing.T) {
+	compilers := []string{"go"}
+	if _, err := exec.LookPath("tinygo"); err == nil {
+		compilers = append(compilers, "tinygo")
+	}
+	for _, compiler := range compilers {
+		t.Run(compiler, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "root with spaces")
+			appDir := filepath.Join(root, "app")
+			writeTestFile(t, appDir, "go.mod", "module example.com/embed-environment\n\ngo 1.22\n")
+			writeTestFile(t, appDir, manifestName, `{"name":"embed-environment","compiler":"`+compiler+`"}`)
+			writeTestFile(t, appDir, "main.go", embedStringSource("message.txt"))
+			writeTestFile(t, appDir, "message.txt", "isolated embed payload")
+			workPath, workContent := writeHostileParentWorkspace(t, root)
+			setHostileCompilerWorkflowEnvironment(t, workPath, "-mod=vendor")
+
+			workspace := filepath.Join(t.TempDir(), "workspace with spaces")
+			output, err := buildApp(buildOptions{
+				appDir: appDir, compiler: compiler, workspace: workspace,
+			})
+			if err != nil {
+				t.Fatalf("buildApp() embed workflow with hostile environment using %s: %v", compiler, err)
+			}
+			assertNonEmptyCompilerOutput(t, output)
+
+			layout := newEmbedTestLayout(t, appDir, compiler, workspace)
+			appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(workspaceModuleConfigForApp(appDir).AppRel))
+			assertEmbedFileContent(t, filepath.Join(appWorkDir, "message.txt"), "isolated embed payload")
+			assertTestFileUnchanged(t, workPath, workContent)
+		})
+	}
+}
+
 func TestEmbedDiscoveryFiltersExternalDependencyInputs(t *testing.T) {
 	root := t.TempDir()
 	externalDir := filepath.Join(root, "external")

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,21 @@ If `--compiler` is omitted, every accepted build uses the compiler currently
 selected by `goframe.json`. A command-line `--compiler=go` or
 `--compiler=tinygo` override remains fixed until the process exits.
 
+## Compiler Environment
+
+Each development package attempt and its embed discovery run inside the hidden
+generated module with `GOWORK=off` and module mode enabled. `goxc` supplies its
+own `GOFLAGS`; ambient `GOFLAGS` values do not configure these commands. This
+keeps a parent `go.work`, vendor mode, overlays, build tags, and other caller
+flags from changing the generated workspace.
+
+The rest of the process environment remains available, including module proxy,
+checksum, private-module authentication, certificate, cache, temporary
+directory, and Go toolchain settings. Dependencies must be represented by the
+application module's authored `require` and `replace` directives. Dependencies
+available only through a parent `go.work` are not supported, and this isolation
+does not establish a general multi-module workspace contract.
+
 ## Watched Inputs
 
 The development loop observes the effective inputs used by packaging:

--- a/docs/multi-package-workspace.md
+++ b/docs/multi-package-workspace.md
@@ -97,6 +97,15 @@ still point at the original target after `go.mod` is written under
 `.goframe/work/<profile>`. This supports normal Go package resolution for
 external Go component packages declared by the app module.
 
+Compiler and embed-discovery subprocesses treat that generated module as their
+module boundary: `GOWORK=off` is enforced and ambient `GOFLAGS` is replaced by
+the flags owned by `goxc`. A parent `go.work` is therefore not a source of
+hidden-workspace dependencies. Proxy, checksum, cache, private-module
+authentication, certificate, temporary-directory, and Go toolchain environment
+settings remain available to the subprocesses. This isolation preserves the
+authored `require` / `replace` model above; it does not add a broad multi-module
+workspace contract.
+
 This model is intentionally used instead of a Go overlay because TinyGo
 support for overlays is not part of the current baseline.
 


### PR DESCRIPTION
## Summary

Isolates Go and TinyGo subprocesses from ambient module-selection and compiler
flags when operating on `goxc`'s generated workspace.

Previously, an unrelated parent `go.work`, shell-level `GOFLAGS`, or persistent
`GOENV` settings could alter package discovery and compilation. Valid
applications could fail under vendor mode, external overlays, modfiles, or
caller-provided build tags.

## Changes

- Adds one private environment boundary shared by:
  - standard Go builds;
  - TinyGo builds;
  - standard Go embed discovery;
  - TinyGo embed discovery.
- Aligns each subprocess's lexical `PWD` with its working directory.
- Forces generated workspaces to use:
  - `GOWORK=off`;
  - `GO111MODULE=on`;
  - `goxc`-owned `GOFLAGS`.
- Prevents ambient vendor mode, modfiles, overlays, build tags, and persistent
  `GOENV` flags from changing generated-workspace behavior.
- Makes the standard Go WASM target explicit through `GOOS=js`,
 .
- Makes the standard Go WASM target explicit through `GOARCH=wasm`, and `CGO_ENABLED=0`.
- Removes conflicting inherited target variables from TinyGo invocations while
  retaining the explicit `-target=wasm` contract.
- Preserves proxy, checksum, private-module authentication, certificate, cache,
  temporary-directory, executable-discovery, and toolchain environment.
- Keeps the TinyGo `XDG_CACHE_HOME` fallback optional and best effort. Failure to
  create the fallback no longer prevents TinyGo from starting.
- Preserves authored `go.mod` `require` and `replace` directives, including
  supported local external-module replacements.

## Validation

The change includes focused and integration coverage for:

- applications nested below unrelated parent workspaces;
- automatic and explicit hostile `GOWORK` values;
- ambient `-mod=vendor`, `-modfile`, `-overlay`, and build-tag flags;
- `GOFLAGS` persisted through a temporary `GOENV` file;
- standard Go and TinyGo build and embed-discovery environments;
- external local `require` / `replace` dependencies;
- embed payloads and workspace paths containing spaces;
- package and watched-development workflows;
- Windows case-insensitive environment-key handling;
- successful, missing, empty, custom, and unavailable TinyGo cache fallbacks;
- preservation of unrelated operational environment;
- absence of parent-process or input-environment mutation.

Local validation passes the full Go, race, debug-tag, vet, browser-smoke,
documentation, artifact, module-path, and size-budget checks.

The complete Go 1.22.12 / TinyGo 0.41.1 example matrix remains byte-identical
across all 11 budgeted examples, including raw WASM and deterministic gzip,
Brotli, and Zstandard outputs.

## Compatibility and limits

This is an internal `goxc` correctness and isolation change.

It does not change:

- public framework APIs;
- CLI flags;
- manifest or package schemas;
- runtime or GOX behavior;
- dependencies or workflows;
- examples or size budgets.

Ambient `GOFLAGS` is intentionally not a supported configuration channel for
generated-workspace compilation. Dependencies available only through a parent
`go.work` remain unsupported and must instead be represented through the
application module's authored `require` and `replace` directives.

The change does not introduce a general multi-module workspace contract,
generated `go.work` files, vendoring, or user-configurable compiler flags.