### PR TITLE
fix(gox): insert generated declarations using Go syntax

### DIFF
--- a/pkg/gox/fuzz_test.go
+++ b/pkg/gox/fuzz_test.go
@@ -53,6 +53,58 @@ func View() any {
 	return <input type="text" value={value} />
 }
 `,
+		`// package fake
+
+package main
+
+func View() any {
+	return <Button />
+}
+`,
+		`package main
+
+import "fmt"
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+		`package main
+
+import (
+	"fmt" // ) is not the end of the import group
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+		`package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+		`package main
+
+// View renders the page.
+func View() any {
+	return <Button />
+}
+`,
 	} {
 		f.Add(seed)
 	}

--- a/pkg/gox/generate.go
+++ b/pkg/gox/generate.go
@@ -3,6 +3,7 @@ package gox
 import (
 	"bytes"
 	"fmt"
+	"go/ast"
 	"go/format"
 	"go/parser"
 	gotoken "go/token"
@@ -84,7 +85,11 @@ func GenerateWithOptions(source []byte, options GenerateOptions) ([]byte, error)
 	output.WriteString(input[cursor:])
 	generatedSource := output.String()
 	if declarations := ctx.declarations(); declarations != "" {
-		generatedSource = insertGeneratedDeclarations(generatedSource, declarations)
+		inserted, err := insertGeneratedDeclarations(options.Filename, generatedSource, declarations)
+		if err != nil {
+			return nil, err
+		}
+		generatedSource = inserted
 	}
 
 	if generated == 0 {
@@ -299,71 +304,47 @@ func importAliasesFromSource(filename, input string) (map[string]string, map[str
 	return aliases, invalid
 }
 
-func insertGeneratedDeclarations(input string, declarations string) string {
-	position := declarationInsertionPoint(input)
-	return input[:position] + "\n" + declarations + input[position:]
-}
-
-func declarationInsertionPoint(input string) int {
-	packageIndex := strings.Index(input, "package ")
-	if packageIndex < 0 {
-		return 0
+func insertGeneratedDeclarations(filename, input, declarations string) (string, error) {
+	fileSet := gotoken.NewFileSet()
+	file, err := parser.ParseFile(
+		fileSet,
+		filename,
+		input,
+		parser.ParseComments|parser.AllErrors|parser.SkipObjectResolution,
+	)
+	if err != nil {
+		return "", fmt.Errorf("%s: parse transformed Go source before generated declarations: %w", filename, err)
 	}
-	packageLineEnd := strings.IndexByte(input[packageIndex:], '\n')
-	if packageLineEnd < 0 {
-		return len(input)
-	}
-	position := packageIndex + packageLineEnd + 1
-	importStart := skipWhitespace(input, position)
-	if !strings.HasPrefix(input[importStart:], "import") || !isKeywordBoundary(input, importStart+len("import")) {
-		return position
+	if file == nil || !file.Package.IsValid() {
+		return "", fmt.Errorf("%s: parse transformed Go source before generated declarations: missing package clause", filename)
 	}
 
-	index := skipWhitespace(input, importStart+len("import"))
-	if index >= len(input) {
-		return len(input)
-	}
-	if input[index] == '(' {
-		depth := 0
-		for index < len(input) {
-			switch input[index] {
-			case '(':
-				depth++
-			case ')':
-				depth--
-				if depth == 0 {
-					index++
-					return lineEnd(input, index)
-				}
-			}
-			index++
+	position := gotoken.NoPos
+	for _, declaration := range file.Decls {
+		if gen, ok := declaration.(*ast.GenDecl); ok && gen.Tok == gotoken.IMPORT {
+			continue
 		}
-		return len(input)
+		position = declaration.Pos()
+		switch declaration := declaration.(type) {
+		case *ast.GenDecl:
+			if declaration.Doc != nil {
+				position = declaration.Doc.Pos()
+			}
+		case *ast.FuncDecl:
+			if declaration.Doc != nil {
+				position = declaration.Doc.Pos()
+			}
+		}
+		break
 	}
-	return lineEnd(input, index)
-}
 
-func skipWhitespace(input string, index int) int {
-	for index < len(input) && unicode.IsSpace(rune(input[index])) {
-		index++
+	offset := len(input)
+	if position.IsValid() {
+		tokenFile := fileSet.File(position)
+		if tokenFile == nil {
+			return "", fmt.Errorf("%s: locate generated declaration insertion position", filename)
+		}
+		offset = tokenFile.Offset(position)
 	}
-	return index
-}
-
-func isKeywordBoundary(input string, index int) bool {
-	if index >= len(input) {
-		return true
-	}
-	character := rune(input[index])
-	return !unicode.IsLetter(character) && !unicode.IsDigit(character) && character != '_'
-}
-
-func lineEnd(input string, index int) int {
-	for index < len(input) && input[index] != '\n' {
-		index++
-	}
-	if index < len(input) {
-		index++
-	}
-	return index
+	return input[:offset] + "\n" + declarations + "\n" + input[offset:], nil
 }

--- a/pkg/gox/generate_test.go
+++ b/pkg/gox/generate_test.go
@@ -2,10 +2,12 @@ package gox
 
 import (
 	"errors"
+	"go/ast"
 	"go/parser"
 	gotoken "go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -102,6 +104,657 @@ func TestGeneratePreservesUnicodeTextBoundaries(t *testing.T) {
 	}
 	if strings.Contains(invalidText, `gf.Text("x\x85 ")`) {
 		t.Fatalf("generated source invented trailing whitespace after an invalid byte:\n%s", invalidText)
+	}
+}
+
+func TestGenerateInsertsComponentDeclarationsUsingGoSyntax(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          string
+		wantImportDecls int
+	}{
+		{
+			name: "no imports",
+			source: `package demo
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+		{
+			name: "single import",
+			source: `package demo
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "aliased single import",
+			source: `package demo
+
+import frame "github.com/graybuton/goframe/pkg/goframe"
+
+func View() any {
+	_ = frame.Node(nil)
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "grouped import",
+			source: `package demo
+
+import (
+	"fmt"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "multiple separate imports",
+			source: `package demo
+
+import "fmt"
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 2,
+		},
+		{
+			name: "comments between imports",
+			source: `package demo
+
+import "fmt"
+
+// Runtime import.
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 2,
+		},
+		{
+			name: "comment between package and import",
+			source: `package demo
+
+// Runtime import.
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "leading line comment containing package decoy",
+			source: `// package fake
+
+package demo
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "leading block comment containing package decoy",
+			source: `/*
+package fake
+*/
+
+package demo
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "grouped import with closing parenthesis in line comment",
+			source: `package demo
+
+import (
+	"fmt" // ) is not the end of the import group
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "grouped import with parentheses in block comment",
+			source: `package demo
+
+import (
+	"fmt" /* ( ) ) */
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var _ = fmt.Sprintf
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "grouped import with parenthesis in import path",
+			source: `package demo
+
+import (
+	_ "example.com/parenthesis)"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name: "cgo preamble",
+			source: `package demo
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 2,
+		},
+		{
+			name:            "semicolon separated declarations",
+			source:          "package demo; import gf \"github.com/graybuton/goframe/pkg/goframe\"; func View() gf.Node { return <Button /> }\n",
+			wantImportDecls: 1,
+		},
+		{
+			name:            "CRLF source",
+			source:          "package demo\r\n\r\nimport gf \"github.com/graybuton/goframe/pkg/goframe\"\r\n\r\nfunc View() gf.Node {\r\n\treturn <Button />\r\n}\r\n",
+			wantImportDecls: 1,
+		},
+		{
+			name: "Unicode comments",
+			source: `// Пример компонента.
+package demo
+
+// Импорт среды выполнения.
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`,
+			wantImportDecls: 1,
+		},
+		{
+			name:            "raw string decoys",
+			source:          "package demo\n\nimport gf \"github.com/graybuton/goframe/pkg/goframe\"\n\nvar Decoy = `package fake\nimport (\n)`\n\nfunc View() gf.Node {\n\treturn <Button />\n}\n",
+			wantImportDecls: 1,
+		},
+		{
+			name: "top level var before component function",
+			source: `package demo
+
+var Authored = 1
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+		{
+			name: "top level type before component function",
+			source: `package demo
+
+type Authored struct{}
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := GenerateOptions{
+				Filename:        "syntax_case.gox",
+				PackageIdentity: "example.com/demo",
+			}
+			first, err := GenerateWithOptions([]byte(test.source), options)
+			if err != nil {
+				t.Fatalf("GenerateWithOptions() error: %v", err)
+			}
+			second, err := GenerateWithOptions([]byte(test.source), options)
+			if err != nil {
+				t.Fatalf("GenerateWithOptions(second) error: %v", err)
+			}
+			if string(first) != string(second) {
+				t.Fatalf("generation is not deterministic:\nfirst:\n%s\nsecond:\n%s", first, second)
+			}
+
+			layout := assertGeneratedDeclarationLayout(t, "syntax_case.gox.go", first, "_goxComponent_syntax_case_Button")
+			if layout.importDecls != test.wantImportDecls {
+				t.Fatalf("import declarations = %d, want %d:\n%s", layout.importDecls, test.wantImportDecls, first)
+			}
+			if !declarationNamePresent(layout.file, "View") {
+				t.Fatalf("authored View declaration is missing:\n%s", first)
+			}
+		})
+	}
+}
+
+func TestGeneratePreservesAuthoredDeclarationDocumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		declaration string
+		wantComment string
+	}{
+		{
+			name: "func",
+			source: `package demo
+
+// View renders the page.
+func View() any {
+	return <Button />
+}
+`,
+			declaration: "View",
+			wantComment: "// View renders the page.",
+		},
+		{
+			name: "var",
+			source: `package demo
+
+// Banner stores authored state.
+var Banner = "hello"
+
+func View() any {
+	return <Button />
+}
+`,
+			declaration: "Banner",
+			wantComment: "// Banner stores authored state.",
+		},
+		{
+			name: "const",
+			source: `package demo
+
+// Kind identifies the view.
+const Kind = "view"
+
+func View() any {
+	return <Button />
+}
+`,
+			declaration: "Kind",
+			wantComment: "// Kind identifies the view.",
+		},
+		{
+			name: "type",
+			source: `package demo
+
+// Model stores view state.
+type Model struct{}
+
+func View() any {
+	return <Button />
+}
+`,
+			declaration: "Model",
+			wantComment: "// Model stores view state.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			generated, err := GenerateWithOptions([]byte(test.source), GenerateOptions{
+				Filename:        "documentation.gox",
+				PackageIdentity: "example.com/demo",
+			})
+			if err != nil {
+				t.Fatalf("GenerateWithOptions() error: %v", err)
+			}
+			layout := assertGeneratedDeclarationLayout(t, "documentation.gox.go", generated, "_goxComponent_documentation_Button")
+			declaration := findNamedDeclaration(layout.file, test.declaration)
+			if declaration == nil {
+				t.Fatalf("authored declaration %q is missing:\n%s", test.declaration, generated)
+			}
+			doc := declarationDoc(declaration)
+			if doc == nil || !commentGroupContains(doc, test.wantComment) {
+				t.Fatalf("documentation for %q was not preserved: %#v\n%s", test.declaration, doc, generated)
+			}
+			if layout.generated.Doc != nil {
+				t.Fatalf("generated declaration received authored documentation: %#v\n%s", layout.generated.Doc, generated)
+			}
+		})
+	}
+}
+
+func TestGeneratePreservesEmbedDirectiveAttachment(t *testing.T) {
+	source := []byte(`package demo
+
+import (
+	_ "embed"
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+//go:embed page.html
+var pageHTML string
+
+func View() gf.Node {
+	return <Button />
+}
+`)
+	generated, err := GenerateWithOptions(source, GenerateOptions{
+		Filename:        "embed_directive.gox",
+		PackageIdentity: "example.com/demo",
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithOptions() error: %v", err)
+	}
+	layout := assertGeneratedDeclarationLayout(t, "embed_directive.gox.go", generated, "_goxComponent_embed_directive_Button")
+	authored := findNamedDeclaration(layout.file, "pageHTML")
+	if authored == nil {
+		t.Fatalf("pageHTML declaration is missing:\n%s", generated)
+	}
+	doc := declarationDoc(authored)
+	if doc == nil || !commentGroupContains(doc, "//go:embed page.html") {
+		t.Fatalf("go:embed directive is not attached to pageHTML: %#v\n%s", doc, generated)
+	}
+	if layout.generated.Pos() >= doc.Pos() {
+		t.Fatalf("generated declaration was not inserted before go:embed directive:\n%s", generated)
+	}
+	if layout.generated.Doc != nil {
+		t.Fatalf("generated declaration received go:embed directive: %#v\n%s", layout.generated.Doc, generated)
+	}
+}
+
+func TestGeneratePreservesCgoPreamble(t *testing.T) {
+	source := []byte(`package demo
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func View() gf.Node {
+	return <Button />
+}
+`)
+	generated, err := GenerateWithOptions(source, GenerateOptions{
+		Filename:        "cgo_preamble.gox",
+		PackageIdentity: "example.com/demo",
+	})
+	if err != nil {
+		t.Fatalf("GenerateWithOptions() error: %v", err)
+	}
+	layout := assertGeneratedDeclarationLayout(t, "cgo_preamble.gox.go", generated, "_goxComponent_cgo_preamble_Button")
+	foundCgoPreamble := false
+	for _, declaration := range layout.file.Decls {
+		gen, ok := declaration.(*ast.GenDecl)
+		if !ok || gen.Tok != gotoken.IMPORT {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			importSpec := spec.(*ast.ImportSpec)
+			path, unquoteErr := strconv.Unquote(importSpec.Path.Value)
+			if unquoteErr == nil && path == "C" {
+				foundCgoPreamble = commentGroupContains(gen.Doc, "#include <stdlib.h>") || commentGroupContains(importSpec.Doc, "#include <stdlib.h>")
+			}
+		}
+	}
+	if !foundCgoPreamble {
+		t.Fatalf("cgo preamble is not attached to import C:\n%s", generated)
+	}
+}
+
+func TestGenerateRejectsMalformedTransformedGoBeforeDeclarations(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "malformed package clause",
+			source: `package
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+		{
+			name: "unterminated import group",
+			source: `package demo
+
+import (
+	"fmt"
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+		{
+			name: "invalid import declaration",
+			source: `package demo
+
+import 123
+
+func View() any {
+	return <Button />
+}
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := GenerateWithOptions([]byte(test.source), GenerateOptions{
+				Filename:        "malformed_insertion.gox",
+				PackageIdentity: "example.com/demo",
+			})
+			if err == nil {
+				t.Fatal("GenerateWithOptions() returned nil error")
+			}
+			for _, want := range []string{
+				"malformed_insertion.gox",
+				"parse transformed Go source before generated declarations",
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not contain %q", err, want)
+				}
+			}
+			if errors.Unwrap(err) == nil {
+				t.Fatalf("error does not preserve the Go parser error: %v", err)
+			}
+		})
+	}
+}
+
+type generatedDeclarationLayout struct {
+	file        *ast.File
+	generated   *ast.GenDecl
+	importDecls int
+}
+
+func assertGeneratedDeclarationLayout(t *testing.T, filename string, generated []byte, wantName string) generatedDeclarationLayout {
+	t.Helper()
+	file, err := parser.ParseFile(
+		gotoken.NewFileSet(),
+		filename,
+		generated,
+		parser.ParseComments|parser.AllErrors|parser.SkipObjectResolution,
+	)
+	if err != nil {
+		t.Fatalf("generated Go does not parse: %v\n%s", err, generated)
+	}
+
+	layout := generatedDeclarationLayout{file: file}
+	firstNonImport := -1
+	generatedIndex := -1
+	generatedNames := 0
+	for index, declaration := range file.Decls {
+		if gen, ok := declaration.(*ast.GenDecl); ok && gen.Tok == gotoken.IMPORT {
+			layout.importDecls++
+			continue
+		}
+		if firstNonImport < 0 {
+			firstNonImport = index
+		}
+		if gen, ok := declaration.(*ast.GenDecl); ok && declarationNamePresentInGenDecl(gen, wantName) {
+			layout.generated = gen
+			generatedIndex = index
+			generatedNames++
+		}
+	}
+	if generatedNames != 1 {
+		t.Fatalf("generated declaration count for %q = %d, want 1:\n%s", wantName, generatedNames, generated)
+	}
+	if generatedIndex != firstNonImport {
+		t.Fatalf("generated declaration index = %d, first non-import declaration index = %d:\n%s", generatedIndex, firstNonImport, generated)
+	}
+	return layout
+}
+
+func declarationNamePresent(file *ast.File, name string) bool {
+	return findNamedDeclaration(file, name) != nil
+}
+
+func findNamedDeclaration(file *ast.File, name string) ast.Decl {
+	for _, declaration := range file.Decls {
+		switch declaration := declaration.(type) {
+		case *ast.FuncDecl:
+			if declaration.Name.Name == name {
+				return declaration
+			}
+		case *ast.GenDecl:
+			if declarationNamePresentInGenDecl(declaration, name) {
+				return declaration
+			}
+		}
+	}
+	return nil
+}
+
+func declarationNamePresentInGenDecl(declaration *ast.GenDecl, name string) bool {
+	for _, spec := range declaration.Specs {
+		switch spec := spec.(type) {
+		case *ast.ValueSpec:
+			for _, identifier := range spec.Names {
+				if identifier.Name == name {
+					return true
+				}
+			}
+		case *ast.TypeSpec:
+			if spec.Name.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func declarationDoc(declaration ast.Decl) *ast.CommentGroup {
+	switch declaration := declaration.(type) {
+	case *ast.FuncDecl:
+		return declaration.Doc
+	case *ast.GenDecl:
+		return declaration.Doc
+	default:
+		return nil
+	}
+}
+
+func commentGroupContains(group *ast.CommentGroup, text string) bool {
+	if group == nil {
+		return false
+	}
+	for _, comment := range group.List {
+		if strings.Contains(comment.Text, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInsertGeneratedDeclarationsAfterPackageAndImportsOnly(t *testing.T) {
+	const declarations = "var _goxComponent_helper_Button = 1\n"
+	tests := []struct {
+		name            string
+		input           string
+		wantImportDecls int
+		trailingComment string
+	}{
+		{name: "package only without trailing newline", input: "package demo"},
+		{name: "package with trailing comment", input: "package demo\n\n// trailing package comment\n", trailingComment: "// trailing package comment"},
+		{name: "single import", input: "package demo\n\nimport \"fmt\"\n", wantImportDecls: 1},
+		{name: "multiple imports and trailing comment", input: "package demo\n\nimport \"fmt\"\nimport \"strings\"\n\n// trailing import comment\n", wantImportDecls: 2, trailingComment: "// trailing import comment"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, err := insertGeneratedDeclarations("package_only.gox", test.input, declarations)
+			if err != nil {
+				t.Fatalf("insertGeneratedDeclarations() error: %v", err)
+			}
+			layout := assertGeneratedDeclarationLayout(t, "package_only.gox.go", []byte(output), "_goxComponent_helper_Button")
+			if layout.importDecls != test.wantImportDecls {
+				t.Fatalf("import declarations = %d, want %d:\n%s", layout.importDecls, test.wantImportDecls, output)
+			}
+			if test.trailingComment != "" {
+				commentIndex := strings.Index(output, test.trailingComment)
+				declarationIndex := strings.Index(output, "_goxComponent_helper_Button")
+				if commentIndex < 0 || declarationIndex < commentIndex {
+					t.Fatalf("trailing comment was not preserved before the appended declaration:\n%s", output)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces GOX's text-based generated-declaration placement with a
Go-parser-backed insertion boundary.

Previously, component type declarations were positioned by searching raw source
bytes for `package`, `import`, and matching parentheses. Valid Go constructs
such as comments before imports, multiple import declarations, cgo preambles,
or parentheses inside import comments could cause generated declarations to be
inserted in the wrong location and produce invalid Go source.

## Changes

- Parses the transformed Go source with `go/parser` before inserting generated
  declarations.
- Uses `go/token` positions to place generated component declarations:
  - after all import declarations;
  - before the first authored non-import declaration;
  - before an attached documentation comment or compiler directive.
- Preserves authored source relationships for:
  - ordinary declaration documentation;
  - `//go:embed` directives;
  - cgo preambles and `import "C"`;
  - comments between package and import declarations;
  - multiple and grouped imports.
- Returns a filename-aware wrapped Go parser error for malformed transformed
  source instead of falling back to byte offset zero.
- Removes the obsolete textual package/import scanner and raw parenthesis
  counter.
- Keeps the existing final `go/format` pass authoritative.
- Extends `FuzzGenerate` with parser-boundary seeds covering comments, multiple
  imports, cgo, and declaration documentation.

## Validation

The focused regression suite covers:

- files without imports;
- single, aliased, grouped, and multiple import declarations;
- comments before and between imports;
- decoy `package` text inside line and block comments;
- parentheses inside import comments, block comments, and import paths;
- cgo preamble attachment;
- authored `func`, `var`, `const`, and `type` documentation;
- `//go:embed` directive attachment;
- semicolon-separated declarations;
- CRLF input;
- Unicode comments;
- raw-string package/import decoys;
- malformed package and import syntax;
- deterministic generation and AST declaration ordering.

Local validation passes:

- repeated and race-enabled focused tests;
- GOX golden and error-golden tests;
- `FuzzGenerate` and `FuzzParseElement`;
- full Go, race, debug-tag, and vet suites;
- repository, browser-smoke, documentation, artifact, and module-path checks;
- the complete Go 1.22.12 / TinyGo 0.41.1 size matrix.

Existing generated GOX output remains byte-identical for the current corpus, and
all 11 budgeted examples retain identical raw WASM and deterministic compressed
artifacts.

## Compatibility

This is an internal GOX compiler correctness change.

It does not change:

- the public API;
- GOX grammar or supported syntax;
- component identity or generated identifier names;
- package-qualified component behavior;
- import alias resolution;
- runtime or `goxc` behavior;
- dependencies, workflows, examples, or size budgets.

Generated declaration collision handling remains a separate concern and is not
part of this change.