### PR TITLE
test(example): characterize retained async navigation

### DIFF
--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -18,6 +18,8 @@ This example shows a narrow integration pattern:
 - a controlled backend failure and recovery path through later navigation;
 - direct hash and browser back/forward navigation through the same router,
   resource, and route-to-form synchronization lifecycle;
+- a separate same-pattern transition route that retains its last committed
+  target and message while the requested target prepares;
 - a route-owned mutation form with client validation, pending and failure
   states, duplicate-submit suppression, and server-confirmed recovery;
 - committed-state confirmation through the existing `UseResource.reload`
@@ -65,6 +67,9 @@ Open <http://127.0.0.1:8080>.
   backend error and recovers after later valid navigation.
 - A delayed backend response is aborted when superseded or unmounted, and it
   cannot replace the current route result.
+- The `/transition-greeting` route keeps its requested target separate from one
+  committed target/message snapshot, so the previous screen can remain visible
+  while the next same-pattern query target prepares.
 - `gf.FetchText` is a low-level text loader, not a server framework or data
   framework.
 - The `/saved-greeting` route keeps the committed value in a read resource and
@@ -108,6 +113,11 @@ Routes exercised by the browser evidence are:
 #/greeting?name=Lin
 #/greeting?name=slow
 #/greeting?name=fail
+#/transition-greeting?name=Ada
+#/transition-greeting?name=Lin
+#/transition-greeting?name=Mia
+#/transition-greeting?name=slow
+#/transition-greeting?name=fail
 #/saved-greeting
 ```
 
@@ -116,6 +126,83 @@ key supersedes the previous generation and the route effect synchronizes the
 controlled draft. Navigating to `/` unmounts the greeting route, form, and
 resource owner. Both cancellation paths run the cleanup returned by
 `gf.FetchText` through `gf.UseResource` ownership.
+
+## Async Navigation Transition Pressure Test
+
+The separate `/transition-greeting?name=...` route measures whether current
+primitives can retain a committed screen while a same-pattern query target
+prepares. The current hash and requested target drive one `gf.UseResource`
+instance. One example-owned `committedGreeting` value holds the displayed name,
+route target, message, and ready marker. An effect copies the requested target
+and ready resource value into that snapshot through one state setter.
+
+### Proven
+
+Two browser runs demonstrated that:
+
+- a slow same-pattern transition keeps the previous committed target and
+  message visible while the hash and requested target already identify `slow`;
+- superseding slow work aborts its request, and `gf.UseResource` prevents the
+  stale result from committing;
+- displayed target and displayed data commit as one observed snapshot, with no
+  mixed target/message pair;
+- controlled failure and retry remain separate from the committed screen;
+- recovery, browser Back, and browser Forward use the same retained-screen and
+  paired-commit path;
+- unmounting the route aborts active slow work and produces no late route
+  activity or commit.
+
+The two runs produced identical behavioral counters:
+
+| Counter | Run 1 | Run 2 |
+|---|---:|---:|
+| transition requests started | 10 | 10 |
+| successful completions | 6 | 6 |
+| failed completions | 2 | 2 |
+| aborted requests | 2 | 2 |
+| transition commits | 6 | 6 |
+| retry attempts | 1 | 1 |
+| stale-result appearances | 0 | 0 |
+| invalid committed pairs | 0 | 0 |
+| old-screen losses after initial commit | 0 | 0 |
+
+### Measured Coordination
+
+| Application-owned concern | Count |
+|---|---:|
+| state slots | 2 |
+| effects | 2 |
+| `UseResource` instances | 1 |
+| reload handoff points | 1 |
+| manual generation counters | 0 |
+| manual attempt IDs | 0 |
+| manual stale-result guards | 0 |
+| manual cleanup callbacks | 0 |
+| app-owned `AbortController` instances | 0 |
+| example-local helper types/functions | 2 |
+| route/data commit handoff points | 1 |
+
+The transition production change adds 161 Go/GOX lines. The browser harness
+adds 907 lines and removes 14, a net increase of 893 lines. These are source
+measurements, not API or size-budget thresholds.
+
+### Remaining Limitation
+
+`location.hash` changes before data readiness. The displayed target and data
+commit together, but the example does not provide an atomic URL + screen + data
+transaction.
+
+The retained-screen evidence covers same-pattern query transitions. The
+cross-pattern scenario proves unmount cancellation only; it does not prove
+cross-pattern old-screen retention. The evidence does not cover redirects,
+blockers, route loaders, a global cache, or prefetch. The existing `/greeting`
+route remains the baseline where pending navigation removes the previous ready
+message.
+
+### Decision
+
+Result A: Current primitives are sufficient for the demonstrated same-pattern
+retained transition flow; no public transition or loader API is selected.
 
 ## Mutation Flow
 
@@ -174,10 +261,14 @@ request context before commit. Unsupported methods return HTTP 405 with
 | cancellation | `gf.UseResource` cleanup invoking `gf.FetchText` cleanup |
 | stale completion suppression | `gf.UseResource` generation checks and `gf.FetchText` active state |
 | loading/failed/ready UI | explicit branches in `GreetingRoute` |
+| transition requested target | current `/transition-greeting` route props and resource key |
+| transition committed screen | one `TransitionGreetingRoute` state slot containing target and message |
+| transition commit handoff | one effect commits a ready resource for the current requested target |
+| transition retry | the active resource's returned `reload` function |
 | global shell retention | `App`, `ServerBackedShell`, and the route-content container outside the matched route subtree |
 | same-pattern form/input retention | pattern-keyed `RouterView` reconciliation retains the greeting form and input across query changes and reloads |
-| old-screen retention during pending | not provided; the route shows loading and removes the previous ready result |
-| atomic route + data commit | not provided; the hash target commits before the resource is ready |
+| baseline greeting old-screen retention during pending | not provided; `GreetingRoute` shows loading and removes the previous ready result |
+| atomic URL + screen + data commit | not provided; the hash target commits before the resource is ready |
 | controlled mutation draft | `SavedGreetingRoute` and its dedicated `gf.UseState` slot |
 | client validation | `SavedGreetingRoute` submit handler trims the draft and rejects an empty name |
 | mutation pending state | route-owned mutation status plus the active request owner |
@@ -253,6 +344,13 @@ behavioral outcomes, balanced scheduling, attributable component work, and no
 input update leaking into the next scenario rather than fixing incidental DOM
 totals as product contracts.
 
+Each run then performs ten isolated transition-route fetches: six successful
+completions, two controlled failures, and two aborts. Six valid committed
+target/message pairs were observed, including Back and Forward. One failed
+target was retried. No stale result, invalid pair, or old-screen loss after the
+initial commit was observed. The transition route mounted once and unmounted
+once, while app, shell, and route-content-container identity remained stable.
+
 Direct, Back, and Forward navigation each prove that route target, resource key,
 controlled input, and result refer to the same normalized name. Same-target
 success and failure submissions keep the hash unchanged while starting a new
@@ -313,6 +411,21 @@ cost covers the saved route, mutation state and owner, browser POST transport,
 and visible lifecycle branches. It does not authorize a budget increase or a
 shared runtime abstraction.
 
+The transition pressure-test branch was also compared with its frozen base
+using Go `1.22.12` and TinyGo `0.41.1`. The raw WASM was resolved through
+`asset-manifest.json`; compressed measurements use `gzip -n -9`, Brotli quality
+11, and Zstandard level 19.
+
+| Artifact | Frozen base | Transition branch | Delta |
+|---|---:|---:|---:|
+| raw WASM | 180,336 B | 194,393 B | +14,057 B |
+| gzip | 76,325 B | 80,475 B | +4,150 B |
+| Brotli | 63,513 B | 66,896 B | +3,383 B |
+| Zstandard | 67,426 B | 71,131 B | +3,705 B |
+
+These values are informational. No server-backed threshold or repository size
+budget changed.
+
 ## Evidence Verdict
 
 Verdict: **SUFFICIENT**.
@@ -343,8 +456,10 @@ examples/server-backed/
 │   └── styles.css
 └── cmd/
     ├── app/
-    │   ├── app.gox             # routes, read resources, and mutation owner
-    │   └── mutation_js.go      # example-local browser POST transport
+    │   ├── app.gox             # routes, resources, transition UI, and mutation owner
+    │   ├── mutation_js.go      # example-local browser POST transport
+    │   ├── transition.go       # committed transition snapshot helper
+    │   └── transition_test.go  # pure snapshot handoff coverage
     └── server/
         ├── main.go             # plain Go net/http server
         ├── saved_greeting.go   # synchronized store and endpoint
@@ -368,10 +483,12 @@ localhost port, opens the app through Chrome/CDP, and verifies route-driven
 loading, same-target reload/retry, direct and history-driven input
 synchronization, exact request aborts, stale-result suppression, controlled
 failure and recovery, global shell retention, same-pattern form/input retention,
-expected cross-pattern remounts, saved-state loading, validation without a POST,
-duplicate-write suppression, failure preservation, successful reload
-confirmation, mutation unmount cancellation, route-load versus reload
-attribution, final backend/UI consistency, and update/DOM bridge evidence.
+expected cross-pattern remounts, retained transition screens, paired committed
+target/data observations, transition failure/retry/recovery, saved-state
+loading, validation without a POST, duplicate-write suppression, failure
+preservation, successful reload confirmation, mutation unmount cancellation,
+route-load versus reload attribution, final backend/UI consistency, and
+update/DOM bridge evidence.
 
 ## Non-goals
 
@@ -387,6 +504,7 @@ This example intentionally does not provide:
 - RPC or a data transport framework;
 - SSR or hydration;
 - route loaders;
+- atomic URL + screen + data transitions;
 - auth/session helpers;
 - a global resource cache;
 - JSON/data framework behavior.

--- a/examples/server-backed/assets/styles.css
+++ b/examples/server-backed/assets/styles.css
@@ -139,3 +139,16 @@ h2 {
   color: #166534;
   font-weight: 700;
 }
+
+.transition-committed {
+  border: 1px solid #bbf7d0;
+  border-radius: 18px;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.transition-failure {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: start;
+}

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -20,6 +20,11 @@ type GreetingRouteProps struct {
 	Target string
 }
 
+type TransitionGreetingRouteProps struct {
+	Name   string
+	Target string
+}
+
 type SavedGreetingRouteProps struct {
 	Target string
 }
@@ -82,6 +87,7 @@ func (owner *savedGreetingMutationOwner) cancel() {
 var router = gf.NewHashRouter([]gf.Route{
 	gf.RoutePath("/", homeRoute),
 	gf.RoutePath("/greeting", greetingRoute),
+	gf.RoutePath("/transition-greeting", transitionGreetingRoute),
 	gf.RoutePath("/saved-greeting", savedGreetingRoute),
 	gf.NotFoundRoute(notFoundRoute),
 })
@@ -113,6 +119,13 @@ func ServerBackedShell(props ServerBackedShellProps) gf.Node {
 					<gf.RouterLink To="/saved-greeting" Class="home-link" TestID="server-backed-saved-link">
 						Saved greeting
 					</gf.RouterLink>
+					<gf.RouterLink
+						To="/transition-greeting?name=Ada"
+						Class="home-link"
+						TestID="server-backed-transition-link"
+					>
+						Retained transition
+					</gf.RouterLink>
 				</nav>
 			</section>
 
@@ -129,6 +142,13 @@ func homeRoute(ctx gf.RouteContext) gf.Node {
 
 func greetingRoute(ctx gf.RouteContext) gf.Node {
 	return <GreetingRoute
+		Name={normalizedGreetingName(ctx.Query().Get("name"))}
+		Target={routeTarget(ctx)}
+	/>
+}
+
+func transitionGreetingRoute(ctx gf.RouteContext) gf.Node {
+	return <TransitionGreetingRoute
 		Name={normalizedGreetingName(ctx.Query().Get("name"))}
 		Target={routeTarget(ctx)}
 	/>
@@ -298,6 +318,116 @@ func GreetingRoute(props GreetingRouteProps) gf.Node {
 			)}
 			{resource.Ready() && (
 				<p class="status message" data-testid="greeting-message">{resource.Value}</p>
+			)}
+		</div>
+	)
+}
+
+func TransitionGreetingRoute(props TransitionGreetingRouteProps) gf.Node {
+	draft, setDraft := gf.UseState(props.Name)
+	committed, setCommitted := gf.UseState(committedGreeting{})
+	gf.UseEffect(func() gf.Cleanup {
+		if draft != props.Name {
+			setDraft(props.Name)
+		}
+		return nil
+	}, gf.Deps(props.Name))
+
+	resource, reload := gf.UseResource(greetingPath(props.Name), gf.FetchText)
+	gf.UseEffect(func() gf.Cleanup {
+		next, changed := nextCommittedGreeting(
+			committed,
+			props.Name,
+			props.Target,
+			resource,
+		)
+		if changed {
+			setCommitted(next)
+		}
+		return nil
+	}, gf.Deps(
+		props.Name,
+		props.Target,
+		int(resource.Status),
+		resource.Value,
+	))
+
+	submitGreeting := func(event gf.Event) {
+		event.PreventDefault()
+		next := normalizedGreetingName(draft)
+		if next != draft {
+			setDraft(next)
+		}
+		if next == props.Name {
+			reload()
+			return
+		}
+		gf.Navigate(gf.WithQuery("/transition-greeting", gf.QueryValues{
+			"name": {next},
+		}))
+	}
+
+	status := "loading"
+	if resource.Failed() {
+		status = "failed"
+	} else if committed.Ready &&
+		resource.Ready() &&
+		committed.Target == props.Target {
+		status = "ready"
+	} else if committed.Ready {
+		status = "pending"
+	}
+
+	return (
+		<div data-testid="server-backed-transition-route">
+			<p class="eyebrow" data-testid="server-backed-route-name">Retained transition route</p>
+			<h2>Prepared backend response</h2>
+			<p class="muted">Requested target</p>
+			<p class="route-target" data-testid="transition-requested-target">{props.Target}</p>
+			<p class="muted" data-testid="transition-status">{status}</p>
+
+			<form class="greeting-form" data-testid="transition-form" OnSubmit={submitGreeting}>
+				<label class="field">
+					<span>Name</span>
+					<input
+						data-testid="transition-name"
+						Type="text"
+						Value={draft}
+						OnInput={func(event gf.InputEvent) {
+							setDraft(event.Value())
+						}}
+					/>
+				</label>
+				<button data-testid="transition-submit" Type="submit">Prepare greeting</button>
+			</form>
+
+			{committed.Ready && (
+				<section class="transition-committed" data-testid="transition-committed-screen">
+					<p class="muted">Committed target</p>
+					<p class="route-target" data-testid="transition-committed-target">{committed.Target}</p>
+					<p class="status message" data-testid="transition-message">{committed.Message}</p>
+				</section>
+			)}
+
+			{status == "loading" && (
+				<p class="status loading" data-testid="transition-pending">
+					Preparing the initial greeting for {props.Name}...
+				</p>
+			)}
+			{status == "pending" && (
+				<p class="status loading" data-testid="transition-pending">
+					Preparing {props.Name} while the committed screen remains visible...
+				</p>
+			)}
+			{resource.Failed() && (
+				<div class="transition-failure">
+					<div class="status failed" data-testid="transition-error">{greetingErrorText(resource)}</div>
+					<button data-testid="transition-retry" Type="button" OnClick={func(gf.Event) {
+						reload()
+					}}>
+						Retry requested target
+					</button>
+				</div>
 			)}
 		</div>
 	)

--- a/examples/server-backed/cmd/app/transition.go
+++ b/examples/server-backed/cmd/app/transition.go
@@ -1,0 +1,31 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type committedGreeting struct {
+	Name    string
+	Target  string
+	Message string
+	Ready   bool
+}
+
+func nextCommittedGreeting(
+	current committedGreeting,
+	requestedName string,
+	requestedTarget string,
+	resource gf.Resource[string],
+) (committedGreeting, bool) {
+	if !resource.Ready() {
+		return current, false
+	}
+	next := committedGreeting{
+		Name:    requestedName,
+		Target:  requestedTarget,
+		Message: resource.Value,
+		Ready:   true,
+	}
+	if next == current {
+		return current, false
+	}
+	return next, true
+}

--- a/examples/server-backed/cmd/app/transition_test.go
+++ b/examples/server-backed/cmd/app/transition_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func TestNextCommittedGreetingIgnoresUnreadyResource(t *testing.T) {
+	current := committedGreeting{
+		Name:    "Ada",
+		Target:  "/transition-greeting?name=Ada",
+		Message: "Hello, Ada, from Go backend!",
+		Ready:   true,
+	}
+	for _, resource := range []gf.Resource[string]{
+		{Status: gf.ResourceLoading},
+		{Status: gf.ResourceFailed, Err: errors.New("failed")},
+	} {
+		next, changed := nextCommittedGreeting(
+			current,
+			"Lin",
+			"/transition-greeting?name=Lin",
+			resource,
+		)
+		if changed {
+			t.Fatalf("nextCommittedGreeting(%v) changed committed state", resource.Status)
+		}
+		if next != current {
+			t.Fatalf("nextCommittedGreeting(%v) = %#v, want %#v", resource.Status, next, current)
+		}
+	}
+}
+
+func TestNextCommittedGreetingCommitsMatchingReadyPair(t *testing.T) {
+	next, changed := nextCommittedGreeting(
+		committedGreeting{},
+		"Ada",
+		"/transition-greeting?name=Ada",
+		gf.Resource[string]{
+			Status: gf.ResourceReady,
+			Value:  "Hello, Ada, from Go backend!",
+		},
+	)
+	if !changed {
+		t.Fatal("nextCommittedGreeting did not commit ready resource")
+	}
+	want := committedGreeting{
+		Name:    "Ada",
+		Target:  "/transition-greeting?name=Ada",
+		Message: "Hello, Ada, from Go backend!",
+		Ready:   true,
+	}
+	if next != want {
+		t.Fatalf("nextCommittedGreeting = %#v, want %#v", next, want)
+	}
+
+	repeated, changed := nextCommittedGreeting(
+		next,
+		"Ada",
+		"/transition-greeting?name=Ada",
+		gf.Resource[string]{
+			Status: gf.ResourceReady,
+			Value:  "Hello, Ada, from Go backend!",
+		},
+	)
+	if changed {
+		t.Fatal("repeated identical ready state changed committed snapshot")
+	}
+	if repeated != want {
+		t.Fatalf("repeated ready state = %#v, want %#v", repeated, want)
+	}
+}
+
+func TestNextCommittedGreetingReplacesPriorPairTogether(t *testing.T) {
+	current := committedGreeting{
+		Name:    "Ada",
+		Target:  "/transition-greeting?name=Ada",
+		Message: "Hello, Ada, from Go backend!",
+		Ready:   true,
+	}
+	next, changed := nextCommittedGreeting(
+		current,
+		"Lin",
+		"/transition-greeting?name=Lin",
+		gf.Resource[string]{
+			Status: gf.ResourceReady,
+			Value:  "Hello, Lin, from Go backend!",
+		},
+	)
+	if !changed {
+		t.Fatal("newer ready target did not change committed snapshot")
+	}
+	want := committedGreeting{
+		Name:    "Lin",
+		Target:  "/transition-greeting?name=Lin",
+		Message: "Hello, Lin, from Go backend!",
+		Ready:   true,
+	}
+	if next != want {
+		t.Fatalf("newer ready target = %#v, want %#v", next, want)
+	}
+}

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -32,6 +32,12 @@ const staleSettleMS = slowDelayMS + 300;
 const failureName = "fail";
 const failureStatus = "failed";
 const failureMessage = "goframe: fetch returned HTTP 500";
+const transitionInitialName = "Ada";
+const transitionInitialMessage = "Hello, Ada, from Go backend!";
+const transitionFastName = "Lin";
+const transitionFastMessage = "Hello, Lin, from Go backend!";
+const transitionHistoryName = "Mia";
+const transitionHistoryMessage = "Hello, Mia, from Go backend!";
 const savedGreetingTarget = "/saved-greeting";
 const savedGreetingHash = `#${savedGreetingTarget}`;
 const savedInitialName = "GoFrame";
@@ -46,6 +52,7 @@ const componentNames = [
     "RouterRoute",
     "HomeRoute",
     "GreetingRoute",
+    "TransitionGreetingRoute",
     "SavedGreetingRoute",
     "NotFoundRoute",
 ];
@@ -456,6 +463,346 @@ try {
     ], "route targets visited");
     console.log(`server-backed async navigation evidence: ${JSON.stringify(routeEvidence)}`);
 
+    await startScenario(client, "transition-initial-commit");
+    await navigateTransitionHash(client, transitionInitialName);
+    await waitForTransitionInitialLoading(client, transitionInitialName, "transition initial Ada loading");
+    await waitForTransitionCommitted(
+        client,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition initial Ada commit",
+    );
+    const transitionInitialReport = await finishScenario(client, "transition-initial-commit");
+    assertTransitionRouteReport(transitionInitialReport, "transition initial commit", {
+        outcome: "success",
+        commits: 1,
+        routeChanges: 1,
+        samePattern: false,
+    });
+    assertState(await appState(client), {
+        route: "transitionGreeting",
+        hash: transitionGreetingHash(transitionInitialName),
+        transitionRequestedTarget: transitionGreetingTarget(transitionInitialName),
+        transitionCommittedTarget: transitionGreetingTarget(transitionInitialName),
+        transitionStatus: "ready",
+        transitionMessage: transitionInitialMessage,
+        transitionInput: transitionInitialName,
+        transitionPending: false,
+        transitionFailed: false,
+        transitionCommittedScreen: true,
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+    }, "server-backed transition initial commit");
+
+    await prepareTransitionName(client, slowName);
+    await startScenario(client, "transition-slow-start");
+    await dispatchTransitionSubmit(client);
+    const transitionSlowRequest = await waitForTransitionSlowActive(
+        client,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition slow request active",
+    );
+    const transitionSlowReport = await finishScenario(client, "transition-slow-start");
+    assertTransitionRouteReport(transitionSlowReport, "transition slow start", {
+        outcome: "pending",
+        commits: 0,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+    assertState(await appState(client), {
+        route: "transitionGreeting",
+        hash: transitionGreetingHash(slowName),
+        transitionRequestedTarget: transitionGreetingTarget(slowName),
+        transitionCommittedTarget: transitionGreetingTarget(transitionInitialName),
+        transitionStatus: "pending",
+        transitionMessage: transitionInitialMessage,
+        transitionPending: true,
+        transitionFailed: false,
+        transitionCommittedScreen: true,
+    }, "server-backed transition URL advanced while Ada remained committed");
+
+    await prepareTransitionName(client, transitionFastName);
+    await startScenario(client, "transition-slow-supersede");
+    await dispatchTransitionSubmit(client);
+    await waitForTransitionPending(
+        client,
+        transitionFastName,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition Lin pending with Ada committed",
+    );
+    await waitForTransitionRequestAbort(client, transitionSlowRequest.id, "transition slow request abort");
+    await waitForTransitionCommitted(
+        client,
+        transitionFastName,
+        transitionFastMessage,
+        "transition Lin paired commit",
+    );
+    await wait(staleSettleMS);
+    const transitionSupersedeReport = await finishScenario(client, "transition-slow-supersede");
+    assertTransitionRouteReport(transitionSupersedeReport, "transition slow supersede", {
+        outcome: "success",
+        aborted: 1,
+        commits: 1,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+    assertRequest(await transitionRequestEvidence(client, transitionSlowRequest.id), {
+        name: slowName,
+        outcome: "aborted",
+        aborted: true,
+    }, "transition superseded slow request");
+    assertState(await appState(client), {
+        transitionRequestedTarget: transitionGreetingTarget(transitionFastName),
+        transitionCommittedTarget: transitionGreetingTarget(transitionFastName),
+        transitionStatus: "ready",
+        transitionMessage: transitionFastMessage,
+        transitionPending: false,
+        transitionFailed: false,
+    }, "server-backed transition stale slow result ignored");
+
+    await prepareTransitionName(client, failureName);
+    await startScenario(client, "transition-controlled-failure");
+    await dispatchTransitionSubmit(client);
+    await waitForTransitionPending(
+        client,
+        failureName,
+        transitionFastName,
+        transitionFastMessage,
+        "transition failure pending with Lin committed",
+    );
+    await waitForTransitionFailure(
+        client,
+        failureName,
+        transitionFastName,
+        transitionFastMessage,
+        "transition controlled failure",
+    );
+    const transitionFailureReport = await finishScenario(client, "transition-controlled-failure");
+    assertTransitionRouteReport(transitionFailureReport, "transition controlled failure", {
+        outcome: "failed",
+        failures: 1,
+        commits: 0,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    const transitionRetryBaseline = await evidenceState(client);
+    await startScenario(client, "transition-failure-retry");
+    await dispatchTransitionRetry(client);
+    await waitForTransitionRequestCount(
+        client,
+        transitionRetryBaseline.transitionRequestsStarted + 1,
+        "transition retry request",
+    );
+    await waitForTransitionPending(
+        client,
+        failureName,
+        transitionFastName,
+        transitionFastMessage,
+        "transition retry pending with Lin committed",
+    );
+    await waitForTransitionFailure(
+        client,
+        failureName,
+        transitionFastName,
+        transitionFastMessage,
+        "transition retry failure",
+    );
+    const transitionRetryReport = await finishScenario(client, "transition-failure-retry");
+    assertTransitionRouteReport(transitionRetryReport, "transition failure retry", {
+        outcome: "failed",
+        failures: 1,
+        retries: 1,
+        commits: 0,
+        routeChanges: 0,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    await prepareTransitionName(client, transitionInitialName);
+    await startScenario(client, "transition-failure-recovery");
+    await dispatchTransitionSubmit(client);
+    await waitForTransitionPending(
+        client,
+        transitionInitialName,
+        transitionFastName,
+        transitionFastMessage,
+        "transition recovery pending with Lin committed",
+    );
+    await waitForTransitionCommitted(
+        client,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition failure recovery commit",
+    );
+    const transitionRecoveryReport = await finishScenario(client, "transition-failure-recovery");
+    assertTransitionRouteReport(transitionRecoveryReport, "transition failure recovery", {
+        outcome: "success",
+        commits: 1,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    await prepareTransitionName(client, transitionHistoryName);
+    await startScenario(client, "transition-history-anchor");
+    await dispatchTransitionSubmit(client);
+    await waitForTransitionPending(
+        client,
+        transitionHistoryName,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition history target pending with Ada committed",
+    );
+    await waitForTransitionCommitted(
+        client,
+        transitionHistoryName,
+        transitionHistoryMessage,
+        "transition history target commit",
+    );
+    const transitionHistoryReport = await finishScenario(client, "transition-history-anchor");
+    assertTransitionRouteReport(transitionHistoryReport, "transition history anchor", {
+        outcome: "success",
+        commits: 1,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    await startScenario(client, "transition-browser-back");
+    await client.evaluate("history.back()");
+    await waitForTransitionPending(
+        client,
+        transitionInitialName,
+        transitionHistoryName,
+        transitionHistoryMessage,
+        "transition browser Back pending",
+    );
+    await waitForTransitionCommitted(
+        client,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition browser Back commit",
+    );
+    const transitionBackReport = await finishScenario(client, "transition-browser-back");
+    assertTransitionRouteReport(transitionBackReport, "transition browser Back", {
+        outcome: "success",
+        commits: 1,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    await startScenario(client, "transition-browser-forward");
+    await client.evaluate("history.forward()");
+    await waitForTransitionPending(
+        client,
+        transitionHistoryName,
+        transitionInitialName,
+        transitionInitialMessage,
+        "transition browser Forward pending",
+    );
+    await waitForTransitionCommitted(
+        client,
+        transitionHistoryName,
+        transitionHistoryMessage,
+        "transition browser Forward commit",
+    );
+    const transitionForwardReport = await finishScenario(client, "transition-browser-forward");
+    assertTransitionRouteReport(transitionForwardReport, "transition browser Forward", {
+        outcome: "success",
+        commits: 1,
+        routeChanges: 1,
+        samePattern: true,
+        committedScreenSame: true,
+    });
+
+    await prepareTransitionName(client, slowName);
+    await startScenario(client, "transition-unmount-cancellation");
+    await dispatchTransitionSubmit(client);
+    const transitionUnmountRequest = await waitForTransitionSlowActive(
+        client,
+        transitionHistoryName,
+        transitionHistoryMessage,
+        "transition unmount slow request active",
+    );
+    await navigateHome(client);
+    await waitForRoute(client, "home", "/");
+    await waitForTransitionRequestAbort(
+        client,
+        transitionUnmountRequest.id,
+        "transition route unmount slow request abort",
+    );
+    const transitionRouteCountsAfterUnmount = await componentActivity(client, "TransitionGreetingRoute");
+    await wait(staleSettleMS);
+    const transitionRouteCountsAfterSettle = await componentActivity(client, "TransitionGreetingRoute");
+    assertState(
+        transitionRouteCountsAfterSettle,
+        transitionRouteCountsAfterUnmount,
+        "transition route stayed inactive after unmount",
+    );
+    const transitionUnmountReport = await finishScenario(client, "transition-unmount-cancellation");
+    assertTransitionUnmountReport(transitionUnmountReport, "transition unmount cancellation");
+    assertRequest(await transitionRequestEvidence(client, transitionUnmountRequest.id), {
+        name: slowName,
+        outcome: "aborted",
+        aborted: true,
+    }, "transition route-unmounted slow request");
+    assertState(await appState(client), {
+        route: "home",
+        hash: "#/",
+        routeTarget: "/",
+        transitionRoute: false,
+        transitionMessage: "",
+        transitionStatus: "",
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+    }, "server-backed transition route unmounted");
+
+    const transitionEvidence = await evidenceState(client);
+    assertEvidence(transitionEvidence, {
+        transitionRequestsStarted: 10,
+        transitionSuccessfulCompletions: 6,
+        transitionFailedCompletions: 2,
+        transitionAborts: 2,
+        activeTransitionRequests: 0,
+        transitionCommits: 6,
+        transitionFailures: 2,
+        transitionRetryAttempts: 1,
+        transitionStaleResultAppearances: 0,
+        transitionInvalidCommittedPairs: 0,
+        transitionOldScreenLosses: 0,
+        transitionRouteMounts: 1,
+        transitionRouteUnmounts: 1,
+    }, "final retained transition evidence");
+    assertStringArray(transitionEvidence.transitionRequestedTargetsObserved, [
+        transitionGreetingTarget(transitionInitialName),
+        transitionGreetingTarget(slowName),
+        transitionGreetingTarget(transitionFastName),
+        transitionGreetingTarget(failureName),
+        transitionGreetingTarget(transitionInitialName),
+        transitionGreetingTarget(transitionHistoryName),
+        transitionGreetingTarget(transitionInitialName),
+        transitionGreetingTarget(transitionHistoryName),
+        transitionGreetingTarget(slowName),
+    ], "transition requested targets observed");
+    assertCommittedPairArray(transitionEvidence.transitionCommittedPairsObserved, [
+        transitionPair(transitionInitialName, transitionInitialMessage),
+        transitionPair(transitionFastName, transitionFastMessage),
+        transitionPair(transitionInitialName, transitionInitialMessage),
+        transitionPair(transitionHistoryName, transitionHistoryMessage),
+        transitionPair(transitionInitialName, transitionInitialMessage),
+        transitionPair(transitionHistoryName, transitionHistoryMessage),
+    ], "transition committed pairs observed");
+    console.log(`server-backed retained transition evidence: ${JSON.stringify(transitionEvidence)}`);
+
     await startScenario(client, "saved-initial-state");
     await navigateSavedGreeting(client);
     await waitForSavedReadLoading(client, "saved greeting initial read loading");
@@ -711,6 +1058,16 @@ try {
         activeMutationRequests: 0,
         duplicateSubmitAttempts: 1,
         staleCommittedValueAppearances: 0,
+        transitionRequestsStarted: 10,
+        transitionSuccessfulCompletions: 6,
+        transitionFailedCompletions: 2,
+        transitionAborts: 2,
+        activeTransitionRequests: 0,
+        transitionCommits: 6,
+        transitionRetryAttempts: 1,
+        transitionStaleResultAppearances: 0,
+        transitionInvalidCommittedPairs: 0,
+        transitionOldScreenLosses: 0,
         appIdentityChanges: 0,
         shellIdentityChanges: 0,
         routeContentIdentityChanges: 0,
@@ -732,6 +1089,16 @@ try {
         greetingHash(updatedName),
         greetingHash(failureName),
         greetingHash(updatedName),
+        transitionGreetingHash(transitionInitialName),
+        transitionGreetingHash(slowName),
+        transitionGreetingHash(transitionFastName),
+        transitionGreetingHash(failureName),
+        transitionGreetingHash(transitionInitialName),
+        transitionGreetingHash(transitionHistoryName),
+        transitionGreetingHash(transitionInitialName),
+        transitionGreetingHash(transitionHistoryName),
+        transitionGreetingHash(slowName),
+        "#/",
         savedGreetingHash,
         "#/",
         savedGreetingHash,
@@ -825,6 +1192,22 @@ function greetingHash(name) {
     return `#${greetingTarget(name)}`;
 }
 
+function transitionGreetingTarget(name) {
+    return `/transition-greeting?name=${encodeURIComponent(name)}`;
+}
+
+function transitionGreetingHash(name) {
+    return `#${transitionGreetingTarget(name)}`;
+}
+
+function transitionPair(name, message) {
+    return {
+        name,
+        target: transitionGreetingTarget(name),
+        message,
+    };
+}
+
 async function initializeBrowserEvidence(client) {
     const initialized = await client.evaluate("window.__serverBackedEvidence?.initialize() ?? null");
     if (!initialized?.ready) {
@@ -913,6 +1296,43 @@ async function prepareSavedGreetingName(client, name) {
     return report;
 }
 
+async function prepareTransitionName(client, name) {
+    const baseline = await client.callFunction(`function(name) {
+        const input = document.querySelector("[data-testid='transition-name']");
+        if (!input) {
+            return { ok: false, reason: "missing transition input" };
+        }
+        const owner = "TransitionGreetingRoute";
+        const renders = window.goframeComponentRenderCounts?.[owner] || 0;
+        const patches = window.goframeComponentPatchCounts?.[owner] || 0;
+        input.value = name;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, owner, renders, patches, value: input.value };
+    }`, name);
+    if (!baseline?.ok) {
+        throw new Error(`APP FAILURE: could not prepare transition input: ${JSON.stringify(baseline)}`);
+    }
+
+    let updated = null;
+    await waitForCondition(async () => {
+        updated = await transitionInputPreparationState(client);
+        return updated.value === name &&
+            updated.renders > baseline.renders &&
+            updated.patches > baseline.patches;
+    }, `controlled transition input ${name} framework update`);
+
+    await waitForBrowserFrames(client, 2);
+    const settled = await transitionInputPreparationState(client);
+    if (settled.value !== name ||
+        settled.renders !== updated.renders ||
+        settled.patches !== updated.patches) {
+        throw new Error(`APP FAILURE: controlled transition input ${name} did not settle: ${JSON.stringify({ baseline, updated, settled })}`);
+    }
+    const report = { name, owner: baseline.owner, baseline, updated, settled };
+    console.log(`server-backed transition input preparation: ${JSON.stringify(report)}`);
+    return report;
+}
+
 async function savedInputPreparationState(client) {
     return await client.callFunction(`function() {
         const owner = "SavedGreetingRoute";
@@ -921,6 +1341,18 @@ async function savedInputPreparationState(client) {
             renders: window.goframeComponentRenderCounts?.[owner] || 0,
             patches: window.goframeComponentPatchCounts?.[owner] || 0,
             value: document.querySelector("[data-testid='saved-greeting-input']")?.value ?? "",
+        };
+    }`);
+}
+
+async function transitionInputPreparationState(client) {
+    return await client.callFunction(`function() {
+        const owner = "TransitionGreetingRoute";
+        return {
+            owner,
+            renders: window.goframeComponentRenderCounts?.[owner] || 0,
+            patches: window.goframeComponentPatchCounts?.[owner] || 0,
+            value: document.querySelector("[data-testid='transition-name']")?.value ?? "",
         };
     }`);
 }
@@ -967,6 +1399,38 @@ async function dispatchGreetingSubmit(client) {
         }
         return { ok: true };
     }`);
+}
+
+async function dispatchTransitionSubmit(client) {
+    const result = await client.evaluate(`(() => {
+        const form = document.querySelector("[data-testid='transition-form']");
+        if (!form) {
+            return { ok: false, reason: "missing transition form" };
+        }
+        if (typeof form.requestSubmit === "function") {
+            form.requestSubmit();
+        } else {
+            form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        }
+        return { ok: true };
+    })()`);
+    if (!result?.ok) {
+        throw new Error(`APP FAILURE: could not submit transition form: ${JSON.stringify(result)}`);
+    }
+}
+
+async function dispatchTransitionRetry(client) {
+    const result = await client.evaluate(`(() => {
+        const retry = document.querySelector("[data-testid='transition-retry']");
+        if (!retry) {
+            return { ok: false, reason: "missing transition retry" };
+        }
+        retry.click();
+        return { ok: true };
+    })()`);
+    if (!result?.ok) {
+        throw new Error(`APP FAILURE: could not retry transition: ${JSON.stringify(result)}`);
+    }
 }
 
 async function dispatchSavedGreetingSubmit(client) {
@@ -1036,6 +1500,104 @@ async function waitForFailure(client, expectedError, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
         return state.failed && state.status === failureStatus && state.error === expectedError;
+    }, label);
+}
+
+async function waitForTransitionInitialLoading(client, name, label) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "transitionGreeting" &&
+            state.hash === transitionGreetingHash(name) &&
+            state.transitionRequestedTarget === transitionGreetingTarget(name) &&
+            state.transitionStatus === "loading" &&
+            state.transitionInput === name &&
+            state.transitionPending &&
+            !state.transitionFailed &&
+            !state.transitionCommittedScreen;
+    }, label);
+}
+
+async function waitForTransitionPending(client, requestedName, committedName, committedMessage, label) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "transitionGreeting" &&
+            state.hash === transitionGreetingHash(requestedName) &&
+            state.transitionRequestedTarget === transitionGreetingTarget(requestedName) &&
+            state.transitionCommittedTarget === transitionGreetingTarget(committedName) &&
+            state.transitionStatus === "pending" &&
+            state.transitionMessage === committedMessage &&
+            state.transitionInput === requestedName &&
+            state.transitionPending &&
+            !state.transitionFailed &&
+            state.transitionCommittedScreen;
+    }, label);
+}
+
+async function waitForTransitionCommitted(client, name, message, label) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "transitionGreeting" &&
+            state.hash === transitionGreetingHash(name) &&
+            state.transitionRequestedTarget === transitionGreetingTarget(name) &&
+            state.transitionCommittedTarget === transitionGreetingTarget(name) &&
+            state.transitionStatus === "ready" &&
+            state.transitionMessage === message &&
+            state.transitionInput === name &&
+            !state.transitionPending &&
+            !state.transitionFailed &&
+            state.transitionCommittedScreen;
+    }, label);
+}
+
+async function waitForTransitionFailure(client, requestedName, committedName, committedMessage, label) {
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        return state.route === "transitionGreeting" &&
+            state.hash === transitionGreetingHash(requestedName) &&
+            state.transitionRequestedTarget === transitionGreetingTarget(requestedName) &&
+            state.transitionCommittedTarget === transitionGreetingTarget(committedName) &&
+            state.transitionStatus === "failed" &&
+            state.transitionMessage === committedMessage &&
+            state.transitionInput === requestedName &&
+            !state.transitionPending &&
+            state.transitionFailed &&
+            state.transitionError === failureMessage &&
+            state.transitionCommittedScreen;
+    }, label);
+}
+
+async function waitForTransitionSlowActive(client, committedName, committedMessage, label) {
+    let request = null;
+    await waitForCondition(async () => {
+        const state = await appState(client);
+        const evidence = await evidenceState(client);
+        request = [...evidence.transitionRequests].reverse().find((entry) =>
+            entry.name === slowName &&
+            entry.outcome === "pending",
+        ) ?? null;
+        return state.hash === transitionGreetingHash(slowName) &&
+            state.transitionStatus === "pending" &&
+            state.transitionCommittedTarget === transitionGreetingTarget(committedName) &&
+            state.transitionMessage === committedMessage &&
+            evidence.activeTransitionRequests === 1 &&
+            request !== null;
+    }, label);
+    return request;
+}
+
+async function waitForTransitionRequestAbort(client, requestID, label) {
+    await waitForCondition(async () => {
+        const evidence = await evidenceState(client);
+        const request = await transitionRequestEvidence(client, requestID);
+        return request?.aborted === true &&
+            request.outcome === "aborted" &&
+            evidence.activeTransitionRequests === 0;
+    }, label);
+}
+
+async function waitForTransitionRequestCount(client, expected, label) {
+    await waitForCondition(async () => {
+        return (await evidenceState(client)).transitionRequestsStarted === expected;
     }, label);
 }
 
@@ -1161,6 +1723,13 @@ async function navigateGreetingHash(client, name) {
     }`, greetingTarget(name));
 }
 
+async function navigateTransitionHash(client, name) {
+    await client.callFunction(`function(target) {
+        window.location.hash = target;
+        return window.location.hash;
+    }`, transitionGreetingTarget(name));
+}
+
 async function appState(client) {
     return await client.callFunction(`function() {
         const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() ?? "";
@@ -1168,8 +1737,10 @@ async function appState(client) {
         const key = document.querySelector("[data-testid='greeting-resource-key']")?.textContent.trim() ?? "";
         const home = document.querySelector("[data-testid='server-backed-home']");
         const greeting = document.querySelector("[data-testid='server-backed-greeting-route']");
+        const transitionGreeting = document.querySelector("[data-testid='server-backed-transition-route']");
         const savedGreeting = document.querySelector("[data-testid='server-backed-saved-route']");
         const notFound = document.querySelector("[data-testid='server-backed-not-found']");
+        const transitionError = document.querySelector("[data-testid='transition-error']")?.textContent.trim() ?? "";
         const mutationError = document.querySelector("[data-testid='saved-greeting-mutation-error']")?.textContent.trim() ?? "";
         const mutationStatus = document.querySelector("[data-testid='saved-greeting-mutation-status']")?.textContent.trim() ?? "";
         const identity = window.__serverBackedEvidence?.checkIdentity() ?? {};
@@ -1178,7 +1749,17 @@ async function appState(client) {
             shell: Boolean(document.querySelector("[data-testid='server-backed-shell']")),
             form: Boolean(document.querySelector("[data-testid='greeting-form']")),
             routeContent: Boolean(document.querySelector("[data-testid='server-backed-route-content']")),
-            route: home ? "home" : greeting ? "greeting" : savedGreeting ? "savedGreeting" : notFound ? "notFound" : "missing",
+            route: home
+                ? "home"
+                : greeting
+                    ? "greeting"
+                    : transitionGreeting
+                        ? "transitionGreeting"
+                        : savedGreeting
+                            ? "savedGreeting"
+                            : notFound
+                                ? "notFound"
+                                : "missing",
             hash: window.location.hash,
             routeTarget: document.querySelector("[data-testid='server-backed-route-target']")?.textContent.trim() ?? "",
             loading: Boolean(document.querySelector("[data-testid='greeting-loading']")),
@@ -1190,6 +1771,16 @@ async function appState(client) {
             message,
             error,
             errorNonEmpty: error.length > 0,
+            transitionRoute: Boolean(transitionGreeting),
+            transitionRequestedTarget: document.querySelector("[data-testid='transition-requested-target']")?.textContent.trim() ?? "",
+            transitionCommittedTarget: document.querySelector("[data-testid='transition-committed-target']")?.textContent.trim() ?? "",
+            transitionStatus: document.querySelector("[data-testid='transition-status']")?.textContent.trim() ?? "",
+            transitionMessage: document.querySelector("[data-testid='transition-message']")?.textContent.trim() ?? "",
+            transitionInput: document.querySelector("[data-testid='transition-name']")?.value ?? "",
+            transitionPending: Boolean(document.querySelector("[data-testid='transition-pending']")),
+            transitionFailed: Boolean(document.querySelector("[data-testid='transition-error']")),
+            transitionError,
+            transitionCommittedScreen: Boolean(document.querySelector("[data-testid='transition-committed-screen']")),
             savedForm: Boolean(document.querySelector("[data-testid='saved-greeting-form']")),
             savedInput: document.querySelector("[data-testid='saved-greeting-input']")?.value ?? "",
             savedResourceKey: document.querySelector("[data-testid='saved-greeting-resource-key']")?.textContent.trim() ?? "",
@@ -1218,6 +1809,12 @@ async function evidenceState(client) {
 async function requestEvidence(client, requestID) {
     return await client.callFunction(`function(requestID) {
         return window.__serverBackedEvidence?.request(requestID) ?? null;
+    }`, requestID);
+}
+
+async function transitionRequestEvidence(client, requestID) {
+    return await client.callFunction(`function(requestID) {
+        return window.__serverBackedEvidence?.transitionRequest(requestID) ?? null;
     }`, requestID);
 }
 
@@ -1257,6 +1854,7 @@ function assertGreetingRouteReport(report, label, options) {
         failed: options.outcome === "failed" ? 1 : 0,
     };
     assertState(report.requests, expectedRequests, `${label} request delta`);
+    assertNoTransitionRequests(report, label);
     if (report.routeTargets.length !== options.routeChanges || report.routeContentMutations < 1) {
         throw new Error(`APP FAILURE: ${label} route evidence changed: ${JSON.stringify(report)}`);
     }
@@ -1271,10 +1869,88 @@ function assertHomeNavigationReport(report, label) {
         succeeded: 0,
         failed: 0,
     }, `${label} request delta`);
+    assertNoTransitionRequests(report, label);
     if (report.routeTargets.length !== 1 || report.routeContentMutations < 1) {
         throw new Error(`APP FAILURE: ${label} home evidence changed: ${JSON.stringify(report)}`);
     }
     assertReportIdentity(report, label, false);
+}
+
+function assertTransitionRouteReport(report, label, options) {
+    assertSchedulingReport(report, label, "TransitionGreetingRoute");
+    assertState(report.requests, {
+        started: 0,
+        aborted: 0,
+        succeeded: 0,
+        failed: 0,
+    }, `${label} baseline greeting request delta`);
+    assertState(report.transitionRequests, {
+        started: 1,
+        aborted: options.aborted ?? 0,
+        succeeded: options.outcome === "success" ? 1 : 0,
+        failed: options.outcome === "failed" ? 1 : 0,
+        active: options.outcome === "pending" ? 1 : 0,
+    }, `${label} transition request delta`);
+    assertState(report.transition, {
+        commits: options.commits ?? 0,
+        failures: options.failures ?? 0,
+        retries: options.retries ?? 0,
+        staleResultAppearances: 0,
+        invalidCommittedPairs: 0,
+        oldScreenLosses: 0,
+        routeMounts: options.samePattern ? 0 : 1,
+        routeUnmounts: 0,
+    }, `${label} transition state delta`);
+    if (report.routeTargets.length !== options.routeChanges || report.routeContentMutations < 1) {
+        throw new Error(`APP FAILURE: ${label} route evidence changed: ${JSON.stringify(report)}`);
+    }
+    assertState(report.identity, {
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+        transitionFormSame: options.samePattern,
+        transitionInputSame: options.samePattern,
+        transitionCommittedScreenSame: options.committedScreenSame ?? options.samePattern,
+    }, `${label} identity`);
+}
+
+function assertTransitionUnmountReport(report, label) {
+    assertSchedulingReport(report, label, "HomeRoute");
+    assertState(report.requests, {
+        started: 0,
+        aborted: 0,
+        succeeded: 0,
+        failed: 0,
+    }, `${label} baseline greeting request delta`);
+    assertState(report.transitionRequests, {
+        started: 1,
+        aborted: 1,
+        succeeded: 0,
+        failed: 0,
+        active: 0,
+    }, `${label} transition request delta`);
+    assertState(report.transition, {
+        commits: 0,
+        failures: 0,
+        retries: 0,
+        staleResultAppearances: 0,
+        invalidCommittedPairs: 0,
+        oldScreenLosses: 0,
+        routeMounts: 0,
+        routeUnmounts: 1,
+    }, `${label} transition state delta`);
+    assertStringArray(report.routeTargets, [
+        transitionGreetingHash(slowName),
+        "#/",
+    ], `${label} route targets`);
+    assertState(report.identity, {
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+        transitionFormSame: false,
+        transitionInputSame: false,
+        transitionCommittedScreenSame: false,
+    }, `${label} identity`);
 }
 
 function assertSavedGreetingReport(report, label, options) {
@@ -1285,6 +1961,7 @@ function assertSavedGreetingReport(report, label, options) {
         succeeded: 0,
         failed: 0,
     }, `${label} greeting request delta`);
+    assertNoTransitionRequests(report, label);
     assertState(report.savedRequests, {
         getsStarted: options.getsStarted ?? 0,
         getsCompleted: options.getsCompleted ?? 0,
@@ -1322,6 +1999,7 @@ function assertSavedMutationUnmountReport(report, label) {
         succeeded: 0,
         failed: 0,
     }, `${label} greeting request delta`);
+    assertNoTransitionRequests(report, label);
     assertState(report.savedRequests, {
         getsStarted: 0,
         getsCompleted: 0,
@@ -1348,6 +2026,16 @@ function assertSavedMutationUnmountReport(report, label) {
         savedFormSame: false,
         savedInputSame: false,
     }, `${label} identity`);
+}
+
+function assertNoTransitionRequests(report, label) {
+    assertState(report.transitionRequests, {
+        started: 0,
+        aborted: 0,
+        succeeded: 0,
+        failed: 0,
+        active: 0,
+    }, `${label} transition request delta`);
 }
 
 function assertSchedulingReport(report, label, component) {
@@ -1378,6 +2066,8 @@ function assertFiniteReport(report, label) {
         scheduling: report.scheduling,
         componentRenders: report.componentRenders,
         componentPatches: report.componentPatches,
+        transitionRequests: report.transitionRequests,
+        transition: report.transition,
     })) {
         for (const [name, value] of Object.entries(group)) {
             if (!Number.isFinite(value) || value < 0) {
@@ -1402,6 +2092,13 @@ function assertEvidence(actual, expected, label) {
 }
 
 function assertStringArray(actual, expected, label) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+function assertCommittedPairArray(actual, expected, label) {
     if (JSON.stringify(actual) !== JSON.stringify(expected)) {
         throw new Error(`APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
     }
@@ -1434,9 +2131,12 @@ function installServerBackedEvidenceExpression() {
     const componentNames = ${JSON.stringify(componentNames)};
     const slowMessage = ${JSON.stringify(slowMessage)};
     const requests = [];
+    const transitionRequests = [];
     const savedRequests = [];
     const committedValuesObserved = [];
     const routeTargetsVisited = [];
+    const transitionRequestedTargetsObserved = [];
+    const transitionCommittedPairsObserved = [];
     const operations = ${JSON.stringify(emptyOperations())};
     const scheduling = {
         requestAnimationFrame: 0,
@@ -1446,11 +2146,28 @@ function installServerBackedEvidenceExpression() {
     };
     const renderReports = [];
     let nextRequestID = 1;
+    let nextTransitionRequestID = 1;
     let nextSavedRequestID = 1;
     let aborts = 0;
     let successfulCompletions = 0;
     let failedCompletions = 0;
     let staleResultAppearances = 0;
+    let transitionSuccessfulCompletions = 0;
+    let transitionFailedCompletions = 0;
+    let transitionAborts = 0;
+    let activeTransitionRequests = 0;
+    let transitionCommits = 0;
+    let transitionFailures = 0;
+    let transitionRetryAttempts = 0;
+    let transitionStaleResultAppearances = 0;
+    let transitionInvalidCommittedPairs = 0;
+    let transitionOldScreenLosses = 0;
+    let transitionRouteMounts = 0;
+    let transitionRouteUnmounts = 0;
+    let lastTransitionRequestedTarget = "";
+    let lastTransitionCommittedKey = "";
+    let lastTransitionFailure = "";
+    let transitionRouteMounted = false;
     let routeContentMutations = 0;
     let lastMessage = "";
     let lastCommittedValue = "";
@@ -1499,6 +2216,10 @@ function installServerBackedEvidenceExpression() {
                 return { ready: false };
             }
             routeTargetsVisited.push(window.location.hash);
+            transitionRouteMounted = Boolean(
+                document.querySelector("[data-testid='server-backed-transition-route']"),
+            );
+            captureTransitionState();
             new MutationObserver((records) => {
                 routeContentMutations += records.length;
                 const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() || "";
@@ -1515,6 +2236,7 @@ function installServerBackedEvidenceExpression() {
                     committedValuesObserved.push(committed);
                     lastCommittedValue = committed;
                 }
+                captureTransitionState();
             }).observe(this.stable.routeContent, {
                 childList: true,
                 subtree: true,
@@ -1542,6 +2264,10 @@ function installServerBackedEvidenceExpression() {
             const request = requests.find((entry) => entry.id === id);
             return request ? { ...request } : null;
         },
+        transitionRequest(id) {
+            const request = transitionRequests.find((entry) => entry.id === id);
+            return request ? { ...request } : null;
+        },
         savedRequest(id) {
             const request = savedRequests.find((entry) => entry.id === id);
             return request ? { ...request } : null;
@@ -1554,6 +2280,21 @@ function installServerBackedEvidenceExpression() {
                 successfulCompletions,
                 failedCompletions,
                 staleResultAppearances,
+                transitionRequestsStarted: transitionRequests.length,
+                transitionSuccessfulCompletions,
+                transitionFailedCompletions,
+                transitionAborts,
+                activeTransitionRequests,
+                transitionCommits,
+                transitionFailures,
+                transitionRetryAttempts,
+                transitionStaleResultAppearances,
+                transitionInvalidCommittedPairs,
+                transitionOldScreenLosses,
+                transitionRouteMounts,
+                transitionRouteUnmounts,
+                transitionRequestedTargetsObserved: [...transitionRequestedTargetsObserved],
+                transitionCommittedPairsObserved: transitionCommittedPairsObserved.map((pair) => ({ ...pair })),
                 savedGetsStarted,
                 savedGetsCompleted,
                 savedGetsFailed,
@@ -1573,6 +2314,7 @@ function installServerBackedEvidenceExpression() {
                 routeContentIdentityChanges: this.identityChanged.routeContent ? 1 : 0,
                 routeContentMutations,
                 requests: requests.map((request) => ({ ...request })),
+                transitionRequests: transitionRequests.map((request) => ({ ...request })),
                 savedRequests: savedRequests.map((request) => ({ ...request })),
             };
         },
@@ -1589,47 +2331,69 @@ function installServerBackedEvidenceExpression() {
             duplicateSubmitAttempts++;
         }
     }, true);
+    document.addEventListener("click", (event) => {
+        if (event.target?.closest?.("[data-testid='transition-retry']")) {
+            transitionRetryAttempts++;
+        }
+    }, true);
 
     const originalFetch = window.fetch.bind(window);
     window.fetch = function(input, init) {
         const requestURL = new URL(typeof input === "string" ? input : input.url, window.location.href);
         if (requestURL.pathname === "/api/greeting") {
             const signal = init?.signal;
+            const transition = Boolean(
+                document.querySelector("[data-testid='server-backed-transition-route']"),
+            );
             const request = {
-                id: nextRequestID++,
+                id: transition ? nextTransitionRequestID++ : nextRequestID++,
                 name: requestURL.searchParams.get("name") || "",
                 target: requestURL.pathname + requestURL.search,
                 outcome: "pending",
                 aborted: false,
+                flow: transition ? "transition" : "greeting",
             };
-            requests.push(request);
+            if (transition) {
+                transitionRequests.push(request);
+                activeTransitionRequests++;
+            } else {
+                requests.push(request);
+            }
+            const finish = (outcome) => {
+                if (request.outcome !== "pending") return;
+                request.outcome = outcome;
+                if (transition) {
+                    activeTransitionRequests--;
+                    if (outcome === "success") transitionSuccessfulCompletions++;
+                    else if (outcome === "aborted") transitionAborts++;
+                    else transitionFailedCompletions++;
+                    return;
+                }
+                if (outcome === "success") successfulCompletions++;
+                else if (outcome === "aborted") aborts++;
+                else failedCompletions++;
+            };
             if (signal) {
                 signal.addEventListener("abort", () => {
-                    if (request.aborted) return;
+                    if (request.aborted || request.outcome !== "pending") return;
                     request.aborted = true;
-                    request.outcome = "aborted";
-                    aborts++;
+                    finish("aborted");
                 }, { once: true });
             }
             return originalFetch(input, init).then((response) => {
                 // Keep loading observable without changing the backend or runtime.
                 return new Promise((resolve) => {
                     window.setTimeout(() => {
-                        if (!request.aborted) {
-                            request.outcome = response.ok ? "success" : "failed";
-                            if (response.ok) successfulCompletions++;
-                            else failedCompletions++;
-                        }
+                        if (!request.aborted) finish(response.ok ? "success" : "failed");
                         resolve(response);
                     }, request.name === ${JSON.stringify(slowName)} ? 0 : 140);
                 });
             }, (error) => {
                 if (signal?.aborted) {
                     request.aborted = true;
-                    request.outcome = "aborted";
+                    finish("aborted");
                 } else {
-                    request.outcome = "failed";
-                    failedCompletions++;
+                    finish("failed");
                 }
                 throw error;
             });
@@ -1717,6 +2481,9 @@ function installServerBackedEvidenceExpression() {
         routeMutationBaseline: 0,
         formBaseline: null,
         inputBaseline: null,
+        transitionFormBaseline: null,
+        transitionInputBaseline: null,
+        transitionCommittedScreenBaseline: null,
         savedFormBaseline: null,
         savedInputBaseline: null,
         committedValueBaseline: 0,
@@ -1730,6 +2497,18 @@ function installServerBackedEvidenceExpression() {
                 aborts,
                 successfulCompletions,
                 failedCompletions,
+                transitionRequestsStarted: transitionRequests.length,
+                transitionSuccessfulCompletions,
+                transitionFailedCompletions,
+                transitionAborts,
+                transitionCommits,
+                transitionFailures,
+                transitionRetryAttempts,
+                transitionStaleResultAppearances,
+                transitionInvalidCommittedPairs,
+                transitionOldScreenLosses,
+                transitionRouteMounts,
+                transitionRouteUnmounts,
                 savedGetsStarted,
                 savedGetsCompleted,
                 savedGetsFailed,
@@ -1747,6 +2526,10 @@ function installServerBackedEvidenceExpression() {
             this.routeMutationBaseline = routeContentMutations;
             this.formBaseline = document.querySelector("[data-testid='greeting-form']");
             this.inputBaseline = document.querySelector("[data-testid='greeting-name']");
+            this.transitionFormBaseline = document.querySelector("[data-testid='transition-form']");
+            this.transitionInputBaseline = document.querySelector("[data-testid='transition-name']");
+            this.transitionCommittedScreenBaseline =
+                document.querySelector("[data-testid='transition-committed-screen']");
             this.savedFormBaseline = document.querySelector("[data-testid='saved-greeting-form']");
             this.savedInputBaseline = document.querySelector("[data-testid='saved-greeting-input']");
             this.committedValueBaseline = committedValuesObserved.length;
@@ -1777,6 +2560,13 @@ function installServerBackedEvidenceExpression() {
                     ...evidence.checkIdentity(),
                     formSame: document.querySelector("[data-testid='greeting-form']") === this.formBaseline,
                     inputSame: document.querySelector("[data-testid='greeting-name']") === this.inputBaseline,
+                    transitionFormSame:
+                        document.querySelector("[data-testid='transition-form']") === this.transitionFormBaseline,
+                    transitionInputSame:
+                        document.querySelector("[data-testid='transition-name']") === this.transitionInputBaseline,
+                    transitionCommittedScreenSame:
+                        document.querySelector("[data-testid='transition-committed-screen']") ===
+                            this.transitionCommittedScreenBaseline,
                     savedFormSame: document.querySelector("[data-testid='saved-greeting-form']") === this.savedFormBaseline,
                     savedInputSame: document.querySelector("[data-testid='saved-greeting-input']") === this.savedInputBaseline,
                 },
@@ -1785,6 +2575,35 @@ function installServerBackedEvidenceExpression() {
                     aborted: aborts - this.requestBaseline.aborts,
                     succeeded: successfulCompletions - this.requestBaseline.successfulCompletions,
                     failed: failedCompletions - this.requestBaseline.failedCompletions,
+                },
+                transitionRequests: {
+                    started: transitionRequests.length - this.requestBaseline.transitionRequestsStarted,
+                    aborted: transitionAborts - this.requestBaseline.transitionAborts,
+                    succeeded:
+                        transitionSuccessfulCompletions -
+                        this.requestBaseline.transitionSuccessfulCompletions,
+                    failed:
+                        transitionFailedCompletions -
+                        this.requestBaseline.transitionFailedCompletions,
+                    active: activeTransitionRequests,
+                },
+                transition: {
+                    commits: transitionCommits - this.requestBaseline.transitionCommits,
+                    failures: transitionFailures - this.requestBaseline.transitionFailures,
+                    retries: transitionRetryAttempts - this.requestBaseline.transitionRetryAttempts,
+                    staleResultAppearances:
+                        transitionStaleResultAppearances -
+                        this.requestBaseline.transitionStaleResultAppearances,
+                    invalidCommittedPairs:
+                        transitionInvalidCommittedPairs -
+                        this.requestBaseline.transitionInvalidCommittedPairs,
+                    oldScreenLosses:
+                        transitionOldScreenLosses -
+                        this.requestBaseline.transitionOldScreenLosses,
+                    routeMounts: transitionRouteMounts - this.requestBaseline.transitionRouteMounts,
+                    routeUnmounts:
+                        transitionRouteUnmounts -
+                        this.requestBaseline.transitionRouteUnmounts,
                 },
                 savedRequests: {
                     getsStarted: savedGetsStarted - this.requestBaseline.savedGetsStarted,
@@ -1870,6 +2689,80 @@ function installServerBackedEvidenceExpression() {
                 return callback();
             });
         };
+    }
+
+    function captureTransitionState() {
+        const route = document.querySelector("[data-testid='server-backed-transition-route']");
+        const mounted = Boolean(route);
+        if (mounted !== transitionRouteMounted) {
+            if (mounted) transitionRouteMounts++;
+            else transitionRouteUnmounts++;
+            transitionRouteMounted = mounted;
+            if (!mounted) {
+                lastTransitionRequestedTarget = "";
+                lastTransitionFailure = "";
+            }
+        }
+        if (!mounted) return;
+
+        const requestedTarget =
+            document.querySelector("[data-testid='transition-requested-target']")?.textContent.trim() || "";
+        if (requestedTarget && requestedTarget !== lastTransitionRequestedTarget) {
+            transitionRequestedTargetsObserved.push(requestedTarget);
+            lastTransitionRequestedTarget = requestedTarget;
+        }
+
+        const committedScreen =
+            document.querySelector("[data-testid='transition-committed-screen']");
+        const committedTarget =
+            document.querySelector("[data-testid='transition-committed-target']")?.textContent.trim() || "";
+        const committedMessage =
+            document.querySelector("[data-testid='transition-message']")?.textContent.trim() || "";
+        if (committedScreen && committedTarget && committedMessage) {
+            const name = transitionNameFromTarget(committedTarget);
+            const valid = name !== "" &&
+                committedMessage === "Hello, " + name + ", from Go backend!";
+            if (!valid) {
+                transitionInvalidCommittedPairs++;
+            }
+            const committedKey = committedTarget + "\\u0000" + committedMessage;
+            if (committedKey !== lastTransitionCommittedKey) {
+                transitionCommittedPairsObserved.push({
+                    name,
+                    target: committedTarget,
+                    message: committedMessage,
+                });
+                transitionCommits++;
+                if (committedMessage === slowMessage) {
+                    transitionStaleResultAppearances++;
+                }
+                lastTransitionCommittedKey = committedKey;
+            }
+        } else if (transitionCommits > 0) {
+            transitionOldScreenLosses++;
+        }
+
+        const failure =
+            document.querySelector("[data-testid='transition-error']")?.textContent.trim() || "";
+        if (!failure) {
+            lastTransitionFailure = "";
+        } else {
+            const failureKey = requestedTarget + "\\u0000" + failure;
+            if (failureKey !== lastTransitionFailure) {
+                transitionFailures++;
+                lastTransitionFailure = failureKey;
+            }
+        }
+    }
+
+    function transitionNameFromTarget(target) {
+        try {
+            const parsed = new URL(target, "http://goframe.invalid");
+            if (parsed.pathname !== "/transition-greeting") return "";
+            return parsed.searchParams.get("name") || "GoFrame";
+        } catch {
+            return "";
+        }
     }
 
     return true;


### PR DESCRIPTION
## Summary

Adds an executable async-navigation pressure test to the existing
`examples/server-backed` reference application.

The new `/transition-greeting` flow measures whether the current hash router,
component ownership, `UseResource`, and `FetchText` primitives can retain the
last committed screen while a newer same-pattern query target prepares.

The result is intentionally example-local. This PR does not introduce a public
transition, route-loader, cache, or navigation API.

## Scope

- Adds a dedicated `/transition-greeting?name=...` route.
- Separates:
  - the requested hash/query target;
  - the currently committed visible target;
  - the resource result preparing the next committed screen.
- Stores the committed name, route target, and backend message in one
  application-owned snapshot.
- Commits a ready target/message pair through one state update.
- Keeps the prior committed screen visible while a new target is loading.
- Keeps preparation failures separate from the committed screen.
- Uses the reload function returned by `UseResource` for retry.
- Leaves cancellation, key invalidation, cleanup, and stale-result suppression
  under the existing `UseResource` and `FetchText` ownership.
- Adds focused pure tests for the committed-snapshot handoff.
- Extends the existing server-backed browser harness rather than creating a
  second integration runner.
- Records the measured coordination cost and resulting design decision in the
  example README.

## Browser Evidence

The browser scenarios cover:

- initial transition loading and first committed result;
- retention of a committed Ada screen while a slow target is pending;
- superseding slow work with a newer fast target;
- exact abort and stale-result suppression;
- controlled failure while retaining the previous committed screen;
- retry through the resource reload closure;
- recovery through a later valid target;
- browser Back and Forward using the same retained-screen path;
- cancellation and absence of late commits after route unmount.

Two focused runs produced the same behavioral counters:

| Counter | Run 1 | Run 2 |
|---|---:|---:|
| transition requests started | 10 | 10 |
| successful completions | 6 | 6 |
| failed completions | 2 | 2 |
| aborted requests | 2 | 2 |
| committed target/message pairs | 6 | 6 |
| retry attempts | 1 | 1 |
| stale-result appearances | 0 | 0 |
| invalid committed pairs | 0 | 0 |
| old-screen losses after initial commit | 0 | 0 |

Mutation-observed evidence rejects mixed states such as a new committed target
with the previous target's message.

## Coordination Result

The demonstrated transition flow requires:

- 2 application-owned state slots;
- 2 effects;
- 1 `UseResource` instance;
- 1 reload handoff;
- 1 route/data commit handoff;
- 0 manual generation counters;
- 0 manual attempt identifiers;
- 0 manual stale-result guards;
- 0 manual cleanup callbacks;
- 0 application-owned `AbortController` instances.

Based on this bounded flow, the existing primitives are sufficient for
same-pattern retained async navigation. No public transition or route-loader API
is selected by this PR.

## Compatibility And Impact

This PR does not change:

- `pkg/goframe`;
- `pkg/gox`;
- `cmd/goxc`;
- public APIs;
- router or resource semantics;
- the backend protocol;
- dependencies or workflows;
- release files or roadmap state;
- repository size budgets.

The existing `/greeting` route remains the baseline behavior where a new
resource key replaces the previous ready message with loading UI.

The existing greeting, mutation, retry, cancellation, Back/Forward, identity,
and stale-result browser scenarios remain covered.

## Validation

Local validation includes:

- focused transition tests repeated 100 times;
- focused race tests repeated 20 times;
- server-backed packaging with standard Go and TinyGo;
- two focused server-backed browser runs;
- the full Go test suite;
- command/package race tests;
- debug-tag tests;
- `go vet`;
- `scripts/check.sh`;
- aggregate browser smoke;
- the WASM size gate;
- documentation, artifact, and module-path checks;
- `git diff --check`.

All 11 existing budgeted examples remain byte-identical to the frozen base,
including raw WASM and deterministic gzip, Brotli, and Zstandard output.

The server-backed example grows by:

| Artifact | Delta |
|---|---:|
| raw WASM | +14,057 B |
| gzip | +4,150 B |
| Brotli | +3,383 B |
| Zstandard | +3,705 B |

These measurements are informational. No threshold was introduced or changed.

## Known Limitations

- `location.hash` changes before the requested data is ready.
- The displayed target and data commit together, but URL, screen, and data do
  not form one atomic transaction.
- Retained-screen behavior is demonstrated for same-pattern query transitions.
- Cross-pattern evidence covers unmount cancellation, not old-screen retention.
- Redirects, blockers, prefetch, route loaders, global caching, and mutation
  coordination are outside this PR.

## Non-Goals

- no public transition API;
- no route-loader API;
- no history/path router;
- no redirect or blocker framework;
- no global cache or prefetch policy;
- no Suspense-style rendering;
- no runtime commit buffer;
- no server-function or RPC abstraction.