### PR TITLE
test(history): characterize path routing deployment

### DIFF
--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -393,6 +393,11 @@ export GOFRAME_SERVER_BACKED_CHROME_DEBUG_PORT="${GOFRAME_SERVER_BACKED_CHROME_D
 node --experimental-websocket scripts/server-backed-browser-smoke.mjs
 
 echo
+echo "== History routing deployment pressure =="
+export GOFRAME_HISTORY_ROUTING_CHROME_DEBUG_PORT="${GOFRAME_HISTORY_ROUTING_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/history-routing-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo

--- a/scripts/fixtures/history-routing/README.md
+++ b/scripts/fixtures/history-routing/README.md
@@ -1,0 +1,143 @@
+# History Routing Deployment Pressure Fixture
+
+This fixture measures the browser ownership and deployment contract required to
+use clean History API paths with the current GoFrame primitives. It is evidence
+for one bounded application shape, not a production server or a public routing
+API proposal.
+
+## Baseline
+
+The existing hash router keeps the route after `#`, so the HTTP server only
+needs to serve the package index at `/`. In the baseline browser run, `/`,
+`/#/issues/1`, and a refresh of that hash route loaded successfully from the
+ordinary static server. A direct request for `/users/42` returned `404`.
+
+Hash routing therefore avoids an HTML navigation fallback, deployment-base
+stripping, and deep-path document-base handling.
+
+## Proven
+
+The deterministic Go and browser checks prove the following behavior:
+
+- strict static serving supports a clean-path client push after the root page
+  has booted, but a direct load or refresh of that deep path returns `404`;
+- bounded fallback serving restores root and subpath direct loads and refreshes;
+- push, replace, Back, and Forward synchronize the browser location and the
+  rendered route;
+- route parameters, query text, percent decoding, trailing-slash normalization,
+  and application not-found rendering are deterministic;
+- the retained application root does not remount during navigation;
+- the router owner adds one `popstate` listener and removes that exact listener
+  when unmounted;
+- real static files are served as files, including
+  `application/wasm` for WASM;
+- missing assets, API paths, traversal attempts, and paths outside the
+  deployment base remain non-fallback responses;
+- the package index is not modified on disk.
+
+The two focused browser runs produced identical counters:
+
+| Counter | Run 1 | Run 2 |
+|---|---:|---:|
+| push navigations | 4 | 4 |
+| replace navigations | 2 | 2 |
+| popstate events | 4 | 4 |
+| direct deep-link boots | 2 | 2 |
+| refresh recoveries | 2 | 2 |
+| application not-found renders | 1 | 1 |
+| HTML fallback responses | 2 | 2 |
+| static file responses | 4 | 4 |
+| missing-asset 404 responses | 5 | 5 |
+| API 404 responses | 2 | 2 |
+| incorrect fallback responses | 0 | 0 |
+| router mounts | 1 | 1 |
+| router unmounts | 1 | 1 |
+| listener additions | 1 | 1 |
+| listener removals | 1 | 1 |
+| application-root identity changes | 0 | 0 |
+| route-target mismatches | 0 | 0 |
+
+## Required Deployment Contract
+
+The demonstrated clean-path deployment needs all of these policies:
+
+1. Explicit HTML navigation fallback for missing extensionless application
+   routes and trailing-slash routes.
+2. Asset and API exclusions so missing resources remain `404` rather than
+   receiving the package index.
+3. Static-file precedence and correct content types, including
+   `application/wasm`.
+4. One normalized deployment base, with fallback and static responses confined
+   to that base.
+5. A document asset base for deep URLs. This fixture injects one response-only
+   `<base href>` element and rejects an index that already contains one.
+
+The fixture server accepts only `GET` and `HEAD`. HTML fallback additionally
+requires an HTML `Accept` value. It is a controlled evidence server, not a
+production-hardened hosting implementation.
+
+## Measured Browser Coordination
+
+- Fixture application Go/GOX: 343 lines.
+- Pure route model: 268 lines.
+- State or reducer slots: 3 total, including 1 current-target state slot.
+- Effects: 1.
+- `popstate` listeners: 1.
+- Cleanup callbacks: 1.
+- Navigation handoffs: 2, one push helper and one replace helper.
+- Route-model operations: 5 exported boundary/match operations and 7 private
+  normalization or parsing helpers.
+- JavaScript-specific helpers: 6.
+- Global mutable route-state variables: 0. The package has one immutable
+  component-type token stored at package scope.
+- Browser harness: 773 lines.
+
+## Measured Server Coordination
+
+- Fixture server production code: 392 lines.
+- Fixture server tests: 252 lines.
+- Server modes: 2 (`strict` and `fallback`).
+- Named fallback predicates: 4 (`allowsHTMLFallback`, `acceptsHTML`,
+  `isAPIPath`, and `looksLikeAssetPath`).
+- Explicit fallback exclusion classes: 5 (unsupported methods, unsafe or
+  outside-base paths, API paths, asset-shaped paths, and non-HTML requests).
+- Index-response transformations: 1 response-only document-base injection.
+- Base-path rules: 2 (normalize the leading/trailing slash form, then constrain
+  all serving and fallback decisions to that base).
+
+The fixture WASM was packaged with TinyGo 0.41.1 on Linux amd64 using Go 1.24.4.
+The sizes are informational and introduce no threshold:
+
+| Encoding | Bytes |
+|---|---:|
+| raw | 123147 |
+| gzip (`-n -9`) | 48428 |
+| Brotli (`-q 11`) | 39732 |
+| Zstandard (`-19`) | 42996 |
+
+## Limitations
+
+The evidence covers root deployment, `/app/` subpath deployment, static-file
+hosting, direct deep links, refresh, push, replace, Back, Forward, query
+handling, trailing-slash normalization, application not-found rendering, and
+listener teardown.
+
+It does not cover redirects, navigation blockers, route data loading, SSR,
+hydration, CDN- or provider-specific rewrite syntax, service workers, or broad
+browser compatibility. The fixture server does not establish production
+hosting support.
+
+## Decision
+
+**Result A:** An example-local History API adapter and explicit deployment
+contract are sufficient for the demonstrated fixture. No public API is selected
+yet.
+
+The repeated browser ownership is one current-target state slot, one effect,
+one listener with one cleanup, and two explicit push/replace handoffs. The
+deployment requirement is more substantial: a bounded HTML navigation fallback
+with API and asset exclusions, static-file precedence, correct MIME types,
+deployment-base ownership, and deep-URL document-base handling.
+
+Hash routing remains supported. This evidence does not select a public history
+router, production server, redirect API, blocker API, or data-loading API.

--- a/scripts/fixtures/history-routing/assets/index.html
+++ b/scripts/fixtures/history-routing/assets/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GoFrame history routing pressure fixture</title>
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/history-routing/assets/styles.css
+++ b/scripts/fixtures/history-routing/assets/styles.css
@@ -1,0 +1,35 @@
+:root {
+    color-scheme: light dark;
+    font-family: system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+}
+
+.history-app {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: 52rem;
+    padding: 2rem;
+}
+
+.history-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.history-card {
+    border: 1px solid currentColor;
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.history-evidence {
+    display: grid;
+    gap: 0.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    margin-top: 1.5rem;
+}

--- a/scripts/fixtures/history-routing/cmd/app/app.gox
+++ b/scripts/fixtures/history-routing/cmd/app/app.gox
@@ -1,0 +1,229 @@
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/history-routing/internal/historyroute"
+)
+
+type evidenceEvent int
+
+const (
+	evidencePush evidenceEvent = iota
+	evidenceReplace
+	evidencePopstate
+	evidenceRouterMount
+	evidenceRouterUnmount
+	evidenceListenerAdd
+	evidenceListenerRemove
+)
+
+type evidenceState struct {
+	Pushes           int
+	Replaces         int
+	Popstates        int
+	RouterMounts     int
+	RouterUnmounts   int
+	ListenerAdds     int
+	ListenerRemovals int
+}
+
+type historyRouterProps struct {
+	Record func(evidenceEvent)
+}
+
+var historyRouterType = gf.NewComponentType(
+	"fixture.history-routing.Router",
+	"HistoryRoutingFixtureRouter",
+)
+
+func App() gf.Node {
+	routerActive, setRouterActive := gf.UseState(true)
+	evidence, record := gf.UseReducer(evidenceState{}, reduceEvidence)
+	router := historyRouterNode(routerActive, record)
+
+	return (
+		<main class="history-app" data-testid="history-app">
+			<header>
+				<p>History API deployment pressure fixture</p>
+				<button
+					Type="button"
+					data-testid="history-router-unmount"
+					OnClick={func() {
+						setRouterActive(false)
+					}}
+				>
+					Unmount router owner
+				</button>
+			</header>
+
+			{router}
+
+			<section class="history-evidence" data-testid="history-evidence">
+				<span data-testid="history-navigation-count">
+					{gf.ToString(evidence.Pushes + evidence.Replaces)}
+				</span>
+				<span data-testid="history-push-count">{gf.ToString(evidence.Pushes)}</span>
+				<span data-testid="history-replace-count">{gf.ToString(evidence.Replaces)}</span>
+				<span data-testid="history-popstate-count">{gf.ToString(evidence.Popstates)}</span>
+				<span data-testid="history-router-mount-count">{gf.ToString(evidence.RouterMounts)}</span>
+				<span data-testid="history-router-unmount-count">{gf.ToString(evidence.RouterUnmounts)}</span>
+				<span data-testid="history-listener-add-count">{gf.ToString(evidence.ListenerAdds)}</span>
+				<span data-testid="history-listener-remove-count">{gf.ToString(evidence.ListenerRemovals)}</span>
+			</section>
+		</main>
+	)
+}
+
+func historyRouterNode(active bool, record func(evidenceEvent)) gf.Node {
+	if active {
+		return gf.ComponentT(
+			historyRouterType,
+			historyRouterProps{Record: record},
+			renderHistoryRouter,
+		)
+	}
+	return gf.El(
+		"section",
+		gf.Props{
+			"class":       "history-card",
+			"data-testid": "history-router-inactive",
+		},
+		gf.El("p", nil, gf.Text("The router owner is unmounted.")),
+	)
+}
+
+func reduceEvidence(state evidenceState, event evidenceEvent) evidenceState {
+	switch event {
+	case evidencePush:
+		state.Pushes++
+	case evidenceReplace:
+		state.Replaces++
+	case evidencePopstate:
+		state.Popstates++
+	case evidenceRouterMount:
+		state.RouterMounts++
+	case evidenceRouterUnmount:
+		state.RouterUnmounts++
+	case evidenceListenerAdd:
+		state.ListenerAdds++
+	case evidenceListenerRemove:
+		state.ListenerRemovals++
+	}
+	return state
+}
+
+func renderHistoryRouter(props historyRouterProps) gf.Node {
+	base := browserHistoryBasePath()
+	current, setCurrent := gf.UseState(browserHistoryCurrentTarget(base))
+
+	gf.UseEffect(func() gf.Cleanup {
+		props.Record(evidenceRouterMount)
+		props.Record(evidenceListenerAdd)
+		cleanup := browserHistorySubscribe(base, func(target string) {
+			props.Record(evidencePopstate)
+			setCurrent(target)
+		})
+		return func() {
+			cleanup()
+			props.Record(evidenceListenerRemove)
+			props.Record(evidenceRouterUnmount)
+		}
+	})
+
+	push := func(target string) {
+		setCurrent(browserHistoryPush(base, target))
+		props.Record(evidencePush)
+	}
+	replace := func(target string) {
+		setCurrent(browserHistoryReplace(base, target))
+		props.Record(evidenceReplace)
+	}
+
+	homeHref, _ := historyroute.LocationForTarget(base, "/")
+	userHref, _ := historyroute.LocationForTarget(base, "/users/42")
+	searchHref, _ := historyroute.LocationForTarget(base, "/search?q=goframe")
+	match := historyroute.MatchTarget(current)
+	goHome := func(event gf.Event) {
+		event.PreventDefault()
+		push("/")
+	}
+	goUser := func(event gf.Event) {
+		event.PreventDefault()
+		push("/users/42")
+	}
+	goSearch := func(event gf.Event) {
+		event.PreventDefault()
+		push("/search?q=goframe")
+	}
+	replaceSettings := func() {
+		replace("/settings/")
+	}
+	goNotFound := func() {
+		push("/does-not-exist")
+	}
+
+	notFound := historyNotFoundNode(match.NotFound)
+
+	return (
+		<section class="history-card" data-testid="history-router-owner">
+			<nav class="history-nav">
+				<a
+					href={homeHref}
+					data-testid="history-home-link"
+					OnClick={goHome}
+				>
+					Home
+				</a>
+				<a
+					href={userHref}
+					data-testid="history-user-link"
+					OnClick={goUser}
+				>
+					User 42
+				</a>
+				<a
+					href={searchHref}
+					data-testid="history-search-link"
+					OnClick={goSearch}
+				>
+					Search
+				</a>
+				<button
+					Type="button"
+					data-testid="history-settings-replace"
+					OnClick={replaceSettings}
+				>
+					Replace with settings
+				</button>
+				<button
+					Type="button"
+					data-testid="history-not-found-link"
+					OnClick={goNotFound}
+				>
+					Unknown route
+				</button>
+			</nav>
+
+			<div data-testid="history-route-view">
+				<p data-testid="history-route-name">{match.Name}</p>
+				<p data-testid="history-route-target">{match.Target}</p>
+				<p data-testid="history-route-query">{match.RawQuery}</p>
+				<p data-testid="history-route-param">{match.Param}</p>
+				<p data-testid="history-route-query-value">{match.QueryValue}</p>
+				<p data-testid="history-base-path">{base}</p>
+				{notFound}
+			</div>
+		</section>
+	)
+}
+
+func historyNotFoundNode(notFound bool) gf.Node {
+	if !notFound {
+		return gf.Empty()
+	}
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "history-not-found"},
+		gf.Text("No application route matches this target."),
+	)
+}

--- a/scripts/fixtures/history-routing/cmd/app/history_js.go
+++ b/scripts/fixtures/history-routing/cmd/app/history_js.go
@@ -1,0 +1,75 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"strings"
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/history-routing/internal/historyroute"
+)
+
+func browserHistoryBasePath() string {
+	document := js.Global().Get("document")
+	if document.IsUndefined() || document.IsNull() {
+		return "/"
+	}
+	baseURI := document.Get("baseURI")
+	if baseURI.IsUndefined() || baseURI.IsNull() || baseURI.String() == "" {
+		return "/"
+	}
+	parsed := js.Global().Get("URL").New(baseURI.String())
+	base, err := historyroute.NormalizeBase(parsed.Get("pathname").String())
+	if err != nil {
+		return "/"
+	}
+	return base
+}
+
+func browserHistoryCurrentTarget(base string) string {
+	location := js.Global().Get("location")
+	if location.IsUndefined() || location.IsNull() {
+		return "/"
+	}
+	target, inside, err := historyroute.TargetFromLocation(
+		base,
+		location.Get("pathname").String(),
+		strings.TrimPrefix(location.Get("search").String(), "?"),
+	)
+	if err != nil || !inside {
+		return "/"
+	}
+	return target
+}
+
+func browserHistoryPush(base, target string) string {
+	return browserHistoryChange("pushState", base, target)
+}
+
+func browserHistoryReplace(base, target string) string {
+	return browserHistoryChange("replaceState", base, target)
+}
+
+func browserHistoryChange(method, base, target string) string {
+	target = historyroute.NormalizeTarget(target)
+	location, err := historyroute.LocationForTarget(base, target)
+	if err != nil {
+		panic("history fixture: construct browser location: " + err.Error())
+	}
+	js.Global().Get("history").Call(method, js.Null(), "", location)
+	return target
+}
+
+func browserHistorySubscribe(base string, callback func(string)) gf.Cleanup {
+	var listener js.Func
+	listener = js.FuncOf(func(this js.Value, args []js.Value) any {
+		callback(browserHistoryCurrentTarget(base))
+		return nil
+	})
+	js.Global().Call("addEventListener", "popstate", listener)
+	return func() {
+		js.Global().Call("removeEventListener", "popstate", listener)
+		listener.Release()
+	}
+}

--- a/scripts/fixtures/history-routing/cmd/app/history_nonjs.go
+++ b/scripts/fixtures/history-routing/cmd/app/history_nonjs.go
@@ -1,0 +1,28 @@
+//go:build !js || !wasm
+
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/history-routing/internal/historyroute"
+)
+
+func browserHistoryBasePath() string {
+	return "/"
+}
+
+func browserHistoryCurrentTarget(string) string {
+	return "/"
+}
+
+func browserHistoryPush(_ string, target string) string {
+	return historyroute.NormalizeTarget(target)
+}
+
+func browserHistoryReplace(_ string, target string) string {
+	return historyroute.NormalizeTarget(target)
+}
+
+func browserHistorySubscribe(string, func(string)) gf.Cleanup {
+	return nil
+}

--- a/scripts/fixtures/history-routing/cmd/app/main.go
+++ b/scripts/fixtures/history-routing/cmd/app/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/scripts/fixtures/history-routing/cmd/server/main.go
+++ b/scripts/fixtures/history-routing/cmd/server/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+)
+
+func main() {
+	packageDir := flag.String("package", "", "packaged GoFrame standalone directory")
+	address := flag.String("addr", "127.0.0.1:8080", "listen address")
+	mode := flag.String("mode", string(serverModeStrict), "serving mode: strict or fallback")
+	base := flag.String("base", "/", "deployment base path")
+	flag.Parse()
+
+	if *packageDir == "" {
+		log.Fatal("--package is required")
+	}
+	handler, err := newPackageServer(serverConfig{
+		PackageDir: *packageDir,
+		Mode:       serverMode(*mode),
+		Base:       *base,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("serving %s at http://%s in %s mode under %s", *packageDir, *address, *mode, handler.base)
+	log.Fatal(http.ListenAndServe(*address, handler))
+}

--- a/scripts/fixtures/history-routing/cmd/server/server.go
+++ b/scripts/fixtures/history-routing/cmd/server/server.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"html"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/graybuton/goframe/scripts/fixtures/history-routing/internal/historyroute"
+)
+
+type serverMode string
+
+const (
+	serverModeStrict   serverMode = "strict"
+	serverModeFallback serverMode = "fallback"
+
+	responseClassHeader = "X-GoFrame-History-Response"
+)
+
+type serverConfig struct {
+	PackageDir string
+	Mode       serverMode
+	Base       string
+}
+
+type packageServer struct {
+	packageDir string
+	mode       serverMode
+	base       string
+	index      []byte
+}
+
+func newPackageServer(config serverConfig) (*packageServer, error) {
+	switch config.Mode {
+	case serverModeStrict, serverModeFallback:
+	default:
+		return nil, fmt.Errorf("unsupported server mode %q", config.Mode)
+	}
+	base, err := historyroute.NormalizeBase(config.Base)
+	if err != nil {
+		return nil, fmt.Errorf("normalize deployment base: %w", err)
+	}
+	packageDir, err := filepath.Abs(config.PackageDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve package directory: %w", err)
+	}
+	info, err := os.Lstat(packageDir)
+	if err != nil {
+		return nil, fmt.Errorf("inspect package directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("package directory %s is a symlink", packageDir)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("package directory %s is not a directory", packageDir)
+	}
+
+	indexPath := filepath.Join(packageDir, "index.html")
+	indexInfo, err := os.Lstat(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect package index: %w", err)
+	}
+	if indexInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("package index %s is a symlink", indexPath)
+	}
+	if !indexInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("package index %s is not a regular file", indexPath)
+	}
+	index, err := os.ReadFile(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("read package index: %w", err)
+	}
+	index, err = injectDocumentBase(index, base)
+	if err != nil {
+		return nil, err
+	}
+
+	return &packageServer{
+		packageDir: packageDir,
+		mode:       config.Mode,
+		base:       base,
+		index:      index,
+	}, nil
+}
+
+func (server *packageServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	if request == nil || request.URL == nil {
+		server.notFound(response, request)
+		return
+	}
+	if request.Method != http.MethodGet && request.Method != http.MethodHead {
+		response.Header().Set("Allow", "GET, HEAD")
+		response.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	requestPath, err := cleanRequestPath(request.URL)
+	if err != nil {
+		server.notFound(response, request)
+		return
+	}
+	relative, inside := relativeRequestPath(server.base, requestPath)
+	if !inside {
+		server.notFound(response, request)
+		return
+	}
+	if relative == "" || relative == "index.html" {
+		server.serveIndex(response, request, "index")
+		return
+	}
+
+	filePath, exists := server.staticFile(relative)
+	if exists {
+		server.serveStatic(response, request, filePath, relative)
+		return
+	}
+
+	if server.mode == serverModeFallback && allowsHTMLFallback(request, requestPath, relative) {
+		server.serveIndex(response, request, "fallback")
+		return
+	}
+	server.notFound(response, request)
+}
+
+func (server *packageServer) staticFile(relative string) (string, bool) {
+	parts := strings.Split(filepath.ToSlash(relative), "/")
+	current := server.packageDir
+	for index, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", false
+		}
+		current = filepath.Join(current, filepath.FromSlash(part))
+		info, err := os.Lstat(current)
+		if err != nil {
+			return "", false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", false
+		}
+		if index < len(parts)-1 {
+			if !info.IsDir() {
+				return "", false
+			}
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			return "", false
+		}
+	}
+	return current, true
+}
+
+func (server *packageServer) serveIndex(response http.ResponseWriter, request *http.Request, class string) {
+	response.Header().Set("Content-Type", "text/html; charset=utf-8")
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set(responseClassHeader, class)
+	writeResponse(response, request, server.index)
+}
+
+func (server *packageServer) serveStatic(response http.ResponseWriter, request *http.Request, filePath, relative string) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		server.notFound(response, request)
+		return
+	}
+	response.Header().Set("Content-Type", staticContentType(relative))
+	response.Header().Set(responseClassHeader, "static")
+	writeResponse(response, request, content)
+}
+
+func (server *packageServer) notFound(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set(responseClassHeader, "not-found")
+	if request == nil {
+		response.WriteHeader(http.StatusNotFound)
+		return
+	}
+	http.NotFound(response, request)
+}
+
+func writeResponse(response http.ResponseWriter, request *http.Request, content []byte) {
+	response.Header().Set("Content-Length", strconv.Itoa(len(content)))
+	response.WriteHeader(http.StatusOK)
+	if request.Method != http.MethodHead {
+		_, _ = response.Write(content)
+	}
+}
+
+func cleanRequestPath(requestURL *url.URL) (string, error) {
+	escaped := requestURL.EscapedPath()
+	decoded, err := url.PathUnescape(escaped)
+	if err != nil {
+		return "", errors.New("request path contains malformed escaping")
+	}
+	if decoded == "" {
+		decoded = "/"
+	}
+	if !strings.HasPrefix(decoded, "/") {
+		return "", errors.New("request path must start with slash")
+	}
+	if strings.ContainsRune(decoded, '\\') || strings.ContainsRune(requestURL.RawPath, '\\') {
+		return "", errors.New("request path contains backslash")
+	}
+	for _, part := range strings.Split(decoded, "/") {
+		if part == "." || part == ".." {
+			return "", errors.New("request path contains traversal")
+		}
+	}
+	cleaned := pathpkg.Clean(decoded)
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if strings.HasSuffix(decoded, "/") && cleaned != "/" {
+		cleaned += "/"
+	}
+	return cleaned, nil
+}
+
+func relativeRequestPath(base, requestPath string) (string, bool) {
+	if base == "/" {
+		return strings.TrimPrefix(requestPath, "/"), true
+	}
+	if requestPath == base {
+		return "", true
+	}
+	prefix := strings.TrimSuffix(base, "/")
+	if !strings.HasPrefix(requestPath, prefix+"/") {
+		return "", false
+	}
+	return strings.TrimPrefix(requestPath, prefix+"/"), true
+}
+
+func allowsHTMLFallback(request *http.Request, requestPath, relative string) bool {
+	if !acceptsHTML(request.Header.Get("Accept")) {
+		return false
+	}
+	if isAPIPath(relative) || looksLikeAssetPath(relative) {
+		return false
+	}
+	return strings.HasSuffix(requestPath, "/") || pathpkg.Ext(relative) == ""
+}
+
+func acceptsHTML(value string) bool {
+	for _, item := range strings.Split(value, ",") {
+		mediaType := strings.TrimSpace(strings.SplitN(item, ";", 2)[0])
+		if mediaType == "text/html" || mediaType == "application/xhtml+xml" {
+			return true
+		}
+	}
+	return false
+}
+
+func isAPIPath(relative string) bool {
+	relative = strings.Trim(relative, "/")
+	return relative == "api" || strings.HasPrefix(relative, "api/")
+}
+
+func looksLikeAssetPath(relative string) bool {
+	relative = strings.Trim(relative, "/")
+	return relative == "assets" ||
+		strings.HasPrefix(relative, "assets/") ||
+		pathpkg.Ext(relative) != ""
+}
+
+func staticContentType(relative string) string {
+	switch strings.ToLower(pathpkg.Ext(relative)) {
+	case ".wasm":
+		return "application/wasm"
+	case ".js":
+		return "text/javascript; charset=utf-8"
+	case ".css":
+		return "text/css; charset=utf-8"
+	}
+	if value := mime.TypeByExtension(pathpkg.Ext(relative)); value != "" {
+		return value
+	}
+	return "application/octet-stream"
+}
+
+func injectDocumentBase(index []byte, base string) ([]byte, error) {
+	if asciiTagIndex(index, "base") >= 0 {
+		return nil, errors.New("package index already contains a base element")
+	}
+	head := asciiTagIndex(index, "head")
+	closeHead := asciiClosingTagIndex(index, "head")
+	if head < 0 || closeHead < 0 || closeHead <= head {
+		return nil, errors.New("package index must contain one complete head element")
+	}
+	headEnd := bytes.IndexByte(index[head:], '>')
+	if headEnd < 0 || head+headEnd >= closeHead {
+		return nil, errors.New("package index contains a malformed head element")
+	}
+	headEnd += head + 1
+	injection := []byte("\n    <base href=\"" + html.EscapeString(base) + "\" />")
+	result := make([]byte, 0, len(index)+len(injection))
+	result = append(result, index[:headEnd]...)
+	result = append(result, injection...)
+	result = append(result, index[headEnd:]...)
+	return result, nil
+}
+
+func asciiTagIndex(content []byte, name string) int {
+	return asciiElementIndex(content, "<"+name, false)
+}
+
+func asciiClosingTagIndex(content []byte, name string) int {
+	return asciiElementIndex(content, "</"+name, true)
+}
+
+func asciiElementIndex(content []byte, prefix string, closing bool) int {
+	for index := 0; index+len(prefix) <= len(content); index++ {
+		if !asciiEqualFold(content[index:index+len(prefix)], prefix) {
+			continue
+		}
+		next := index + len(prefix)
+		if next >= len(content) {
+			continue
+		}
+		if closing {
+			if content[next] == '>' || isASCIISpace(content[next]) {
+				return index
+			}
+			continue
+		}
+		if content[next] == '>' || content[next] == '/' || isASCIISpace(content[next]) {
+			return index
+		}
+	}
+	return -1
+}
+
+func asciiEqualFold(content []byte, value string) bool {
+	if len(content) != len(value) {
+		return false
+	}
+	for index := range content {
+		left := content[index]
+		right := value[index]
+		if left >= 'A' && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if right >= 'A' && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if left != right {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIISpace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
+}

--- a/scripts/fixtures/history-routing/cmd/server/server_test.go
+++ b/scripts/fixtures/history-routing/cmd/server/server_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testIndex = `<!doctype html>
+<html>
+<head><title>fixture</title></head>
+<body data-history-package-index="true">fixture index</body>
+</html>
+`
+
+func TestPackageServerStrictAndFallbackModes(t *testing.T) {
+	packageDir := writeTestPackage(t, testIndex)
+	strict := newTestPackageServer(t, packageDir, serverModeStrict, "/")
+	fallback := newTestPackageServer(t, packageDir, serverModeFallback, "/")
+
+	tests := []struct {
+		name        string
+		handler     http.Handler
+		method      string
+		target      string
+		accept      string
+		status      int
+		class       string
+		contains    string
+		notContains string
+	}{
+		{name: "strict root", handler: strict, method: http.MethodGet, target: "/", status: http.StatusOK, class: "index", contains: `<base href="/" />`},
+		{name: "strict deep route", handler: strict, method: http.MethodGet, target: "/users/42", accept: "text/html", status: http.StatusNotFound, class: "not-found", notContains: "fixture index"},
+		{name: "fallback deep route", handler: fallback, method: http.MethodGet, target: "/users/42", accept: "text/html", status: http.StatusOK, class: "fallback", contains: "fixture index"},
+		{name: "fallback trailing slash", handler: fallback, method: http.MethodGet, target: "/settings/", accept: "text/html", status: http.StatusOK, class: "fallback", contains: "fixture index"},
+		{name: "fallback requires html accept", handler: fallback, method: http.MethodGet, target: "/users/42", accept: "application/json", status: http.StatusNotFound, class: "not-found", notContains: "fixture index"},
+		{name: "head fallback", handler: fallback, method: http.MethodHead, target: "/users/42", accept: "text/html", status: http.StatusOK, class: "fallback", notContains: "fixture index"},
+		{name: "unsupported method", handler: fallback, method: http.MethodPost, target: "/users/42", accept: "text/html", status: http.StatusMethodNotAllowed},
+		{name: "existing css", handler: fallback, method: http.MethodGet, target: "/assets/styles.css", status: http.StatusOK, class: "static", contains: "fixture-style"},
+		{name: "existing wasm", handler: fallback, method: http.MethodGet, target: "/assets/bundle.wasm", status: http.StatusOK, class: "static", contains: "wasm"},
+		{name: "missing asset", handler: fallback, method: http.MethodGet, target: "/assets/missing.js", accept: "text/html", status: http.StatusNotFound, class: "not-found", notContains: "fixture index"},
+		{name: "missing root asset", handler: fallback, method: http.MethodGet, target: "/missing.wasm", accept: "text/html", status: http.StatusNotFound, class: "not-found", notContains: "fixture index"},
+		{name: "api path", handler: fallback, method: http.MethodGet, target: "/api/missing", accept: "text/html", status: http.StatusNotFound, class: "not-found", notContains: "fixture index"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := requestServer(t, test.handler, test.method, test.target, test.accept)
+			if response.Code != test.status {
+				t.Fatalf("status = %d, want %d; body=%q", response.Code, test.status, response.Body.String())
+			}
+			if test.class != "" && response.Header().Get(responseClassHeader) != test.class {
+				t.Fatalf("%s = %q, want %q", responseClassHeader, response.Header().Get(responseClassHeader), test.class)
+			}
+			if test.contains != "" && !strings.Contains(response.Body.String(), test.contains) {
+				t.Fatalf("body %q does not contain %q", response.Body.String(), test.contains)
+			}
+			if test.notContains != "" && strings.Contains(response.Body.String(), test.notContains) {
+				t.Fatalf("body unexpectedly contains %q", test.notContains)
+			}
+		})
+	}
+
+	css := requestServer(t, fallback, http.MethodGet, "/assets/styles.css", "")
+	if got := css.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/css") {
+		t.Fatalf("CSS Content-Type = %q", got)
+	}
+	wasm := requestServer(t, fallback, http.MethodGet, "/assets/bundle.wasm", "")
+	if got := wasm.Header().Get("Content-Type"); got != "application/wasm" {
+		t.Fatalf("WASM Content-Type = %q", got)
+	}
+}
+
+func TestPackageServerSubpathAndTraversal(t *testing.T) {
+	packageDir := writeTestPackage(t, testIndex)
+	server := newTestPackageServer(t, packageDir, serverModeFallback, "app")
+
+	tests := []struct {
+		target string
+		accept string
+		status int
+		class  string
+	}{
+		{target: "/app/", status: http.StatusOK, class: "index"},
+		{target: "/app/users/42", accept: "text/html", status: http.StatusOK, class: "fallback"},
+		{target: "/app/assets/styles.css", status: http.StatusOK, class: "static"},
+		{target: "/app/assets/missing.js", accept: "text/html", status: http.StatusNotFound, class: "not-found"},
+		{target: "/app/api/missing", accept: "text/html", status: http.StatusNotFound, class: "not-found"},
+		{target: "/users/42", accept: "text/html", status: http.StatusNotFound, class: "not-found"},
+		{target: "/application/users/42", accept: "text/html", status: http.StatusNotFound, class: "not-found"},
+		{target: "/app/%2e%2e/secret", accept: "text/html", status: http.StatusNotFound, class: "not-found"},
+	}
+	for _, test := range tests {
+		t.Run(test.target, func(t *testing.T) {
+			response := requestServer(t, server, http.MethodGet, test.target, test.accept)
+			if response.Code != test.status || response.Header().Get(responseClassHeader) != test.class {
+				t.Fatalf("response = %d %q, want %d %q; body=%q", response.Code, response.Header().Get(responseClassHeader), test.status, test.class, response.Body.String())
+			}
+		})
+	}
+
+	response := requestServer(t, server, http.MethodGet, "/app/users/42", "text/html")
+	if !strings.Contains(response.Body.String(), `<base href="/app/" />`) {
+		t.Fatalf("subpath response missing document base: %q", response.Body.String())
+	}
+}
+
+func TestPackageServerIndexTransformationDoesNotMutatePackage(t *testing.T) {
+	packageDir := writeTestPackage(t, testIndex)
+	before, err := os.ReadFile(filepath.Join(packageDir, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := newTestPackageServer(t, packageDir, serverModeFallback, "/app/")
+
+	for _, target := range []string{"/app/", "/app/users/42"} {
+		response := requestServer(t, server, http.MethodGet, target, "text/html")
+		if response.Code != http.StatusOK {
+			t.Fatalf("%s status = %d", target, response.Code)
+		}
+		if count := strings.Count(response.Body.String(), "<base "); count != 1 {
+			t.Fatalf("%s base element count = %d", target, count)
+		}
+	}
+
+	after, err := os.ReadFile(filepath.Join(packageDir, "index.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("package index changed on disk")
+	}
+}
+
+func TestPackageServerRejectsInvalidIndexAndPackageInputs(t *testing.T) {
+	t.Run("missing index", func(t *testing.T) {
+		packageDir := t.TempDir()
+		if _, err := newPackageServer(serverConfig{PackageDir: packageDir, Mode: serverModeStrict, Base: "/"}); err == nil || !strings.Contains(err.Error(), "package index") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("irregular index", func(t *testing.T) {
+		packageDir := t.TempDir()
+		if err := os.Mkdir(filepath.Join(packageDir, "index.html"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := newPackageServer(serverConfig{PackageDir: packageDir, Mode: serverModeStrict, Base: "/"}); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("malformed head", func(t *testing.T) {
+		packageDir := writeTestPackage(t, "<html><body>missing head</body></html>")
+		if _, err := newPackageServer(serverConfig{PackageDir: packageDir, Mode: serverModeStrict, Base: "/"}); err == nil || !strings.Contains(err.Error(), "complete head") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("existing base", func(t *testing.T) {
+		packageDir := writeTestPackage(t, `<html><head><base href="/already/"></head><body></body></html>`)
+		if _, err := newPackageServer(serverConfig{PackageDir: packageDir, Mode: serverModeStrict, Base: "/"}); err == nil || !strings.Contains(err.Error(), "already contains a base") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("symlink package root", func(t *testing.T) {
+		realRoot := writeTestPackage(t, testIndex)
+		alias := filepath.Join(t.TempDir(), "package-alias")
+		if err := os.Symlink(realRoot, alias); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		if _, err := newPackageServer(serverConfig{PackageDir: alias, Mode: serverModeStrict, Base: "/"}); err == nil || !strings.Contains(err.Error(), "is a symlink") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestPackageServerDoesNotFollowStaticSymlinks(t *testing.T) {
+	packageDir := writeTestPackage(t, testIndex)
+	external := filepath.Join(t.TempDir(), "external.js")
+	if err := os.WriteFile(external, []byte("external-secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(packageDir, "assets", "linked.js")
+	if err := os.Symlink(external, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	server := newTestPackageServer(t, packageDir, serverModeFallback, "/")
+	response := requestServer(t, server, http.MethodGet, "/assets/linked.js", "text/html")
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", response.Code)
+	}
+	if strings.Contains(response.Body.String(), "external-secret") {
+		t.Fatal("external symlink target was served")
+	}
+}
+
+func writeTestPackage(t *testing.T, index string) string {
+	t.Helper()
+	packageDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(packageDir, "index.html"), []byte(index), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assets := filepath.Join(packageDir, "assets")
+	if err := os.Mkdir(assets, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assets, "styles.css"), []byte("fixture-style"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assets, "bundle.wasm"), []byte("wasm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assets, "wasm_exec.js"), []byte("runtime"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return packageDir
+}
+
+func newTestPackageServer(t *testing.T, packageDir string, mode serverMode, base string) *packageServer {
+	t.Helper()
+	server, err := newPackageServer(serverConfig{PackageDir: packageDir, Mode: mode, Base: base})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server
+}
+
+func requestServer(t *testing.T, handler http.Handler, method, target, accept string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, "http://fixture.test"+target, nil)
+	if accept != "" {
+		request.Header.Set("Accept", accept)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code == http.StatusOK && method != http.MethodHead {
+		result := response.Result()
+		defer result.Body.Close()
+		if _, err := io.ReadAll(result.Body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return response
+}

--- a/scripts/fixtures/history-routing/goframe.json
+++ b/scripts/fixtures/history-routing/goframe.json
@@ -1,0 +1,6 @@
+{
+  "name": "history-routing",
+  "entry": "./cmd/app",
+  "compiler": "tinygo",
+  "assets": "./assets"
+}

--- a/scripts/fixtures/history-routing/internal/historyroute/route.go
+++ b/scripts/fixtures/history-routing/internal/historyroute/route.go
@@ -1,0 +1,268 @@
+package historyroute
+
+import (
+	"errors"
+	pathpkg "path"
+	"strings"
+)
+
+// Match is the fixture's deterministic view of one application target.
+type Match struct {
+	Name           string
+	Target         string
+	Path           string
+	RawQuery       string
+	Param          string
+	QueryValue     string
+	NotFound       bool
+	MalformedPath  bool
+	MalformedQuery bool
+}
+
+// NormalizeBase returns a leading- and trailing-slash deployment base.
+func NormalizeBase(base string) (string, error) {
+	if base == "" {
+		return "/", nil
+	}
+	if strings.ContainsAny(base, "?#\\") {
+		return "", errors.New("deployment base must be a URL path")
+	}
+	if !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
+	for _, part := range strings.Split(base, "/") {
+		if part == ".." {
+			return "", errors.New("deployment base must not contain parent traversal")
+		}
+	}
+	base = pathpkg.Clean(base)
+	if base == "." || base == "/" {
+		return "/", nil
+	}
+	return strings.TrimSuffix(base, "/") + "/", nil
+}
+
+// NormalizeTarget applies the fixture's route and trailing-slash policy.
+func NormalizeTarget(target string) string {
+	path, rawQuery := splitTarget(target)
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	path = pathpkg.Clean(path)
+	if path == "." || path == "" {
+		path = "/"
+	}
+	if path == "/settings" {
+		path = "/settings/"
+	}
+	if rawQuery == "" {
+		return path
+	}
+	return path + "?" + rawQuery
+}
+
+// TargetFromLocation strips base and preserves the browser query text.
+func TargetFromLocation(base, pathname, search string) (string, bool, error) {
+	base, err := NormalizeBase(base)
+	if err != nil {
+		return "", false, err
+	}
+	pathname = normalizeLocationPath(pathname)
+	internal, ok := stripBase(base, pathname)
+	if !ok {
+		return "", false, nil
+	}
+	search = strings.TrimPrefix(search, "?")
+	if search != "" {
+		internal += "?" + search
+	}
+	return NormalizeTarget(internal), true, nil
+}
+
+// LocationForTarget applies base to one normalized internal target.
+func LocationForTarget(base, target string) (string, error) {
+	base, err := NormalizeBase(base)
+	if err != nil {
+		return "", err
+	}
+	target = NormalizeTarget(target)
+	path, rawQuery := splitTarget(target)
+	location := path
+	if base != "/" {
+		prefix := strings.TrimSuffix(base, "/")
+		if path == "/" {
+			location = base
+		} else {
+			location = prefix + path
+		}
+	}
+	if rawQuery != "" {
+		location += "?" + rawQuery
+	}
+	return location, nil
+}
+
+// MatchTarget matches one normalized application target.
+func MatchTarget(target string) Match {
+	target = NormalizeTarget(target)
+	path, rawQuery := splitTarget(target)
+	query, queryOK := parseQuery(rawQuery)
+	result := Match{
+		Target:         target,
+		Path:           path,
+		RawQuery:       rawQuery,
+		MalformedQuery: !queryOK,
+	}
+
+	switch {
+	case path == "/":
+		result.Name = "home"
+		return result
+	case path == "/settings/":
+		result.Name = "settings"
+		return result
+	case path == "/search":
+		result.Name = "search"
+		if queryOK {
+			result.QueryValue = query["q"]
+		}
+		return result
+	}
+
+	parts := routeParts(path)
+	if len(parts) == 2 && parts[0] == "users" {
+		param, pathOK := decodePercent(parts[1], false)
+		if pathOK && param != "" && !strings.Contains(param, "/") {
+			result.Name = "user"
+			result.Param = param
+			if queryOK {
+				result.QueryValue = query["tab"]
+			}
+			return result
+		}
+		result.MalformedPath = !pathOK
+	}
+
+	result.Name = "not-found"
+	result.NotFound = true
+	return result
+}
+
+func normalizeLocationPath(pathname string) string {
+	if pathname == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(pathname, "/") {
+		pathname = "/" + pathname
+	}
+	cleaned := pathpkg.Clean(pathname)
+	if cleaned == "." || cleaned == "" {
+		return "/"
+	}
+	if strings.HasSuffix(pathname, "/") && cleaned != "/" {
+		cleaned += "/"
+	}
+	return cleaned
+}
+
+func stripBase(base, pathname string) (string, bool) {
+	if base == "/" {
+		return pathname, true
+	}
+	prefix := strings.TrimSuffix(base, "/")
+	if pathname == base {
+		return "/", true
+	}
+	if !strings.HasPrefix(pathname, prefix+"/") {
+		return "", false
+	}
+	internal := strings.TrimPrefix(pathname, prefix)
+	if internal == "" {
+		internal = "/"
+	}
+	return internal, true
+}
+
+func splitTarget(target string) (string, string) {
+	if index := strings.IndexByte(target, '?'); index >= 0 {
+		return target[:index], target[index+1:]
+	}
+	return target, ""
+}
+
+func routeParts(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return nil
+	}
+	return strings.Split(path, "/")
+}
+
+func parseQuery(raw string) (map[string]string, bool) {
+	values := map[string]string{}
+	if raw == "" {
+		return values, true
+	}
+	for _, item := range strings.Split(raw, "&") {
+		if item == "" {
+			continue
+		}
+		name := item
+		value := ""
+		if index := strings.IndexByte(item, '='); index >= 0 {
+			name = item[:index]
+			value = item[index+1:]
+		}
+		decodedName, nameOK := decodePercent(name, true)
+		decodedValue, valueOK := decodePercent(value, true)
+		if !nameOK || !valueOK {
+			return map[string]string{}, false
+		}
+		if _, exists := values[decodedName]; !exists {
+			values[decodedName] = decodedValue
+		}
+	}
+	return values, true
+}
+
+func decodePercent(value string, plusAsSpace bool) (string, bool) {
+	var builder strings.Builder
+	for index := 0; index < len(value); index++ {
+		current := value[index]
+		if plusAsSpace && current == '+' {
+			builder.WriteByte(' ')
+			continue
+		}
+		if current != '%' {
+			builder.WriteByte(current)
+			continue
+		}
+		if index+2 >= len(value) {
+			return value, false
+		}
+		high, highOK := hexValue(value[index+1])
+		low, lowOK := hexValue(value[index+2])
+		if !highOK || !lowOK {
+			return value, false
+		}
+		builder.WriteByte(high<<4 | low)
+		index += 2
+	}
+	return builder.String(), true
+}
+
+func hexValue(value byte) (byte, bool) {
+	switch {
+	case value >= '0' && value <= '9':
+		return value - '0', true
+	case value >= 'a' && value <= 'f':
+		return value - 'a' + 10, true
+	case value >= 'A' && value <= 'F':
+		return value - 'A' + 10, true
+	default:
+		return 0, false
+	}
+}

--- a/scripts/fixtures/history-routing/internal/historyroute/route_test.go
+++ b/scripts/fixtures/history-routing/internal/historyroute/route_test.go
@@ -1,0 +1,122 @@
+package historyroute
+
+import "testing"
+
+func TestNormalizeTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "empty", target: "", want: "/"},
+		{name: "leading slash", target: "users/42", want: "/users/42"},
+		{name: "repeated slash", target: "//users///42//", want: "/users/42"},
+		{name: "ordinary trailing slash", target: "/users/42/", want: "/users/42"},
+		{name: "settings canonical slash", target: "/settings", want: "/settings/"},
+		{name: "query preserved", target: "/search?q=a%2Fb", want: "/search?q=a%2Fb"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := NormalizeTarget(test.target); got != test.want {
+				t.Fatalf("NormalizeTarget(%q) = %q, want %q", test.target, got, test.want)
+			}
+		})
+	}
+}
+
+func TestMatchTarget(t *testing.T) {
+	tests := []struct {
+		target         string
+		name           string
+		param          string
+		query          string
+		notFound       bool
+		malformedPath  bool
+		malformedQuery bool
+	}{
+		{target: "/", name: "home"},
+		{target: "/users/42", name: "user", param: "42"},
+		{target: "/users/7?tab=activity", name: "user", param: "7", query: "activity"},
+		{target: "/users/Ada%20Lovelace", name: "user", param: "Ada Lovelace"},
+		{target: "/search?q=goframe", name: "search", query: "goframe"},
+		{target: "/settings/", name: "settings"},
+		{target: "/does-not-exist", name: "not-found", notFound: true},
+		{target: "/users/%ZZ", name: "not-found", notFound: true, malformedPath: true},
+		{target: "/search?q=%ZZ", name: "search", malformedQuery: true},
+	}
+	for _, test := range tests {
+		t.Run(test.target, func(t *testing.T) {
+			got := MatchTarget(test.target)
+			if got.Name != test.name ||
+				got.Param != test.param ||
+				got.QueryValue != test.query ||
+				got.NotFound != test.notFound ||
+				got.MalformedPath != test.malformedPath ||
+				got.MalformedQuery != test.malformedQuery {
+				t.Fatalf("MatchTarget(%q) = %#v", test.target, got)
+			}
+		})
+	}
+}
+
+func TestTargetFromLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		pathname string
+		search   string
+		want     string
+		inside   bool
+	}{
+		{name: "root", base: "/", pathname: "/", want: "/", inside: true},
+		{name: "root deep", base: "/", pathname: "/users/42", search: "?tab=activity", want: "/users/42?tab=activity", inside: true},
+		{name: "subpath home", base: "/app/", pathname: "/app/", want: "/", inside: true},
+		{name: "subpath deep", base: "/app", pathname: "/app/search", search: "q=goframe", want: "/search?q=goframe", inside: true},
+		{name: "outside subpath", base: "/app/", pathname: "/users/42", inside: false},
+		{name: "prefix sibling", base: "/app/", pathname: "/application/users/42", inside: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, inside, err := TargetFromLocation(test.base, test.pathname, test.search)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want || inside != test.inside {
+				t.Fatalf("TargetFromLocation(%q, %q, %q) = %q, %v; want %q, %v", test.base, test.pathname, test.search, got, inside, test.want, test.inside)
+			}
+		})
+	}
+}
+
+func TestLocationForTarget(t *testing.T) {
+	tests := []struct {
+		base   string
+		target string
+		want   string
+	}{
+		{base: "/", target: "/", want: "/"},
+		{base: "/", target: "/users/42?tab=activity", want: "/users/42?tab=activity"},
+		{base: "/app/", target: "/", want: "/app/"},
+		{base: "/app", target: "/users/42", want: "/app/users/42"},
+		{base: "app", target: "/settings", want: "/app/settings/"},
+	}
+	for _, test := range tests {
+		t.Run(test.base+" "+test.target, func(t *testing.T) {
+			got, err := LocationForTarget(test.base, test.target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("LocationForTarget(%q, %q) = %q, want %q", test.base, test.target, got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBaseRejectsNonPathInput(t *testing.T) {
+	for _, base := range []string{"/app/?q=1", "/app/#x", `\app`, "../app", "/app/../"} {
+		if _, err := NormalizeBase(base); err == nil {
+			t.Fatalf("NormalizeBase(%q) succeeded", base)
+		}
+	}
+}

--- a/scripts/history-routing-browser-smoke.mjs
+++ b/scripts/history-routing-browser-smoke.mjs
@@ -1,0 +1,773 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:net";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureDir = join(rootDir, "scripts", "fixtures", "history-routing");
+const fixturePackageDir = join(fixtureDir, ".goframe", "package", "standalone");
+const routerDir = join(rootDir, "examples", "router");
+const routerPackageDir = join(routerDir, ".goframe", "package", "standalone");
+const chrome = process.env.CHROME ?? "google-chrome";
+const tempRoot = await mkdtemp(join(tmpdir(), "goframe-history-routing-"));
+const profile = await mkdtemp(join(tmpdir(), "goframe-history-routing-chrome-"));
+const debugPort = Number(process.env.GOFRAME_HISTORY_ROUTING_CHROME_DEBUG_PORT ?? await pickFreePort());
+const historyServer = join(tempRoot, "history-routing-server");
+const counters = {
+    pushNavigations: 0,
+    replaceNavigations: 0,
+    popstateEvents: 0,
+    directDeepLinkBoots: 0,
+    refreshRecoveries: 0,
+    applicationNotFoundRenders: 0,
+    htmlFallbackResponses: 0,
+    staticFileResponses: 0,
+    missingAsset404Responses: 0,
+    api404Responses: 0,
+    incorrectFallbackResponses: 0,
+    routerMounts: 0,
+    routerUnmounts: 0,
+    listenerAdditions: 0,
+    listenerRemovals: 0,
+    appRootIdentityChanges: 0,
+    routeTargetMismatches: 0,
+};
+
+let browser = null;
+let browserError = "";
+let client = null;
+
+try {
+    const goxc = await prepareTools();
+    await runCommand(goxc, ["package", fixtureDir, "--compiler=go"]);
+    await runCommand(goxc, ["package", routerDir, "--compiler=go"]);
+
+    const assetManifest = JSON.parse(await readFile(join(fixturePackageDir, "asset-manifest.json"), "utf8"));
+    const wasmPath = assetManifest.entrypoints?.wasm;
+    const stylePath = assetManifest.entrypoints?.styles?.[0];
+    if (!wasmPath || !stylePath) {
+        throw new Error(`HARNESS FAILURE: fixture package entrypoints are incomplete: ${JSON.stringify(assetManifest.entrypoints)}`);
+    }
+
+    browser = spawn(chrome, [
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profile}`,
+        "about:blank",
+    ], {
+        stdio: ["ignore", "ignore", "pipe"],
+    });
+    browser.stderr.on("data", (chunk) => {
+        browserError += chunk;
+    });
+
+    const page = await waitForPage(debugPort);
+    client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+
+    await runHashBaseline(client, goxc);
+    await runStrictPathPhase(client);
+    await runRootFallbackPhase(client, wasmPath, stylePath);
+    await runSubpathFallbackPhase(client, wasmPath, stylePath);
+
+    assert(counters.routeTargetMismatches === 0, "route-target mismatches must remain zero");
+    assert(counters.incorrectFallbackResponses === 0, "incorrect fallback responses must remain zero");
+    assert(counters.appRootIdentityChanges === 0, "app-root identity changes must remain zero");
+    assert(counters.listenerAdditions === counters.listenerRemovals, "listener additions and removals must balance after teardown");
+
+    console.log(`history routing behavioral counters: ${JSON.stringify(counters)}`);
+    console.log("history routing deployment pressure: ok");
+} finally {
+    client?.close();
+    await stopProcess(browser, false);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await rm(join(fixtureDir, ".goframe"), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await rm(join(routerDir, ".goframe"), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function prepareTools() {
+    await runCommand("go", ["build", "-o", historyServer, "./scripts/fixtures/history-routing/cmd/server"]);
+    if (process.env.GOXC) {
+        return process.env.GOXC;
+    }
+    const goxc = join(tempRoot, "goxc");
+    await runCommand("go", ["build", "-o", goxc, "./cmd/goxc"]);
+    return goxc;
+}
+
+async function runHashBaseline(browserClient, goxc) {
+    const port = await pickFreePort();
+    const server = await startServer(
+        goxc,
+        ["serve", `--dir=${routerPackageDir}`, `--port=${port}`],
+        `http://127.0.0.1:${port}/`,
+        "hash-router baseline",
+    );
+    const origin = `http://127.0.0.1:${port}`;
+    try {
+        const root = await fetch(`${origin}/`);
+        const hash = await fetch(`${origin}/#/issues/1`);
+        const path = await fetch(`${origin}/users/42`);
+        assert(root.status === 200, `hash baseline root returned ${root.status}`);
+        assert(hash.status === 200, `hash baseline hash URL returned ${hash.status}`);
+        assert(path.status === 404, `hash baseline path URL returned ${path.status}`);
+
+        await navigate(browserClient, `${origin}/`);
+        await waitForHashRoute(browserClient, "home", "");
+
+        await navigate(browserClient, `${origin}/#/issues/1`);
+        await waitForHashRoute(browserClient, "details", "#/issues/1");
+        await browserClient.call("Page.reload", { ignoreCache: true });
+        await waitForHashRoute(browserClient, "details", "#/issues/1");
+
+        await navigate(browserClient, `${origin}/users/42`);
+        await waitForNoApp(browserClient, "router-shell");
+        console.log("phase 1 hash-router baseline: root/hash/refresh 200; clean path 404");
+    } finally {
+        await stopProcess(server.child, true);
+    }
+}
+
+async function runStrictPathPhase(browserClient) {
+    const port = await pickFreePort();
+    const origin = `http://127.0.0.1:${port}`;
+    const server = await startFixtureServer(port, "strict", "/", `${origin}/`);
+    try {
+        await navigate(browserClient, `${origin}/`);
+        await waitForHistoryRoute(browserClient, "home", "/");
+        await rememberAppRoot(browserClient);
+
+        await click(browserClient, "history-user-link");
+        await waitForHistoryRoute(browserClient, "user", "/users/42");
+        counters.pushNavigations++;
+        await assertHistoryState(browserClient, {
+            pathname: "/users/42",
+            search: "",
+            param: "42",
+            basePath: "/",
+            appSame: true,
+        }, "strict client push");
+
+        const response = await fetch(`${origin}/users/42`, { headers: { Accept: "text/html" } });
+        assert(response.status === 404, `strict deep route returned ${response.status}`);
+        await browserClient.call("Page.reload", { ignoreCache: true });
+        await waitForNoApp(browserClient, "history-app");
+        console.log("phase 2 strict server: client push works; direct deep route and refresh remain 404");
+    } finally {
+        await stopProcess(server.child, true);
+    }
+}
+
+async function runRootFallbackPhase(browserClient, wasmPath, stylePath) {
+    const port = await pickFreePort();
+    const origin = `http://127.0.0.1:${port}`;
+    const server = await startFixtureServer(port, "fallback", "/", `${origin}/`);
+    try {
+        await navigate(browserClient, `${origin}/users/42?tab=activity`);
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.directDeepLinkBoots++;
+        await assertHistoryState(browserClient, {
+            pathname: "/users/42",
+            search: "?tab=activity",
+            param: "42",
+            query: "tab=activity",
+            queryValue: "activity",
+            basePath: "/",
+        }, "root direct deep link");
+
+        await browserClient.call("Page.reload", { ignoreCache: true });
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.refreshRecoveries++;
+        await rememberAppRoot(browserClient);
+
+        await click(browserClient, "history-search-link");
+        await waitForHistoryRoute(browserClient, "search", "/search?q=goframe");
+        counters.pushNavigations++;
+        await assertHistoryState(browserClient, {
+            pathname: "/search",
+            search: "?q=goframe",
+            query: "q=goframe",
+            queryValue: "goframe",
+            basePath: "/",
+            appSame: true,
+        }, "root push navigation");
+
+        const historyLength = await browserClient.evaluate("history.length");
+        await click(browserClient, "history-settings-replace");
+        await waitForHistoryRoute(browserClient, "settings", "/settings/");
+        counters.replaceNavigations++;
+        await assertHistoryState(browserClient, {
+            pathname: "/settings/",
+            search: "",
+            basePath: "/",
+            appSame: true,
+        }, "root replace navigation");
+        assert(await browserClient.evaluate("history.length") === historyLength, "replaceState created a history entry");
+
+        await browserClient.evaluate("history.back()");
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.popstateEvents++;
+        await assertHistoryState(browserClient, {
+            pathname: "/users/42",
+            search: "?tab=activity",
+            queryValue: "activity",
+            appSame: true,
+        }, "root Back");
+
+        await browserClient.evaluate("history.forward()");
+        await waitForHistoryRoute(browserClient, "settings", "/settings/");
+        counters.popstateEvents++;
+        await assertHistoryState(browserClient, {
+            pathname: "/settings/",
+            appSame: true,
+        }, "root Forward");
+
+        await click(browserClient, "history-not-found-link");
+        await waitForHistoryRoute(browserClient, "not-found", "/does-not-exist");
+        counters.pushNavigations++;
+        counters.applicationNotFoundRenders++;
+        await assertHistoryState(browserClient, {
+            pathname: "/does-not-exist",
+            notFound: true,
+            appSame: true,
+        }, "root application not-found");
+
+        await runHTTPContractProbes(origin, "/", wasmPath, stylePath);
+        console.log("phases 3-4 root fallback: direct/refresh/navigation/history and bounded HTTP fallback passed");
+    } finally {
+        await stopProcess(server.child, true);
+    }
+}
+
+async function runSubpathFallbackPhase(browserClient, wasmPath, stylePath) {
+    const port = await pickFreePort();
+    const origin = `http://127.0.0.1:${port}`;
+    const server = await startFixtureServer(port, "fallback", "/app/", `${origin}/app/`);
+    try {
+        await navigate(browserClient, `${origin}/app/users/42?tab=activity`);
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.directDeepLinkBoots++;
+        await assertHistoryState(browserClient, {
+            pathname: "/app/users/42",
+            search: "?tab=activity",
+            param: "42",
+            queryValue: "activity",
+            basePath: "/app/",
+            documentBasePath: "/app/",
+            stylesheetPath: `/app/${stylePath}`,
+        }, "subpath direct deep link");
+
+        await browserClient.call("Page.reload", { ignoreCache: true });
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.refreshRecoveries++;
+        await rememberAppRoot(browserClient);
+
+        await click(browserClient, "history-search-link");
+        await waitForHistoryRoute(browserClient, "search", "/search?q=goframe");
+        counters.pushNavigations++;
+        await assertHistoryState(browserClient, {
+            pathname: "/app/search",
+            search: "?q=goframe",
+            queryValue: "goframe",
+            basePath: "/app/",
+            appSame: true,
+        }, "subpath push navigation");
+
+        const historyLength = await browserClient.evaluate("history.length");
+        await click(browserClient, "history-settings-replace");
+        await waitForHistoryRoute(browserClient, "settings", "/settings/");
+        counters.replaceNavigations++;
+        await assertHistoryState(browserClient, {
+            pathname: "/app/settings/",
+            basePath: "/app/",
+            appSame: true,
+        }, "subpath replace navigation");
+        assert(await browserClient.evaluate("history.length") === historyLength, "subpath replaceState created a history entry");
+
+        await browserClient.evaluate("history.back()");
+        await waitForHistoryRoute(browserClient, "user", "/users/42?tab=activity");
+        counters.popstateEvents++;
+        await assertHistoryState(browserClient, {
+            pathname: "/app/users/42",
+            search: "?tab=activity",
+            appSame: true,
+        }, "subpath Back");
+
+        await browserClient.evaluate("history.forward()");
+        await waitForHistoryRoute(browserClient, "settings", "/settings/");
+        counters.popstateEvents++;
+        await assertHistoryState(browserClient, {
+            pathname: "/app/settings/",
+            appSame: true,
+        }, "subpath Forward");
+
+        await runSubpathHTTPProbes(origin, wasmPath, stylePath);
+        await verifyListenerCleanup(browserClient);
+        console.log("phases 5-6 subpath fallback and listener cleanup: passed");
+    } finally {
+        await stopProcess(server.child, true);
+    }
+}
+
+async function runHTTPContractProbes(origin, base, wasmPath, stylePath) {
+    await probeResponse(origin, "/users/42", {
+        status: 200,
+        className: "fallback",
+        containsIndex: true,
+        base,
+    });
+    for (const path of [
+        "/assets/missing.js",
+        "/assets/missing.css",
+        "/assets/missing.wasm",
+        "/missing.js",
+    ]) {
+        await probeResponse(origin, path, {
+            status: 404,
+            className: "not-found",
+            containsIndex: false,
+            category: "missing-asset",
+        });
+    }
+    await probeResponse(origin, "/api/missing", {
+        status: 404,
+        className: "not-found",
+        containsIndex: false,
+        category: "api",
+    });
+    await probeResponse(origin, `/${wasmPath}`, {
+        status: 200,
+        className: "static",
+        contentType: "application/wasm",
+        nonEmpty: true,
+    });
+    await probeResponse(origin, `/${stylePath}`, {
+        status: 200,
+        className: "static",
+        contentTypePrefix: "text/css",
+        nonEmpty: true,
+    });
+}
+
+async function runSubpathHTTPProbes(origin, wasmPath, stylePath) {
+    await probeResponse(origin, "/app/users/42", {
+        status: 200,
+        className: "fallback",
+        containsIndex: true,
+        base: "/app/",
+    });
+    await probeResponse(origin, `/app/${wasmPath}`, {
+        status: 200,
+        className: "static",
+        contentType: "application/wasm",
+        nonEmpty: true,
+    });
+    await probeResponse(origin, `/app/${stylePath}`, {
+        status: 200,
+        className: "static",
+        contentTypePrefix: "text/css",
+        nonEmpty: true,
+    });
+    await probeResponse(origin, "/app/assets/missing.js", {
+        status: 404,
+        className: "not-found",
+        containsIndex: false,
+        category: "missing-asset",
+    });
+    await probeResponse(origin, "/app/api/missing", {
+        status: 404,
+        className: "not-found",
+        containsIndex: false,
+        category: "api",
+    });
+    await probeResponse(origin, "/users/42", {
+        status: 404,
+        className: "not-found",
+        containsIndex: false,
+    });
+}
+
+async function probeResponse(origin, path, expected) {
+    const response = await fetch(`${origin}${path}`, {
+        headers: { Accept: "text/html,application/xhtml+xml" },
+        redirect: "manual",
+    });
+    const content = new Uint8Array(await response.arrayBuffer());
+    const text = new TextDecoder().decode(content);
+    const className = response.headers.get("x-goframe-history-response") ?? "";
+    const contentType = response.headers.get("content-type") ?? "";
+    const correct =
+        response.status === expected.status &&
+        className === expected.className &&
+        (!expected.containsIndex || text.includes("GoFrame history routing pressure fixture")) &&
+        (expected.containsIndex !== false || !text.includes("GoFrame history routing pressure fixture")) &&
+        (!expected.base || text.includes(`<base href="${expected.base}" />`)) &&
+        (!expected.contentType || contentType === expected.contentType) &&
+        (!expected.contentTypePrefix || contentType.startsWith(expected.contentTypePrefix)) &&
+        (!expected.nonEmpty || content.length > 0);
+    if (!correct) {
+        counters.incorrectFallbackResponses++;
+        throw new Error(`HARNESS FAILURE: HTTP probe ${path}: ${JSON.stringify({
+            status: response.status,
+            className,
+            contentType,
+            bodyPrefix: text.slice(0, 160),
+            expected,
+        })}`);
+    }
+
+    if (className === "fallback") {
+        counters.htmlFallbackResponses++;
+    } else if (className === "static") {
+        counters.staticFileResponses++;
+    }
+    if (expected.category === "missing-asset") {
+        counters.missingAsset404Responses++;
+    } else if (expected.category === "api") {
+        counters.api404Responses++;
+    }
+}
+
+async function verifyListenerCleanup(browserClient) {
+    const before = await historyState(browserClient);
+    assert(before.routerMounts === 1, `router mount count before teardown = ${before.routerMounts}`);
+    assert(before.listenerAdds === 1, `listener add count before teardown = ${before.listenerAdds}`);
+
+    await click(browserClient, "history-router-unmount");
+    await waitForCondition(async () => {
+        const state = await historyState(browserClient);
+        return state.routerInactive && state.routerUnmounts === 1 && state.listenerRemovals === 1;
+    }, "router listener cleanup");
+
+    const removed = await historyState(browserClient);
+    const popstatesBefore = removed.popstates;
+    const originalLocation = removed.pathname + removed.search;
+    await browserClient.evaluate(`history.pushState(null, "", "/app/users/99"); history.back()`);
+    await waitForCondition(async () => {
+        const state = await historyState(browserClient);
+        return state.pathname + state.search === originalLocation;
+    }, "history activity after router teardown");
+    await wait(100);
+    const after = await historyState(browserClient);
+    assert(after.routerInactive, "router owner remounted after teardown");
+    assert(after.popstates === popstatesBefore, `inactive router observed popstate: ${after.popstates} != ${popstatesBefore}`);
+
+    counters.routerMounts = after.routerMounts;
+    counters.routerUnmounts = after.routerUnmounts;
+    counters.listenerAdditions = after.listenerAdds;
+    counters.listenerRemovals = after.listenerRemovals;
+}
+
+async function assertHistoryState(browserClient, expected, label) {
+    const actual = await historyState(browserClient);
+    const targetMatches = actual.target === (expected.target ?? actual.pathname.replace(/^\/app(?=\/)/, "") + actual.search);
+    if (!targetMatches) {
+        counters.routeTargetMismatches++;
+    }
+    if (expected.appSame === true && !actual.appSame) {
+        counters.appRootIdentityChanges++;
+    }
+    const fields = { ...expected };
+    delete fields.target;
+    for (const [key, value] of Object.entries(fields)) {
+        if (actual[key] !== value) {
+            throw new Error(`APP FAILURE: ${label}: ${key} got ${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; state=${JSON.stringify(actual)}`);
+        }
+    }
+    if (!targetMatches) {
+        throw new Error(`APP FAILURE: ${label}: displayed target ${JSON.stringify(actual.target)} does not match URL ${JSON.stringify(actual.pathname + actual.search)}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+async function rememberAppRoot(browserClient) {
+    await browserClient.evaluate(`window.__historyPressureApp = document.querySelector("[data-testid='history-app']")`);
+}
+
+async function click(browserClient, testID) {
+    await browserClient.evaluate(`document.querySelector("[data-testid='${testID}']").click()`);
+}
+
+async function waitForHistoryRoute(browserClient, route, target) {
+    await waitForCondition(async () => {
+        const state = await historyState(browserClient);
+        return state.app && state.route === route && state.target === target && state.listenerAdds === 1;
+    }, `history route ${route} ${target}`);
+}
+
+async function historyState(browserClient) {
+    return await browserClient.evaluate(`(() => {
+        const text = (id) => document.querySelector("[data-testid='" + id + "']")?.textContent.trim() ?? "";
+        const number = (id) => Number(text(id) || "0");
+        const base = document.querySelector("base");
+        const stylesheet = [...document.querySelectorAll("link[rel='stylesheet']")][0];
+        return {
+            app: Boolean(document.querySelector("[data-testid='history-app']")),
+            routerInactive: Boolean(document.querySelector("[data-testid='history-router-inactive']")),
+            route: text("history-route-name"),
+            target: text("history-route-target"),
+            query: text("history-route-query"),
+            param: text("history-route-param"),
+            queryValue: text("history-route-query-value"),
+            basePath: text("history-base-path"),
+            notFound: Boolean(document.querySelector("[data-testid='history-not-found']")),
+            pathname: location.pathname,
+            search: location.search,
+            documentBasePath: base ? new URL(base.href).pathname : "",
+            stylesheetPath: stylesheet ? new URL(stylesheet.href).pathname : "",
+            appSame: window.__historyPressureApp
+                ? window.__historyPressureApp === document.querySelector("[data-testid='history-app']")
+                : null,
+            pushes: number("history-push-count"),
+            replaces: number("history-replace-count"),
+            popstates: number("history-popstate-count"),
+            routerMounts: number("history-router-mount-count"),
+            routerUnmounts: number("history-router-unmount-count"),
+            listenerAdds: number("history-listener-add-count"),
+            listenerRemovals: number("history-listener-remove-count"),
+        };
+    })()`);
+}
+
+async function waitForHashRoute(browserClient, route, hash) {
+    await waitForCondition(async () => {
+        const state = await browserClient.evaluate(`(() => ({
+            hash: location.hash,
+            home: Boolean(document.querySelector("[data-testid='router-home']")),
+            details: Boolean(document.querySelector("[data-testid='router-issue-details']")),
+        }))()`);
+        const actualRoute = state.home ? "home" : state.details ? "details" : "missing";
+        return actualRoute === route && state.hash === hash;
+    }, `hash route ${route} ${hash}`);
+}
+
+async function waitForNoApp(browserClient, testID) {
+    await waitForCondition(async () => {
+        return await browserClient.evaluate(`document.readyState === "complete" && !document.querySelector("[data-testid='${testID}']")`);
+    }, `document without ${testID}`);
+}
+
+async function startFixtureServer(port, mode, base, readyURL) {
+    return await startServer(
+        historyServer,
+        [
+            `--package=${fixturePackageDir}`,
+            `--addr=127.0.0.1:${port}`,
+            `--mode=${mode}`,
+            `--base=${base}`,
+        ],
+        readyURL,
+        `history fixture ${mode} ${base}`,
+    );
+}
+
+async function startServer(command, args, readyURL, label) {
+    const child = spawn(command, args, {
+        cwd: rootDir,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+            ...process.env,
+            GOWORK: "off",
+        },
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+        output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+        output += chunk;
+    });
+    await waitForHTTP(readyURL, child, label, () => output);
+    return { child, output: () => output };
+}
+
+async function waitForHTTP(url, child, label, output) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 120; attempt++) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+            throw new Error(`HARNESS FAILURE: ${label} exited before HTTP was available\n${output()}`);
+        }
+        try {
+            const response = await fetch(url);
+            if (response.ok) {
+                return;
+            }
+            lastError = new Error(`HTTP ${response.status}`);
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: ${label} did not become ready: ${lastError?.message ?? ""}\n${output()}`);
+}
+
+async function navigate(browserClient, url) {
+    await browserClient.call("Page.navigate", { url });
+}
+
+async function waitForPage(port) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        if (browser?.exitCode !== null) {
+            throw new Error(`HARNESS FAILURE: Chrome exited before CDP was ready\n${browserError}`);
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            const targets = await response.json();
+            const page = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+            if (page) {
+                return page;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools did not become ready: ${lastError?.message ?? ""}\n${browserError}`);
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolveOpen, reject) => {
+        socket.addEventListener("open", resolveOpen, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result);
+        }
+    });
+    return {
+        call(method, params = {}) {
+            return new Promise((resolveCall, reject) => {
+                const id = nextID++;
+                pending.set(id, { resolve: resolveCall, reject });
+                socket.send(JSON.stringify({ id, method, params }));
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(`APP FAILURE: browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`);
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function waitForCondition(check, label) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 200; attempt++) {
+        try {
+            if (await check()) {
+                return;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ""}`);
+}
+
+function runCommand(command, args) {
+    return new Promise((resolveCommand, reject) => {
+        const child = spawn(command, args, {
+            cwd: rootDir,
+            stdio: "inherit",
+            env: {
+                ...process.env,
+                GOWORK: "off",
+            },
+        });
+        child.on("error", reject);
+        child.on("exit", (code, signal) => {
+            if (code === 0) {
+                resolveCommand();
+                return;
+            }
+            reject(new Error(`${command} ${args.join(" ")} failed with ${signal ?? code}`));
+        });
+    });
+}
+
+async function stopProcess(child, processGroup) {
+    if (!child || child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+    const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
+    terminate(child, processGroup, "SIGTERM");
+    const stopped = await Promise.race([
+        exited.then(() => true),
+        wait(2000).then(() => false),
+    ]);
+    if (!stopped && child.exitCode === null && child.signalCode === null) {
+        terminate(child, processGroup, "SIGKILL");
+        await Promise.race([exited, wait(1000)]);
+    }
+}
+
+function terminate(child, processGroup, signal) {
+    try {
+        if (processGroup) {
+            process.kill(-child.pid, signal);
+            return;
+        }
+    } catch {
+        // Fall through to direct child termination.
+    }
+    try {
+        child.kill(signal);
+    } catch {
+        // The process may have exited between checks.
+    }
+}
+
+function pickFreePort() {
+    return new Promise((resolvePort, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            server.close(() => resolvePort(address.port));
+        });
+    });
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(`APP FAILURE: ${message}`);
+    }
+}
+
+function wait(duration) {
+    return new Promise((resolveWait) => setTimeout(resolveWait, duration));
+}

--- a/scripts/history-routing-browser-smoke.mjs
+++ b/scripts/history-routing-browser-smoke.mjs
@@ -588,7 +588,12 @@ async function startServer(command, args, readyURL, label) {
     child.stderr.on("data", (chunk) => {
         output += chunk;
     });
-    await waitForHTTP(readyURL, child, label, () => output);
+    try {
+        await waitForHTTP(readyURL, child, label, () => output);
+    } catch (error) {
+        await stopProcess(child, true);
+        throw error;
+    }
     return { child, output: () => output };
 }
 


### PR DESCRIPTION
## Summary

Adds a bounded history/path-routing deployment pressure test without changing
GoFrame's public router, runtime, or packaging APIs.

The new fixture characterizes what clean browser paths require beyond the
current hash-router contract:

- browser History API ownership;
- direct deep-link and refresh behavior;
- explicit HTML navigation fallback;
- asset and API fallback exclusions;
- root and subpath deployment;
- deep-URL asset resolution through a document base.

The result remains fixture-local. This PR does not select or introduce a public
history router.

## Scope

- Adds an isolated fixture under `scripts/fixtures/history-routing`.
- Implements an example-local History API adapter using:
  - one current-target state slot;
  - one effect;
  - one `popstate` listener;
  - one matching cleanup;
  - explicit `pushState` and `replaceState` handoffs.
- Adds a pure route model covering:
  - route matching;
  - params and queries;
  - percent decoding;
  - malformed escape handling;
  - trailing-slash policy;
  - deployment-base stripping and application.
- Adds a plain Go `net/http` evidence server with:
  - `strict` static-file mode;
  - bounded `fallback` mode;
  - root and subpath deployment;
  - response-only `<base href>` injection.
- Adds focused route-model and server tests.
- Adds a dedicated Chrome/CDP browser harness.
- Integrates the focused harness into the aggregate browser-smoke gate.
- Records the measured browser and deployment contract in the fixture README.

## Deployment Evidence

The fixture compares three deployment shapes.

### Hash-router baseline

The existing hash router keeps application routes after `#`.

The browser and server evidence confirms:

```text
/                   → 200
/#/issues/1         → 200
refresh /#/issues/1 → 200
/users/42           → 404
```

Hash routing therefore does not require the server to distinguish application
routes from missing static files.

### Strict path serving

With ordinary static serving:

- client-side `pushState` navigation works after the root document has loaded;
- direct deep links return `404`;
- refreshing a deep path returns `404`.

This demonstrates that path routing requires an explicit hosting contract even
when the browser-side adapter is small.

### Bounded HTML fallback

Fallback mode serves the package index only when the request:

- uses `GET` or `HEAD`;
- is inside the configured deployment base;
- accepts HTML;
- does not resolve to a real static file;
- represents an extensionless or trailing-slash application route;
- is not an API or asset-shaped path.

The evidence verifies that:

| Request class | Result |
|---|---|
| application deep route | HTML fallback |
| real WASM, JS, or CSS | static file |
| missing asset | `404` |
| API path | `404` |
| path outside deployment base | `404` |
| traversal attempt | `404` |

WASM continues to use `application/wasm`.

## Browser Evidence

The focused browser harness covers:

- direct deep-link boot;
- deep-route refresh;
- client-side push navigation;
- replace navigation without a new history entry;
- Back and Forward through `popstate`;
- params and query preservation;
- trailing-slash route matching;
- application not-found rendering;
- retained application-root identity;
- root deployment;
- `/app/` subpath deployment;
- correct subpath asset resolution;
- exact listener cleanup after router-owner unmount.

Two focused runs produced identical behavioral counters:

| Counter | Run 1 | Run 2 |
|---|---:|---:|
| push navigations | 4 | 4 |
| replace navigations | 2 | 2 |
| `popstate` events | 4 | 4 |
| direct deep-link boots | 2 | 2 |
| refresh recoveries | 2 | 2 |
| application not-found renders | 1 | 1 |
| HTML fallback probes | 2 | 2 |
| static-file probes | 4 | 4 |
| missing-asset `404` probes | 5 | 5 |
| API `404` probes | 2 | 2 |
| incorrect fallback responses | 0 | 0 |
| router mounts | 1 | 1 |
| router unmounts | 1 | 1 |
| listener additions | 1 | 1 |
| listener removals | 1 | 1 |
| application-root identity changes | 0 | 0 |
| route-target mismatches | 0 | 0 |

## Coordination Result

The demonstrated browser integration requires:

- 1 current-target state slot;
- 1 effect;
- 1 `popstate` listener;
- 1 cleanup callback;
- 1 push handoff;
- 1 replace handoff;
- 0 global mutable route-state variables.

The browser-side ownership is small and repeatable.

The deployment contract is more substantial:

- explicit navigation fallback;
- static-file precedence;
- API and asset exclusions;
- correct MIME types;
- normalized deployment-base ownership;
- a deep-URL document asset base.

Based on this bounded fixture, an example-local adapter and explicit deployment
contract are sufficient for the demonstrated flows. No public history-router API
is selected by this PR.

## Compatibility And Impact

This PR does not change:

- `pkg/goframe`;
- `pkg/gox`;
- `cmd/goxc`;
- `RouterView`, `Navigate`, or the current hash router;
- public APIs;
- package output;
- `goxc serve`;
- existing examples;
- dependencies or workflows;
- roadmap or release state;
- repository size budgets.

Hash routing remains the current supported routing surface and continues to
require no deep-path fallback.

The fixture server is evidence infrastructure, not a production server or a
supported deployment product.

## Validation

Local validation passes with Go 1.22.12 and TinyGo 0.41.1:

- route-model tests repeated 100 times;
- route-model race tests repeated 20 times;
- server tests repeated 100 times;
- server race tests repeated 20 times;
- fixture packaging with standard Go and TinyGo;
- two focused Chrome/CDP browser runs;
- Windows server cross-compilation;
- the full Go test suite;
- command and package race tests;
- debug-tag tests;
- `go vet`;
- `scripts/check.sh`;
- aggregate browser smoke;
- the WASM size gate;
- documentation, artifact, and module-path checks;
- `git diff --check`.

All 11 existing budgeted examples remain byte-identical to the frozen base,
including raw WASM and deterministic gzip, Brotli, and Zstandard output.

The new history-routing fixture measures:

| Artifact | Size |
|---|---:|
| raw WASM | 122,421 B |
| gzip | 48,064 B |
| Brotli | 39,601 B |
| Zstandard | 42,753 B |

These values are informational. No threshold was introduced.

## Known Limitations

- The fixture proves behavior in one Linux Chromium/CDP environment.
- Trailing-slash matching is deterministic, but automatic browser-URL
  canonicalization is not selected as a contract.
- The HTML `Accept` check is intentionally fixture-level rather than complete
  production content negotiation.
- CDN- and provider-specific rewrite syntax is not covered.
- Redirects and navigation blockers are not covered.
- Route data loading and async transitions are not part of this fixture.
- SSR, hydration, service workers, and production hosting support are not
  established.

## Non-Goals

- no public history router;
- no changes to the existing hash router;
- no production server;
- no changes to `goxc serve`;
- no redirect or blocker API;
- no file-based routing;
- no route loaders;
- no transition API;
- no SSR or hydration;
- no deployment-provider adapters.