### PR TITLE
test(document): characterize head metadata ownership

### DIFF
--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -398,6 +398,11 @@ export GOFRAME_HISTORY_ROUTING_CHROME_DEBUG_PORT="${GOFRAME_HISTORY_ROUTING_CHRO
 GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/history-routing-browser-smoke.mjs
 
 echo
+echo "== Document state ownership pressure =="
+export GOFRAME_DOCUMENT_STATE_CHROME_DEBUG_PORT="${GOFRAME_DOCUMENT_STATE_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/document-state-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo

--- a/scripts/document-state-browser-smoke.mjs
+++ b/scripts/document-state-browser-smoke.mjs
@@ -1,0 +1,948 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:net";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureDir = join(rootDir, "scripts", "fixtures", "document-state");
+const chrome = process.env.CHROME ?? "google-chrome";
+const tempRoot = await mkdtemp(join(tmpdir(), "goframe-document-state-"));
+const profile = await mkdtemp(join(tmpdir(), "goframe-document-state-chrome-"));
+const appPort = Number(process.env.GOFRAME_DOCUMENT_STATE_PORT ?? await pickFreePort());
+const debugPort = Number(
+    process.env.GOFRAME_DOCUMENT_STATE_CHROME_DEBUG_PORT ?? await pickFreePort(),
+);
+const origin = `http://127.0.0.1:${appPort}`;
+const appURL = `${origin}/?smoke=${Date.now()}#/`;
+
+const authoredBaseline = {
+    title: "GoFrame document-state fixture",
+    description: "Authored document-state baseline",
+};
+const unrelatedValue = "preserve-me";
+const speculativeState = {
+    title: "Speculative failure · GoFrame",
+    description: "This description must never commit.",
+};
+
+let browser = null;
+let browserError = "";
+let client = null;
+let server = null;
+const commandOutput = [];
+
+try {
+    const goxc = await prepareTools();
+    await runCommand(goxc, ["package", fixtureDir, "--compiler=tinygo"]);
+    await runCommand(goxc, ["package", fixtureDir, "--compiler=go"]);
+
+    server = await startServer(
+        goxc,
+        ["serve", fixtureDir, `--port=${appPort}`],
+        `${origin}/`,
+        "document-state fixture",
+    );
+
+    browser = spawn(chrome, [
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profile}`,
+        "about:blank",
+    ], {
+        stdio: ["ignore", "ignore", "pipe"],
+    });
+    browser.stderr.on("data", (chunk) => {
+        browserError += chunk;
+    });
+
+    const page = await waitForPage(debugPort);
+    client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Page.addScriptToEvaluateOnNewDocument", {
+        source: `(${installHeadObserver.toString()})()`,
+    });
+
+    await client.call("Page.navigate", { url: appURL });
+    await waitForCondition(async () => {
+        const state = await documentState(client);
+        return state.baselineCaptured && state.app;
+    }, "authored baseline capture and fixture boot");
+    await assertAuthoredBaselineCapture(client);
+    await rememberAppRoot(client);
+
+    await setObservationPhase(client, "initial-home");
+    await waitForDocumentState(client, routeState(
+        "home",
+        "/",
+        "Home · GoFrame",
+        "Document-state home route.",
+    ), "initial home owner");
+
+    await setObservationPhase(client, "same-pattern");
+    await click(client, "document-user-42-link");
+    await waitForDocumentState(client, userState("42"), "user 42");
+    await click(client, "document-user-7-link");
+    await waitForDocumentState(client, userState("7"), "same-pattern user 7");
+
+    await setObservationPhase(client, "not-found");
+    await click(client, "document-not-found-link");
+    await waitForDocumentState(client, routeState(
+        "not-found",
+        "/does-not-exist",
+        "Not found · GoFrame",
+        "No document-state route matched.",
+    ), "not-found owner");
+
+    await setObservationPhase(client, "nested-override");
+    await click(client, "document-user-42-link");
+    await waitForDocumentState(client, userState("42"), "nested flow user 42");
+    await click(client, "document-editor-open");
+    await waitForDocumentState(client, editorState("42"), "editing user 42");
+    await click(client, "document-user-7-link");
+    await waitForDocumentState(client, editorState("7"), "parent update under editor");
+    await click(client, "document-editor-close");
+    await waitForDocumentState(client, userState("7"), "editor reveals latest parent");
+
+    await setObservationPhase(client, "cross-pattern");
+    await click(client, "document-editor-open");
+    await waitForDocumentState(client, editorState("7"), "editor before cross-pattern navigation");
+    await click(client, "document-search-link");
+    const search = routeState(
+        "search",
+        "/search?q=runtime",
+        "Search: runtime · GoFrame",
+        "Search results for runtime.",
+    );
+    await waitForDocumentState(client, search, "cross-pattern search");
+    await assertStableDocumentState(client, search, "cross-pattern cleanup");
+
+    const rapidStart = await headSnapshotCount(client);
+    await setObservationPhase(
+        client,
+        "rapid-update",
+        ["User A · GoFrame", "User B · GoFrame"],
+        ["Profile for user A.", "Profile for user B."],
+    );
+    await click(client, "document-rapid-update");
+    const userC = userState("C");
+    await waitForDocumentState(client, userC, "rapid user C");
+    await assertStableDocumentState(client, userC, "rapid user C settle");
+    await assertNoStaleRapidSnapshots(client, rapidStart);
+
+    await setObservationPhase(client, "history");
+    await click(client, "document-home-link");
+    const home = routeState(
+        "home",
+        "/",
+        "Home · GoFrame",
+        "Document-state home route.",
+    );
+    await waitForDocumentState(client, home, "history home commit");
+    await click(client, "document-search-link");
+    await waitForDocumentState(client, search, "history search commit");
+    await client.evaluate("history.back()");
+    await waitForDocumentState(client, home, "Back");
+    await client.evaluate("history.forward()");
+    await waitForDocumentState(client, search, "Forward");
+
+    await setObservationPhase(client, "failed-render");
+    const beforeFailure = await documentState(client);
+    await click(client, "document-failure-trigger");
+    await waitForCondition(async () => {
+        const state = await documentState(client);
+        return state.failureFallback &&
+            state.errorBoundaryCaptures === beforeFailure.errorBoundaryCaptures + 1;
+    }, "speculative failure fallback");
+    await assertDocumentState(client, search, "failed render retains route owner");
+    const afterFailure = await documentState(client);
+    assert(
+        afterFailure.speculativeAppearances === 0,
+        `speculative metadata appeared ${afterFailure.speculativeAppearances} times`,
+    );
+    assert(
+        !afterFailure.ownershipEvents.some((event) => event.owner === "speculative"),
+        "speculative owner reached the committed ownership model",
+    );
+    await click(client, "document-failure-reset");
+    await waitForCondition(async () => {
+        const state = await documentState(client);
+        return !state.failureFallback;
+    }, "failed subtree removal");
+    await assertDocumentState(client, search, "failed subtree removal retains route owner");
+
+    await setObservationPhase(client, "scope-unmount");
+    await click(client, "document-scope-unmount");
+    await waitForBaselineRestoration(client);
+    await assertHeadNodeIdentity(client, "scope unmount");
+
+    await setObservationPhase(client, "scope-remount");
+    await click(client, "document-scope-remount");
+    await waitForDocumentState(client, search, "scope remount current route");
+    await assertHeadNodeIdentity(client, "scope remount");
+    await assertAppRootIdentity(client);
+
+    const final = await documentState(client);
+    const counters = collectBehavioralCounters(final);
+    assert(counters.routeMetadataCommits > 0, "route metadata commits were not observed");
+    assert(counters.nestedOwnerActivations > 0, "nested owner activation was not observed");
+    assert(counters.nestedOwnerReleases > 0, "nested owner release was not observed");
+    assert(counters.ownerUpdates > 0, "owner updates were not observed");
+    assert(counters.ownerRemovals > 0, "owner removals were not observed");
+    assert(counters.titleMutationBatches > 0, "title mutations were not observed");
+    assert(counters.descriptionMutationBatches > 0, "description mutations were not observed");
+    assert(counters.headSnapshots > 0, "head snapshots were not observed");
+    assert(counters.baselineRestorations === 1, `baseline restorations = ${counters.baselineRestorations}, want 1`);
+    assert(counters.scopeMounts === 2, `scope mounts = ${counters.scopeMounts}, want 2`);
+    assert(counters.scopeUnmounts === 1, `scope unmounts = ${counters.scopeUnmounts}, want 1`);
+    assert(counters.errorBoundaryCaptures === 1, `boundary captures = ${counters.errorBoundaryCaptures}, want 1`);
+    assert(counters.invalidPairs === 0, `invalid title/description pairs = ${counters.invalidPairs}`);
+    assert(counters.duplicateDescriptions === 0, `duplicate descriptions = ${counters.duplicateDescriptions}`);
+    assert(counters.staleAppearances === 0, `stale metadata appearances = ${counters.staleAppearances}`);
+    assert(counters.speculativeAppearances === 0, `speculative metadata appearances = ${counters.speculativeAppearances}`);
+    assert(counters.appRootIdentityChanges === 0, `app-root identity changes = ${counters.appRootIdentityChanges}`);
+    assert(counters.unrelatedMetaMutations === 0, `unrelated-meta mutations = ${counters.unrelatedMetaMutations}`);
+
+    console.log(`document state behavioral counters: ${JSON.stringify(counters)}`);
+    console.log("document state ownership pressure: ok");
+} catch (error) {
+    const diagnostics = await collectDiagnostics();
+    throw new Error(`${error.message}\n${JSON.stringify(diagnostics, null, 2)}`, {
+        cause: error,
+    });
+} finally {
+    client?.close();
+    await stopProcess(browser, false);
+    await stopProcess(server?.child, true);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    await rm(join(fixtureDir, ".goframe"), {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+    });
+}
+
+function routeState(route, target, title, description) {
+    return {
+        scopeActive: true,
+        route,
+        target,
+        hash: `#${target}`,
+        activeOwner: "route",
+        title,
+        description,
+    };
+}
+
+function userState(id) {
+    return routeState(
+        "user",
+        `/users/${id}`,
+        `User ${id} · GoFrame`,
+        `Profile for user ${id}.`,
+    );
+}
+
+function editorState(id) {
+    return {
+        ...userState(id),
+        activeOwner: "editor",
+        title: `Editing User ${id} · GoFrame`,
+        description: `Editing profile for user ${id}.`,
+        editor: true,
+    };
+}
+
+async function prepareTools() {
+    if (process.env.GOXC) {
+        return process.env.GOXC;
+    }
+    const goxc = join(tempRoot, "goxc");
+    await runCommand("go", ["build", "-o", goxc, "./cmd/goxc"]);
+    return goxc;
+}
+
+async function assertAuthoredBaselineCapture(browserClient) {
+    const state = await documentState(browserClient);
+    assert(state.baselineCaptured, "authored baseline was not captured before app ownership");
+    assert(state.authoredTitle === authoredBaseline.title, `authored title = ${JSON.stringify(state.authoredTitle)}`);
+    assert(
+        state.authoredDescription === authoredBaseline.description,
+        `authored description = ${JSON.stringify(state.authoredDescription)}`,
+    );
+    assert(state.authoredDescriptionCount === 1, `authored description count = ${state.authoredDescriptionCount}`);
+    assert(state.authoredUnrelated === unrelatedValue, `authored unrelated meta = ${JSON.stringify(state.authoredUnrelated)}`);
+}
+
+async function waitForDocumentState(browserClient, expected, label) {
+    await waitForCondition(async () => {
+        const state = await documentState(browserClient);
+        return documentStateMatches(state, expected);
+    }, label);
+    await assertDocumentState(browserClient, expected, label);
+}
+
+async function assertDocumentState(browserClient, expected, label) {
+    const state = await documentState(browserClient);
+    const mismatches = [];
+    for (const [field, value] of Object.entries(expected)) {
+        if (state[field] !== value) {
+            mismatches.push(`${field}=${JSON.stringify(state[field])}, want ${JSON.stringify(value)}`);
+        }
+    }
+    if (state.expectedTitle !== expected.title) {
+        mismatches.push(`expectedTitle=${JSON.stringify(state.expectedTitle)}, want ${JSON.stringify(expected.title)}`);
+    }
+    if (state.expectedDescription !== expected.description) {
+        mismatches.push(`expectedDescription=${JSON.stringify(state.expectedDescription)}, want ${JSON.stringify(expected.description)}`);
+    }
+    if (state.descriptionCount !== 1) {
+        mismatches.push(`descriptionCount=${state.descriptionCount}, want 1`);
+    }
+    if (state.unrelated !== unrelatedValue) {
+        mismatches.push(`unrelated=${JSON.stringify(state.unrelated)}, want ${JSON.stringify(unrelatedValue)}`);
+    }
+    if (!state.titleNodeSame || !state.descriptionNodeSame) {
+        mismatches.push(`node identities title=${state.titleNodeSame} description=${state.descriptionNodeSame}`);
+    }
+    if (!state.appSame && state.appIdentityCaptured) {
+        mismatches.push("application root identity changed");
+    }
+    if (mismatches.length > 0) {
+        throw new Error(`APP FAILURE: ${label}: ${mismatches.join("; ")}`);
+    }
+    console.log(`${label}: ok`);
+}
+
+function documentStateMatches(state, expected) {
+    return Object.entries(expected).every(([field, value]) => state[field] === value) &&
+        state.expectedTitle === expected.title &&
+        state.expectedDescription === expected.description &&
+        state.descriptionCount === 1 &&
+        state.unrelated === unrelatedValue;
+}
+
+async function assertStableDocumentState(browserClient, expected, label) {
+    for (let attempt = 0; attempt < 5; attempt++) {
+        await wait(100);
+        await assertDocumentState(browserClient, expected, `${label} ${attempt + 1}/5`);
+    }
+}
+
+async function waitForBaselineRestoration(browserClient) {
+    await waitForCondition(async () => {
+        const state = await documentState(browserClient);
+        return state.scopeInactive &&
+            state.activeOwner === "authored-baseline" &&
+            state.title === authoredBaseline.title &&
+            state.description === authoredBaseline.description &&
+            state.expectedTitle === authoredBaseline.title &&
+            state.expectedDescription === authoredBaseline.description;
+    }, "authored baseline restoration");
+    const state = await documentState(browserClient);
+    assert(state.descriptionCount === 1, `baseline description count = ${state.descriptionCount}`);
+    assert(state.unrelated === unrelatedValue, `baseline unrelated meta = ${JSON.stringify(state.unrelated)}`);
+    console.log("authored baseline restoration: ok");
+}
+
+async function assertNoStaleRapidSnapshots(browserClient, start) {
+    const result = await browserClient.evaluate(`(() => {
+        const evidence = globalThis.__documentStateHeadEvidence;
+        const staleTitles = new Set(["User A · GoFrame", "User B · GoFrame"]);
+        const staleDescriptions = new Set(["Profile for user A.", "Profile for user B."]);
+        const snapshots = evidence.snapshots.slice(${start});
+        return {
+            stale: snapshots.filter((snapshot) =>
+                staleTitles.has(snapshot.title) ||
+                staleDescriptions.has(snapshot.description)
+            ),
+            count: snapshots.length,
+        };
+    })()`);
+    assert(result.stale.length === 0, `rapid updates exposed stale metadata: ${JSON.stringify(result)}`);
+}
+
+async function setObservationPhase(
+    browserClient,
+    phase,
+    forbiddenTitles = [],
+    forbiddenDescriptions = [],
+) {
+    await browserClient.evaluate(`(() => {
+        const evidence = globalThis.__documentStateHeadEvidence;
+        evidence.phase = ${JSON.stringify(phase)};
+        evidence.forbiddenTitles = ${JSON.stringify(forbiddenTitles)};
+        evidence.forbiddenDescriptions = ${JSON.stringify(forbiddenDescriptions)};
+        return true;
+    })()`);
+}
+
+async function headSnapshotCount(browserClient) {
+    return await browserClient.evaluate(
+        "globalThis.__documentStateHeadEvidence?.snapshots.length ?? 0",
+    );
+}
+
+async function rememberAppRoot(browserClient) {
+    const captured = await browserClient.evaluate(`(() => {
+        globalThis.__documentStateAppRoot =
+            document.querySelector("[data-testid='document-state-app']");
+        return Boolean(globalThis.__documentStateAppRoot);
+    })()`);
+    assert(captured, "application root was unavailable for identity capture");
+}
+
+async function assertAppRootIdentity(browserClient) {
+    const same = await browserClient.evaluate(`(
+        globalThis.__documentStateAppRoot ===
+        document.querySelector("[data-testid='document-state-app']")
+    )`);
+    assert(same, "application root identity changed");
+}
+
+async function assertHeadNodeIdentity(browserClient, label) {
+    const state = await documentState(browserClient);
+    assert(state.titleNodeSame, `title node identity changed during ${label}`);
+    assert(state.descriptionNodeSame, `description node identity changed during ${label}`);
+}
+
+async function click(browserClient, testID) {
+    const clicked = await browserClient.evaluate(`(() => {
+        const element = document.querySelector(
+            "[data-testid='${testID}']"
+        );
+        if (!element) return false;
+        element.click();
+        return true;
+    })()`);
+    assert(clicked, `missing element for click ${testID}`);
+}
+
+async function documentState(browserClient) {
+    return await browserClient.evaluate(`(() => {
+        const text = (id) =>
+            document.querySelector("[data-testid='" + id + "']")
+                ?.textContent.trim() ?? "";
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const unrelated = document.querySelector(
+            'head meta[name="fixture-unrelated"]'
+        );
+        const head = globalThis.__documentStateHeadEvidence || {};
+        const app = globalThis.goframeDocumentStateEvidence || {};
+        const titleNode = document.querySelector("head title");
+        const descriptionNode = descriptions[0] || null;
+        return {
+            href: location.href,
+            hash: location.hash,
+            app: Boolean(document.querySelector(
+                "[data-testid='document-state-app']"
+            )),
+            scopeActive: Boolean(document.querySelector(
+                "[data-testid='document-state-scope']"
+            )),
+            scopeInactive: Boolean(document.querySelector(
+                "[data-testid='document-state-scope-inactive']"
+            )),
+            failureFallback: Boolean(document.querySelector(
+                "[data-testid='document-failure-fallback']"
+            )),
+            editor: Boolean(document.querySelector(
+                "[data-testid='document-editor']"
+            )),
+            route: text("document-route-name"),
+            target: text("document-route-target"),
+            activeOwner: text("document-active-owner"),
+            expectedTitle: text("document-expected-title"),
+            expectedDescription: text("document-expected-description"),
+            title: document.title,
+            description: descriptionNode?.getAttribute("content") ?? "",
+            descriptionCount: descriptions.length,
+            unrelated: unrelated?.getAttribute("content") ?? "",
+            baselineCaptured: Boolean(head.baselineCaptured),
+            authoredTitle: head.authoredTitle ?? "",
+            authoredDescription: head.authoredDescription ?? "",
+            authoredDescriptionCount: head.authoredDescriptionCount ?? 0,
+            authoredUnrelated: head.authoredUnrelated ?? "",
+            titleNodeSame: head.titleNode === titleNode,
+            descriptionNodeSame: head.descriptionNode === descriptionNode,
+            appIdentityCaptured: Boolean(globalThis.__documentStateAppRoot),
+            appSame: globalThis.__documentStateAppRoot
+                ? globalThis.__documentStateAppRoot === document.querySelector(
+                    "[data-testid='document-state-app']"
+                )
+                : null,
+            titleMutationBatches: head.titleMutationBatches ?? 0,
+            descriptionMutationBatches:
+                head.descriptionMutationBatches ?? 0,
+            headSnapshots: head.headSnapshots ?? 0,
+            invalidPairs: head.invalidPairs ?? 0,
+            duplicateDescriptions: head.duplicateDescriptions ?? 0,
+            staleAppearances: head.staleAppearances ?? 0,
+            speculativeAppearances: head.speculativeAppearances ?? 0,
+            unrelatedMetaMutations: head.unrelatedMetaMutations ?? 0,
+            headSnapshotRecords: Array.from(head.snapshots || []),
+            routeMetadataCommits: Array.from(app.ownershipEvents || [])
+                .filter((event) =>
+                    event.owner === "route" &&
+                    (event.change === "added" || event.change === "updated")
+                ).length,
+            nestedOwnerActivations: app.nestedOwnerActivations ?? 0,
+            nestedOwnerReleases: app.nestedOwnerReleases ?? 0,
+            ownerUpdates: app.ownerUpdates ?? 0,
+            ownerRemovals: app.ownerRemovals ?? 0,
+            baselineRestorations: app.baselineRestorations ?? 0,
+            scopeMounts: app.scopeMounts ?? 0,
+            scopeUnmounts: app.scopeUnmounts ?? 0,
+            errorBoundaryCaptures: app.errorBoundaryCaptures ?? 0,
+            ownershipEvents: Array.from(app.ownershipEvents || []),
+            runtimeErrors: Array.from(app.runtimeErrors || []),
+        };
+    })()`);
+}
+
+function collectBehavioralCounters(state) {
+    return {
+        routeMetadataCommits: state.routeMetadataCommits,
+        nestedOwnerActivations: state.nestedOwnerActivations,
+        nestedOwnerReleases: state.nestedOwnerReleases,
+        ownerUpdates: state.ownerUpdates,
+        ownerRemovals: state.ownerRemovals,
+        titleMutationBatches: state.titleMutationBatches,
+        descriptionMutationBatches: state.descriptionMutationBatches,
+        headSnapshots: state.headSnapshots,
+        invalidPairs: state.invalidPairs,
+        duplicateDescriptions: state.duplicateDescriptions,
+        staleAppearances: state.staleAppearances,
+        speculativeAppearances: state.speculativeAppearances,
+        baselineRestorations: state.baselineRestorations,
+        scopeMounts: state.scopeMounts,
+        scopeUnmounts: state.scopeUnmounts,
+        errorBoundaryCaptures: state.errorBoundaryCaptures,
+        appRootIdentityChanges: state.appSame ? 0 : 1,
+        unrelatedMetaMutations: state.unrelatedMetaMutations,
+    };
+}
+
+function installHeadObserver() {
+    const evidence = {
+        baselineCaptured: false,
+        authoredTitle: "",
+        authoredDescription: "",
+        authoredDescriptionCount: 0,
+        authoredUnrelated: "",
+        titleNode: null,
+        descriptionNode: null,
+        unrelatedNode: null,
+        titleMutationBatches: 0,
+        descriptionMutationBatches: 0,
+        headSnapshots: 0,
+        invalidPairs: 0,
+        duplicateDescriptions: 0,
+        staleAppearances: 0,
+        speculativeAppearances: 0,
+        unrelatedMetaMutations: 0,
+        phase: "document-parse",
+        forbiddenTitles: [],
+        forbiddenDescriptions: [],
+        snapshots: [],
+    };
+    globalThis.__documentStateHeadEvidence = evidence;
+
+    const captureBaseline = () => {
+        if (evidence.baselineCaptured) return true;
+        const titles = document.querySelectorAll("head title");
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const unrelated = document.querySelector(
+            'head meta[name="fixture-unrelated"]'
+        );
+        if (titles.length !== 1 || descriptions.length !== 1 || !unrelated) {
+            return false;
+        }
+        evidence.titleNode = titles[0];
+        evidence.descriptionNode = descriptions[0];
+        evidence.unrelatedNode = unrelated;
+        evidence.authoredTitle = titles[0].textContent;
+        evidence.authoredDescription =
+            descriptions[0].getAttribute("content") ?? "";
+        evidence.authoredDescriptionCount = descriptions.length;
+        evidence.authoredUnrelated =
+            unrelated.getAttribute("content") ?? "";
+        evidence.baselineCaptured = true;
+        return true;
+    };
+
+    const containsNode = (record, node) => {
+        if (!node) return false;
+        if (record.target === node || node.contains(record.target)) return true;
+        return [...record.addedNodes, ...record.removedNodes].some(
+            (changed) => changed === node ||
+                (changed.nodeType === Node.ELEMENT_NODE &&
+                    changed.contains(node))
+        );
+    };
+
+    const isDescriptionNode = (node) =>
+        node?.nodeType === Node.ELEMENT_NODE &&
+        node.matches?.('meta[name="description"]');
+
+    const observer = new MutationObserver((records) => {
+        const baselineWasCaptured = evidence.baselineCaptured;
+        if (!captureBaseline()) return;
+        if (!baselineWasCaptured) return;
+        const titleTouched = records.some((record) =>
+            containsNode(record, evidence.titleNode)
+        );
+        const descriptionTouched = records.some((record) =>
+            containsNode(record, evidence.descriptionNode) ||
+            [...record.addedNodes, ...record.removedNodes].some(
+                isDescriptionNode
+            )
+        );
+        const unrelatedTouched = records.some((record) =>
+            containsNode(record, evidence.unrelatedNode)
+        );
+        if (!titleTouched && !descriptionTouched && !unrelatedTouched) {
+            return;
+        }
+        if (titleTouched) evidence.titleMutationBatches++;
+        if (descriptionTouched) evidence.descriptionMutationBatches++;
+        if (unrelatedTouched) evidence.unrelatedMetaMutations++;
+
+        const text = (id) =>
+            document.querySelector("[data-testid='" + id + "']")
+                ?.textContent.trim() ?? "";
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const description = descriptions[0]?.getAttribute("content") ?? "";
+        const unrelated = document.querySelector(
+            'head meta[name="fixture-unrelated"]'
+        )?.getAttribute("content") ?? "";
+        const snapshot = {
+            phase: evidence.phase,
+            title: document.title,
+            description,
+            descriptionCount: descriptions.length,
+            unrelated,
+            route: text("document-route-name"),
+            target: text("document-route-target"),
+            activeOwner: text("document-active-owner"),
+            expectedTitle: text("document-expected-title"),
+            expectedDescription: text("document-expected-description"),
+        };
+        evidence.snapshots.push(snapshot);
+        evidence.headSnapshots++;
+
+        if (snapshot.expectedTitle && (
+            snapshot.title !== snapshot.expectedTitle ||
+            snapshot.description !== snapshot.expectedDescription
+        )) {
+            evidence.invalidPairs++;
+        }
+        if (snapshot.descriptionCount !== 1) {
+            evidence.duplicateDescriptions++;
+        }
+        if (snapshot.unrelated !== evidence.authoredUnrelated) {
+            evidence.unrelatedMetaMutations++;
+        }
+        if (
+            snapshot.title === "Speculative failure · GoFrame" ||
+            snapshot.description === "This description must never commit."
+        ) {
+            evidence.speculativeAppearances++;
+        }
+        if (
+            evidence.forbiddenTitles.includes(snapshot.title) ||
+            evidence.forbiddenDescriptions.includes(snapshot.description)
+        ) {
+            evidence.staleAppearances++;
+        }
+    });
+    observer.observe(document, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+    });
+    queueMicrotask(captureBaseline);
+    document.addEventListener("DOMContentLoaded", captureBaseline, {
+        once: true,
+    });
+}
+
+async function collectDiagnostics() {
+    const diagnostics = {
+        appURL,
+        appPort,
+        debugPort,
+        browserStderr: browserError.slice(-6000),
+        serverOutput: server?.output?.().slice(-6000) ?? "",
+        commandOutput: commandOutput.slice(-8),
+    };
+    if (client) {
+        try {
+            const state = await documentState(client);
+            diagnostics.page = {
+                href: state.href,
+                hash: state.hash,
+                route: state.route,
+                target: state.target,
+                activeOwner: state.activeOwner,
+                expectedTitle: state.expectedTitle,
+                actualTitle: state.title,
+                expectedDescription: state.expectedDescription,
+                actualDescription: state.description,
+                descriptionCount: state.descriptionCount,
+                unrelated: state.unrelated,
+                failureFallback: state.failureFallback,
+                runtimeErrors: state.runtimeErrors,
+                recentHeadSnapshots: state.headSnapshotRecords.slice(-12),
+                recentOwnershipEvents: state.ownershipEvents.slice(-12),
+            };
+        } catch (error) {
+            diagnostics.pageError = error.message;
+        }
+    }
+    return diagnostics;
+}
+
+async function startServer(command, args, readyURL, label) {
+    const child = spawn(command, args, {
+        cwd: rootDir,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+            ...process.env,
+            GOWORK: "off",
+        },
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+        output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+        output += chunk;
+    });
+    try {
+        await waitForHTTP(readyURL, child, label, () => output);
+    } catch (error) {
+        await stopProcess(child, true);
+        throw error;
+    }
+    return { child, output: () => output };
+}
+
+async function waitForHTTP(url, child, label, output) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 120; attempt++) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+            throw new Error(
+                `HARNESS FAILURE: ${label} exited before HTTP was available\n${output()}`,
+            );
+        }
+        try {
+            const response = await fetch(url);
+            if (response.ok) return;
+            lastError = new Error(`HTTP ${response.status}`);
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: ${label} did not become ready: ${lastError?.message ?? ""}\n${output()}`,
+    );
+}
+
+async function waitForPage(port) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        if (browser?.exitCode !== null) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome exited before CDP was ready\n${browserError}`,
+            );
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            const targets = await response.json();
+            const page = targets.find(
+                (entry) => entry.type === "page" &&
+                    entry.webSocketDebuggerUrl
+            );
+            if (page) return page;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: Chrome DevTools did not become ready: ${lastError?.message ?? ""}\n${browserError}`,
+    );
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolveOpen, reject) => {
+        socket.addEventListener("open", resolveOpen, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) return;
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result);
+        }
+    });
+    return {
+        call(method, params = {}) {
+            return new Promise((resolveCall, reject) => {
+                const id = nextID++;
+                pending.set(id, { resolve: resolveCall, reject });
+                socket.send(JSON.stringify({ id, method, params }));
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(
+                    `APP FAILURE: browser evaluation failed: ${JSON.stringify(result.exceptionDetails)}`,
+                );
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function waitForCondition(check, label) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 200; attempt++) {
+        try {
+            if (await check()) return;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: timed out waiting for ${label}` +
+        (lastError ? `: ${lastError.message}` : ""),
+    );
+}
+
+function runCommand(command, args) {
+    return new Promise((resolveCommand, reject) => {
+        const child = spawn(command, args, {
+            cwd: rootDir,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: {
+                ...process.env,
+                GOWORK: "off",
+            },
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+            output += chunk;
+            process.stdout.write(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+            output += chunk;
+            process.stderr.write(chunk);
+        });
+        child.on("error", reject);
+        child.on("exit", (code, signal) => {
+            commandOutput.push({
+                command,
+                args,
+                status: signal ?? code,
+                output: output.slice(-6000),
+            });
+            if (code === 0) {
+                resolveCommand();
+                return;
+            }
+            reject(
+                new Error(
+                    `${command} ${args.join(" ")} failed with ${signal ?? code}`,
+                ),
+            );
+        });
+    });
+}
+
+async function stopProcess(child, processGroup) {
+    if (!child || child.exitCode !== null || child.signalCode !== null) return;
+    const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
+    terminate(child, processGroup, "SIGTERM");
+    const stopped = await Promise.race([
+        exited.then(() => true),
+        wait(2000).then(() => false),
+    ]);
+    if (!stopped && child.exitCode === null && child.signalCode === null) {
+        terminate(child, processGroup, "SIGKILL");
+        await Promise.race([exited, wait(1000)]);
+    }
+}
+
+function terminate(child, processGroup, signal) {
+    try {
+        if (processGroup) {
+            process.kill(-child.pid, signal);
+            return;
+        }
+    } catch {
+        // Fall through to direct child termination.
+    }
+    try {
+        child.kill(signal);
+    } catch {
+        // The process may have exited between checks.
+    }
+}
+
+function pickFreePort() {
+    return new Promise((resolvePort, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            server.close(() => resolvePort(address.port));
+        });
+    });
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(`APP FAILURE: ${message}`);
+    }
+}
+
+function wait(duration) {
+    return new Promise((resolveWait) => setTimeout(resolveWait, duration));
+}

--- a/scripts/fixtures/document-state/README.md
+++ b/scripts/fixtures/document-state/README.md
@@ -1,0 +1,166 @@
+# Document State Ownership Pressure Fixture
+
+This fixture measures one bounded browser ownership question: whether independent
+component owners can coordinate an authored document title and description with
+the current GoFrame effect, unmount, router, and Error Boundary APIs. It is
+executable evidence, not a public document-head API proposal.
+
+## Baseline
+
+GoFrame exposes committed effects and browser DOM access, but it has no public
+document-head ownership abstraction. The existing router example retains its
+authored `goframe router` title after route navigation and has no route-driven
+description meta element.
+
+A temporary uncommitted save/restore probe used this sequence:
+
+```text
+parent User 42
+nested Editing User 42
+parent update to User 7
+nested cleanup
+```
+
+The nested cleanup restored the value it captured at mount, producing stale
+`User 42` title and description values instead of the latest `User 7` pair.
+This demonstrates a failure in that specific independent captured-value
+composition; it is not a claim about every possible application design.
+
+## Proven
+
+The host tests and two standard Go/WASM browser runs prove:
+
+- the authored title, description, and unrelated meta element are captured
+  before application ownership commits;
+- route owners apply deterministic Home, user, search, and not-found pairs;
+- same-pattern user updates replace title and description coherently;
+- an editor owner overrides its route owner;
+- route-owner updates do not change editor priority;
+- editor cleanup reveals the latest route state;
+- cross-pattern cleanup does not overwrite the new route owner;
+- rapid A, B, and C navigation settles on C without exposing A or B metadata;
+- Back and Forward align the hash target, rendered target, title, and
+  description;
+- a speculative owner in a failed render never enters the committed registry
+  or document head;
+- unmounting the owner scope restores the authored baseline, and remounting
+  reapplies the current hash route;
+- the authored title and description nodes retain identity;
+- exactly one description meta element remains present;
+- the unrelated authored meta value remains unchanged;
+- every observed title/description mutation delivery contains the expected
+  pair.
+
+Title and description remain separate DOM writes. The evidence does not claim
+an atomic browser head transaction.
+
+## Ownership Model
+
+The fixture uses one package-local ordered coordinator created by `main` and
+passed through component props. Route, editor, and speculative owners are
+separate component instances using the same private `useDocumentState` helper.
+
+New owners append to priority order. Updating an existing owner changes its
+desired pair without changing priority. Removing the top owner reveals the
+latest remaining owner; removing a non-top owner leaves the visible owner
+unchanged. Removing the final owner selects the authored baseline.
+
+Owner effects update the pure coordinator after commit and pass its selected
+snapshot to the retained application root. A separate committed effect applies
+that snapshot after the expected-state markers have been patched. Browser DOM
+access remains in the `js && wasm` adapter.
+
+There is no global mutable ownership registry. The fixture publishes one
+mutable JavaScript evidence object for browser counters and diagnostics; the
+application never reads it as ownership state.
+
+## Measured Coordination
+
+- Fixture application Go/GOX: 704 lines.
+- Pure ownership model: 167 lines.
+- Ownership model tests: 166 lines.
+- Browser adapter: 175 JS/WASM lines plus 37 host-stub lines.
+- Browser harness: 948 lines.
+- Application-owned state slots: 4 call sites.
+- Reducers: 0.
+- Effects: 3 call sites, with at most 4 committed effect slots while the editor
+  is active.
+- `UseUnmount`: 2 call sites, with at most 3 committed registrations while the
+  editor is active.
+- Owner records: at most 2 committed records (`route` and `editor`).
+- Cleanup callbacks: 2 registration sites, with at most 3 mounted callbacks.
+- Browser DOM query sites: 3.
+- Browser DOM write sites: 2.
+- Head elements created: 0.
+- Head elements removed: 0.
+- Global mutable ownership variables: 0.
+- Global mutable evidence variables: 1.
+- Pure helper types/functions: 6 types and 9 functions.
+- Route/head handoff points: 1 selected-snapshot callback boundary.
+
+The focused browser runs produced identical counters:
+
+| Counter | Run 1 | Run 2 |
+|---|---:|---:|
+| route metadata commits | 13 | 13 |
+| nested owner activations | 2 | 2 |
+| nested owner releases | 2 | 2 |
+| owner updates | 3 | 3 |
+| owner removals | 12 | 12 |
+| title mutation batches | 17 | 17 |
+| description mutation batches | 17 | 17 |
+| head snapshots | 17 | 17 |
+| invalid title/description pairs | 0 | 0 |
+| duplicate description observations | 0 | 0 |
+| stale metadata appearances | 0 | 0 |
+| speculative metadata appearances | 0 | 0 |
+| baseline restorations | 1 | 1 |
+| scope mounts | 2 | 2 |
+| scope unmounts | 1 | 1 |
+| Error Boundary captures | 1 | 1 |
+| application-root identity changes | 0 | 0 |
+| unrelated-meta mutations | 0 | 0 |
+
+The fixture was packaged with TinyGo 0.41.1 using Go 1.22.12 on Linux amd64.
+Sizes are informational and introduce no threshold:
+
+| Encoding | Bytes |
+|---|---:|
+| raw | 314205 |
+| gzip (`-n -9`) | 133222 |
+| Brotli (`-q 11`) | 109017 |
+| Zstandard (`-19`) | 115582 |
+
+## Failure Semantics
+
+`SpeculativeDocumentOwner` declares its desired pair through the ordinary
+private hook and then panics during the same render. The nearest
+`gf.ErrorBoundary` displays fallback UI. The runtime rolls back the failed
+render attempt, so the owner's effect does not commit, no owner record is
+created, and the previously committed route state remains active.
+
+Removing the failed subtree leaves the route metadata unchanged. Standard
+Go/WASM supplies the browser panic-containment evidence. TinyGo compilation is
+covered, but TinyGo trap-mode panic containment is not claimed.
+
+## Remaining Limitations
+
+The evidence covers one document, title, description, nested owners,
+same-pattern route updates, cross-pattern route changes, Back, Forward, failed
+render isolation, scope teardown, and authored baseline restoration.
+
+It does not cover SSR, hydration, arbitrary head elements, canonical links,
+Open Graph or other social metadata, JSON-LD, scripts, styles, multiple browser
+documents, coordination with external head mutations, or broad browser
+compatibility. It does not establish production SEO support.
+
+## Decision
+
+**Result B:** Correct nested and out-of-order ownership requires one small
+shared coordinator in this demonstrated fixture. The repeated contract is
+ordered ownership with priority-preserving updates and current-state reveal on
+release.
+
+No public document-state API is selected in this branch. The evidence records a
+possible narrow ownership problem for later comparison; it does not select an
+arbitrary head manager, router integration, SSR contract, or metadata framework.

--- a/scripts/fixtures/document-state/assets/index.html
+++ b/scripts/fixtures/document-state/assets/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GoFrame document-state fixture</title>
+    <meta
+        name="description"
+        content="Authored document-state baseline"
+    />
+    <meta name="fixture-unrelated" content="preserve-me" />
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/document-state/assets/styles.css
+++ b/scripts/fixtures/document-state/assets/styles.css
@@ -1,0 +1,43 @@
+:root {
+    color-scheme: light dark;
+    font-family: system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+}
+
+.document-state-app {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: 58rem;
+    padding: 2rem;
+}
+
+.document-state-nav,
+.document-state-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.document-state-card,
+.document-state-evidence {
+    border: 1px solid currentColor;
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.document-state-evidence {
+    display: grid;
+    gap: 0.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+    margin-bottom: 1rem;
+}
+
+.document-state-editor {
+    border-inline-start: 0.25rem solid currentColor;
+    margin-top: 1rem;
+    padding-inline-start: 1rem;
+}

--- a/scripts/fixtures/document-state/cmd/app/app.gox
+++ b/scripts/fixtures/document-state/cmd/app/app.gox
@@ -1,0 +1,465 @@
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state/internal/documentstate"
+)
+
+type AppProps struct {
+	Adapter     *browserDocumentAdapter
+	Coordinator *documentstate.Coordinator
+}
+
+type DocumentCommitterProps struct {
+	Adapter  *browserDocumentAdapter
+	Snapshot documentstate.Snapshot
+}
+
+type DocumentScopeProps struct {
+	Coordinator *documentstate.Coordinator
+	OnSnapshot  func(documentstate.Snapshot)
+}
+
+type DocumentOwnerProps struct {
+	Coordinator *documentstate.Coordinator
+	OnSnapshot  func(documentstate.Snapshot)
+	Owner       string
+	State       documentstate.State
+	Children    []gf.Node
+}
+
+type RoutePageProps struct {
+	Coordinator *documentstate.Coordinator
+	OnSnapshot  func(documentstate.Snapshot)
+	Name        string
+	Target      string
+	State       documentstate.State
+	Summary     string
+}
+
+type UserPageProps struct {
+	Coordinator *documentstate.Coordinator
+	OnSnapshot  func(documentstate.Snapshot)
+	ID          string
+	Target      string
+}
+
+type SpeculativeDocumentOwnerProps struct {
+	Coordinator *documentstate.Coordinator
+	OnSnapshot  func(documentstate.Snapshot)
+}
+
+var (
+	documentRoutePageType = gf.NewComponentType(
+		"fixture.document-state.RoutePage",
+		"DocumentStateRoutePage",
+	)
+	documentUserPageType = gf.NewComponentType(
+		"fixture.document-state.UserPage",
+		"DocumentStateUserPage",
+	)
+)
+
+func App(props AppProps) gf.Node {
+	scopeActive, setScopeActive := gf.UseState(true)
+	snapshot, setSnapshot := gf.UseState(props.Coordinator.Snapshot())
+	onSnapshot := func(next documentstate.Snapshot) {
+		setSnapshot(next)
+	}
+
+	scope := documentScopeNode(scopeActive, DocumentScopeProps{
+		Coordinator: props.Coordinator,
+		OnSnapshot:  onSnapshot,
+	})
+	scopeControl := documentScopeControl(scopeActive, setScopeActive)
+
+	return (
+		<main class="document-state-app" data-testid="document-state-app">
+			<header>
+				<h1>Document state ownership pressure</h1>
+				<p>
+					Independent component owners coordinate one authored title and
+					description pair.
+				</p>
+			</header>
+
+			<DocumentCommitter Adapter={props.Adapter} Snapshot={snapshot} />
+
+			<section class="document-state-evidence" data-testid="document-state-evidence">
+				<span data-testid="document-active-owner">{activeOwnerLabel(snapshot)}</span>
+				<span data-testid="document-expected-title">{snapshot.State.Title}</span>
+				<span data-testid="document-expected-description">{snapshot.State.Description}</span>
+			</section>
+
+			<div class="document-state-controls">
+				{scopeControl}
+			</div>
+
+			{scope}
+		</main>
+	)
+}
+
+func DocumentCommitter(props DocumentCommitterProps) gf.Node {
+	title := props.Snapshot.State.Title
+	description := props.Snapshot.State.Description
+	gf.UseEffect(func() gf.Cleanup {
+		if err := props.Adapter.Apply(documentstate.State{
+			Title:       title,
+			Description: description,
+		}); err != nil {
+			panic("document-state fixture: apply document state: " + err.Error())
+		}
+		return nil
+	}, gf.Deps(title, description))
+	return gf.Empty()
+}
+
+func DocumentScope(props DocumentScopeProps) gf.Node {
+	failureActive, setFailureActive := gf.UseState(false)
+	gf.UseEffect(func() gf.Cleanup {
+		recordDocumentScopeMount()
+		return nil
+	})
+	gf.UseUnmount(func() {
+		recordDocumentScopeUnmount()
+	})
+
+	router := newDocumentRouter(props)
+	failureNode := speculativeFailureNode(failureActive, props)
+	return (
+		<section class="document-state-card" data-testid="document-state-scope">
+			<nav class="document-state-nav" aria-label="Document state routes">
+				<gf.RouterLink To="/" TestID="document-home-link">Home</gf.RouterLink>
+				<gf.RouterLink To="/users/42" TestID="document-user-42-link">User 42</gf.RouterLink>
+				<gf.RouterLink To="/users/7" TestID="document-user-7-link">User 7</gf.RouterLink>
+				<gf.RouterLink
+					To={gf.WithQuery("/search", gf.QueryValues{"q": {"runtime"}})}
+					TestID="document-search-link"
+				>
+					Search
+				</gf.RouterLink>
+				<gf.RouterLink To="/does-not-exist" TestID="document-not-found-link">
+					Unknown
+				</gf.RouterLink>
+				<button
+					Type="button"
+					data-testid="document-rapid-update"
+					OnClick={func() {
+						gf.Navigate("/users/A")
+						gf.Navigate("/users/B")
+						gf.Navigate("/users/C")
+					}}
+				>
+					Rapid A, B, C
+				</button>
+				<button
+					Type="button"
+					data-testid="document-failure-trigger"
+					OnClick={func() {
+						setFailureActive(true)
+					}}
+				>
+					Trigger speculative failure
+				</button>
+			</nav>
+
+			<gf.ErrorBoundary
+				Fallback={func(ctx gf.ErrorBoundaryContext) gf.Node {
+					return documentFailureFallback(ctx, setFailureActive)
+				}}
+			>
+				{failureNode}
+			</gf.ErrorBoundary>
+
+			{gf.RouterView(router)}
+		</section>
+	)
+}
+
+func DocumentOwner(props DocumentOwnerProps) gf.Node {
+	useDocumentState(
+		props.Coordinator,
+		props.OnSnapshot,
+		props.Owner,
+		props.State,
+	)
+	return gf.Fragment(props.Children...)
+}
+
+func RoutePage(props RoutePageProps) gf.Node {
+	return (
+		<DocumentOwner
+			Coordinator={props.Coordinator}
+			OnSnapshot={props.OnSnapshot}
+			Owner="route"
+			State={props.State}
+		>
+			<section data-testid="document-route-view">
+				<h2>{props.Summary}</h2>
+				<p data-testid="document-route-name">{props.Name}</p>
+				<p data-testid="document-route-target">{props.Target}</p>
+			</section>
+		</DocumentOwner>
+	)
+}
+
+func UserPage(props UserPageProps) gf.Node {
+	editorOpen, setEditorOpen := gf.UseState(false)
+	editor := documentEditorNode(editorOpen, props, setEditorOpen)
+	state := userDocumentState(props.ID)
+
+	return (
+		<DocumentOwner
+			Coordinator={props.Coordinator}
+			OnSnapshot={props.OnSnapshot}
+			Owner="route"
+			State={state}
+		>
+			<section data-testid="document-route-view">
+				<h2>User {props.ID}</h2>
+				<p data-testid="document-route-name">user</p>
+				<p data-testid="document-route-target">{props.Target}</p>
+				<button
+					Type="button"
+					data-testid="document-editor-open"
+					OnClick={func() {
+						setEditorOpen(true)
+					}}
+				>
+					Open editor
+				</button>
+				{editor}
+			</section>
+		</DocumentOwner>
+	)
+}
+
+func SpeculativeDocumentOwner(props SpeculativeDocumentOwnerProps) gf.Node {
+	useDocumentState(
+		props.Coordinator,
+		props.OnSnapshot,
+		"speculative",
+		documentstate.State{
+			Title:       "Speculative failure · GoFrame",
+			Description: "This description must never commit.",
+		},
+	)
+	panic("document-state speculative render failure")
+}
+
+func useDocumentState(
+	coordinator *documentstate.Coordinator,
+	onSnapshot func(documentstate.Snapshot),
+	owner string,
+	state documentstate.State,
+) {
+	gf.UseEffect(func() gf.Cleanup {
+		transition, err := coordinator.Set(owner, state)
+		if err != nil {
+			panic("document-state fixture: set owner: " + err.Error())
+		}
+		if transition.Change != documentstate.ChangeNone {
+			recordDocumentStateTransition(transition)
+			onSnapshot(transition.Snapshot)
+		}
+		return nil
+	}, gf.Deps(owner, state.Title, state.Description))
+	gf.UseUnmount(func() {
+		transition, err := coordinator.Remove(owner)
+		if err != nil {
+			panic("document-state fixture: remove owner: " + err.Error())
+		}
+		if transition.Change != documentstate.ChangeNone {
+			recordDocumentStateTransition(transition)
+			onSnapshot(transition.Snapshot)
+		}
+	})
+}
+
+func newDocumentRouter(props DocumentScopeProps) *gf.Router {
+	return gf.NewHashRouter([]gf.Route{
+		gf.RoutePath("/", func(ctx gf.RouteContext) gf.Node {
+			return documentRoutePage(props, RoutePageProps{
+				Name:    "home",
+				Target:  routeTarget(ctx),
+				State:   documentstate.State{Title: "Home · GoFrame", Description: "Document-state home route."},
+				Summary: "Home",
+			})
+		}),
+		gf.RoutePath("/users/:id", func(ctx gf.RouteContext) gf.Node {
+			return gf.ComponentT(
+				documentUserPageType,
+				UserPageProps{
+					Coordinator: props.Coordinator,
+					OnSnapshot:  props.OnSnapshot,
+					ID:          ctx.Param("id"),
+					Target:      routeTarget(ctx),
+				},
+				UserPage,
+			)
+		}),
+		gf.RoutePath("/search", func(ctx gf.RouteContext) gf.Node {
+			query := ctx.Query().Get("q")
+			return documentRoutePage(props, RoutePageProps{
+				Name:    "search",
+				Target:  routeTarget(ctx),
+				State:   documentstate.State{Title: "Search: " + query + " · GoFrame", Description: "Search results for " + query + "."},
+				Summary: "Search results",
+			})
+		}),
+		gf.NotFoundRoute(func(ctx gf.RouteContext) gf.Node {
+			return documentRoutePage(props, RoutePageProps{
+				Name:    "not-found",
+				Target:  routeTarget(ctx),
+				State:   documentstate.State{Title: "Not found · GoFrame", Description: "No document-state route matched."},
+				Summary: "Not found",
+			})
+		}),
+	})
+}
+
+func documentRoutePage(scope DocumentScopeProps, props RoutePageProps) gf.Node {
+	props.Coordinator = scope.Coordinator
+	props.OnSnapshot = scope.OnSnapshot
+	return gf.ComponentT(documentRoutePageType, props, RoutePage)
+}
+
+func documentEditorNode(
+	active bool,
+	props UserPageProps,
+	setActive func(bool),
+) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	return (
+		<DocumentOwner
+			Coordinator={props.Coordinator}
+			OnSnapshot={props.OnSnapshot}
+			Owner="editor"
+			State={documentstate.State{
+				Title:       "Editing User " + props.ID + " · GoFrame",
+				Description: "Editing profile for user " + props.ID + ".",
+			}}
+		>
+			<aside class="document-state-editor" data-testid="document-editor">
+				<p>Editing user {props.ID}</p>
+				<button
+					Type="button"
+					data-testid="document-editor-close"
+					OnClick={func() {
+						setActive(false)
+					}}
+				>
+					Close editor
+				</button>
+			</aside>
+		</DocumentOwner>
+	)
+}
+
+func speculativeFailureNode(
+	active bool,
+	props DocumentScopeProps,
+) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	return (
+		<SpeculativeDocumentOwner
+			Coordinator={props.Coordinator}
+			OnSnapshot={props.OnSnapshot}
+		/>
+	)
+}
+
+func documentFailureFallback(
+	ctx gf.ErrorBoundaryContext,
+	setFailureActive func(bool),
+) gf.Node {
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "document-failure-fallback"},
+		gf.El("p", nil, gf.Text("Speculative document owner failed during render.")),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "document-failure-reset",
+				"OnClick": func() {
+					setFailureActive(false)
+					ctx.Reset()
+				},
+			},
+			gf.Text("Remove failed owner"),
+		),
+	)
+}
+
+func documentScopeNode(
+	active bool,
+	props DocumentScopeProps,
+) gf.Node {
+	if active {
+		return (
+			<DocumentScope
+				Coordinator={props.Coordinator}
+				OnSnapshot={props.OnSnapshot}
+			/>
+		)
+	}
+	return (
+		<section data-testid="document-state-scope-inactive">
+			Document-state owners are unmounted.
+		</section>
+	)
+}
+
+func documentScopeControl(
+	active bool,
+	setActive func(bool),
+) gf.Node {
+	if active {
+		return gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "document-scope-unmount",
+				"OnClick": func() {
+					setActive(false)
+				},
+			},
+			gf.Text("Unmount document owners"),
+		)
+	}
+	return gf.El(
+		"button",
+		gf.Props{
+			"data-testid": "document-scope-remount",
+			"OnClick": func() {
+				setActive(true)
+			},
+		},
+		gf.Text("Remount document owners"),
+	)
+}
+
+func userDocumentState(id string) documentstate.State {
+	return documentstate.State{
+		Title:       "User " + id + " · GoFrame",
+		Description: "Profile for user " + id + ".",
+	}
+}
+
+func routeTarget(ctx gf.RouteContext) string {
+	if ctx.RawQuery == "" {
+		return ctx.Path
+	}
+	return ctx.Path + "?" + ctx.RawQuery
+}
+
+func activeOwnerLabel(snapshot documentstate.Snapshot) string {
+	if !snapshot.HasOwner {
+		return "authored-baseline"
+	}
+	return snapshot.ActiveOwner
+}

--- a/scripts/fixtures/document-state/cmd/app/document_js.go
+++ b/scripts/fixtures/document-state/cmd/app/document_js.go
@@ -1,0 +1,175 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state/internal/documentstate"
+)
+
+type browserDocumentAdapter struct {
+	title       js.Value
+	description js.Value
+	unrelated   js.Value
+	baseline    documentstate.State
+	current     documentstate.State
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	document := js.Global().Get("document")
+	if document.IsUndefined() || document.IsNull() {
+		return nil, errors.New("document is unavailable")
+	}
+	titles := document.Call("querySelectorAll", "head title")
+	if titles.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one authored title element, found %d",
+			titles.Get("length").Int(),
+		)
+	}
+	descriptions := document.Call(
+		"querySelectorAll",
+		`head meta[name="description"]`,
+	)
+	if descriptions.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one authored description element, found %d",
+			descriptions.Get("length").Int(),
+		)
+	}
+	unrelated := document.Call(
+		"querySelector",
+		`head meta[name="fixture-unrelated"]`,
+	)
+	if unrelated.IsUndefined() || unrelated.IsNull() {
+		return nil, errors.New("authored unrelated metadata is missing")
+	}
+
+	title := titles.Index(0)
+	description := descriptions.Index(0)
+	baseline := documentstate.State{
+		Title:       title.Get("textContent").String(),
+		Description: description.Call("getAttribute", "content").String(),
+	}
+	return &browserDocumentAdapter{
+		title:       title,
+		description: description,
+		unrelated:   unrelated,
+		baseline:    baseline,
+		current:     baseline,
+	}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() documentstate.State {
+	if adapter == nil {
+		return documentstate.State{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(state documentstate.State) error {
+	if adapter == nil {
+		return errors.New("document adapter is nil")
+	}
+	if !adapter.title.Get("isConnected").Bool() {
+		return errors.New("authored title element is no longer connected")
+	}
+	if !adapter.description.Get("isConnected").Bool() {
+		return errors.New("authored description element is no longer connected")
+	}
+	if adapter.unrelated.Call("getAttribute", "content").String() != "preserve-me" {
+		return errors.New("unrelated authored metadata changed")
+	}
+
+	previous := adapter.current
+	if adapter.title.Get("textContent").String() != state.Title {
+		adapter.title.Set("textContent", state.Title)
+	}
+	if adapter.description.Call("getAttribute", "content").String() != state.Description {
+		adapter.description.Call("setAttribute", "content", state.Description)
+	}
+	adapter.current = state
+	if previous != adapter.baseline && state == adapter.baseline {
+		incrementDocumentStateEvidence("baselineRestorations")
+	}
+	return nil
+}
+
+func initDocumentStateEvidence() {
+	evidence := js.Global().Get("Object").New()
+	for _, field := range []string{
+		"routeMetadataCommits",
+		"nestedOwnerActivations",
+		"nestedOwnerReleases",
+		"ownerUpdates",
+		"ownerRemovals",
+		"baselineRestorations",
+		"scopeMounts",
+		"scopeUnmounts",
+		"errorBoundaryCaptures",
+	} {
+		evidence.Set(field, 0)
+	}
+	evidence.Set("ownershipEvents", js.Global().Get("Array").New())
+	evidence.Set("runtimeErrors", js.Global().Get("Array").New())
+	js.Global().Set("goframeDocumentStateEvidence", evidence)
+}
+
+func recordDocumentStateTransition(transition documentstate.Transition) {
+	if transition.Change == documentstate.ChangeNone {
+		return
+	}
+	switch {
+	case transition.Owner == "route":
+		incrementDocumentStateEvidence("routeMetadataCommits")
+	case transition.Owner == "editor" && transition.Change == documentstate.ChangeAdded:
+		incrementDocumentStateEvidence("nestedOwnerActivations")
+	case transition.Owner == "editor" && transition.Change == documentstate.ChangeRemoved:
+		incrementDocumentStateEvidence("nestedOwnerReleases")
+	}
+	if transition.Change == documentstate.ChangeUpdated {
+		incrementDocumentStateEvidence("ownerUpdates")
+	}
+	if transition.Change == documentstate.ChangeRemoved {
+		incrementDocumentStateEvidence("ownerRemovals")
+	}
+
+	event := js.Global().Get("Object").New()
+	event.Set("owner", transition.Owner)
+	event.Set("change", transition.Change.String())
+	event.Set("activeOwner", transition.Snapshot.ActiveOwner)
+	event.Set("title", transition.Snapshot.State.Title)
+	event.Set("description", transition.Snapshot.State.Description)
+	documentStateEvidence().Get("ownershipEvents").Call("push", event)
+}
+
+func recordDocumentScopeMount() {
+	incrementDocumentStateEvidence("scopeMounts")
+}
+
+func recordDocumentScopeUnmount() {
+	incrementDocumentStateEvidence("scopeUnmounts")
+}
+
+func recordDocumentStateError(info gf.ErrorInfo) {
+	incrementDocumentStateEvidence("errorBoundaryCaptures")
+	report := js.Global().Get("Object").New()
+	report.Set("phase", info.Phase.String())
+	report.Set("component", info.Component)
+	report.Set("operation", info.Operation)
+	report.Set("panic", gf.ToString(info.Panic))
+	documentStateEvidence().Get("runtimeErrors").Call("push", report)
+}
+
+func incrementDocumentStateEvidence(field string) {
+	evidence := documentStateEvidence()
+	evidence.Set(field, evidence.Get(field).Int()+1)
+}
+
+func documentStateEvidence() js.Value {
+	return js.Global().Get("goframeDocumentStateEvidence")
+}

--- a/scripts/fixtures/document-state/cmd/app/document_nonjs.go
+++ b/scripts/fixtures/document-state/cmd/app/document_nonjs.go
@@ -1,0 +1,37 @@
+//go:build !js || !wasm
+
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state/internal/documentstate"
+)
+
+type browserDocumentAdapter struct {
+	baseline documentstate.State
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	return &browserDocumentAdapter{}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() documentstate.State {
+	if adapter == nil {
+		return documentstate.State{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(documentstate.State) error {
+	return nil
+}
+
+func initDocumentStateEvidence() {}
+
+func recordDocumentStateTransition(documentstate.Transition) {}
+
+func recordDocumentScopeMount() {}
+
+func recordDocumentScopeUnmount() {}
+
+func recordDocumentStateError(gf.ErrorInfo) {}

--- a/scripts/fixtures/document-state/cmd/app/main.go
+++ b/scripts/fixtures/document-state/cmd/app/main.go
@@ -1,0 +1,27 @@
+//go:build js && wasm
+
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state/internal/documentstate"
+)
+
+func main() {
+	initDocumentStateEvidence()
+	adapter, err := newBrowserDocumentAdapter()
+	if err != nil {
+		panic("document-state fixture: " + err.Error())
+	}
+	coordinator := documentstate.New(adapter.Baseline())
+	gf.SetErrorHandler(recordDocumentStateError)
+
+	done := make(chan struct{})
+	gf.Mount("root", func() gf.Node {
+		return App(AppProps{
+			Adapter:     adapter,
+			Coordinator: coordinator,
+		})
+	})
+	<-done
+}

--- a/scripts/fixtures/document-state/goframe.json
+++ b/scripts/fixtures/document-state/goframe.json
@@ -1,0 +1,6 @@
+{
+  "name": "document-state",
+  "entry": "./cmd/app",
+  "compiler": "tinygo",
+  "assets": "./assets"
+}

--- a/scripts/fixtures/document-state/internal/documentstate/model.go
+++ b/scripts/fixtures/document-state/internal/documentstate/model.go
@@ -1,0 +1,167 @@
+package documentstate
+
+import (
+	"errors"
+	"strings"
+)
+
+// State is one title and description pair selected by an owner.
+type State struct {
+	Title       string
+	Description string
+}
+
+// Snapshot describes the currently selected document state.
+type Snapshot struct {
+	State       State
+	ActiveOwner string
+	HasOwner    bool
+}
+
+// Change identifies one ownership-model transition.
+type Change uint8
+
+const (
+	ChangeNone Change = iota
+	ChangeAdded
+	ChangeUpdated
+	ChangeRemoved
+)
+
+// String returns the stable fixture evidence name for a change.
+func (change Change) String() string {
+	switch change {
+	case ChangeAdded:
+		return "added"
+	case ChangeUpdated:
+		return "updated"
+	case ChangeRemoved:
+		return "removed"
+	default:
+		return "none"
+	}
+}
+
+// Transition is the selected state after one model operation.
+type Transition struct {
+	Snapshot Snapshot
+	Change   Change
+	Owner    string
+}
+
+type ownerRecord struct {
+	key   string
+	state State
+}
+
+// Coordinator keeps owner priority in mount order while allowing in-place
+// owner updates.
+type Coordinator struct {
+	baseline State
+	owners   []ownerRecord
+	index    map[string]int
+}
+
+// New creates a coordinator with an authored document baseline.
+func New(baseline State) *Coordinator {
+	return &Coordinator{
+		baseline: baseline,
+		index:    make(map[string]int),
+	}
+}
+
+// Snapshot returns the currently selected owner state or the baseline.
+func (coordinator *Coordinator) Snapshot() Snapshot {
+	if coordinator == nil || len(coordinator.owners) == 0 {
+		if coordinator == nil {
+			return Snapshot{}
+		}
+		return Snapshot{State: coordinator.baseline}
+	}
+	active := coordinator.owners[len(coordinator.owners)-1]
+	return Snapshot{
+		State:       active.state,
+		ActiveOwner: active.key,
+		HasOwner:    true,
+	}
+}
+
+// Set adds an owner or updates its desired state without changing its priority.
+func (coordinator *Coordinator) Set(owner string, state State) (Transition, error) {
+	if err := validateOwner(owner); err != nil {
+		return Transition{}, err
+	}
+	if coordinator == nil {
+		return Transition{}, errors.New("document-state coordinator is nil")
+	}
+	if index, ok := coordinator.index[owner]; ok {
+		if coordinator.owners[index].state == state {
+			return coordinator.transition(owner, ChangeNone), nil
+		}
+		coordinator.owners[index].state = state
+		return coordinator.transition(owner, ChangeUpdated), nil
+	}
+	coordinator.index[owner] = len(coordinator.owners)
+	coordinator.owners = append(coordinator.owners, ownerRecord{
+		key:   owner,
+		state: state,
+	})
+	return coordinator.transition(owner, ChangeAdded), nil
+}
+
+// Remove releases an owner. Removing a non-top owner leaves the selected state
+// unchanged.
+func (coordinator *Coordinator) Remove(owner string) (Transition, error) {
+	if err := validateOwner(owner); err != nil {
+		return Transition{}, err
+	}
+	if coordinator == nil {
+		return Transition{}, errors.New("document-state coordinator is nil")
+	}
+	index, ok := coordinator.index[owner]
+	if !ok {
+		return coordinator.transition(owner, ChangeNone), nil
+	}
+	delete(coordinator.index, owner)
+	copy(coordinator.owners[index:], coordinator.owners[index+1:])
+	coordinator.owners = coordinator.owners[:len(coordinator.owners)-1]
+	for next := index; next < len(coordinator.owners); next++ {
+		coordinator.index[coordinator.owners[next].key] = next
+	}
+	return coordinator.transition(owner, ChangeRemoved), nil
+}
+
+// OwnerKeys returns owner keys in deterministic priority order.
+func (coordinator *Coordinator) OwnerKeys() []string {
+	if coordinator == nil {
+		return nil
+	}
+	keys := make([]string, len(coordinator.owners))
+	for index, owner := range coordinator.owners {
+		keys[index] = owner.key
+	}
+	return keys
+}
+
+// OwnerCount reports the number of active owner records.
+func (coordinator *Coordinator) OwnerCount() int {
+	if coordinator == nil {
+		return 0
+	}
+	return len(coordinator.owners)
+}
+
+func (coordinator *Coordinator) transition(owner string, change Change) Transition {
+	return Transition{
+		Snapshot: coordinator.Snapshot(),
+		Change:   change,
+		Owner:    owner,
+	}
+}
+
+func validateOwner(owner string) error {
+	if owner == "" || strings.TrimSpace(owner) == "" {
+		return errors.New("document-state owner key must not be empty")
+	}
+	return nil
+}

--- a/scripts/fixtures/document-state/internal/documentstate/model_test.go
+++ b/scripts/fixtures/document-state/internal/documentstate/model_test.go
@@ -1,0 +1,166 @@
+package documentstate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCoordinatorBaselineAndFirstOwner(t *testing.T) {
+	baseline := State{Title: "baseline", Description: "authored"}
+	coordinator := New(baseline)
+
+	assertSnapshot(t, coordinator.Snapshot(), Snapshot{State: baseline})
+	transition := mustSet(t, coordinator, "route", State{
+		Title:       "Home",
+		Description: "Home route",
+	})
+	if transition.Change != ChangeAdded {
+		t.Fatalf("first change = %v, want added", transition.Change)
+	}
+	assertSnapshot(t, transition.Snapshot, Snapshot{
+		State:       State{Title: "Home", Description: "Home route"},
+		ActiveOwner: "route",
+		HasOwner:    true,
+	})
+}
+
+func TestCoordinatorNestedUpdateAndRemoval(t *testing.T) {
+	coordinator := New(State{Title: "baseline", Description: "authored"})
+	mustSet(t, coordinator, "route", State{
+		Title:       "User 42",
+		Description: "Profile 42",
+	})
+	mustSet(t, coordinator, "editor", State{
+		Title:       "Editing User 42",
+		Description: "Editing 42",
+	})
+
+	updated := mustSet(t, coordinator, "route", State{
+		Title:       "User 7",
+		Description: "Profile 7",
+	})
+	if updated.Change != ChangeUpdated {
+		t.Fatalf("parent change = %v, want updated", updated.Change)
+	}
+	assertSnapshot(t, updated.Snapshot, Snapshot{
+		State:       State{Title: "Editing User 42", Description: "Editing 42"},
+		ActiveOwner: "editor",
+		HasOwner:    true,
+	})
+	if got := coordinator.OwnerKeys(); !reflect.DeepEqual(got, []string{"route", "editor"}) {
+		t.Fatalf("owner order after parent update = %v", got)
+	}
+
+	mustSet(t, coordinator, "editor", State{
+		Title:       "Editing User 7",
+		Description: "Editing 7",
+	})
+	removed := mustRemove(t, coordinator, "editor")
+	assertSnapshot(t, removed.Snapshot, Snapshot{
+		State:       State{Title: "User 7", Description: "Profile 7"},
+		ActiveOwner: "route",
+		HasOwner:    true,
+	})
+}
+
+func TestCoordinatorOutOfOrderAndFinalRemoval(t *testing.T) {
+	baseline := State{Title: "baseline", Description: "authored"}
+	coordinator := New(baseline)
+	mustSet(t, coordinator, "route", State{Title: "route", Description: "route"})
+	mustSet(t, coordinator, "dialog", State{Title: "dialog", Description: "dialog"})
+	mustSet(t, coordinator, "tooltip", State{Title: "tooltip", Description: "tooltip"})
+
+	nonTop := mustRemove(t, coordinator, "dialog")
+	assertSnapshot(t, nonTop.Snapshot, Snapshot{
+		State:       State{Title: "tooltip", Description: "tooltip"},
+		ActiveOwner: "tooltip",
+		HasOwner:    true,
+	})
+	if got := coordinator.OwnerKeys(); !reflect.DeepEqual(got, []string{"route", "tooltip"}) {
+		t.Fatalf("owner order after non-top removal = %v", got)
+	}
+
+	top := mustRemove(t, coordinator, "tooltip")
+	if top.Snapshot.ActiveOwner != "route" {
+		t.Fatalf("active owner after top removal = %q", top.Snapshot.ActiveOwner)
+	}
+	final := mustRemove(t, coordinator, "route")
+	assertSnapshot(t, final.Snapshot, Snapshot{State: baseline})
+	if coordinator.OwnerCount() != 0 {
+		t.Fatalf("owner count = %d, want 0", coordinator.OwnerCount())
+	}
+}
+
+func TestCoordinatorRepeatedAndDuplicateOwnerUpdates(t *testing.T) {
+	coordinator := New(State{})
+	first := State{Title: "first", Description: "pair"}
+	mustSet(t, coordinator, "route", first)
+
+	identical := mustSet(t, coordinator, "route", first)
+	if identical.Change != ChangeNone {
+		t.Fatalf("identical change = %v, want none", identical.Change)
+	}
+	if coordinator.OwnerCount() != 1 {
+		t.Fatalf("owner count after duplicate key = %d, want 1", coordinator.OwnerCount())
+	}
+
+	mustSet(t, coordinator, "nested", State{Title: "nested", Description: "pair"})
+	changed := mustSet(t, coordinator, "route", State{Title: "latest", Description: "pair"})
+	if changed.Snapshot.ActiveOwner != "nested" {
+		t.Fatalf("owner update changed priority: active = %q", changed.Snapshot.ActiveOwner)
+	}
+}
+
+func TestCoordinatorRejectsMalformedOwnerKeys(t *testing.T) {
+	coordinator := New(State{})
+	for _, owner := range []string{"", " ", "\t\n"} {
+		if _, err := coordinator.Set(owner, State{}); err == nil {
+			t.Fatalf("Set(%q) succeeded", owner)
+		}
+		if _, err := coordinator.Remove(owner); err == nil {
+			t.Fatalf("Remove(%q) succeeded", owner)
+		}
+	}
+}
+
+func TestCoordinatorPreservesStatePairsAndCallerValues(t *testing.T) {
+	baseline := State{Title: "baseline title", Description: "baseline description"}
+	desired := State{Title: "route title", Description: "route description"}
+	coordinator := New(baseline)
+	transition := mustSet(t, coordinator, "route", desired)
+
+	if baseline != (State{Title: "baseline title", Description: "baseline description"}) {
+		t.Fatalf("baseline input changed: %#v", baseline)
+	}
+	if desired != (State{Title: "route title", Description: "route description"}) {
+		t.Fatalf("desired input changed: %#v", desired)
+	}
+	if transition.Snapshot.State != desired {
+		t.Fatalf("selected pair = %#v, want %#v", transition.Snapshot.State, desired)
+	}
+}
+
+func mustSet(t *testing.T, coordinator *Coordinator, owner string, state State) Transition {
+	t.Helper()
+	transition, err := coordinator.Set(owner, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return transition
+}
+
+func mustRemove(t *testing.T, coordinator *Coordinator, owner string) Transition {
+	t.Helper()
+	transition, err := coordinator.Remove(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return transition
+}
+
+func assertSnapshot(t *testing.T, got, want Snapshot) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("snapshot = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a bounded document-state fixture to characterize ownership of an authored
`<title>` and `meta[name="description"]` using GoFrame's current component,
effect, router, and Error Boundary APIs.

This PR does not change the runtime or introduce a public document-head API.

## What changed

- Adds an isolated document-state pressure fixture.
- Adds a fixture-local ordered ownership coordinator with focused host tests.
- Covers route metadata, nested overrides, same-pattern updates, Back/Forward,
  failed renders, scope teardown, and authored baseline restoration.
- Adds a Chrome/CDP harness with pre-boot `<head>` mutation observation.
- Integrates the fixture into the aggregate browser-smoke gate.

## Findings

Independent effect-local save/restore is insufficient for the demonstrated
nested flow: when a parent owner updates beneath an active child, captured-value
cleanup can restore stale metadata.

A small ordered coordinator is sufficient for the tested contract:

- new owners receive priority;
- owner updates preserve priority;
- removing an owner reveals the latest remaining state;
- removing the final owner restores the authored baseline.

The browser evidence also confirms that:

- speculative metadata from a failed render never commits;
- title and description remain aligned at observer delivery and settled
  application boundaries;
- the authored head nodes retain identity;
- the description element is never duplicated;
- unrelated authored metadata remains unchanged.

This is **Result B** for the fixture. No public API is selected.

## Validation

- repeated and race-enabled ownership-model tests;
- standard Go and TinyGo packaging;
- two deterministic Go/WASM browser runs with identical counters;
- full tests, race checks, debug-tag tests, and `go vet`;
- aggregate browser smoke and WASM size gates;
- documentation, artifact, and module-path checks;
- byte-identical output for all existing budgeted examples.

## Scope

The evidence covers one browser document, one title, one description element,
nested owners, route changes, browser history, failed-render isolation, and
baseline restoration.

It does not establish support for arbitrary head elements, canonical or social
metadata, SSR, hydration, external head mutations, broad browser compatibility,
or production SEO workflows.