### PR TITLE
feat(example): integrate route data and document state

### DIFF
--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -188,7 +188,7 @@ read request attribution from later draft edits.
 | head elements removed | 0 |
 | global mutable ownership variables | 0 |
 | document-state and mutation-attribution helper lines | 263 |
-| pure document/mutation test lines | 547 |
+| pure document/mutation test lines | 574 |
 | browser adapter lines | 137 (115 browser, 22 host stub) |
 | document-state helper declarations | 11 types, 28 helper functions |
 | existing app/GOX file delta | +370 / -128 (net +242) |
@@ -205,10 +205,10 @@ Linux amd64. These sizes are informational and introduce no threshold:
 
 | Encoding | Frozen base | Integrated reference | Delta |
 |---|---:|---:|---:|
-| raw | 194393 | 372422 | +178029 |
-| gzip (`-n -9`) | 80475 | 152642 | +72167 |
-| Brotli (`-q 11`) | 66896 | 123179 | +56283 |
-| Zstandard (`-19`) | 71131 | 131033 | +59902 |
+| raw | 194393 | 372409 | +178016 |
+| gzip (`-n -9`) | 80475 | 152651 | +72176 |
+| Brotli (`-q 11`) | 66896 | 123064 | +56168 |
+| Zstandard (`-19`) | 71131 | 131032 | +59901 |
 
 ### Decision
 
@@ -384,6 +384,12 @@ separate values. Input remains editable while the existing POST owner is
 active. Pending and server-failure metadata use the submitted target; success
 metadata uses the trimmed non-empty response body. A later draft edit therefore
 cannot rename an active request or its confirmation.
+
+A trimmed zero-length POST response is not confirmation. The literal non-empty
+value `"empty"` remains a valid confirmed greeting. A pure metadata and
+confirmation regression test keeps these cases distinct; the browser evidence
+continues to exercise the `slow` submitted target, editable `Mia` draft, and
+confirmed `slow` response.
 
 ## Backend Contract
 

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -79,6 +79,131 @@ Open <http://127.0.0.1:8080>.
 - Client validation and server failure leave the previous committed value
   visible, and a later valid submit clears the mutation error.
 
+## Integrated Route Data And Document State
+
+The example also coordinates route-driven title and description metadata with
+its existing reads, retained transitions, failures, history navigation, and
+server-confirmed mutation flow.
+
+### Proven
+
+Two focused browser runs demonstrated that:
+
+- Home, ordinary greeting, retained greeting, saved greeting, and not-found
+  routes select deterministic title/description pairs;
+- the retained transition keeps the committed screen metadata while a newer
+  requested hash target is pending, failed, or retrying, then updates screen
+  and metadata to the same committed target;
+- Back and Forward use that same requested-versus-committed distinction;
+- the saved editor temporarily overrides route metadata during editing,
+  validation, pending mutation, failure, and server confirmation;
+- the saved route owner updates underneath the active editor, and releasing
+  the editor reveals the latest server-confirmed route metadata rather than an
+  older captured value;
+- mutation failure retains committed route data and metadata, while later
+  recovery reveals the newly confirmed value;
+- cross-pattern navigation removes saved owners, aborts active work, and does
+  not restore stale saved metadata;
+- unmounting the route-owner scope restores the authored title and description,
+  and remounting reapplies the current Home pair without replacing the
+  application, shell, or route-panel nodes;
+- exactly one authored description element remains present, and the authored
+  title, description, and viewport nodes retain identity.
+
+The selected application pair remained consistent at MutationObserver delivery
+and settled application boundaries. Title and description are still separate
+DOM writes; this evidence does not claim an atomic browser head mutation.
+
+The focused runs produced identical document-state counters:
+
+| Counter | Run 1 | Run 2 |
+|---|---:|---:|
+| title mutation batches | 41 | 41 |
+| description mutation batches | 41 | 41 |
+| relevant head snapshots | 133 | 133 |
+| invalid title/description pairs | 0 | 0 |
+| duplicate-description observations | 0 | 0 |
+| viewport mutations | 0 | 0 |
+| title-node replacements | 0 | 0 |
+| description-node replacements | 0 | 0 |
+| requested transition metadata appearances | 0 | 0 |
+| stale document-state appearances | 0 | 0 |
+| authored-baseline restorations | 1 | 1 |
+| route-owner scope unmounts | 1 | 1 |
+| route-owner scope remounts | 1 | 1 |
+| saved-editor activations | 3 | 3 |
+| saved-editor releases | 3 | 3 |
+
+The existing request evidence also remained unchanged: 11 ordinary greeting
+requests (6 successful, 3 failed, and 2 aborted), 10 retained-transition
+requests (6 successful, 2 failed, and 2 aborted), 4 saved-greeting GETs, and 4
+saved-greeting POSTs (2 completed, 1 failed, and 1 aborted).
+
+### Ownership Model
+
+The application repeats the ordered-owner contract from the isolated document
+state fixture. New owners receive top priority; updating an existing owner
+preserves priority; removing the active owner reveals the latest state of the
+next owner; and removing the final owner restores the authored baseline.
+
+Route and saved-editor metadata are independent component owners. Their
+committed effects update one application-local coordinator, which returns one
+selected snapshot through a callback to the retained `App`. A separate
+committed effect applies that pair through the browser adapter. There is no
+global mutable ownership registry.
+
+### Measured Coordination
+
+| Application-local concern | Measurement |
+|---|---:|
+| state slots added | 3 call sites |
+| effects added | 2 call sites; at most 3 committed slots |
+| `UseUnmount` registrations added | 1 call site; at most 2 registrations |
+| owner records at peak | 2 (`route`, `saved-editor`) |
+| ownership handoff points | 1 selected-snapshot callback |
+| document-state context/prop boundaries | 4 |
+| browser DOM query sites | 6 |
+| browser DOM write sites | 2 |
+| head elements created | 0 |
+| head elements removed | 0 |
+| global mutable ownership variables | 0 |
+| pure coordinator lines | 214 |
+| pure coordinator test lines | 345 |
+| browser adapter lines | 137 (115 browser, 22 host stub) |
+| document-state helper declarations | 10 types, 25 helper functions |
+| existing app/GOX file delta | +355 / -128 (net +227) |
+| total production Go/GOX delta | +706 / -128 (net +578) |
+| browser harness delta | +780 / -4 (net +776) |
+
+The helper declaration count treats the browser and host adapter variants as
+separate source declarations and excludes the retained `App` entry point.
+The four context/prop boundaries are `main` to `App`, `App` to the committer,
+`App` to owners through context, and route/editor metadata to `DocumentOwner`.
+
+The server-backed reference was packaged with Go 1.22.12 and TinyGo 0.41.1 on
+Linux amd64. These sizes are informational and introduce no threshold:
+
+| Encoding | Frozen base | Integrated reference | Delta |
+|---|---:|---:|---:|
+| raw | 194393 | 372697 | +178304 |
+| gzip (`-n -9`) | 80475 | 152268 | +71793 |
+| Brotli (`-q 11`) | 66896 | 123201 | +56305 |
+| Zstandard (`-19`) | 71131 | 131582 | +60451 |
+
+### Decision
+
+**Result B:** The same ordered ownership contract appears in both the isolated
+fixture and this integrated route/resource/mutation reference. The measured
+coordination supports a separate narrow API design stage, but this example does
+not add or select a public document-state API.
+
+### Limits
+
+This example does not establish arbitrary head-element management, canonical
+links, Open Graph or other social metadata, JSON-LD, scripts, styles, SSR,
+hydration, production SEO, broad browser compatibility, or full
+URL/screen/data atomicity.
+
 ## Route Flow
 
 The executable flow uses only existing GoFrame primitives:

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -82,6 +82,9 @@ Open <http://127.0.0.1:8080>.
 - Editing the controlled draft during an active POST does not change the
   submitted target, pending metadata, request count, or eventual
   server-confirmed metadata.
+- An accepted saved-greeting submit activates the nested editor metadata owner
+  after the duplicate-submit guard and before validation or request state,
+  including when no input event occurred after `Finish editing`.
 - Client validation and server failure leave the previous committed value
   visible, and a later valid submit clears the mutation error.
 
@@ -104,6 +107,11 @@ Two local focused browser runs demonstrated that:
 - Back and Forward use that same requested-versus-committed distinction;
 - the saved editor temporarily overrides route metadata during editing,
   validation, pending mutation, failure, and server confirmation;
+- whitespace validation and the existing slow mutation both reactivate the
+  saved editor after `Finish editing` without another input event; validation
+  starts no request, while the slow flow starts its existing single POST;
+- duplicate submissions remain rejected before editor activation or request
+  state changes;
 - changing the editable draft from `slow` to `Mia` during the active `slow`
   POST leaves pending metadata attributed to `slow`, starts no additional
   request, and preserves the duplicate-submit guard;
@@ -131,9 +139,9 @@ The focused runs produced identical document-state counters:
 
 | Counter | Run 1 | Run 2 |
 |---|---:|---:|
-| title mutation batches | 41 | 41 |
-| description mutation batches | 41 | 41 |
-| relevant head snapshots | 135 | 135 |
+| title mutation batches | 43 | 43 |
+| description mutation batches | 43 | 43 |
+| relevant head snapshots | 139 | 139 |
 | invalid title/description pairs | 0 | 0 |
 | duplicate-description observations | 0 | 0 |
 | viewport mutations | 0 | 0 |
@@ -146,15 +154,16 @@ The focused runs produced identical document-state counters:
 | authored-baseline restorations | 1 | 1 |
 | route-owner scope unmounts | 1 | 1 |
 | route-owner scope remounts | 1 | 1 |
-| saved-editor activations | 3 | 3 |
-| saved-editor releases | 3 | 3 |
+| saved-editor activations | 5 | 5 |
+| saved-editor releases | 5 | 5 |
 
 The existing request evidence also remained unchanged: 11 ordinary greeting
 requests (6 successful, 3 failed, and 2 aborted), 10 retained-transition
 requests (6 successful, 2 failed, and 2 aborted), 4 saved-greeting GETs, and 4
 saved-greeting POSTs (2 completed, 1 failed, and 1 aborted). Editing `Mia`
 during the active `slow` POST added zero POSTs, GET reloads, or mutation
-attempts.
+attempts. Activating ownership from accepted submissions added zero GETs,
+POSTs, reloads, or mutation attempts to these totals.
 
 ### Ownership Model
 
@@ -191,9 +200,9 @@ read request attribution from later draft edits.
 | pure document/mutation test lines | 574 |
 | browser adapter lines | 137 (115 browser, 22 host stub) |
 | document-state helper declarations | 11 types, 28 helper functions |
-| existing app/GOX file delta | +370 / -128 (net +242) |
-| total production Go/GOX delta | +781 / -129 (net +652) |
-| browser harness delta | +1121 / -16 (net +1105) |
+| existing app/GOX file delta | +371 / -128 (net +243) |
+| total production Go/GOX delta | +782 / -129 (net +653) |
+| browser harness delta | +1262 / -16 (net +1246) |
 
 The helper declaration count treats the browser and host adapter variants as
 separate source declarations and excludes the retained `App` entry point.
@@ -205,10 +214,10 @@ Linux amd64. These sizes are informational and introduce no threshold:
 
 | Encoding | Frozen base | Integrated reference | Delta |
 |---|---:|---:|---:|
-| raw | 194393 | 372409 | +178016 |
-| gzip (`-n -9`) | 80475 | 152651 | +72176 |
-| Brotli (`-q 11`) | 66896 | 123064 | +56168 |
-| Zstandard (`-19`) | 71131 | 131032 | +59901 |
+| raw | 194393 | 372505 | +178112 |
+| gzip (`-n -9`) | 80475 | 152675 | +72200 |
+| Brotli (`-q 11`) | 66896 | 123042 | +56146 |
+| Zstandard (`-19`) | 71131 | 131031 | +59900 |
 
 ### Decision
 
@@ -358,6 +367,8 @@ browser transport helper, and the existing read-resource reload contract:
 GET /api/saved-greeting through UseResource and FetchText
 -> committed value is ready
 -> edit the controlled route-owned draft
+-> reject a duplicate submit while an existing POST is active
+-> activate saved-editor metadata ownership
 -> trim and validate on submit
 -> capture one immutable submitted target
 -> POST form data through the example-local fetch helper
@@ -378,6 +389,12 @@ reloads the read resource, and clears the prior error.
 The route reports `idle`, `pending`, `validation failed`, `server failed`, and
 `success` mutation states independently from the read resource's loading,
 failed, and ready states.
+
+Every accepted non-duplicate submit activates the `saved-editor` owner before
+validation or request state changes. This keeps validation, pending, failure,
+and success metadata nested under the editor even after `Finish editing` and
+without another input event. The duplicate guard runs first and therefore
+changes neither owner nor request state.
 
 The controlled draft, submitted mutation target, and confirmed response are
 separate values. Input remains editable while the existing POST owner is
@@ -432,6 +449,7 @@ request context before commit. Unsupported methods return HTTP 405 with
 | submitted mutation target | immutable trimmed value captured by `SavedGreetingRoute` when the existing request owner begins |
 | confirmed mutation value | trimmed non-empty POST response stored beside the submitted target |
 | client validation | `SavedGreetingRoute` submit handler trims the draft and rejects an empty name |
+| saved-editor activation | accepted non-duplicate submit after the duplicate guard and before validation or request state |
 | mutation pending state | route-owned mutation status plus the active request owner |
 | duplicate-submit suppression | the request owner's synchronous `active` guard; the button also reflects pending state |
 | POST transport | example-local `postSavedGreeting` browser helper |
@@ -529,6 +547,9 @@ simulated with extra application state.
 
 The same two final runs produced identical mutation request evidence:
 
+- whitespace validation and the existing slow submit each released the editor
+  first and submitted without another input event; the owner changed from
+  `route` to `saved-editor` in both cases;
 - four saved-state GETs started and completed, with zero GET failures: two
   ordinary route loads and two successful-mutation reloads;
 - four mutation POSTs: two completed, one controlled failure, and one aborted

--- a/examples/server-backed/README.md
+++ b/examples/server-backed/README.md
@@ -22,6 +22,8 @@ This example shows a narrow integration pattern:
   target and message while the requested target prepares;
 - a route-owned mutation form with client validation, pending and failure
   states, duplicate-submit suppression, and server-confirmed recovery;
+- immutable submitted-target and confirmed-response metadata attribution while
+  the controlled mutation draft remains editable;
 - committed-state confirmation through the existing `UseResource.reload`
   contract after each successful write.
 
@@ -73,9 +75,13 @@ Open <http://127.0.0.1:8080>.
 - `gf.FetchText` is a low-level text loader, not a server framework or data
   framework.
 - The `/saved-greeting` route keeps the committed value in a read resource and
-  keeps draft, pending, and mutation-error state local to the route.
+  keeps draft, submitted/confirmed mutation target, pending, and mutation-error
+  state local to the route.
 - A successful form-encoded `POST` triggers the read resource's existing
   `reload` closure. The UI does not update the committed value optimistically.
+- Editing the controlled draft during an active POST does not change the
+  submitted target, pending metadata, request count, or eventual
+  server-confirmed metadata.
 - Client validation and server failure leave the previous committed value
   visible, and a later valid submit clears the mutation error.
 
@@ -87,16 +93,23 @@ server-confirmed mutation flow.
 
 ### Proven
 
-Two focused browser runs demonstrated that:
+Two local focused browser runs demonstrated that:
 
-- Home, ordinary greeting, retained greeting, saved greeting, and not-found
-  routes select deterministic title/description pairs;
+- Home, ordinary greeting, retained greeting, and saved greeting routes select
+  deterministic title/description pairs;
+- the pure metadata mapping test covers the not-found title/description pair;
 - the retained transition keeps the committed screen metadata while a newer
   requested hash target is pending, failed, or retrying, then updates screen
   and metadata to the same committed target;
 - Back and Forward use that same requested-versus-committed distinction;
 - the saved editor temporarily overrides route metadata during editing,
   validation, pending mutation, failure, and server confirmation;
+- changing the editable draft from `slow` to `Mia` during the active `slow`
+  POST leaves pending metadata attributed to `slow`, starts no additional
+  request, and preserves the duplicate-submit guard;
+- the successful POST records the trimmed server response `slow`; confirmed
+  metadata remains attributed to that value while the controlled draft is
+  still `Mia`, with no false `Mia` confirmation;
 - the saved route owner updates underneath the active editor, and releasing
   the editor reveals the latest server-confirmed route metadata rather than an
   older captured value;
@@ -120,7 +133,7 @@ The focused runs produced identical document-state counters:
 |---|---:|---:|
 | title mutation batches | 41 | 41 |
 | description mutation batches | 41 | 41 |
-| relevant head snapshots | 133 | 133 |
+| relevant head snapshots | 135 | 135 |
 | invalid title/description pairs | 0 | 0 |
 | duplicate-description observations | 0 | 0 |
 | viewport mutations | 0 | 0 |
@@ -128,6 +141,8 @@ The focused runs produced identical document-state counters:
 | description-node replacements | 0 | 0 |
 | requested transition metadata appearances | 0 | 0 |
 | stale document-state appearances | 0 | 0 |
+| submitted-target metadata mismatches | 0 | 0 |
+| false server-confirmation appearances | 0 | 0 |
 | authored-baseline restorations | 1 | 1 |
 | route-owner scope unmounts | 1 | 1 |
 | route-owner scope remounts | 1 | 1 |
@@ -137,7 +152,9 @@ The focused runs produced identical document-state counters:
 The existing request evidence also remained unchanged: 11 ordinary greeting
 requests (6 successful, 3 failed, and 2 aborted), 10 retained-transition
 requests (6 successful, 2 failed, and 2 aborted), 4 saved-greeting GETs, and 4
-saved-greeting POSTs (2 completed, 1 failed, and 1 aborted).
+saved-greeting POSTs (2 completed, 1 failed, and 1 aborted). Editing `Mia`
+during the active `slow` POST added zero POSTs, GET reloads, or mutation
+attempts.
 
 ### Ownership Model
 
@@ -150,13 +167,16 @@ Route and saved-editor metadata are independent component owners. Their
 committed effects update one application-local coordinator, which returns one
 selected snapshot through a callback to the retained `App`. A separate
 committed effect applies that pair through the browser adapter. There is no
-global mutable ownership registry.
+global mutable ownership registry. The saved route keeps one request-attribution
+value: its submitted target remains immutable for the active request, and its
+confirmed field records the successful response. Document metadata does not
+read request attribution from later draft edits.
 
 ### Measured Coordination
 
 | Application-local concern | Measurement |
 |---|---:|
-| state slots added | 3 call sites |
+| state slots added | 4 call sites |
 | effects added | 2 call sites; at most 3 committed slots |
 | `UseUnmount` registrations added | 1 call site; at most 2 registrations |
 | owner records at peak | 2 (`route`, `saved-editor`) |
@@ -167,13 +187,13 @@ global mutable ownership registry.
 | head elements created | 0 |
 | head elements removed | 0 |
 | global mutable ownership variables | 0 |
-| pure coordinator lines | 214 |
-| pure coordinator test lines | 345 |
+| document-state and mutation-attribution helper lines | 263 |
+| pure document/mutation test lines | 547 |
 | browser adapter lines | 137 (115 browser, 22 host stub) |
-| document-state helper declarations | 10 types, 25 helper functions |
-| existing app/GOX file delta | +355 / -128 (net +227) |
-| total production Go/GOX delta | +706 / -128 (net +578) |
-| browser harness delta | +780 / -4 (net +776) |
+| document-state helper declarations | 11 types, 28 helper functions |
+| existing app/GOX file delta | +370 / -128 (net +242) |
+| total production Go/GOX delta | +781 / -129 (net +652) |
+| browser harness delta | +1121 / -16 (net +1105) |
 
 The helper declaration count treats the browser and host adapter variants as
 separate source declarations and excludes the retained `App` entry point.
@@ -185,10 +205,10 @@ Linux amd64. These sizes are informational and introduce no threshold:
 
 | Encoding | Frozen base | Integrated reference | Delta |
 |---|---:|---:|---:|
-| raw | 194393 | 372697 | +178304 |
-| gzip (`-n -9`) | 80475 | 152268 | +71793 |
-| Brotli (`-q 11`) | 66896 | 123201 | +56305 |
-| Zstandard (`-19`) | 71131 | 131582 | +60451 |
+| raw | 194393 | 372422 | +178029 |
+| gzip (`-n -9`) | 80475 | 152642 | +72167 |
+| Brotli (`-q 11`) | 66896 | 123179 | +56283 |
+| Zstandard (`-19`) | 71131 | 131033 | +59902 |
 
 ### Decision
 
@@ -339,9 +359,11 @@ GET /api/saved-greeting through UseResource and FetchText
 -> committed value is ready
 -> edit the controlled route-owned draft
 -> trim and validate on submit
+-> capture one immutable submitted target
 -> POST form data through the example-local fetch helper
--> keep the previous committed value visible while pending
+-> keep the previous committed value visible and the draft editable while pending
 -> reject a duplicate submit while the POST is active
+-> bind successful metadata to the trimmed server response
 -> on success, call the read resource's reload closure
 -> GET confirms and renders the committed server value
 ```
@@ -356,6 +378,12 @@ reloads the read resource, and clears the prior error.
 The route reports `idle`, `pending`, `validation failed`, `server failed`, and
 `success` mutation states independently from the read resource's loading,
 failed, and ready states.
+
+The controlled draft, submitted mutation target, and confirmed response are
+separate values. Input remains editable while the existing POST owner is
+active. Pending and server-failure metadata use the submitted target; success
+metadata uses the trimmed non-empty response body. A later draft edit therefore
+cannot rename an active request or its confirmation.
 
 ## Backend Contract
 
@@ -395,6 +423,8 @@ request context before commit. Unsupported methods return HTTP 405 with
 | baseline greeting old-screen retention during pending | not provided; `GreetingRoute` shows loading and removes the previous ready result |
 | atomic URL + screen + data commit | not provided; the hash target commits before the resource is ready |
 | controlled mutation draft | `SavedGreetingRoute` and its dedicated `gf.UseState` slot |
+| submitted mutation target | immutable trimmed value captured by `SavedGreetingRoute` when the existing request owner begins |
+| confirmed mutation value | trimmed non-empty POST response stored beside the submitted target |
 | client validation | `SavedGreetingRoute` submit handler trims the draft and rejects an empty name |
 | mutation pending state | route-owned mutation status plus the active request owner |
 | duplicate-submit suppression | the request owner's synchronous `active` guard; the button also reflects pending state |
@@ -402,18 +432,20 @@ request context before commit. Unsupported methods return HTTP 405 with
 | server validation | the saved-greeting HTTP handler |
 | committed server state | mutex-protected server store, observed by the route's read resource |
 | mutation error | `SavedGreetingRoute` mutation-error state |
-| successful commit confirmation | POST success callback followed by a fresh resource GET |
+| successful metadata confirmation | the actual trimmed POST response, never the later mutable draft |
+| successful committed-state confirmation | POST success callback followed by a fresh resource GET |
 | read-resource reload | `SavedGreetingRoute` calls the closure returned by `gf.UseResource` |
 | stale mutation completion protection | the route request owner's mounted/active guard and the transport helper's active guard |
 | route/component lifetime | `RouterView` mounts the route; `gf.UseUnmount` cancels its active POST helper |
 
 Example-local coordination now consists of one Home draft slot, one Greeting
-draft slot, and four SavedGreetingRoute slots for draft, mutation status,
-mutation error, and a stable request-owner pointer. The three routes have one
-submit handler each. Greeting keeps one query-to-draft effect and one read
-resource; SavedGreetingRoute keeps one read resource and one unmount callback.
-Four route functions feed one route table. The write path adds one browser POST
-helper and one success-to-reload coordination point.
+draft slot, and six `SavedGreetingRoute` slots for draft, mutation status,
+mutation error, submitted/confirmed target, a stable request-owner pointer, and
+editor ownership. The three routes have one submit handler each. Greeting
+keeps one query-to-draft effect and one read resource; `SavedGreetingRoute`
+keeps one read resource and one unmount callback. Four route functions feed one
+route table. The write path adds one browser POST helper and one
+success-to-reload coordination point.
 
 The application contains:
 
@@ -428,6 +460,8 @@ The application contains:
   route owner and one `gf.UseUnmount` callback that invokes it;
 - mutation lifecycle state: one status slot and one error slot, separate from
   the read resource's loading/error state;
+- mutation attribution state: one submitted/confirmed target slot, separate
+  from the editable draft;
 - resource lifecycle effects outside `gf.UseResource`: `0`;
 - route/form synchronization effects: `1`;
 - successful-mutation reload coordination points: `1`.
@@ -437,7 +471,8 @@ The application contains:
 `scripts/server-backed-browser-smoke.mjs` installs browser-only instrumentation
 before loading the app. It records greeting GETs and their exact abort signals,
 saved-state GET causes, completed, failed, and aborted mutation POSTs, active
-writes, duplicate submit attempts, committed values, debug-tag render/update
+writes, duplicate submit attempts, submitted POST targets, successful response
+values, current editor drafts, committed values, debug-tag render/update
 flushes, structural DOM operations, route targets, global shell identity, and
 per-scenario form/input identity.
 Before a form scenario starts, the harness waits for the state-owning route's
@@ -494,6 +529,12 @@ The same two final runs produced identical mutation request evidence:
   when the saved-greeting route unmounted;
 - one duplicate submit attempt during the slow write and exactly one POST in
   that scenario;
+- the input changed from `slow` to `Mia` while the one `slow` POST remained
+  active; pending metadata stayed on `slow`, and the edit added no request,
+  reload, or mutation attempt;
+- the successful response and committed route value were both `slow` while the
+  input remained `Mia`; confirmed metadata stayed on `slow`, with zero target
+  mismatches and zero false-confirmation appearances;
 - two read-resource reloads, one after each successful mutation;
 - zero read-resource reloads after the canceled mutation;
 - committed values observed in order: `GoFrame`, `slow`, `Grace`;
@@ -611,9 +652,10 @@ failure and recovery, global shell retention, same-pattern form/input retention,
 expected cross-pattern remounts, retained transition screens, paired committed
 target/data observations, transition failure/retry/recovery, saved-state
 loading, validation without a POST, duplicate-write suppression, failure
-preservation, successful reload confirmation, mutation unmount cancellation,
-route-load versus reload attribution, final backend/UI consistency, and
-update/DOM bridge evidence.
+preservation, pending-draft mutation attribution, server-response confirmation,
+successful reload confirmation, mutation unmount cancellation, route-load
+versus reload attribution, final backend/UI consistency, and update/DOM bridge
+evidence.
 
 ## Non-goals
 

--- a/examples/server-backed/assets/index.html
+++ b/examples/server-backed/assets/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="GoFrame server-backed application reference."
+    >
     <title>GoFrame Server-Backed Example</title>
     <link rel="stylesheet" href="styles.css">
   </head>

--- a/examples/server-backed/assets/styles.css
+++ b/examples/server-backed/assets/styles.css
@@ -41,6 +41,27 @@ input {
   padding: 2rem;
 }
 
+.document-state-summary {
+  background: #eaf1ff;
+  border: 1px solid #c8d8f6;
+  border-radius: 18px;
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.document-state-values {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.document-state-values span {
+  overflow-wrap: anywhere;
+}
+
+.reference-controls {
+  margin-top: 0.8rem;
+}
+
 .hero,
 .panel {
   background: #fff;
@@ -151,4 +172,18 @@ h2 {
   display: grid;
   gap: 0.75rem;
   justify-items: start;
+}
+
+.saved-editor-state {
+  border: 1px dashed #7c91b2;
+  border-radius: 16px;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: start;
+  margin-top: 1rem;
+  padding: 0.9rem;
+}
+
+.saved-editor-state .muted {
+  margin: 0;
 }

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -7,6 +7,22 @@ import (
 	gf "github.com/graybuton/goframe/pkg/goframe"
 )
 
+type AppProps struct {
+	Adapter     *browserDocumentAdapter
+	Coordinator *serverBackedDocumentCoordinator
+}
+
+type DocumentCommitterProps struct {
+	Adapter  *browserDocumentAdapter
+	Snapshot serverBackedDocumentSnapshot
+}
+
+type DocumentOwnerProps struct {
+	Owner    string
+	State    serverBackedDocumentState
+	Children []gf.Node
+}
+
 type ServerBackedShellProps struct {
 	Children []gf.Node
 }
@@ -39,7 +55,20 @@ type savedGreetingMutationOwner struct {
 	cleanup gf.Cleanup
 }
 
-const savedGreetingAPIPath = "/api/saved-greeting"
+type serverBackedDocumentBindings struct {
+	Coordinator *serverBackedDocumentCoordinator
+	OnSnapshot  func(serverBackedDocumentSnapshot)
+}
+
+const (
+	savedGreetingAPIPath         = "/api/saved-greeting"
+	serverBackedRouteOwner       = "route"
+	serverBackedSavedEditorOwner = "saved-editor"
+)
+
+var serverBackedDocumentContext = gf.CreateContext(
+	serverBackedDocumentBindings{},
+)
 
 func newSavedGreetingMutationOwner() *savedGreetingMutationOwner {
 	return &savedGreetingMutationOwner{mounted: true}
@@ -92,14 +121,93 @@ var router = gf.NewHashRouter([]gf.Route{
 	gf.NotFoundRoute(notFoundRoute),
 })
 
-func App() gf.Node {
+func App(props AppProps) gf.Node {
+	scopeActive, setScopeActive := gf.UseState(true)
+	snapshot, setSnapshot := gf.UseState(props.Coordinator.Snapshot())
+	gf.ProvideContext(serverBackedDocumentContext, serverBackedDocumentBindings{
+		Coordinator: props.Coordinator,
+		OnSnapshot:  setSnapshot,
+	})
+
 	return (
 		<main class="server-backed-app" data-testid="server-backed-app">
+			<DocumentCommitter Adapter={props.Adapter} Snapshot={snapshot} />
+
+			<section class="document-state-summary" data-testid="server-backed-document-state">
+				<p class="eyebrow">Selected document state</p>
+				<div class="document-state-values">
+					<span data-testid="server-backed-document-owner">{activeDocumentOwnerLabel(snapshot)}</span>
+					<span data-testid="server-backed-document-owner-count">{snapshot.OwnerCount}</span>
+					<span data-testid="server-backed-document-title">{snapshot.State.Title}</span>
+					<span data-testid="server-backed-document-description">{snapshot.State.Description}</span>
+				</div>
+				<div class="reference-controls">
+					{documentScopeControl(scopeActive, setScopeActive)}
+				</div>
+			</section>
+
 			<ServerBackedShell>
-				{gf.RouterView(router)}
+				{documentRouteScope(scopeActive)}
 			</ServerBackedShell>
 		</main>
 	)
+}
+
+func DocumentCommitter(props DocumentCommitterProps) gf.Node {
+	title := props.Snapshot.State.Title
+	description := props.Snapshot.State.Description
+	gf.UseEffect(func() gf.Cleanup {
+		if err := props.Adapter.Apply(serverBackedDocumentState{
+			Title:       title,
+			Description: description,
+		}); err != nil {
+			panic("server-backed document state: apply selected state: " + err.Error())
+		}
+		return nil
+	}, gf.Deps(title, description))
+	return gf.Empty()
+}
+
+func DocumentOwner(props DocumentOwnerProps) gf.Node {
+	bindings := gf.UseContext(serverBackedDocumentContext)
+	useServerBackedDocumentState(
+		bindings,
+		props.Owner,
+		props.State,
+	)
+	return gf.Fragment(props.Children...)
+}
+
+func useServerBackedDocumentState(
+	bindings serverBackedDocumentBindings,
+	owner string,
+	state serverBackedDocumentState,
+) {
+	gf.UseEffect(func() gf.Cleanup {
+		if bindings.Coordinator == nil || bindings.OnSnapshot == nil {
+			panic("server-backed document state: missing application bindings")
+		}
+		snapshot, changed, err := bindings.Coordinator.Set(owner, state)
+		if err != nil {
+			panic("server-backed document state: set owner: " + err.Error())
+		}
+		if changed {
+			bindings.OnSnapshot(snapshot)
+		}
+		return nil
+	}, gf.Deps(owner, state.Title, state.Description))
+	gf.UseUnmount(func() {
+		if bindings.Coordinator == nil || bindings.OnSnapshot == nil {
+			panic("server-backed document state: missing application bindings")
+		}
+		snapshot, changed, err := bindings.Coordinator.Remove(owner)
+		if err != nil {
+			panic("server-backed document state: remove owner: " + err.Error())
+		}
+		if changed {
+			bindings.OnSnapshot(snapshot)
+		}
+	})
 }
 
 func ServerBackedShell(props ServerBackedShellProps) gf.Node {
@@ -167,6 +275,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 	mutationStatus, setMutationStatus := gf.UseState("idle")
 	mutationError, setMutationError := gf.UseState("")
 	mutationOwner, _ := gf.UseState(newSavedGreetingMutationOwner())
+	editorActive, setEditorActive := gf.UseState(false)
 	resource, reload := gf.UseResource(savedGreetingAPIPath, gf.FetchText)
 	gf.UseUnmount(func() {
 		mutationOwner.cancel()
@@ -209,50 +318,68 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 		mutationOwner.setCleanup(cleanup)
 	}
 
+	editor := savedGreetingEditorNode(
+		editorActive,
+		draft,
+		mutationStatus,
+		setEditorActive,
+	)
+
 	return (
-		<div data-testid="server-backed-saved-route">
-			<p class="eyebrow" data-testid="server-backed-route-name">Saved greeting route</p>
-			<h2>Committed server state</h2>
-			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
-			<p class="muted" data-testid="saved-greeting-resource-key">{savedGreetingAPIPath}</p>
-			<p class="muted" data-testid="saved-greeting-read-status">{greetingStatus(resource)}</p>
+		<DocumentOwner
+			Owner={serverBackedRouteOwner}
+			State={savedGreetingDocumentMetadata(greetingStatus(resource), resource.Value)}
+		>
+			<div data-testid="server-backed-saved-route">
+				<p class="eyebrow" data-testid="server-backed-route-name">Saved greeting route</p>
+				<h2>Committed server state</h2>
+				<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+				<p class="muted" data-testid="saved-greeting-resource-key">{savedGreetingAPIPath}</p>
+				<p class="muted" data-testid="saved-greeting-read-status">{greetingStatus(resource)}</p>
 
-			{resource.Loading() && (
-				<p class="status loading" data-testid="saved-greeting-read-loading">Loading committed greeting...</p>
-			)}
-			{resource.Failed() && (
-				<div class="status failed" data-testid="saved-greeting-read-error">{greetingErrorText(resource)}</div>
-			)}
-			{resource.Ready() && (
-				<p class="status message" data-testid="saved-greeting-committed">{resource.Value}</p>
-			)}
+				{resource.Loading() && (
+					<p class="status loading" data-testid="saved-greeting-read-loading">Loading committed greeting...</p>
+				)}
+				{resource.Failed() && (
+					<div class="status failed" data-testid="saved-greeting-read-error">{greetingErrorText(resource)}</div>
+				)}
+				{resource.Ready() && (
+					<p class="status message" data-testid="saved-greeting-committed">{resource.Value}</p>
+				)}
 
-			<form class="greeting-form" data-testid="saved-greeting-form" OnSubmit={submitSavedGreeting}>
-				<label class="field">
-					<span>New committed name</span>
-					<input
-						data-testid="saved-greeting-input"
-						Type="text"
-						Value={draft}
-						OnInput={func(event gf.InputEvent) {
-							setDraft(event.Value())
-						}}
-					/>
-				</label>
-				<button
-					data-testid="saved-greeting-submit"
-					Type="submit"
-					Disabled={mutationStatus == "pending"}
-				>
-					Save greeting
-				</button>
-			</form>
+				<form class="greeting-form" data-testid="saved-greeting-form" OnSubmit={submitSavedGreeting}>
+					<label class="field">
+						<span>New committed name</span>
+						<input
+							data-testid="saved-greeting-input"
+							Type="text"
+							Value={draft}
+							OnInput={func(event gf.InputEvent) {
+								setEditorActive(true)
+								setDraft(event.Value())
+								if mutationStatus != "idle" {
+									setMutationStatus("idle")
+									setMutationError("")
+								}
+							}}
+						/>
+					</label>
+					<button
+						data-testid="saved-greeting-submit"
+						Type="submit"
+						Disabled={mutationStatus == "pending"}
+					>
+						Save greeting
+					</button>
+				</form>
 
-			<p class="muted" data-testid="saved-greeting-mutation-status">{mutationStatus}</p>
-			{mutationError != "" && (
-				<div class="status failed" data-testid="saved-greeting-mutation-error">{mutationError}</div>
-			)}
-		</div>
+				<p class="muted" data-testid="saved-greeting-mutation-status">{mutationStatus}</p>
+				{mutationError != "" && (
+					<div class="status failed" data-testid="saved-greeting-mutation-error">{mutationError}</div>
+				)}
+				{editor}
+			</div>
+		</DocumentOwner>
 	)
 }
 
@@ -268,13 +395,15 @@ func HomeRoute(props HomeRouteProps) gf.Node {
 	}
 
 	return (
-		<div data-testid="server-backed-home">
-			<p class="eyebrow" data-testid="server-backed-route-name">Home route</p>
-			<h2>Choose a greeting</h2>
-			<p class="muted">The initial route starts no greeting resource.</p>
-			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
-			{greetingForm(draft, setDraft, submitGreeting)}
-		</div>
+		<DocumentOwner Owner={serverBackedRouteOwner} State={homeDocumentMetadata()}>
+			<div data-testid="server-backed-home">
+				<p class="eyebrow" data-testid="server-backed-route-name">Home route</p>
+				<h2>Choose a greeting</h2>
+				<p class="muted">The initial route starts no greeting resource.</p>
+				<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+				{greetingForm(draft, setDraft, submitGreeting)}
+			</div>
+		</DocumentOwner>
 	)
 }
 
@@ -302,24 +431,29 @@ func GreetingRoute(props GreetingRouteProps) gf.Node {
 	}
 
 	return (
-		<div data-testid="server-backed-greeting-route">
-			<p class="eyebrow" data-testid="server-backed-route-name">Greeting route</p>
-			<h2>Backend response</h2>
-			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
-			<p class="muted" data-testid="greeting-resource-key">{greetingPath(props.Name)}</p>
-			<p class="muted" data-testid="greeting-status">{greetingStatus(resource)}</p>
-			{greetingForm(draft, setDraft, submitGreeting)}
+		<DocumentOwner
+			Owner={serverBackedRouteOwner}
+			State={greetingDocumentMetadata(props.Name)}
+		>
+			<div data-testid="server-backed-greeting-route">
+				<p class="eyebrow" data-testid="server-backed-route-name">Greeting route</p>
+				<h2>Backend response</h2>
+				<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+				<p class="muted" data-testid="greeting-resource-key">{greetingPath(props.Name)}</p>
+				<p class="muted" data-testid="greeting-status">{greetingStatus(resource)}</p>
+				{greetingForm(draft, setDraft, submitGreeting)}
 
-			{resource.Loading() && (
-				<p class="status loading" data-testid="greeting-loading">Loading backend greeting...</p>
-			)}
-			{resource.Failed() && (
-				<div class="status failed" data-testid="greeting-error">{greetingErrorText(resource)}</div>
-			)}
-			{resource.Ready() && (
-				<p class="status message" data-testid="greeting-message">{resource.Value}</p>
-			)}
-		</div>
+				{resource.Loading() && (
+					<p class="status loading" data-testid="greeting-loading">Loading backend greeting...</p>
+				)}
+				{resource.Failed() && (
+					<div class="status failed" data-testid="greeting-error">{greetingErrorText(resource)}</div>
+				)}
+				{resource.Ready() && (
+					<p class="status message" data-testid="greeting-message">{resource.Value}</p>
+				)}
+			</div>
+		</DocumentOwner>
 	)
 }
 
@@ -379,57 +513,62 @@ func TransitionGreetingRoute(props TransitionGreetingRouteProps) gf.Node {
 	}
 
 	return (
-		<div data-testid="server-backed-transition-route">
-			<p class="eyebrow" data-testid="server-backed-route-name">Retained transition route</p>
-			<h2>Prepared backend response</h2>
-			<p class="muted">Requested target</p>
-			<p class="route-target" data-testid="transition-requested-target">{props.Target}</p>
-			<p class="muted" data-testid="transition-status">{status}</p>
+		<DocumentOwner
+			Owner={serverBackedRouteOwner}
+			State={transitionDocumentMetadata(props.Name, committed)}
+		>
+			<div data-testid="server-backed-transition-route">
+				<p class="eyebrow" data-testid="server-backed-route-name">Retained transition route</p>
+				<h2>Prepared backend response</h2>
+				<p class="muted">Requested target</p>
+				<p class="route-target" data-testid="transition-requested-target">{props.Target}</p>
+				<p class="muted" data-testid="transition-status">{status}</p>
 
-			<form class="greeting-form" data-testid="transition-form" OnSubmit={submitGreeting}>
-				<label class="field">
-					<span>Name</span>
-					<input
-						data-testid="transition-name"
-						Type="text"
-						Value={draft}
-						OnInput={func(event gf.InputEvent) {
-							setDraft(event.Value())
-						}}
-					/>
-				</label>
-				<button data-testid="transition-submit" Type="submit">Prepare greeting</button>
-			</form>
+				<form class="greeting-form" data-testid="transition-form" OnSubmit={submitGreeting}>
+					<label class="field">
+						<span>Name</span>
+						<input
+							data-testid="transition-name"
+							Type="text"
+							Value={draft}
+							OnInput={func(event gf.InputEvent) {
+								setDraft(event.Value())
+							}}
+						/>
+					</label>
+					<button data-testid="transition-submit" Type="submit">Prepare greeting</button>
+				</form>
 
-			{committed.Ready && (
-				<section class="transition-committed" data-testid="transition-committed-screen">
-					<p class="muted">Committed target</p>
-					<p class="route-target" data-testid="transition-committed-target">{committed.Target}</p>
-					<p class="status message" data-testid="transition-message">{committed.Message}</p>
-				</section>
-			)}
+				{committed.Ready && (
+					<section class="transition-committed" data-testid="transition-committed-screen">
+						<p class="muted">Committed target</p>
+						<p class="route-target" data-testid="transition-committed-target">{committed.Target}</p>
+						<p class="status message" data-testid="transition-message">{committed.Message}</p>
+					</section>
+				)}
 
-			{status == "loading" && (
-				<p class="status loading" data-testid="transition-pending">
-					Preparing the initial greeting for {props.Name}...
-				</p>
-			)}
-			{status == "pending" && (
-				<p class="status loading" data-testid="transition-pending">
-					Preparing {props.Name} while the committed screen remains visible...
-				</p>
-			)}
-			{resource.Failed() && (
-				<div class="transition-failure">
-					<div class="status failed" data-testid="transition-error">{greetingErrorText(resource)}</div>
-					<button data-testid="transition-retry" Type="button" OnClick={func(gf.Event) {
-						reload()
-					}}>
-						Retry requested target
-					</button>
-				</div>
-			)}
-		</div>
+				{status == "loading" && (
+					<p class="status loading" data-testid="transition-pending">
+						Preparing the initial greeting for {props.Name}...
+					</p>
+				)}
+				{status == "pending" && (
+					<p class="status loading" data-testid="transition-pending">
+						Preparing {props.Name} while the committed screen remains visible...
+					</p>
+				)}
+				{resource.Failed() && (
+					<div class="transition-failure">
+						<div class="status failed" data-testid="transition-error">{greetingErrorText(resource)}</div>
+						<button data-testid="transition-retry" Type="button" OnClick={func(gf.Event) {
+							reload()
+						}}>
+							Retry requested target
+						</button>
+					</div>
+				)}
+			</div>
+		</DocumentOwner>
 	)
 }
 
@@ -454,12 +593,90 @@ func greetingForm(name string, setName func(string), submitGreeting func(gf.Even
 
 func NotFoundRoute(props NotFoundRouteProps) gf.Node {
 	return (
-		<div data-testid="server-backed-not-found">
-			<p class="eyebrow" data-testid="server-backed-route-name">Not found</p>
-			<h2>Unknown route</h2>
-			<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
-		</div>
+		<DocumentOwner Owner={serverBackedRouteOwner} State={notFoundDocumentMetadata()}>
+			<div data-testid="server-backed-not-found">
+				<p class="eyebrow" data-testid="server-backed-route-name">Not found</p>
+				<h2>Unknown route</h2>
+				<p class="route-target" data-testid="server-backed-route-target">{props.Target}</p>
+			</div>
+		</DocumentOwner>
 	)
+}
+
+func savedGreetingEditorNode(
+	active bool,
+	draft string,
+	status string,
+	setActive func(bool),
+) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	return (
+		<DocumentOwner
+			Owner={serverBackedSavedEditorOwner}
+			State={savedGreetingEditorDocumentMetadata(draft, status)}
+		>
+			<aside class="saved-editor-state" data-testid="saved-greeting-editor-state">
+				<p class="muted">The editor temporarily owns document metadata.</p>
+				<button
+					data-testid="saved-greeting-finish-editing"
+					Type="button"
+					OnClick={func(gf.Event) {
+						setActive(false)
+					}}
+				>
+					Finish editing
+				</button>
+			</aside>
+		</DocumentOwner>
+	)
+}
+
+func documentRouteScope(active bool) gf.Node {
+	if active {
+		return gf.RouterView(router)
+	}
+	return (
+		<section data-testid="server-backed-document-scope-inactive">
+			Route document owners are unmounted.
+		</section>
+	)
+}
+
+func documentScopeControl(
+	active bool,
+	setActive func(bool),
+) gf.Node {
+	if active {
+		return gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "server-backed-document-scope-unmount",
+				"OnClick": func() {
+					setActive(false)
+				},
+			},
+			gf.Text("Unmount route document scope"),
+		)
+	}
+	return gf.El(
+		"button",
+		gf.Props{
+			"data-testid": "server-backed-document-scope-remount",
+			"OnClick": func() {
+				setActive(true)
+			},
+		},
+		gf.Text("Remount route document scope"),
+	)
+}
+
+func activeDocumentOwnerLabel(snapshot serverBackedDocumentSnapshot) string {
+	if snapshot.ActiveOwner == "" {
+		return "authored-baseline"
+	}
+	return snapshot.ActiveOwner
 }
 
 func normalizedGreetingName(name string) string {

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -274,6 +274,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 	draft, setDraft := gf.UseState("GoFrame")
 	mutationStatus, setMutationStatus := gf.UseState("idle")
 	mutationError, setMutationError := gf.UseState("")
+	mutationTarget, setMutationTarget := gf.UseState(savedGreetingMutationTarget{})
 	mutationOwner, _ := gf.UseState(newSavedGreetingMutationOwner())
 	editorActive, setEditorActive := gf.UseState(false)
 	resource, reload := gf.UseResource(savedGreetingAPIPath, gf.FetchText)
@@ -288,6 +289,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 		}
 		name := strings.TrimSpace(draft)
 		if name == "" {
+			setMutationTarget(savedGreetingMutationTarget{})
 			setMutationStatus("validation failed")
 			setMutationError("Name is required.")
 			return
@@ -295,10 +297,22 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 		if !mutationOwner.begin() {
 			return
 		}
+		target := savedGreetingMutationTarget{Submitted: name}
+		setMutationTarget(target)
 		setMutationStatus("pending")
 		setMutationError("")
-		cleanup := postSavedGreeting(name, func(_ string) {
+		cleanup := postSavedGreeting(name, func(confirmed string) {
 			if !mutationOwner.complete() {
+				return
+			}
+			target, ok := confirmedSavedGreetingMutationTarget(
+				target,
+				confirmed,
+			)
+			setMutationTarget(target)
+			if !ok {
+				setMutationStatus("server failed")
+				setMutationError("Saved greeting response was empty.")
 				return
 			}
 			setMutationStatus("success")
@@ -308,6 +322,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 			if !mutationOwner.complete() {
 				return
 			}
+			setMutationTarget(target)
 			setMutationStatus("server failed")
 			if err == nil {
 				setMutationError("Saved greeting request failed.")
@@ -322,6 +337,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 		editorActive,
 		draft,
 		mutationStatus,
+		mutationTarget,
 		setEditorActive,
 	)
 
@@ -357,9 +373,17 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 							OnInput={func(event gf.InputEvent) {
 								setEditorActive(true)
 								setDraft(event.Value())
-								if mutationStatus != "idle" {
-									setMutationStatus("idle")
-									setMutationError("")
+								nextStatus, nextError, nextTarget, changed :=
+									savedGreetingMutationAfterInput(
+										mutationOwner.active,
+										mutationStatus,
+										mutationError,
+										mutationTarget,
+									)
+								if changed {
+									setMutationStatus(nextStatus)
+									setMutationError(nextError)
+									setMutationTarget(nextTarget)
 								}
 							}}
 						/>
@@ -607,6 +631,7 @@ func savedGreetingEditorNode(
 	active bool,
 	draft string,
 	status string,
+	target savedGreetingMutationTarget,
 	setActive func(bool),
 ) gf.Node {
 	if !active {
@@ -615,7 +640,7 @@ func savedGreetingEditorNode(
 	return (
 		<DocumentOwner
 			Owner={serverBackedSavedEditorOwner}
-			State={savedGreetingEditorDocumentMetadata(draft, status)}
+			State={savedGreetingEditorDocumentMetadata(draft, status, target)}
 		>
 			<aside class="saved-editor-state" data-testid="saved-greeting-editor-state">
 				<p class="muted">The editor temporarily owns document metadata.</p>

--- a/examples/server-backed/cmd/app/app.gox
+++ b/examples/server-backed/cmd/app/app.gox
@@ -287,6 +287,7 @@ func SavedGreetingRoute(props SavedGreetingRouteProps) gf.Node {
 		if mutationOwner.active {
 			return
 		}
+		setEditorActive(true)
 		name := strings.TrimSpace(draft)
 		if name == "" {
 			setMutationTarget(savedGreetingMutationTarget{})

--- a/examples/server-backed/cmd/app/document_state.go
+++ b/examples/server-backed/cmd/app/document_state.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"errors"
+	"strings"
+)
+
+type serverBackedDocumentState struct {
+	Title       string
+	Description string
+}
+
+type serverBackedDocumentSnapshot struct {
+	State       serverBackedDocumentState
+	ActiveOwner string
+	OwnerCount  int
+}
+
+type serverBackedDocumentOwner struct {
+	key   string
+	state serverBackedDocumentState
+}
+
+type serverBackedDocumentCoordinator struct {
+	baseline serverBackedDocumentState
+	owners   []serverBackedDocumentOwner
+	index    map[string]int
+}
+
+func newServerBackedDocumentCoordinator(
+	baseline serverBackedDocumentState,
+) *serverBackedDocumentCoordinator {
+	return &serverBackedDocumentCoordinator{
+		baseline: baseline,
+		index:    make(map[string]int),
+	}
+}
+
+func (coordinator *serverBackedDocumentCoordinator) Snapshot() serverBackedDocumentSnapshot {
+	if coordinator == nil {
+		return serverBackedDocumentSnapshot{}
+	}
+	count := len(coordinator.owners)
+	if count == 0 {
+		return serverBackedDocumentSnapshot{State: coordinator.baseline}
+	}
+	active := coordinator.owners[count-1]
+	return serverBackedDocumentSnapshot{
+		State:       active.state,
+		ActiveOwner: active.key,
+		OwnerCount:  count,
+	}
+}
+
+func (coordinator *serverBackedDocumentCoordinator) Set(
+	owner string,
+	state serverBackedDocumentState,
+) (serverBackedDocumentSnapshot, bool, error) {
+	if err := validateServerBackedDocumentOwner(owner); err != nil {
+		return serverBackedDocumentSnapshot{}, false, err
+	}
+	if coordinator == nil {
+		return serverBackedDocumentSnapshot{}, false, errors.New(
+			"server-backed document coordinator is nil",
+		)
+	}
+	if index, ok := coordinator.index[owner]; ok {
+		if coordinator.owners[index].state == state {
+			return coordinator.Snapshot(), false, nil
+		}
+		coordinator.owners[index].state = state
+		return coordinator.Snapshot(), true, nil
+	}
+	coordinator.index[owner] = len(coordinator.owners)
+	coordinator.owners = append(coordinator.owners, serverBackedDocumentOwner{
+		key:   owner,
+		state: state,
+	})
+	return coordinator.Snapshot(), true, nil
+}
+
+func (coordinator *serverBackedDocumentCoordinator) Remove(
+	owner string,
+) (serverBackedDocumentSnapshot, bool, error) {
+	if err := validateServerBackedDocumentOwner(owner); err != nil {
+		return serverBackedDocumentSnapshot{}, false, err
+	}
+	if coordinator == nil {
+		return serverBackedDocumentSnapshot{}, false, errors.New(
+			"server-backed document coordinator is nil",
+		)
+	}
+	index, ok := coordinator.index[owner]
+	if !ok {
+		return coordinator.Snapshot(), false, nil
+	}
+	delete(coordinator.index, owner)
+	copy(coordinator.owners[index:], coordinator.owners[index+1:])
+	coordinator.owners = coordinator.owners[:len(coordinator.owners)-1]
+	for next := index; next < len(coordinator.owners); next++ {
+		coordinator.index[coordinator.owners[next].key] = next
+	}
+	return coordinator.Snapshot(), true, nil
+}
+
+func (coordinator *serverBackedDocumentCoordinator) OwnerKeys() []string {
+	if coordinator == nil {
+		return nil
+	}
+	keys := make([]string, len(coordinator.owners))
+	for index, owner := range coordinator.owners {
+		keys[index] = owner.key
+	}
+	return keys
+}
+
+func validateServerBackedDocumentOwner(owner string) error {
+	if owner == "" || strings.TrimSpace(owner) != owner {
+		return errors.New("server-backed document owner key must be non-empty and trimmed")
+	}
+	return nil
+}
+
+func homeDocumentMetadata() serverBackedDocumentState {
+	return serverBackedDocumentState{
+		Title:       "Server-backed Home · GoFrame",
+		Description: "Choose a route-driven server-backed flow.",
+	}
+}
+
+func greetingDocumentMetadata(name string) serverBackedDocumentState {
+	return serverBackedDocumentState{
+		Title:       "Greeting " + name + " · GoFrame",
+		Description: "Backend greeting route for " + name + ".",
+	}
+}
+
+func transitionDocumentMetadata(
+	requestedName string,
+	committed committedGreeting,
+) serverBackedDocumentState {
+	if committed.Ready {
+		return serverBackedDocumentState{
+			Title:       "Retained greeting: " + committed.Name + " · GoFrame",
+			Description: "Committed retained greeting for " + committed.Name + ".",
+		}
+	}
+	return serverBackedDocumentState{
+		Title:       "Preparing retained greeting for " + requestedName + " · GoFrame",
+		Description: "Preparing the first retained greeting for " + requestedName + ".",
+	}
+}
+
+func savedGreetingDocumentMetadata(
+	status string,
+	value string,
+) serverBackedDocumentState {
+	switch status {
+	case "ready":
+		return serverBackedDocumentState{
+			Title:       "Saved greeting: " + value + " · GoFrame",
+			Description: "Committed saved greeting: " + value + ".",
+		}
+	case "failed":
+		return serverBackedDocumentState{
+			Title:       "Saved greeting unavailable · GoFrame",
+			Description: "The committed saved greeting could not be loaded.",
+		}
+	default:
+		return serverBackedDocumentState{
+			Title:       "Saved greeting · GoFrame",
+			Description: "Loading the committed saved greeting.",
+		}
+	}
+}
+
+func savedGreetingEditorDocumentMetadata(
+	draft string,
+	status string,
+) serverBackedDocumentState {
+	name := strings.TrimSpace(draft)
+	if name == "" {
+		name = "empty"
+	}
+	switch status {
+	case "pending":
+		return serverBackedDocumentState{
+			Title:       "Saving greeting: " + name + " · GoFrame",
+			Description: "Saving the greeting " + name + ".",
+		}
+	case "validation failed", "server failed":
+		return serverBackedDocumentState{
+			Title:       "Saved greeting needs attention · GoFrame",
+			Description: "The draft " + name + " has not been committed.",
+		}
+	case "success":
+		return serverBackedDocumentState{
+			Title:       "Saved greeting confirmed: " + name + " · GoFrame",
+			Description: "The server confirmed " + name + "; finish editing to reveal committed metadata.",
+		}
+	default:
+		return serverBackedDocumentState{
+			Title:       "Editing saved greeting: " + name + " · GoFrame",
+			Description: "Unsaved saved-greeting draft: " + name + ".",
+		}
+	}
+}
+
+func notFoundDocumentMetadata() serverBackedDocumentState {
+	return serverBackedDocumentState{
+		Title:       "Not found · GoFrame",
+		Description: "No server-backed route matched.",
+	}
+}

--- a/examples/server-backed/cmd/app/document_state.go
+++ b/examples/server-backed/cmd/app/document_state.go
@@ -204,16 +204,16 @@ func savedGreetingEditorDocumentMetadata(
 			Description: "The draft " + name + " has not been committed.",
 		}
 	case "success":
-		name := savedGreetingMetadataName(target.Confirmed)
-		if name == "empty" {
+		confirmed := strings.TrimSpace(target.Confirmed)
+		if confirmed == "" {
 			return serverBackedDocumentState{
 				Title:       "Saved greeting needs attention · GoFrame",
 				Description: "The server did not confirm a saved greeting.",
 			}
 		}
 		return serverBackedDocumentState{
-			Title:       "Saved greeting confirmed: " + name + " · GoFrame",
-			Description: "The server confirmed " + name + "; finish editing to reveal committed metadata.",
+			Title:       "Saved greeting confirmed: " + confirmed + " · GoFrame",
+			Description: "The server confirmed " + confirmed + "; finish editing to reveal committed metadata.",
 		}
 	default:
 		name := savedGreetingMetadataName(draft)

--- a/examples/server-backed/cmd/app/document_state.go
+++ b/examples/server-backed/cmd/app/document_state.go
@@ -10,6 +10,11 @@ type serverBackedDocumentState struct {
 	Description string
 }
 
+type savedGreetingMutationTarget struct {
+	Submitted string
+	Confirmed string
+}
+
 type serverBackedDocumentSnapshot struct {
 	State       serverBackedDocumentState
 	ActiveOwner string
@@ -177,33 +182,77 @@ func savedGreetingDocumentMetadata(
 func savedGreetingEditorDocumentMetadata(
 	draft string,
 	status string,
+	target savedGreetingMutationTarget,
 ) serverBackedDocumentState {
-	name := strings.TrimSpace(draft)
-	if name == "" {
-		name = "empty"
-	}
 	switch status {
 	case "pending":
+		name := savedGreetingMetadataName(target.Submitted)
 		return serverBackedDocumentState{
 			Title:       "Saving greeting: " + name + " · GoFrame",
 			Description: "Saving the greeting " + name + ".",
 		}
-	case "validation failed", "server failed":
+	case "validation failed":
+		name := savedGreetingMetadataName(draft)
+		return serverBackedDocumentState{
+			Title:       "Saved greeting needs attention · GoFrame",
+			Description: "The draft " + name + " has not been committed.",
+		}
+	case "server failed":
+		name := savedGreetingMetadataName(target.Submitted)
 		return serverBackedDocumentState{
 			Title:       "Saved greeting needs attention · GoFrame",
 			Description: "The draft " + name + " has not been committed.",
 		}
 	case "success":
+		name := savedGreetingMetadataName(target.Confirmed)
+		if name == "empty" {
+			return serverBackedDocumentState{
+				Title:       "Saved greeting needs attention · GoFrame",
+				Description: "The server did not confirm a saved greeting.",
+			}
+		}
 		return serverBackedDocumentState{
 			Title:       "Saved greeting confirmed: " + name + " · GoFrame",
 			Description: "The server confirmed " + name + "; finish editing to reveal committed metadata.",
 		}
 	default:
+		name := savedGreetingMetadataName(draft)
 		return serverBackedDocumentState{
 			Title:       "Editing saved greeting: " + name + " · GoFrame",
 			Description: "Unsaved saved-greeting draft: " + name + ".",
 		}
 	}
+}
+
+func confirmedSavedGreetingMutationTarget(
+	target savedGreetingMutationTarget,
+	response string,
+) (savedGreetingMutationTarget, bool) {
+	target.Confirmed = strings.TrimSpace(response)
+	return target, target.Confirmed != ""
+}
+
+func savedGreetingMutationAfterInput(
+	active bool,
+	status string,
+	mutationError string,
+	target savedGreetingMutationTarget,
+) (string, string, savedGreetingMutationTarget, bool) {
+	if active ||
+		(status == "idle" &&
+			mutationError == "" &&
+			target == (savedGreetingMutationTarget{})) {
+		return status, mutationError, target, false
+	}
+	return "idle", "", savedGreetingMutationTarget{}, true
+}
+
+func savedGreetingMetadataName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "empty"
+	}
+	return value
 }
 
 func notFoundDocumentMetadata() serverBackedDocumentState {

--- a/examples/server-backed/cmd/app/document_state_js.go
+++ b/examples/server-backed/cmd/app/document_state_js.go
@@ -1,0 +1,115 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"syscall/js"
+)
+
+type browserDocumentAdapter struct {
+	title           js.Value
+	description     js.Value
+	viewport        js.Value
+	viewportContent string
+	baseline        serverBackedDocumentState
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	document := js.Global().Get("document")
+	if document.IsUndefined() || document.IsNull() {
+		return nil, errors.New("document is unavailable")
+	}
+
+	titles := document.Call("querySelectorAll", "head title")
+	if titles.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one authored title element, found %d",
+			titles.Get("length").Int(),
+		)
+	}
+	descriptions := document.Call(
+		"querySelectorAll",
+		`head meta[name="description"]`,
+	)
+	if descriptions.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one authored description element, found %d",
+			descriptions.Get("length").Int(),
+		)
+	}
+	viewports := document.Call(
+		"querySelectorAll",
+		`head meta[name="viewport"]`,
+	)
+	if viewports.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected exactly one authored viewport element, found %d",
+			viewports.Get("length").Int(),
+		)
+	}
+
+	title := titles.Index(0)
+	description := descriptions.Index(0)
+	viewport := viewports.Index(0)
+	return &browserDocumentAdapter{
+		title:           title,
+		description:     description,
+		viewport:        viewport,
+		viewportContent: viewport.Call("getAttribute", "content").String(),
+		baseline: serverBackedDocumentState{
+			Title:       title.Get("textContent").String(),
+			Description: description.Call("getAttribute", "content").String(),
+		},
+	}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() serverBackedDocumentState {
+	if adapter == nil {
+		return serverBackedDocumentState{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(state serverBackedDocumentState) error {
+	if adapter == nil {
+		return errors.New("document adapter is nil")
+	}
+	document := js.Global().Get("document")
+	titles := document.Call("querySelectorAll", "head title")
+	if titles.Get("length").Int() != 1 ||
+		!titles.Index(0).Equal(adapter.title) ||
+		!adapter.title.Get("isConnected").Bool() {
+		return errors.New("authored title element changed identity")
+	}
+	descriptions := document.Call(
+		"querySelectorAll",
+		`head meta[name="description"]`,
+	)
+	if descriptions.Get("length").Int() != 1 ||
+		!descriptions.Index(0).Equal(adapter.description) ||
+		!adapter.description.Get("isConnected").Bool() {
+		return errors.New("authored description element changed identity")
+	}
+	viewports := document.Call(
+		"querySelectorAll",
+		`head meta[name="viewport"]`,
+	)
+	if viewports.Get("length").Int() != 1 ||
+		!viewports.Index(0).Equal(adapter.viewport) ||
+		!adapter.viewport.Get("isConnected").Bool() {
+		return errors.New("authored viewport element changed identity")
+	}
+	if adapter.viewport.Call("getAttribute", "content").String() != adapter.viewportContent {
+		return errors.New("authored viewport content changed")
+	}
+
+	if adapter.title.Get("textContent").String() != state.Title {
+		adapter.title.Set("textContent", state.Title)
+	}
+	if adapter.description.Call("getAttribute", "content").String() != state.Description {
+		adapter.description.Call("setAttribute", "content", state.Description)
+	}
+	return nil
+}

--- a/examples/server-backed/cmd/app/document_state_nonjs.go
+++ b/examples/server-backed/cmd/app/document_state_nonjs.go
@@ -1,0 +1,22 @@
+//go:build !js || !wasm
+
+package main
+
+type browserDocumentAdapter struct {
+	baseline serverBackedDocumentState
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	return &browserDocumentAdapter{}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() serverBackedDocumentState {
+	if adapter == nil {
+		return serverBackedDocumentState{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(serverBackedDocumentState) error {
+	return nil
+}

--- a/examples/server-backed/cmd/app/document_state_test.go
+++ b/examples/server-backed/cmd/app/document_state_test.go
@@ -349,6 +349,19 @@ func TestSavedMutationDocumentMetadataAttribution(t *testing.T) {
 			},
 		},
 		{
+			name:   "success preserves literal empty response",
+			draft:  "another draft",
+			status: "success",
+			target: savedGreetingMutationTarget{
+				Submitted: "empty",
+				Confirmed: "empty",
+			},
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting confirmed: empty · GoFrame",
+				Description: "The server confirmed empty; finish editing to reveal committed metadata.",
+			},
+		},
+		{
 			name:   "server failure keeps submitted target after draft edit",
 			draft:  "Mia",
 			status: "server failed",
@@ -397,6 +410,20 @@ func TestSavedMutationConfirmationNormalizesResponse(t *testing.T) {
 		Confirmed: "confirmed",
 	}) {
 		t.Fatalf("confirmed target = %#v", target)
+	}
+
+	target, ok = confirmedSavedGreetingMutationTarget(
+		savedGreetingMutationTarget{Submitted: "empty"},
+		"  empty  ",
+	)
+	if !ok {
+		t.Fatal("literal empty server response was rejected")
+	}
+	if target != (savedGreetingMutationTarget{
+		Submitted: "empty",
+		Confirmed: "empty",
+	}) {
+		t.Fatalf("literal empty confirmed target = %#v", target)
 	}
 
 	target, ok = confirmedSavedGreetingMutationTarget(target, " \t ")

--- a/examples/server-backed/cmd/app/document_state_test.go
+++ b/examples/server-backed/cmd/app/document_state_test.go
@@ -46,7 +46,14 @@ func TestDocumentStateCoordinatorRetainsLatestRemainingOwner(t *testing.T) {
 		t.Fatalf("owner order after route update = %v", got)
 	}
 
-	editorUpdated := savedGreetingEditorDocumentMetadata("Grace", "success")
+	editorUpdated := savedGreetingEditorDocumentMetadata(
+		"Grace",
+		"success",
+		savedGreetingMutationTarget{
+			Submitted: "Grace",
+			Confirmed: "Grace",
+		},
+	)
 	mustSetDocumentOwner(t, coordinator, "saved-editor", editorUpdated)
 	snapshot = mustRemoveDocumentOwner(t, coordinator, "saved-editor")
 	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
@@ -217,7 +224,11 @@ func TestDocumentMetadataMapping(t *testing.T) {
 		},
 		{
 			name: "saved editor",
-			got:  savedGreetingEditorDocumentMetadata("slow", "idle"),
+			got: savedGreetingEditorDocumentMetadata(
+				"slow",
+				"idle",
+				savedGreetingMutationTarget{},
+			),
 			want: serverBackedDocumentState{
 				Title:       "Editing saved greeting: slow · GoFrame",
 				Description: "Unsaved saved-greeting draft: slow.",
@@ -225,7 +236,11 @@ func TestDocumentMetadataMapping(t *testing.T) {
 		},
 		{
 			name: "saved editor pending",
-			got:  savedGreetingEditorDocumentMetadata("slow", "pending"),
+			got: savedGreetingEditorDocumentMetadata(
+				"slow",
+				"pending",
+				savedGreetingMutationTarget{Submitted: "slow"},
+			),
 			want: serverBackedDocumentState{
 				Title:       "Saving greeting: slow · GoFrame",
 				Description: "Saving the greeting slow.",
@@ -233,7 +248,11 @@ func TestDocumentMetadataMapping(t *testing.T) {
 		},
 		{
 			name: "saved editor validation failure",
-			got:  savedGreetingEditorDocumentMetadata("   ", "validation failed"),
+			got: savedGreetingEditorDocumentMetadata(
+				"   ",
+				"validation failed",
+				savedGreetingMutationTarget{},
+			),
 			want: serverBackedDocumentState{
 				Title:       "Saved greeting needs attention · GoFrame",
 				Description: "The draft empty has not been committed.",
@@ -241,7 +260,11 @@ func TestDocumentMetadataMapping(t *testing.T) {
 		},
 		{
 			name: "saved editor server failure",
-			got:  savedGreetingEditorDocumentMetadata("fail", "server failed"),
+			got: savedGreetingEditorDocumentMetadata(
+				"fail",
+				"server failed",
+				savedGreetingMutationTarget{Submitted: "fail"},
+			),
 			want: serverBackedDocumentState{
 				Title:       "Saved greeting needs attention · GoFrame",
 				Description: "The draft fail has not been committed.",
@@ -249,7 +272,14 @@ func TestDocumentMetadataMapping(t *testing.T) {
 		},
 		{
 			name: "saved editor confirmed",
-			got:  savedGreetingEditorDocumentMetadata("Grace", "success"),
+			got: savedGreetingEditorDocumentMetadata(
+				"Grace",
+				"success",
+				savedGreetingMutationTarget{
+					Submitted: "Grace",
+					Confirmed: "Grace",
+				},
+			),
 			want: serverBackedDocumentState{
 				Title:       "Saved greeting confirmed: Grace · GoFrame",
 				Description: "The server confirmed Grace; finish editing to reveal committed metadata.",
@@ -274,6 +304,174 @@ func TestDocumentMetadataMapping(t *testing.T) {
 	}
 }
 
+func TestSavedMutationDocumentMetadataAttribution(t *testing.T) {
+	tests := []struct {
+		name   string
+		draft  string
+		status string
+		target savedGreetingMutationTarget
+		want   serverBackedDocumentState
+	}{
+		{
+			name:   "pending keeps submitted target after draft edit",
+			draft:  "Mia",
+			status: "pending",
+			target: savedGreetingMutationTarget{Submitted: "slow"},
+			want: serverBackedDocumentState{
+				Title:       "Saving greeting: slow · GoFrame",
+				Description: "Saving the greeting slow.",
+			},
+		},
+		{
+			name:   "success uses confirmed response after draft edit",
+			draft:  "Mia",
+			status: "success",
+			target: savedGreetingMutationTarget{
+				Submitted: "slow",
+				Confirmed: "slow",
+			},
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting confirmed: slow · GoFrame",
+				Description: "The server confirmed slow; finish editing to reveal committed metadata.",
+			},
+		},
+		{
+			name:   "success prefers normalized server response to submitted target",
+			draft:  "Mia",
+			status: "success",
+			target: savedGreetingMutationTarget{
+				Submitted: "submitted",
+				Confirmed: "confirmed",
+			},
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting confirmed: confirmed · GoFrame",
+				Description: "The server confirmed confirmed; finish editing to reveal committed metadata.",
+			},
+		},
+		{
+			name:   "server failure keeps submitted target after draft edit",
+			draft:  "Mia",
+			status: "server failed",
+			target: savedGreetingMutationTarget{Submitted: "fail"},
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting needs attention · GoFrame",
+				Description: "The draft fail has not been committed.",
+			},
+		},
+		{
+			name:   "validation failure follows current invalid draft",
+			draft:  "   ",
+			status: "validation failed",
+			target: savedGreetingMutationTarget{},
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting needs attention · GoFrame",
+				Description: "The draft empty has not been committed.",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := savedGreetingEditorDocumentMetadata(
+				test.draft,
+				test.status,
+				test.target,
+			)
+			if got != test.want {
+				t.Fatalf("metadata = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSavedMutationConfirmationNormalizesResponse(t *testing.T) {
+	target, ok := confirmedSavedGreetingMutationTarget(
+		savedGreetingMutationTarget{Submitted: "submitted"},
+		"  confirmed  ",
+	)
+	if !ok {
+		t.Fatal("non-empty server response was rejected")
+	}
+	if target != (savedGreetingMutationTarget{
+		Submitted: "submitted",
+		Confirmed: "confirmed",
+	}) {
+		t.Fatalf("confirmed target = %#v", target)
+	}
+
+	target, ok = confirmedSavedGreetingMutationTarget(target, " \t ")
+	if ok {
+		t.Fatal("empty server response was accepted")
+	}
+	if target.Confirmed != "" {
+		t.Fatalf("empty response retained confirmation %q", target.Confirmed)
+	}
+}
+
+func TestSavedMutationInputState(t *testing.T) {
+	activeTarget := savedGreetingMutationTarget{Submitted: "slow"}
+	status, mutationError, target, changed := savedGreetingMutationAfterInput(
+		true,
+		"pending",
+		"",
+		activeTarget,
+	)
+	if changed ||
+		status != "pending" ||
+		mutationError != "" ||
+		target != activeTarget {
+		t.Fatalf(
+			"active mutation changed after input: status=%q error=%q target=%#v changed=%v",
+			status,
+			mutationError,
+			target,
+			changed,
+		)
+	}
+
+	completedTarget := savedGreetingMutationTarget{
+		Submitted: "slow",
+		Confirmed: "slow",
+	}
+	status, mutationError, target, changed = savedGreetingMutationAfterInput(
+		false,
+		"success",
+		"obsolete",
+		completedTarget,
+	)
+	if !changed ||
+		status != "idle" ||
+		mutationError != "" ||
+		target != (savedGreetingMutationTarget{}) {
+		t.Fatalf(
+			"completed mutation was not cleared after input: status=%q error=%q target=%#v changed=%v",
+			status,
+			mutationError,
+			target,
+			changed,
+		)
+	}
+
+	status, mutationError, target, changed = savedGreetingMutationAfterInput(
+		false,
+		"idle",
+		"",
+		savedGreetingMutationTarget{},
+	)
+	if changed ||
+		status != "idle" ||
+		mutationError != "" ||
+		target != (savedGreetingMutationTarget{}) {
+		t.Fatalf(
+			"idle mutation changed after input: status=%q error=%q target=%#v changed=%v",
+			status,
+			mutationError,
+			target,
+			changed,
+		)
+	}
+}
+
 func TestDocumentStateIntegratedSavedEditorReveal(t *testing.T) {
 	coordinator := newServerBackedDocumentCoordinator(serverBackedDocumentState{
 		Title:       "authored",
@@ -289,7 +487,11 @@ func TestDocumentStateIntegratedSavedEditorReveal(t *testing.T) {
 		t,
 		coordinator,
 		"saved-editor",
-		savedGreetingEditorDocumentMetadata("Grace", "pending"),
+		savedGreetingEditorDocumentMetadata(
+			"Grace",
+			"pending",
+			savedGreetingMutationTarget{Submitted: "Grace"},
+		),
 	)
 	mustSetDocumentOwner(
 		t,

--- a/examples/server-backed/cmd/app/document_state_test.go
+++ b/examples/server-backed/cmd/app/document_state_test.go
@@ -1,0 +1,345 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDocumentStateCoordinatorRetainsLatestRemainingOwner(t *testing.T) {
+	baseline := serverBackedDocumentState{
+		Title:       "authored",
+		Description: "baseline",
+	}
+	routeInitial := serverBackedDocumentState{
+		Title:       "Saved greeting: GoFrame · GoFrame",
+		Description: "Committed saved greeting: GoFrame.",
+	}
+	editorInitial := serverBackedDocumentState{
+		Title:       "Editing saved greeting: slow · GoFrame",
+		Description: "Unsaved saved-greeting draft: slow.",
+	}
+	routeUpdated := serverBackedDocumentState{
+		Title:       "Saved greeting: Grace · GoFrame",
+		Description: "Committed saved greeting: Grace.",
+	}
+	coordinator := newServerBackedDocumentCoordinator(baseline)
+
+	assertDocumentSnapshot(t, coordinator.Snapshot(), serverBackedDocumentSnapshot{
+		State: baseline,
+	})
+	mustSetDocumentOwner(t, coordinator, "route", routeInitial)
+	mustSetDocumentOwner(t, coordinator, "saved-editor", editorInitial)
+
+	snapshot, changed, err := coordinator.Set("route", routeUpdated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("route update was ignored")
+	}
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State:       editorInitial,
+		ActiveOwner: "saved-editor",
+		OwnerCount:  2,
+	})
+	if got := coordinator.OwnerKeys(); !reflect.DeepEqual(got, []string{"route", "saved-editor"}) {
+		t.Fatalf("owner order after route update = %v", got)
+	}
+
+	editorUpdated := savedGreetingEditorDocumentMetadata("Grace", "success")
+	mustSetDocumentOwner(t, coordinator, "saved-editor", editorUpdated)
+	snapshot = mustRemoveDocumentOwner(t, coordinator, "saved-editor")
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State:       routeUpdated,
+		ActiveOwner: "route",
+		OwnerCount:  1,
+	})
+
+	snapshot = mustRemoveDocumentOwner(t, coordinator, "route")
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State: baseline,
+	})
+}
+
+func TestDocumentStateCoordinatorNonTopRemovalAndNoOpUpdates(t *testing.T) {
+	coordinator := newServerBackedDocumentCoordinator(serverBackedDocumentState{
+		Title:       "authored",
+		Description: "baseline",
+	})
+	route := serverBackedDocumentState{Title: "route", Description: "route"}
+	editor := serverBackedDocumentState{Title: "editor", Description: "editor"}
+	mustSetDocumentOwner(t, coordinator, "route", route)
+	mustSetDocumentOwner(t, coordinator, "saved-editor", editor)
+
+	snapshot, changed, err := coordinator.Set("route", route)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("identical route update reported a change")
+	}
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State:       editor,
+		ActiveOwner: "saved-editor",
+		OwnerCount:  2,
+	})
+
+	snapshot = mustRemoveDocumentOwner(t, coordinator, "route")
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State:       editor,
+		ActiveOwner: "saved-editor",
+		OwnerCount:  1,
+	})
+}
+
+func TestDocumentStateCoordinatorRejectsMalformedOwnerKeys(t *testing.T) {
+	coordinator := newServerBackedDocumentCoordinator(serverBackedDocumentState{})
+	for _, owner := range []string{"", " ", "\troute", "route "} {
+		if _, _, err := coordinator.Set(owner, serverBackedDocumentState{}); err == nil {
+			t.Fatalf("Set(%q) succeeded", owner)
+		}
+		if _, _, err := coordinator.Remove(owner); err == nil {
+			t.Fatalf("Remove(%q) succeeded", owner)
+		}
+	}
+}
+
+func TestDocumentStateOwnerIdentityDoesNotChangePriority(t *testing.T) {
+	coordinator := newServerBackedDocumentCoordinator(serverBackedDocumentState{})
+	mustSetDocumentOwner(t, coordinator, "route", serverBackedDocumentState{
+		Title: "first",
+	})
+	mustSetDocumentOwner(t, coordinator, "saved-editor", serverBackedDocumentState{
+		Title: "editor",
+	})
+	mustSetDocumentOwner(t, coordinator, "route", serverBackedDocumentState{
+		Title: "latest",
+	})
+
+	if got := coordinator.OwnerKeys(); !reflect.DeepEqual(got, []string{"route", "saved-editor"}) {
+		t.Fatalf("owner update changed fixed owner priority: %v", got)
+	}
+}
+
+func TestDocumentStateCoordinatorDoesNotMutateCallerValues(t *testing.T) {
+	baseline := serverBackedDocumentState{Title: "authored", Description: "baseline"}
+	desired := serverBackedDocumentState{Title: "route", Description: "selected"}
+	coordinator := newServerBackedDocumentCoordinator(baseline)
+	mustSetDocumentOwner(t, coordinator, "route", desired)
+
+	if baseline != (serverBackedDocumentState{Title: "authored", Description: "baseline"}) {
+		t.Fatalf("baseline changed: %#v", baseline)
+	}
+	if desired != (serverBackedDocumentState{Title: "route", Description: "selected"}) {
+		t.Fatalf("desired state changed: %#v", desired)
+	}
+}
+
+func TestDocumentMetadataMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		got  serverBackedDocumentState
+		want serverBackedDocumentState
+	}{
+		{
+			name: "home",
+			got:  homeDocumentMetadata(),
+			want: serverBackedDocumentState{
+				Title:       "Server-backed Home · GoFrame",
+				Description: "Choose a route-driven server-backed flow.",
+			},
+		},
+		{
+			name: "greeting",
+			got:  greetingDocumentMetadata("Ada"),
+			want: serverBackedDocumentState{
+				Title:       "Greeting Ada · GoFrame",
+				Description: "Backend greeting route for Ada.",
+			},
+		},
+		{
+			name: "transition initial",
+			got:  transitionDocumentMetadata("Ada", committedGreeting{}),
+			want: serverBackedDocumentState{
+				Title:       "Preparing retained greeting for Ada · GoFrame",
+				Description: "Preparing the first retained greeting for Ada.",
+			},
+		},
+		{
+			name: "transition committed ignores requested slow",
+			got: transitionDocumentMetadata("slow", committedGreeting{
+				Name:    "Ada",
+				Target:  "/transition-greeting?name=Ada",
+				Message: "Hello, Ada, from Go backend!",
+				Ready:   true,
+			}),
+			want: serverBackedDocumentState{
+				Title:       "Retained greeting: Ada · GoFrame",
+				Description: "Committed retained greeting for Ada.",
+			},
+		},
+		{
+			name: "transition committed Lin",
+			got: transitionDocumentMetadata("Lin", committedGreeting{
+				Name:    "Lin",
+				Target:  "/transition-greeting?name=Lin",
+				Message: "Hello, Lin, from Go backend!",
+				Ready:   true,
+			}),
+			want: serverBackedDocumentState{
+				Title:       "Retained greeting: Lin · GoFrame",
+				Description: "Committed retained greeting for Lin.",
+			},
+		},
+		{
+			name: "saved loading",
+			got:  savedGreetingDocumentMetadata("loading", ""),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting · GoFrame",
+				Description: "Loading the committed saved greeting.",
+			},
+		},
+		{
+			name: "saved ready",
+			got:  savedGreetingDocumentMetadata("ready", "GoFrame"),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting: GoFrame · GoFrame",
+				Description: "Committed saved greeting: GoFrame.",
+			},
+		},
+		{
+			name: "saved failure",
+			got:  savedGreetingDocumentMetadata("failed", ""),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting unavailable · GoFrame",
+				Description: "The committed saved greeting could not be loaded.",
+			},
+		},
+		{
+			name: "saved editor",
+			got:  savedGreetingEditorDocumentMetadata("slow", "idle"),
+			want: serverBackedDocumentState{
+				Title:       "Editing saved greeting: slow · GoFrame",
+				Description: "Unsaved saved-greeting draft: slow.",
+			},
+		},
+		{
+			name: "saved editor pending",
+			got:  savedGreetingEditorDocumentMetadata("slow", "pending"),
+			want: serverBackedDocumentState{
+				Title:       "Saving greeting: slow · GoFrame",
+				Description: "Saving the greeting slow.",
+			},
+		},
+		{
+			name: "saved editor validation failure",
+			got:  savedGreetingEditorDocumentMetadata("   ", "validation failed"),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting needs attention · GoFrame",
+				Description: "The draft empty has not been committed.",
+			},
+		},
+		{
+			name: "saved editor server failure",
+			got:  savedGreetingEditorDocumentMetadata("fail", "server failed"),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting needs attention · GoFrame",
+				Description: "The draft fail has not been committed.",
+			},
+		},
+		{
+			name: "saved editor confirmed",
+			got:  savedGreetingEditorDocumentMetadata("Grace", "success"),
+			want: serverBackedDocumentState{
+				Title:       "Saved greeting confirmed: Grace · GoFrame",
+				Description: "The server confirmed Grace; finish editing to reveal committed metadata.",
+			},
+		},
+		{
+			name: "not found",
+			got:  notFoundDocumentMetadata(),
+			want: serverBackedDocumentState{
+				Title:       "Not found · GoFrame",
+				Description: "No server-backed route matched.",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got != test.want {
+				t.Fatalf("metadata = %#v, want %#v", test.got, test.want)
+			}
+		})
+	}
+}
+
+func TestDocumentStateIntegratedSavedEditorReveal(t *testing.T) {
+	coordinator := newServerBackedDocumentCoordinator(serverBackedDocumentState{
+		Title:       "authored",
+		Description: "baseline",
+	})
+	mustSetDocumentOwner(
+		t,
+		coordinator,
+		"route",
+		savedGreetingDocumentMetadata("ready", "GoFrame"),
+	)
+	mustSetDocumentOwner(
+		t,
+		coordinator,
+		"saved-editor",
+		savedGreetingEditorDocumentMetadata("Grace", "pending"),
+	)
+	mustSetDocumentOwner(
+		t,
+		coordinator,
+		"route",
+		savedGreetingDocumentMetadata("ready", "Grace"),
+	)
+	snapshot := mustRemoveDocumentOwner(t, coordinator, "saved-editor")
+
+	assertDocumentSnapshot(t, snapshot, serverBackedDocumentSnapshot{
+		State:       savedGreetingDocumentMetadata("ready", "Grace"),
+		ActiveOwner: "route",
+		OwnerCount:  1,
+	})
+}
+
+func mustSetDocumentOwner(
+	t *testing.T,
+	coordinator *serverBackedDocumentCoordinator,
+	owner string,
+	state serverBackedDocumentState,
+) serverBackedDocumentSnapshot {
+	t.Helper()
+	snapshot, _, err := coordinator.Set(owner, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func mustRemoveDocumentOwner(
+	t *testing.T,
+	coordinator *serverBackedDocumentCoordinator,
+	owner string,
+) serverBackedDocumentSnapshot {
+	t.Helper()
+	snapshot, _, err := coordinator.Remove(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func assertDocumentSnapshot(
+	t *testing.T,
+	got serverBackedDocumentSnapshot,
+	want serverBackedDocumentSnapshot,
+) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("document snapshot = %#v, want %#v", got, want)
+	}
+}

--- a/examples/server-backed/cmd/app/main.go
+++ b/examples/server-backed/cmd/app/main.go
@@ -5,7 +5,17 @@ package main
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
 func main() {
+	adapter, err := newBrowserDocumentAdapter()
+	if err != nil {
+		panic("server-backed document state: " + err.Error())
+	}
+	coordinator := newServerBackedDocumentCoordinator(adapter.Baseline())
 	done := make(chan struct{})
-	gf.Mount("root", App)
+	gf.Mount("root", func() gf.Node {
+		return App(AppProps{
+			Adapter:     adapter,
+			Coordinator: coordinator,
+		})
+	})
 	<-done
 }

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -42,6 +42,7 @@ const savedGreetingTarget = "/saved-greeting";
 const savedGreetingHash = `#${savedGreetingTarget}`;
 const savedInitialName = "GoFrame";
 const savedSlowName = "slow";
+const savedEditedDraftName = "Mia";
 const savedFailureName = "fail";
 const savedRecoveryName = "Grace";
 const savedFailureMessage = "controlled saved greeting failure";
@@ -900,8 +901,48 @@ try {
     const slowMutationBaseline = await evidenceState(client);
     await startScenario(client, "saved-slow-duplicate");
     await dispatchSavedGreetingSubmit(client);
-    await waitForSavedMutationPending(client, savedInitialName, "saved greeting slow mutation pending");
+    await waitForSavedMutationPending(
+        client,
+        savedInitialName,
+        savedSlowName,
+        "saved greeting slow mutation pending",
+    );
     await waitForMutationPostCount(client, slowMutationBaseline.mutationPostsStarted + 1, "saved greeting slow POST start");
+    const slowMutationRequest = await waitForActiveSavedMutationRequest(
+        client,
+        slowMutationBaseline.mutationPostsStarted + 1,
+        "saved greeting slow POST remains active",
+    );
+    await changeSavedGreetingDraftDuringMutation(
+        client,
+        savedEditedDraftName,
+        savedSlowName,
+    );
+    const pendingAttribution = await captureSavedMutationAttribution(
+        client,
+        "slow-pending-after-draft-change",
+        slowMutationRequest.id,
+    );
+    assertState(pendingAttribution, {
+        draft: savedEditedDraftName,
+        submitted: savedSlowName,
+        confirmed: "",
+        mutationStatus: "pending",
+        committedValue: savedInitialName,
+        activeMutationRequests: 1,
+        title: savedEditorDocumentState(
+            savedEditedDraftName,
+            "pending",
+            { submitted: savedSlowName },
+        ).title,
+        description: savedEditorDocumentState(
+            savedEditedDraftName,
+            "pending",
+            { submitted: savedSlowName },
+        ).description,
+        targetMismatch: false,
+        falseConfirmation: false,
+    }, "saved greeting pending mutation attribution");
     await dispatchSavedGreetingSubmit(client);
     await waitForDuplicateSubmitCount(client, slowMutationBaseline.duplicateSubmitAttempts + 1, "saved greeting duplicate submit attempt");
     await wait(100);
@@ -910,6 +951,37 @@ try {
         activeMutationRequests: 1,
     }, "saved greeting duplicate POST suppression");
     await waitForSavedCommitted(client, savedSlowName, "saved greeting slow committed state");
+    const confirmedAttribution = await captureSavedMutationAttribution(
+        client,
+        "slow-success-after-draft-change",
+        slowMutationRequest.id,
+    );
+    assertState(confirmedAttribution, {
+        draft: savedEditedDraftName,
+        submitted: savedSlowName,
+        confirmed: savedSlowName,
+        mutationStatus: "success",
+        committedValue: savedSlowName,
+        activeMutationRequests: 0,
+        title: savedEditorDocumentState(
+            savedEditedDraftName,
+            "success",
+            {
+                submitted: savedSlowName,
+                confirmed: savedSlowName,
+            },
+        ).title,
+        description: savedEditorDocumentState(
+            savedEditedDraftName,
+            "success",
+            {
+                submitted: savedSlowName,
+                confirmed: savedSlowName,
+            },
+        ).description,
+        targetMismatch: false,
+        falseConfirmation: false,
+    }, "saved greeting confirmed mutation attribution");
     const slowMutationReport = await finishScenario(client, "saved-slow-duplicate");
     assertSavedGreetingReport(slowMutationReport, "saved greeting slow mutation", {
         routeChanges: 0,
@@ -925,12 +997,20 @@ try {
     assertState(await appState(client), {
         savedReadStatus: "ready",
         savedCommitted: savedSlowName,
+        savedInput: savedEditedDraftName,
         mutationStatus: "success",
         mutationError: "",
         mutationErrorNonEmpty: false,
         mutationPending: false,
         mutationSubmitDisabled: false,
     }, "server-backed saved greeting slow success");
+    assertRequest(await savedRequestEvidence(client, slowMutationRequest.id), {
+        method: "POST",
+        name: savedSlowName,
+        confirmed: savedSlowName,
+        outcome: "success",
+        aborted: false,
+    }, "saved greeting slow mutation request attribution");
     await dispatchSavedGreetingFinishEditing(client);
     await assertDocumentState(
         client,
@@ -942,8 +1022,18 @@ try {
     await prepareSavedGreetingName(client, savedFailureName);
     await startScenario(client, "saved-controlled-failure");
     await dispatchSavedGreetingSubmit(client);
-    await waitForSavedMutationPending(client, savedSlowName, "saved greeting controlled failure pending");
-    await waitForSavedMutationFailure(client, savedSlowName, "saved greeting controlled server failure");
+    await waitForSavedMutationPending(
+        client,
+        savedSlowName,
+        savedFailureName,
+        "saved greeting controlled failure pending",
+    );
+    await waitForSavedMutationFailure(
+        client,
+        savedSlowName,
+        savedFailureName,
+        "saved greeting controlled server failure",
+    );
     const savedFailureReport = await finishScenario(client, "saved-controlled-failure");
     assertSavedGreetingReport(savedFailureReport, "saved greeting controlled failure", {
         routeChanges: 0,
@@ -964,7 +1054,12 @@ try {
     await prepareSavedGreetingName(client, savedRecoveryName);
     await startScenario(client, "saved-recovery");
     await dispatchSavedGreetingSubmit(client);
-    await waitForSavedMutationPending(client, savedSlowName, "saved greeting recovery pending");
+    await waitForSavedMutationPending(
+        client,
+        savedSlowName,
+        savedRecoveryName,
+        "saved greeting recovery pending",
+    );
     await waitForSavedCommitted(client, savedRecoveryName, "saved greeting recovery committed state");
     const savedRecoveryReport = await finishScenario(client, "saved-recovery");
     assertSavedGreetingReport(savedRecoveryReport, "saved greeting recovery", {
@@ -999,7 +1094,12 @@ try {
     const savedUnmountBaseline = await evidenceState(client);
     await startScenario(client, "saved-unmount-cancellation");
     await dispatchSavedGreetingSubmit(client);
-    await waitForSavedMutationPending(client, savedRecoveryName, "saved greeting unmount mutation pending");
+    await waitForSavedMutationPending(
+        client,
+        savedRecoveryName,
+        savedSlowName,
+        "saved greeting unmount mutation pending",
+    );
     const unmountedMutationRequest = await waitForActiveSavedMutationRequest(
         client,
         savedUnmountBaseline.mutationPostsStarted + 1,
@@ -1117,6 +1217,8 @@ try {
         activeMutationRequests: 0,
         duplicateSubmitAttempts: 1,
         staleCommittedValueAppearances: 0,
+        savedMutationTargetMismatches: 0,
+        savedFalseConfirmationAppearances: 0,
         transitionRequestsStarted: 10,
         transitionSuccessfulCompletions: 6,
         transitionFailedCompletions: 2,
@@ -1178,6 +1280,14 @@ try {
         "success",
         "aborted",
     ], "saved greeting POST outcomes");
+    assertSavedMutationAttributionArray(
+        finalEvidence.savedMutationAttributionObserved,
+        [
+            pendingAttribution,
+            confirmedAttribution,
+        ],
+        "saved greeting mutation attribution observations",
+    );
     assertState(finalEvidence.document, {
         invalidPairs: 0,
         duplicateDescriptionObservations: 0,
@@ -1354,21 +1464,36 @@ function savedReadyDocumentState(value) {
     };
 }
 
-function savedEditorDocumentState(draft, status) {
-    const name = draft.trim() || "empty";
+function savedEditorDocumentState(draft, status, target = {}) {
+    let name = draft.trim() || "empty";
     if (status === "pending") {
+        name = target.submitted?.trim() || "empty";
         return {
             title: `Saving greeting: ${name} · GoFrame`,
             description: `Saving the greeting ${name}.`,
         };
     }
-    if (status === "validation failed" || status === "server failed") {
+    if (status === "validation failed") {
+        return {
+            title: "Saved greeting needs attention · GoFrame",
+            description: `The draft ${name} has not been committed.`,
+        };
+    }
+    if (status === "server failed") {
+        name = target.submitted?.trim() || "empty";
         return {
             title: "Saved greeting needs attention · GoFrame",
             description: `The draft ${name} has not been committed.`,
         };
     }
     if (status === "success") {
+        name = target.confirmed?.trim() || "empty";
+        if (name === "empty") {
+            return {
+                title: "Saved greeting needs attention · GoFrame",
+                description: "The server did not confirm a saved greeting.",
+            };
+        }
         return {
             title: `Saved greeting confirmed: ${name} · GoFrame`,
             description: `The server confirmed ${name}; finish editing to reveal committed metadata.`,
@@ -1568,6 +1693,78 @@ async function prepareSavedGreetingName(client, name) {
     }
     const report = { name, owner: baseline.owner, baseline, updated, settled };
     console.log(`server-backed saved input preparation: ${JSON.stringify(report)}`);
+    return report;
+}
+
+async function changeSavedGreetingDraftDuringMutation(client, draft, submitted) {
+    const evidenceBefore = await evidenceState(client);
+    const baseline = await client.callFunction(`function(draft) {
+        const input = document.querySelector("[data-testid='saved-greeting-input']");
+        if (!input) {
+            return { ok: false, reason: "missing saved greeting input" };
+        }
+        const owner = "SavedGreetingRoute";
+        const renders = window.goframeComponentRenderCounts?.[owner] || 0;
+        const patches = window.goframeComponentPatchCounts?.[owner] || 0;
+        input.value = draft;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        return { ok: true, owner, renders, patches, value: input.value };
+    }`, draft);
+    if (!baseline?.ok) {
+        throw new Error(
+            `APP FAILURE: could not change pending saved greeting draft: ${JSON.stringify(baseline)}`,
+        );
+    }
+
+    let updated = null;
+    await waitForCondition(async () => {
+        updated = await appState(client);
+        const activity = await savedInputPreparationState(client);
+        const evidence = await evidenceState(client);
+        return updated.savedInput === draft &&
+            updated.mutationStatus === "pending" &&
+            updated.mutationPending &&
+            updated.mutationSubmitDisabled &&
+            activity.renders > baseline.renders &&
+            activity.patches > baseline.patches &&
+            evidence.mutationPostsStarted === evidenceBefore.mutationPostsStarted &&
+            evidence.activeMutationRequests === 1;
+    }, `pending saved greeting draft ${draft} framework update`);
+
+    await assertDocumentState(
+        client,
+        "saved-editor",
+        savedEditorDocumentState(
+            draft,
+            "pending",
+            { submitted },
+        ),
+        `pending saved greeting draft ${draft} document state`,
+    );
+    await waitForDocumentStateToSettle(
+        client,
+        `pending saved greeting draft ${draft}`,
+    );
+
+    const evidenceAfter = await evidenceState(client);
+    assertEvidence(evidenceAfter, {
+        mutationPostsStarted: evidenceBefore.mutationPostsStarted,
+        activeMutationRequests: 1,
+        savedGetsStarted: evidenceBefore.savedGetsStarted,
+        successfulMutationReloadGets:
+            evidenceBefore.successfulMutationReloadGets,
+        duplicateSubmitAttempts: evidenceBefore.duplicateSubmitAttempts,
+    }, "pending saved greeting draft request ownership");
+
+    const report = {
+        draft,
+        submitted,
+        baseline,
+        updated,
+        mutationPostsStarted: evidenceAfter.mutationPostsStarted,
+        activeMutationRequests: evidenceAfter.activeMutationRequests,
+    };
+    console.log(`server-backed pending saved draft change: ${JSON.stringify(report)}`);
     return report;
 }
 
@@ -1991,7 +2188,14 @@ async function waitForSavedCommitted(client, expected, label) {
         await assertDocumentState(
             client,
             "saved-editor",
-            savedEditorDocumentState(state.savedInput, state.mutationStatus),
+            savedEditorDocumentState(
+                state.savedInput,
+                state.mutationStatus,
+                {
+                    submitted: expected,
+                    confirmed: expected,
+                },
+            ),
             `${label} editor document state`,
         );
         return;
@@ -2021,7 +2225,7 @@ async function waitForSavedValidationFailure(client, committed, label) {
     );
 }
 
-async function waitForSavedMutationPending(client, committed, label) {
+async function waitForSavedMutationPending(client, committed, submitted, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
         return state.savedCommitted === committed &&
@@ -2035,12 +2239,16 @@ async function waitForSavedMutationPending(client, committed, label) {
     await assertDocumentState(
         client,
         "saved-editor",
-        savedEditorDocumentState(state.savedInput, "pending"),
+        savedEditorDocumentState(
+            state.savedInput,
+            "pending",
+            { submitted },
+        ),
         `${label} document state`,
     );
 }
 
-async function waitForSavedMutationFailure(client, committed, label) {
+async function waitForSavedMutationFailure(client, committed, submitted, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
         return state.savedCommitted === committed &&
@@ -2054,7 +2262,11 @@ async function waitForSavedMutationFailure(client, committed, label) {
     await assertDocumentState(
         client,
         "saved-editor",
-        savedEditorDocumentState(state.savedInput, "server failed"),
+        savedEditorDocumentState(
+            state.savedInput,
+            "server failed",
+            { submitted },
+        ),
         `${label} document state`,
     );
 }
@@ -2230,6 +2442,25 @@ async function savedRequestEvidence(client, requestID) {
     return await client.callFunction(`function(requestID) {
         return window.__serverBackedEvidence?.savedRequest(requestID) ?? null;
     }`, requestID);
+}
+
+async function captureSavedMutationAttribution(client, phase, requestID) {
+    const observation = await client.callFunction(
+        `function(phase, requestID) {
+            return window.__serverBackedEvidence?.captureSavedMutationAttribution(
+                phase,
+                requestID,
+            ) ?? null;
+        }`,
+        phase,
+        requestID,
+    );
+    if (!observation) {
+        throw new Error(
+            `APP FAILURE: could not capture saved mutation attribution for ${phase}`,
+        );
+    }
+    return observation;
 }
 
 async function startScenario(client, label) {
@@ -2514,6 +2745,15 @@ function assertCommittedPairArray(actual, expected, label) {
     console.log(`${label}: ok`);
 }
 
+function assertSavedMutationAttributionArray(actual, expected, label) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(
+            `APP FAILURE: ${label}: got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`,
+        );
+    }
+    console.log(`${label}: ok`);
+}
+
 function emptyOperations() {
     return {
         createElement: 0,
@@ -2594,6 +2834,9 @@ function installServerBackedEvidenceExpression() {
     let activeMutationRequests = 0;
     let duplicateSubmitAttempts = 0;
     let staleCommittedValueAppearances = 0;
+    let savedMutationTargetMismatches = 0;
+    let savedFalseConfirmationAppearances = 0;
+    const savedMutationAttributionObserved = [];
     const documentSnapshots = [];
     const selectedDocumentPairs = new Set();
     let authoredHead = null;
@@ -2765,6 +3008,9 @@ function installServerBackedEvidenceExpression() {
             const request = savedRequests.find((entry) => entry.id === id);
             return request ? { ...request } : null;
         },
+        captureSavedMutationAttribution(phase, requestID) {
+            return captureSavedMutationAttribution(phase, requestID);
+        },
         documentState() {
             return documentEvidenceState();
         },
@@ -2810,6 +3056,10 @@ function installServerBackedEvidenceExpression() {
                 activeMutationRequests,
                 duplicateSubmitAttempts,
                 staleCommittedValueAppearances,
+                savedMutationTargetMismatches,
+                savedFalseConfirmationAppearances,
+                savedMutationAttributionObserved:
+                    savedMutationAttributionObserved.map((entry) => ({ ...entry })),
                 committedValuesObserved: [...committedValuesObserved],
                 appIdentityChanges: this.identityChanged.app ? 1 : 0,
                 shellIdentityChanges: this.identityChanged.shell ? 1 : 0,
@@ -2923,6 +3173,7 @@ function installServerBackedEvidenceExpression() {
             target: requestURL.pathname + requestURL.search,
             outcome: "pending",
             aborted: false,
+            confirmed: "",
         };
         savedRequests.push(request);
         if (method === "GET") {
@@ -2965,11 +3216,17 @@ function installServerBackedEvidenceExpression() {
             }, { once: true });
         }
         return originalFetch(input, init).then((response) => {
-            return new Promise((resolve) => {
-                window.setTimeout(() => {
-                    if (!request.aborted) finish(response.ok ? "success" : "failed");
-                    resolve(response);
-                }, method === "POST" && name === ${JSON.stringify(savedSlowName)} ? 0 : 140);
+            const confirmed = method === "POST" && response.ok
+                ? response.clone().text()
+                : Promise.resolve("");
+            return confirmed.then((text) => {
+                request.confirmed = text.trim();
+                return new Promise((resolve) => {
+                    window.setTimeout(() => {
+                        if (!request.aborted) finish(response.ok ? "success" : "failed");
+                        resolve(response);
+                    }, method === "POST" && name === ${JSON.stringify(savedSlowName)} ? 0 : 140);
+                });
             });
         }, (error) => {
             if (signal?.aborted) {
@@ -3315,6 +3572,78 @@ function installServerBackedEvidenceExpression() {
             descriptionCount: descriptions.length,
         };
         return true;
+    }
+
+    function captureSavedMutationAttribution(phase, requestID) {
+        const request = savedRequests.find((entry) =>
+            entry.id === requestID &&
+            entry.method === "POST",
+        );
+        if (!request) return null;
+
+        const draft = document.querySelector(
+            "[data-testid='saved-greeting-input']",
+        )?.value || "";
+        const mutationStatus = document.querySelector(
+            "[data-testid='saved-greeting-mutation-status']",
+        )?.textContent.trim() || "";
+        const committedValue = document.querySelector(
+            "[data-testid='saved-greeting-committed']",
+        )?.textContent.trim() || "";
+        const owner = document.querySelector(
+            "[data-testid='server-backed-document-owner']",
+        )?.textContent.trim() || "";
+        const title = document.title;
+        const description = document.querySelector(
+            "head meta[name='description']",
+        )?.getAttribute("content") || "";
+
+        let expectedTitle = "";
+        let expectedDescription = "";
+        if (mutationStatus === "pending") {
+            expectedTitle =
+                "Saving greeting: " + request.name + " · GoFrame";
+            expectedDescription =
+                "Saving the greeting " + request.name + ".";
+        } else if (mutationStatus === "success") {
+            expectedTitle =
+                "Saved greeting confirmed: " + request.confirmed + " · GoFrame";
+            expectedDescription =
+                "The server confirmed " + request.confirmed +
+                "; finish editing to reveal committed metadata.";
+        }
+
+        const pairMatches = owner === "saved-editor" &&
+            expectedTitle !== "" &&
+            title === expectedTitle &&
+            description === expectedDescription;
+        const targetMismatch = mutationStatus === "pending" &&
+            (request.outcome !== "pending" || !pairMatches);
+        const falseConfirmation = mutationStatus === "success" &&
+            (request.outcome !== "success" ||
+                request.confirmed === "" ||
+                !pairMatches);
+        if (targetMismatch) savedMutationTargetMismatches++;
+        if (falseConfirmation) savedFalseConfirmationAppearances++;
+
+        const observation = {
+            phase,
+            requestID,
+            draft,
+            submitted: request.name,
+            confirmed: request.confirmed,
+            requestOutcome: request.outcome,
+            mutationStatus,
+            committedValue,
+            activeMutationRequests,
+            owner,
+            title,
+            description,
+            targetMismatch,
+            falseConfirmation,
+        };
+        savedMutationAttributionObserved.push(observation);
+        return { ...observation };
     }
 
     function captureDocumentSnapshot(phase) {

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -1487,16 +1487,16 @@ function savedEditorDocumentState(draft, status, target = {}) {
         };
     }
     if (status === "success") {
-        name = target.confirmed?.trim() || "empty";
-        if (name === "empty") {
+        const confirmed = target.confirmed?.trim() ?? "";
+        if (confirmed === "") {
             return {
                 title: "Saved greeting needs attention · GoFrame",
                 description: "The server did not confirm a saved greeting.",
             };
         }
         return {
-            title: `Saved greeting confirmed: ${name} · GoFrame`,
-            description: `The server confirmed ${name}; finish editing to reveal committed metadata.`,
+            title: `Saved greeting confirmed: ${confirmed} · GoFrame`,
+            description: `The server confirmed ${confirmed}; finish editing to reveal committed metadata.`,
         };
     }
     return {

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -879,9 +879,55 @@ try {
     }, "server-backed saved greeting initial state");
 
     await prepareSavedGreetingName(client, "   ");
+    await dispatchSavedGreetingFinishEditing(client);
+    await assertDocumentState(
+        client,
+        "route",
+        savedReadyDocumentState(savedInitialName),
+        "saved greeting validation owner released before submit",
+    );
+    const validationOwnershipBeforeSubmit = await captureSavedSubmitOwnership(
+        client,
+        "validation-before-submit",
+    );
+    const initialSavedDocument = savedReadyDocumentState(savedInitialName);
+    assertState(validationOwnershipBeforeSubmit, {
+        draft: "   ",
+        mutationStatus: "idle",
+        activeOwner: "route",
+        expectedTitle: initialSavedDocument.title,
+        actualTitle: initialSavedDocument.title,
+        expectedDescription: initialSavedDocument.description,
+        actualDescription: initialSavedDocument.description,
+        submittedRequestTarget: "",
+        activeRequestCount: 0,
+    }, "saved greeting validation ownership before submit");
     await startScenario(client, "saved-client-validation");
     await dispatchSavedGreetingSubmit(client);
     await waitForSavedValidationFailure(client, savedInitialName, "saved greeting client validation");
+    const validationOwnershipAfterSubmit = await captureSavedSubmitOwnership(
+        client,
+        "validation-after-submit",
+        validationOwnershipBeforeSubmit,
+    );
+    const validationDocument = savedEditorDocumentState(
+        "   ",
+        "validation failed",
+    );
+    assertState(validationOwnershipAfterSubmit, {
+        draft: "   ",
+        mutationStatus: "validation failed",
+        activeOwner: "saved-editor",
+        expectedTitle: validationDocument.title,
+        actualTitle: validationDocument.title,
+        expectedDescription: validationDocument.description,
+        actualDescription: validationDocument.description,
+        submittedRequestTarget: "",
+        activeRequestCount: 0,
+        postDelta: 0,
+        getDelta: 0,
+        inputEventDelta: 0,
+    }, "saved greeting validation ownership after submit");
     const validationReport = await finishScenario(client, "saved-client-validation");
     assertSavedGreetingReport(validationReport, "saved greeting client validation", {
         routeChanges: 0,
@@ -898,6 +944,28 @@ try {
     }, "server-backed saved greeting validation state");
 
     await prepareSavedGreetingName(client, savedSlowName);
+    await dispatchSavedGreetingFinishEditing(client);
+    await assertDocumentState(
+        client,
+        "route",
+        savedReadyDocumentState(savedInitialName),
+        "saved greeting slow owner released before submit",
+    );
+    const slowOwnershipBeforeSubmit = await captureSavedSubmitOwnership(
+        client,
+        "slow-before-submit",
+    );
+    assertState(slowOwnershipBeforeSubmit, {
+        draft: savedSlowName,
+        mutationStatus: "idle",
+        activeOwner: "route",
+        expectedTitle: initialSavedDocument.title,
+        actualTitle: initialSavedDocument.title,
+        expectedDescription: initialSavedDocument.description,
+        actualDescription: initialSavedDocument.description,
+        submittedRequestTarget: "",
+        activeRequestCount: 0,
+    }, "saved greeting slow ownership before submit");
     const slowMutationBaseline = await evidenceState(client);
     await startScenario(client, "saved-slow-duplicate");
     await dispatchSavedGreetingSubmit(client);
@@ -907,6 +975,30 @@ try {
         savedSlowName,
         "saved greeting slow mutation pending",
     );
+    const slowOwnershipDuringPending = await captureSavedSubmitOwnership(
+        client,
+        "slow-during-pending",
+        slowOwnershipBeforeSubmit,
+    );
+    const slowPendingDocument = savedEditorDocumentState(
+        savedSlowName,
+        "pending",
+        { submitted: savedSlowName },
+    );
+    assertState(slowOwnershipDuringPending, {
+        draft: savedSlowName,
+        mutationStatus: "pending",
+        activeOwner: "saved-editor",
+        expectedTitle: slowPendingDocument.title,
+        actualTitle: slowPendingDocument.title,
+        expectedDescription: slowPendingDocument.description,
+        actualDescription: slowPendingDocument.description,
+        submittedRequestTarget: savedSlowName,
+        activeRequestCount: 1,
+        postDelta: 1,
+        getDelta: 0,
+        inputEventDelta: 0,
+    }, "saved greeting slow ownership during pending");
     await waitForMutationPostCount(client, slowMutationBaseline.mutationPostsStarted + 1, "saved greeting slow POST start");
     const slowMutationRequest = await waitForActiveSavedMutationRequest(
         client,
@@ -1219,6 +1311,7 @@ try {
         staleCommittedValueAppearances: 0,
         savedMutationTargetMismatches: 0,
         savedFalseConfirmationAppearances: 0,
+        savedInputEvents: 6,
         transitionRequestsStarted: 10,
         transitionSuccessfulCompletions: 6,
         transitionFailedCompletions: 2,
@@ -1299,8 +1392,8 @@ try {
         baselineRestorations: 1,
         scopeUnmounts: 1,
         scopeRemounts: 1,
-        savedEditorActivations: 3,
-        savedEditorReleases: 3,
+        savedEditorActivations: 5,
+        savedEditorReleases: 5,
         titleIdentityStable: true,
         descriptionIdentityStable: true,
         viewportIdentityStable: true,
@@ -2463,6 +2556,47 @@ async function captureSavedMutationAttribution(client, phase, requestID) {
     return observation;
 }
 
+async function captureSavedSubmitOwnership(client, phase, baseline = null) {
+    const state = await appState(client);
+    const evidence = await evidenceState(client);
+    const savedRequestCount = evidence.savedRequests.length;
+    const newRequests = baseline
+        ? evidence.savedRequests.slice(baseline.savedRequestCount)
+        : [];
+    const submittedRequest = [...newRequests].reverse().find(
+        (request) => request.method === "POST",
+    );
+    const observation = {
+        phase,
+        draft: state.savedInput,
+        mutationStatus: state.mutationStatus,
+        activeOwner: state.documentOwner,
+        expectedTitle: state.documentExpectedTitle,
+        actualTitle: state.documentTitle,
+        expectedDescription: state.documentExpectedDescription,
+        actualDescription: state.documentDescription,
+        submittedRequestTarget: submittedRequest?.name ?? "",
+        activeRequestCount: evidence.activeMutationRequests,
+        savedRequestCount,
+        mutationPostsStarted: evidence.mutationPostsStarted,
+        savedGetsStarted: evidence.savedGetsStarted,
+        savedInputEvents: evidence.savedInputEvents,
+        postDelta: baseline
+            ? evidence.mutationPostsStarted - baseline.mutationPostsStarted
+            : 0,
+        getDelta: baseline
+            ? evidence.savedGetsStarted - baseline.savedGetsStarted
+            : 0,
+        inputEventDelta: baseline
+            ? evidence.savedInputEvents - baseline.savedInputEvents
+            : 0,
+    };
+    console.log(
+        `server-backed saved submit ownership: ${JSON.stringify(observation)}`,
+    );
+    return observation;
+}
+
 async function startScenario(client, label) {
     const started = await client.callFunction(`function(label) {
         return window.__serverBackedAudit?.start(label) ?? false;
@@ -2836,6 +2970,7 @@ function installServerBackedEvidenceExpression() {
     let staleCommittedValueAppearances = 0;
     let savedMutationTargetMismatches = 0;
     let savedFalseConfirmationAppearances = 0;
+    let savedInputEvents = 0;
     const savedMutationAttributionObserved = [];
     const documentSnapshots = [];
     const selectedDocumentPairs = new Set();
@@ -3058,6 +3193,7 @@ function installServerBackedEvidenceExpression() {
                 staleCommittedValueAppearances,
                 savedMutationTargetMismatches,
                 savedFalseConfirmationAppearances,
+                savedInputEvents,
                 savedMutationAttributionObserved:
                     savedMutationAttributionObserved.map((entry) => ({ ...entry })),
                 committedValuesObserved: [...committedValuesObserved],
@@ -3082,6 +3218,11 @@ function installServerBackedEvidenceExpression() {
         if (event.target?.matches?.("[data-testid='saved-greeting-form']") &&
             activeMutationRequests > 0) {
             duplicateSubmitAttempts++;
+        }
+    }, true);
+    document.addEventListener("input", (event) => {
+        if (event.target?.matches?.("[data-testid='saved-greeting-input']")) {
+            savedInputEvents++;
         }
     }, true);
     document.addEventListener("click", (event) => {

--- a/scripts/server-backed-browser-smoke.mjs
+++ b/scripts/server-backed-browser-smoke.mjs
@@ -45,6 +45,11 @@ const savedSlowName = "slow";
 const savedFailureName = "fail";
 const savedRecoveryName = "Grace";
 const savedFailureMessage = "controlled saved greeting failure";
+const authoredDocumentState = {
+    title: "GoFrame Server-Backed Example",
+    description: "GoFrame server-backed application reference.",
+};
+const authoredViewportContent = "width=device-width, initial-scale=1";
 const componentNames = [
     "App",
     "ServerBackedShell",
@@ -121,6 +126,7 @@ try {
     await navigateToApp(client, appURL);
     await waitForAppPage(client, expectedApp);
     await initializeBrowserEvidence(client);
+    await assertPreBootDocumentEvidence(client);
 
     assertState(await appState(client), {
         app: true,
@@ -141,6 +147,12 @@ try {
         shellSame: true,
         routeContentSame: true,
     }, "server-backed initial route");
+    await assertDocumentState(
+        client,
+        "route",
+        homeDocumentState(),
+        "server-backed initial Home document state",
+    );
     assertEvidence(await evidenceState(client), {
         fetchesStarted: 0,
         aborts: 0,
@@ -149,6 +161,39 @@ try {
         shellIdentityChanges: 0,
         routeContentIdentityChanges: 0,
     }, "initial route evidence");
+
+    const documentScopeIdentity = await documentScopeIdentityState(client);
+    await clickDocumentScopeControl(client, "server-backed-document-scope-unmount");
+    await assertDocumentState(
+        client,
+        "authored-baseline",
+        authoredDocumentState,
+        "server-backed authored document baseline after scope unmount",
+    );
+    assertState(await documentScopeIdentityState(client), {
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+        scopeInactive: true,
+    }, "server-backed document scope unmount identity");
+    await clickDocumentScopeControl(client, "server-backed-document-scope-remount");
+    await assertDocumentState(
+        client,
+        "route",
+        homeDocumentState(),
+        "server-backed Home document state after scope remount",
+    );
+    assertState(await documentScopeIdentityState(client), {
+        appSame: true,
+        shellSame: true,
+        routeContentSame: true,
+        scopeInactive: false,
+    }, "server-backed document scope remount identity");
+    if (!documentScopeIdentity.app ||
+        !documentScopeIdentity.shell ||
+        !documentScopeIdentity.routeContent) {
+        throw new Error(`APP FAILURE: document scope identity baseline is incomplete: ${JSON.stringify(documentScopeIdentity)}`);
+    }
 
     await startScenario(client, "direct-hash-navigation");
     await navigateGreetingHash(client, directName);
@@ -886,6 +931,13 @@ try {
         mutationPending: false,
         mutationSubmitDisabled: false,
     }, "server-backed saved greeting slow success");
+    await dispatchSavedGreetingFinishEditing(client);
+    await assertDocumentState(
+        client,
+        "route",
+        savedReadyDocumentState(savedSlowName),
+        "server-backed saved greeting slow route revealed after editor release",
+    );
 
     await prepareSavedGreetingName(client, savedFailureName);
     await startScenario(client, "saved-controlled-failure");
@@ -934,6 +986,13 @@ try {
         mutationPending: false,
         mutationSubmitDisabled: false,
     }, "server-backed saved greeting recovery state");
+    await dispatchSavedGreetingFinishEditing(client);
+    await assertDocumentState(
+        client,
+        "route",
+        savedReadyDocumentState(savedRecoveryName),
+        "server-backed saved greeting recovery route revealed after editor release",
+    );
     await assertSavedGreetingAPI(savedRecoveryName);
 
     await prepareSavedGreetingName(client, savedSlowName);
@@ -1119,7 +1178,52 @@ try {
         "success",
         "aborted",
     ], "saved greeting POST outcomes");
+    assertState(finalEvidence.document, {
+        invalidPairs: 0,
+        duplicateDescriptionObservations: 0,
+        viewportMutations: 0,
+        titleNodeReplacements: 0,
+        descriptionNodeReplacements: 0,
+        transitionRequestedMetadataAppearances: 0,
+        staleMetadataAppearances: 0,
+        baselineRestorations: 1,
+        scopeUnmounts: 1,
+        scopeRemounts: 1,
+        savedEditorActivations: 3,
+        savedEditorReleases: 3,
+        titleIdentityStable: true,
+        descriptionIdentityStable: true,
+        viewportIdentityStable: true,
+    }, "final document state evidence");
+    if (finalEvidence.document.titleMutationBatches < 1 ||
+        finalEvidence.document.descriptionMutationBatches < 1 ||
+        finalEvidence.document.headSnapshots < 1) {
+        throw new Error(
+            `APP FAILURE: document mutation evidence is incomplete: ${JSON.stringify(finalEvidence.document)}`,
+        );
+    }
     console.log(`server-backed mutation evidence: ${JSON.stringify(finalEvidence)}`);
+    console.log(`server-backed document evidence: ${JSON.stringify({
+        titleMutationBatches: finalEvidence.document.titleMutationBatches,
+        descriptionMutationBatches: finalEvidence.document.descriptionMutationBatches,
+        headSnapshots: finalEvidence.document.headSnapshots,
+        invalidPairs: finalEvidence.document.invalidPairs,
+        duplicateDescriptionObservations:
+            finalEvidence.document.duplicateDescriptionObservations,
+        viewportMutations: finalEvidence.document.viewportMutations,
+        titleNodeReplacements: finalEvidence.document.titleNodeReplacements,
+        descriptionNodeReplacements:
+            finalEvidence.document.descriptionNodeReplacements,
+        transitionRequestedMetadataAppearances:
+            finalEvidence.document.transitionRequestedMetadataAppearances,
+        staleMetadataAppearances:
+            finalEvidence.document.staleMetadataAppearances,
+        baselineRestorations: finalEvidence.document.baselineRestorations,
+        scopeUnmounts: finalEvidence.document.scopeUnmounts,
+        scopeRemounts: finalEvidence.document.scopeRemounts,
+        savedEditorActivations: finalEvidence.document.savedEditorActivations,
+        savedEditorReleases: finalEvidence.document.savedEditorReleases,
+    })}`);
 
     client.close();
     console.log("Server-backed browser smoke: ok");
@@ -1208,10 +1312,171 @@ function transitionPair(name, message) {
     };
 }
 
+function homeDocumentState() {
+    return {
+        title: "Server-backed Home · GoFrame",
+        description: "Choose a route-driven server-backed flow.",
+    };
+}
+
+function greetingDocumentState(name) {
+    return {
+        title: `Greeting ${name} · GoFrame`,
+        description: `Backend greeting route for ${name}.`,
+    };
+}
+
+function transitionPreparingDocumentState(name) {
+    return {
+        title: `Preparing retained greeting for ${name} · GoFrame`,
+        description: `Preparing the first retained greeting for ${name}.`,
+    };
+}
+
+function transitionCommittedDocumentState(name) {
+    return {
+        title: `Retained greeting: ${name} · GoFrame`,
+        description: `Committed retained greeting for ${name}.`,
+    };
+}
+
+function savedLoadingDocumentState() {
+    return {
+        title: "Saved greeting · GoFrame",
+        description: "Loading the committed saved greeting.",
+    };
+}
+
+function savedReadyDocumentState(value) {
+    return {
+        title: `Saved greeting: ${value} · GoFrame`,
+        description: `Committed saved greeting: ${value}.`,
+    };
+}
+
+function savedEditorDocumentState(draft, status) {
+    const name = draft.trim() || "empty";
+    if (status === "pending") {
+        return {
+            title: `Saving greeting: ${name} · GoFrame`,
+            description: `Saving the greeting ${name}.`,
+        };
+    }
+    if (status === "validation failed" || status === "server failed") {
+        return {
+            title: "Saved greeting needs attention · GoFrame",
+            description: `The draft ${name} has not been committed.`,
+        };
+    }
+    if (status === "success") {
+        return {
+            title: `Saved greeting confirmed: ${name} · GoFrame`,
+            description: `The server confirmed ${name}; finish editing to reveal committed metadata.`,
+        };
+    }
+    return {
+        title: `Editing saved greeting: ${name} · GoFrame`,
+        description: `Unsaved saved-greeting draft: ${name}.`,
+    };
+}
+
 async function initializeBrowserEvidence(client) {
     const initialized = await client.evaluate("window.__serverBackedEvidence?.initialize() ?? null");
     if (!initialized?.ready) {
         throw new Error(`APP FAILURE: server-backed evidence did not initialize: ${JSON.stringify(initialized)}`);
+    }
+}
+
+async function assertPreBootDocumentEvidence(client) {
+    const document = (await evidenceState(client)).document;
+    assertState(document, {
+        preBootCaptured: true,
+        authoredTitle: authoredDocumentState.title,
+        authoredDescription: authoredDocumentState.description,
+        authoredDescriptionCount: 1,
+        authoredViewportContent,
+        titleIdentityStable: true,
+        descriptionIdentityStable: true,
+        viewportIdentityStable: true,
+    }, "server-backed pre-boot authored head");
+}
+
+async function assertDocumentState(client, owner, expected, label) {
+    let state = null;
+    await waitForCondition(async () => {
+        state = await appState(client);
+        return state.documentOwner === owner &&
+            state.documentExpectedTitle === expected.title &&
+            state.documentExpectedDescription === expected.description &&
+            state.documentTitle === expected.title &&
+            state.documentDescription === expected.description &&
+            state.documentDescriptionCount === 1 &&
+            state.documentTitleIdentityStable &&
+            state.documentDescriptionIdentityStable &&
+            state.documentViewportIdentityStable &&
+            state.documentViewportContent === authoredViewportContent;
+    }, label);
+    const snapshot = await client.callFunction(`function(phase) {
+        return window.__serverBackedEvidence?.captureDocumentSnapshot(phase) ?? null;
+    }`, `settled:${label}`);
+    if (!snapshot?.valid) {
+        throw new Error(`APP FAILURE: ${label} document snapshot is invalid: ${JSON.stringify(snapshot)}`);
+    }
+    return state;
+}
+
+async function waitForDocumentStateToSettle(client, label) {
+    let state = null;
+    await waitForCondition(async () => {
+        state = await appState(client);
+        const schedulingSettled = await client.evaluate(
+            "window.__serverBackedAudit?.schedulingSettled() ?? false",
+        );
+        return schedulingSettled &&
+            state.documentExpectedTitle !== "" &&
+            state.documentExpectedDescription !== "" &&
+            state.documentTitle === state.documentExpectedTitle &&
+            state.documentDescription === state.documentExpectedDescription &&
+            state.documentDescriptionCount === 1 &&
+            state.documentTitleIdentityStable &&
+            state.documentDescriptionIdentityStable &&
+            state.documentViewportIdentityStable &&
+            state.documentViewportContent === authoredViewportContent;
+    }, `${label} document state settled`);
+    const snapshot = await client.callFunction(`function(phase) {
+        return window.__serverBackedEvidence?.captureDocumentSnapshot(phase) ?? null;
+    }`, `settled:${label}`);
+    if (!snapshot?.valid) {
+        throw new Error(`APP FAILURE: ${label} settled document snapshot is invalid: ${JSON.stringify(snapshot)}`);
+    }
+}
+
+async function documentScopeIdentityState(client) {
+    return await client.callFunction(`function() {
+        const identity = window.__serverBackedEvidence?.checkIdentity() ?? {};
+        return {
+            app: Boolean(document.querySelector("[data-testid='server-backed-app']")),
+            shell: Boolean(document.querySelector("[data-testid='server-backed-shell']")),
+            routeContent: Boolean(document.querySelector("[data-testid='server-backed-route-content']")),
+            appSame: identity.appSame ?? false,
+            shellSame: identity.shellSame ?? false,
+            routeContentSame: identity.routeContentSame ?? false,
+            scopeInactive: Boolean(
+                document.querySelector("[data-testid='server-backed-document-scope-inactive']"),
+            ),
+        };
+    }`);
+}
+
+async function clickDocumentScopeControl(client, testID) {
+    const result = await client.callFunction(`function(testID) {
+        const control = document.querySelector("[data-testid='" + testID + "']");
+        if (!control) return { ok: false, reason: "missing control" };
+        control.click();
+        return { ok: true };
+    }`, testID);
+    if (!result?.ok) {
+        throw new Error(`APP FAILURE: could not use document scope control ${testID}: ${JSON.stringify(result)}`);
     }
 }
 
@@ -1276,14 +1541,24 @@ async function prepareSavedGreetingName(client, name) {
         throw new Error(`APP FAILURE: could not prepare saved greeting input: ${JSON.stringify(baseline)}`);
     }
 
-    let updated = null;
     await waitForCondition(async () => {
-        updated = await savedInputPreparationState(client);
+        const updated = await savedInputPreparationState(client);
         return updated.value === name &&
             updated.renders > baseline.renders &&
             updated.patches > baseline.patches;
     }, `controlled saved greeting input ${name} framework update`);
 
+    await assertDocumentState(
+        client,
+        "saved-editor",
+        savedEditorDocumentState(name, "idle"),
+        `controlled saved greeting input ${name} document state`,
+    );
+    await waitForDocumentStateToSettle(
+        client,
+        `controlled saved greeting input ${name}`,
+    );
+    const updated = await savedInputPreparationState(client);
     await waitForBrowserFrames(client, 2);
     const settled = await savedInputPreparationState(client);
     if (settled.value !== name ||
@@ -1447,6 +1722,22 @@ async function dispatchSavedGreetingSubmit(client) {
     }
 }
 
+async function dispatchSavedGreetingFinishEditing(client) {
+    const result = await client.evaluate(`(() => {
+        const control = document.querySelector(
+            "[data-testid='saved-greeting-finish-editing']",
+        );
+        if (!control) {
+            return { ok: false, reason: "missing finish editing control" };
+        }
+        control.click();
+        return { ok: true };
+    })()`);
+    if (!result?.ok) {
+        throw new Error(`APP FAILURE: could not finish saved greeting editing: ${JSON.stringify(result)}`);
+    }
+}
+
 async function waitForGreeting(client, expected, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
@@ -1463,7 +1754,7 @@ async function waitForFetchCount(client, expected, label) {
 async function waitForLoading(client, name, label) {
     await waitForCondition(async () => {
         const state = await appState(client);
-        return state.route === "greeting" &&
+        const liveLoading = state.route === "greeting" &&
             state.hash === greetingHash(name) &&
             state.routeTarget === greetingTarget(name) &&
             state.key === `/api/greeting?name=${encodeURIComponent(name)}` &&
@@ -1472,7 +1763,19 @@ async function waitForLoading(client, name, label) {
             state.loading &&
             !state.ready &&
             !state.failed;
+        if (liveLoading) {
+            return true;
+        }
+        return await client.callFunction(`function(target) {
+            return window.__serverBackedEvidence?.greetingLoadingObserved(target) ?? false;
+        }`, greetingTarget(name));
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        greetingDocumentState(name),
+        `${label} document state`,
+    );
 }
 
 async function waitForSlowActive(client, label) {
@@ -1486,6 +1789,12 @@ async function waitForSlowActive(client, label) {
             state.loading &&
             request !== null;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        greetingDocumentState(slowName),
+        `${label} document state`,
+    );
     return request;
 }
 
@@ -1515,6 +1824,12 @@ async function waitForTransitionInitialLoading(client, name, label) {
             !state.transitionFailed &&
             !state.transitionCommittedScreen;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        transitionPreparingDocumentState(name),
+        `${label} document state`,
+    );
 }
 
 async function waitForTransitionPending(client, requestedName, committedName, committedMessage, label) {
@@ -1531,6 +1846,12 @@ async function waitForTransitionPending(client, requestedName, committedName, co
             !state.transitionFailed &&
             state.transitionCommittedScreen;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        transitionCommittedDocumentState(committedName),
+        `${label} document state`,
+    );
 }
 
 async function waitForTransitionCommitted(client, name, message, label) {
@@ -1547,6 +1868,12 @@ async function waitForTransitionCommitted(client, name, message, label) {
             !state.transitionFailed &&
             state.transitionCommittedScreen;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        transitionCommittedDocumentState(name),
+        `${label} document state`,
+    );
 }
 
 async function waitForTransitionFailure(client, requestedName, committedName, committedMessage, label) {
@@ -1564,6 +1891,12 @@ async function waitForTransitionFailure(client, requestedName, committedName, co
             state.transitionError === failureMessage &&
             state.transitionCommittedScreen;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        transitionCommittedDocumentState(committedName),
+        `${label} document state`,
+    );
 }
 
 async function waitForTransitionSlowActive(client, committedName, committedMessage, label) {
@@ -1582,6 +1915,12 @@ async function waitForTransitionSlowActive(client, committedName, committedMessa
             evidence.activeTransitionRequests === 1 &&
             request !== null;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        transitionCommittedDocumentState(committedName),
+        `${label} document state`,
+    );
     return request;
 }
 
@@ -1606,6 +1945,14 @@ async function waitForRoute(client, route, target) {
         const state = await appState(client);
         return state.route === route && state.routeTarget === target;
     }, `route ${route} at ${target}`);
+    if (route === "home") {
+        await assertDocumentState(
+            client,
+            "route",
+            homeDocumentState(),
+            `route ${route} at ${target} document state`,
+        );
+    }
 }
 
 async function waitForSavedReadLoading(client, label) {
@@ -1620,11 +1967,18 @@ async function waitForSavedReadLoading(client, label) {
             !state.savedReadReady &&
             !state.savedReadFailed;
     }, label);
+    await assertDocumentState(
+        client,
+        "route",
+        savedLoadingDocumentState(),
+        `${label} document state`,
+    );
 }
 
 async function waitForSavedCommitted(client, expected, label) {
+    let state = null;
     await waitForCondition(async () => {
-        const state = await appState(client);
+        state = await appState(client);
         return state.route === "savedGreeting" &&
             state.savedReadStatus === "ready" &&
             state.savedReadReady &&
@@ -1633,6 +1987,21 @@ async function waitForSavedCommitted(client, expected, label) {
             state.savedCommitted === expected &&
             state.mutationStatus !== "pending";
     }, label);
+    if (state.savedEditorActive) {
+        await assertDocumentState(
+            client,
+            "saved-editor",
+            savedEditorDocumentState(state.savedInput, state.mutationStatus),
+            `${label} editor document state`,
+        );
+        return;
+    }
+    await assertDocumentState(
+        client,
+        "route",
+        savedReadyDocumentState(expected),
+        `${label} route document state`,
+    );
 }
 
 async function waitForSavedValidationFailure(client, committed, label) {
@@ -1644,6 +2013,12 @@ async function waitForSavedValidationFailure(client, committed, label) {
             state.mutationError === "Name is required." &&
             !state.mutationPending;
     }, label);
+    await assertDocumentState(
+        client,
+        "saved-editor",
+        savedEditorDocumentState("   ", "validation failed"),
+        `${label} document state`,
+    );
 }
 
 async function waitForSavedMutationPending(client, committed, label) {
@@ -1656,6 +2031,13 @@ async function waitForSavedMutationPending(client, committed, label) {
             state.mutationSubmitDisabled &&
             !state.mutationErrorNonEmpty;
     }, label);
+    const state = await appState(client);
+    await assertDocumentState(
+        client,
+        "saved-editor",
+        savedEditorDocumentState(state.savedInput, "pending"),
+        `${label} document state`,
+    );
 }
 
 async function waitForSavedMutationFailure(client, committed, label) {
@@ -1668,6 +2050,13 @@ async function waitForSavedMutationFailure(client, committed, label) {
             state.mutationErrorNonEmpty &&
             !state.mutationPending;
     }, label);
+    const state = await appState(client);
+    await assertDocumentState(
+        client,
+        "saved-editor",
+        savedEditorDocumentState(state.savedInput, "server failed"),
+        `${label} document state`,
+    );
 }
 
 async function waitForMutationPostCount(client, expected, label) {
@@ -1744,6 +2133,7 @@ async function appState(client) {
         const mutationError = document.querySelector("[data-testid='saved-greeting-mutation-error']")?.textContent.trim() ?? "";
         const mutationStatus = document.querySelector("[data-testid='saved-greeting-mutation-status']")?.textContent.trim() ?? "";
         const identity = window.__serverBackedEvidence?.checkIdentity() ?? {};
+        const documentEvidence = window.__serverBackedEvidence?.documentState() ?? {};
         return {
             app: Boolean(document.querySelector("[data-testid='server-backed-app']")),
             shell: Boolean(document.querySelector("[data-testid='server-backed-shell']")),
@@ -1794,6 +2184,24 @@ async function appState(client) {
             mutationError,
             mutationErrorNonEmpty: mutationError.length > 0,
             mutationSubmitDisabled: document.querySelector("[data-testid='saved-greeting-submit']")?.disabled ?? false,
+            savedEditorActive: Boolean(document.querySelector("[data-testid='saved-greeting-editor-state']")),
+            documentOwner: document.querySelector("[data-testid='server-backed-document-owner']")?.textContent.trim() ?? "",
+            documentOwnerCount:
+                Number(document.querySelector("[data-testid='server-backed-document-owner-count']")?.textContent.trim() ?? 0),
+            documentExpectedTitle:
+                document.querySelector("[data-testid='server-backed-document-title']")?.textContent.trim() ?? "",
+            documentExpectedDescription:
+                document.querySelector("[data-testid='server-backed-document-description']")?.textContent.trim() ?? "",
+            documentTitle: document.title,
+            documentDescription:
+                document.querySelector("head meta[name='description']")?.getAttribute("content") ?? "",
+            documentDescriptionCount:
+                document.querySelectorAll("head meta[name='description']").length,
+            documentViewportContent:
+                document.querySelector("head meta[name='viewport']")?.getAttribute("content") ?? "",
+            documentTitleIdentityStable: documentEvidence.titleIdentityStable ?? false,
+            documentDescriptionIdentityStable: documentEvidence.descriptionIdentityStable ?? false,
+            documentViewportIdentityStable: documentEvidence.viewportIdentityStable ?? false,
             origin: window.location.origin,
             appSame: identity.appSame ?? false,
             shellSame: identity.shellSame ?? false,
@@ -1834,6 +2242,7 @@ async function startScenario(client, label) {
 }
 
 async function finishScenario(client, label) {
+    await waitForDocumentStateToSettle(client, label);
     const report = await client.callFunction(`function(label) {
         return window.__serverBackedAudit?.finish(label) ?? null;
     }`, label);
@@ -2137,6 +2546,7 @@ function installServerBackedEvidenceExpression() {
     const routeTargetsVisited = [];
     const transitionRequestedTargetsObserved = [];
     const transitionCommittedPairsObserved = [];
+    const greetingLoadingTargetsObserved = new Set();
     const operations = ${JSON.stringify(emptyOperations())};
     const scheduling = {
         requestAnimationFrame: 0,
@@ -2184,6 +2594,83 @@ function installServerBackedEvidenceExpression() {
     let activeMutationRequests = 0;
     let duplicateSubmitAttempts = 0;
     let staleCommittedValueAppearances = 0;
+    const documentSnapshots = [];
+    const selectedDocumentPairs = new Set();
+    let authoredHead = null;
+    let documentTitleMutationBatches = 0;
+    let documentDescriptionMutationBatches = 0;
+    let documentInvalidPairs = 0;
+    let documentDuplicateDescriptionObservations = 0;
+    let documentViewportMutations = 0;
+    let documentTitleNodeReplacements = 0;
+    let documentDescriptionNodeReplacements = 0;
+    let documentTransitionRequestedMetadataAppearances = 0;
+    let documentStaleMetadataAppearances = 0;
+    let documentBaselineRestorations = 0;
+    let documentScopeUnmounts = 0;
+    let documentScopeRemounts = 0;
+    let savedEditorActivations = 0;
+    let savedEditorReleases = 0;
+    let lastDocumentOwner = "";
+    let titleIdentityBroken = false;
+    let descriptionIdentityBroken = false;
+    let viewportIdentityBroken = false;
+
+    const documentObserver = new MutationObserver((records) => {
+        const hadAuthoredHead = Boolean(authoredHead);
+        captureAuthoredHead();
+        if (!hadAuthoredHead) {
+            if (authoredHead) captureDocumentSnapshot("pre-boot");
+            return;
+        }
+
+        let titleChanged = false;
+        let descriptionChanged = false;
+        let viewportChanged = false;
+        let expectedChanged = false;
+        let headStructureChanged = false;
+        const evidenceRoot = document.querySelector(
+            "[data-testid='server-backed-document-state']",
+        );
+        for (const record of records) {
+            const target = record.target;
+            if (target === authoredHead.title ||
+                authoredHead.title.contains?.(target)) {
+                titleChanged = true;
+            }
+            if (target === authoredHead.description) {
+                descriptionChanged = true;
+            }
+            if (target === authoredHead.viewport) {
+                viewportChanged = true;
+            }
+            if (target === document.head && record.type === "childList") {
+                headStructureChanged = true;
+            }
+            if (evidenceRoot &&
+                (target === evidenceRoot || evidenceRoot.contains(target))) {
+                expectedChanged = true;
+            }
+        }
+        if (titleChanged) documentTitleMutationBatches++;
+        if (descriptionChanged) documentDescriptionMutationBatches++;
+        if (viewportChanged) documentViewportMutations++;
+        if (titleChanged ||
+            descriptionChanged ||
+            viewportChanged ||
+            expectedChanged ||
+            headStructureChanged) {
+            captureDocumentSnapshot("mutation");
+        }
+    });
+    documentObserver.observe(document, {
+        attributes: true,
+        attributeFilter: ["content"],
+        characterData: true,
+        childList: true,
+        subtree: true,
+    });
+    captureAuthoredHead();
 
     window.goframeComponentRenderCounts = {};
     window.goframeComponentPatchCounts = {};
@@ -2207,6 +2694,9 @@ function installServerBackedEvidenceExpression() {
             routeContent: false,
         },
         initialize() {
+            if (!captureAuthoredHead()) {
+                return { ready: false, reason: "authored head was not captured before application boot" };
+            }
             this.stable = {
                 app: document.querySelector("[data-testid='server-backed-app']"),
                 shell: document.querySelector("[data-testid='server-backed-shell']"),
@@ -2222,6 +2712,7 @@ function installServerBackedEvidenceExpression() {
             captureTransitionState();
             new MutationObserver((records) => {
                 routeContentMutations += records.length;
+                captureGreetingLoadingState();
                 const message = document.querySelector("[data-testid='greeting-message']")?.textContent.trim() || "";
                 if (message === slowMessage && lastMessage !== slowMessage) {
                     staleResultAppearances++;
@@ -2242,6 +2733,8 @@ function installServerBackedEvidenceExpression() {
                 subtree: true,
                 characterData: true,
             });
+            captureDocumentSnapshot("initialize");
+            captureGreetingLoadingState();
             return { ready: true };
         },
         checkIdentity() {
@@ -2271,6 +2764,15 @@ function installServerBackedEvidenceExpression() {
         savedRequest(id) {
             const request = savedRequests.find((entry) => entry.id === id);
             return request ? { ...request } : null;
+        },
+        documentState() {
+            return documentEvidenceState();
+        },
+        greetingLoadingObserved(target) {
+            return greetingLoadingTargetsObserved.has(target);
+        },
+        captureDocumentSnapshot(phase) {
+            return captureDocumentSnapshot(phase);
         },
         snapshot() {
             return {
@@ -2316,6 +2818,7 @@ function installServerBackedEvidenceExpression() {
                 requests: requests.map((request) => ({ ...request })),
                 transitionRequests: transitionRequests.map((request) => ({ ...request })),
                 savedRequests: savedRequests.map((request) => ({ ...request })),
+                document: documentEvidenceState(),
             };
         },
     };
@@ -2334,6 +2837,12 @@ function installServerBackedEvidenceExpression() {
     document.addEventListener("click", (event) => {
         if (event.target?.closest?.("[data-testid='transition-retry']")) {
             transitionRetryAttempts++;
+        }
+        if (event.target?.closest?.("[data-testid='server-backed-document-scope-unmount']")) {
+            documentScopeUnmounts++;
+        }
+        if (event.target?.closest?.("[data-testid='server-backed-document-scope-remount']")) {
+            documentScopeRemounts++;
         }
     }, true);
 
@@ -2622,6 +3131,12 @@ function installServerBackedEvidenceExpression() {
                 committedValues: committedValuesObserved.slice(this.committedValueBaseline),
             };
         },
+        schedulingSettled() {
+            return scheduling.requestAnimationFrame ===
+                scheduling.requestAnimationFrameCallbacks &&
+                scheduling.queueMicrotask ===
+                scheduling.queueMicrotaskCallbacks;
+        },
     };
     window.__serverBackedAudit = audit;
 
@@ -2762,6 +3277,267 @@ function installServerBackedEvidenceExpression() {
             return parsed.searchParams.get("name") || "GoFrame";
         } catch {
             return "";
+        }
+    }
+
+    function captureAuthoredHead() {
+        if (authoredHead) return true;
+        const titles = document.querySelectorAll("head title");
+        const descriptions = document.querySelectorAll(
+            "head meta[name='description']",
+        );
+        const viewports = document.querySelectorAll(
+            "head meta[name='viewport']",
+        );
+        if (titles.length !== 1 ||
+            descriptions.length !== 1 ||
+            viewports.length !== 1) {
+            return false;
+        }
+        const title = titles[0];
+        const description = descriptions[0];
+        const viewport = viewports[0];
+        const titleText = title.textContent;
+        const descriptionText = description.getAttribute("content") || "";
+        const viewportContent = viewport.getAttribute("content") || "";
+        if (titleText !== ${JSON.stringify(authoredDocumentState.title)} ||
+            descriptionText !== ${JSON.stringify(authoredDocumentState.description)} ||
+            viewportContent !== ${JSON.stringify(authoredViewportContent)}) {
+            return false;
+        }
+        authoredHead = {
+            title,
+            description,
+            viewport,
+            titleText,
+            descriptionText,
+            viewportContent,
+            descriptionCount: descriptions.length,
+        };
+        return true;
+    }
+
+    function captureDocumentSnapshot(phase) {
+        const title = document.querySelector("head title");
+        const description = document.querySelector(
+            "head meta[name='description']",
+        );
+        const viewport = document.querySelector(
+            "head meta[name='viewport']",
+        );
+        const descriptionCount = document.querySelectorAll(
+            "head meta[name='description']",
+        ).length;
+        const owner = document.querySelector(
+            "[data-testid='server-backed-document-owner']",
+        )?.textContent.trim() || "";
+        const expectedTitle = document.querySelector(
+            "[data-testid='server-backed-document-title']",
+        )?.textContent.trim() || "";
+        const expectedDescription = document.querySelector(
+            "[data-testid='server-backed-document-description']",
+        )?.textContent.trim() || "";
+        const actualTitle = title?.textContent || "";
+        const actualDescription = description?.getAttribute("content") || "";
+        const viewportContent = viewport?.getAttribute("content") || "";
+        const titleIdentityStable = Boolean(
+            authoredHead && title === authoredHead.title && title?.isConnected,
+        );
+        const descriptionIdentityStable = Boolean(
+            authoredHead &&
+            description === authoredHead.description &&
+            description?.isConnected,
+        );
+        const viewportIdentityStable = Boolean(
+            authoredHead &&
+            viewport === authoredHead.viewport &&
+            viewport?.isConnected,
+        );
+
+        if (!titleIdentityStable && !titleIdentityBroken) {
+            titleIdentityBroken = true;
+            documentTitleNodeReplacements++;
+        }
+        if (!descriptionIdentityStable && !descriptionIdentityBroken) {
+            descriptionIdentityBroken = true;
+            documentDescriptionNodeReplacements++;
+        }
+        if (!viewportIdentityStable && !viewportIdentityBroken) {
+            viewportIdentityBroken = true;
+            documentViewportMutations++;
+        }
+        if (descriptionCount !== 1) {
+            documentDuplicateDescriptionObservations++;
+        }
+        if (authoredHead && viewportContent !== authoredHead.viewportContent) {
+            documentViewportMutations++;
+        }
+
+        if (owner && owner !== lastDocumentOwner) {
+            if (owner === "saved-editor") savedEditorActivations++;
+            if (lastDocumentOwner === "saved-editor") savedEditorReleases++;
+            if (owner === "authored-baseline" &&
+                lastDocumentOwner &&
+                lastDocumentOwner !== "authored-baseline") {
+                documentBaselineRestorations++;
+            }
+            lastDocumentOwner = owner;
+        }
+
+        const expectedReady = expectedTitle !== "" && expectedDescription !== "";
+        const pairValid = !expectedReady ||
+            (actualTitle === expectedTitle &&
+                actualDescription === expectedDescription);
+        const valid = Boolean(
+            authoredHead &&
+            titleIdentityStable &&
+            descriptionIdentityStable &&
+            viewportIdentityStable &&
+            descriptionCount === 1 &&
+            viewportContent === authoredHead.viewportContent &&
+            pairValid,
+        );
+        if (!valid && expectedReady) {
+            documentInvalidPairs++;
+        }
+
+        const actualPairKey = actualTitle + "\\u0000" + actualDescription;
+        const expectedPairKey = expectedTitle + "\\u0000" + expectedDescription;
+        if (expectedReady && pairValid) {
+            selectedDocumentPairs.add(expectedPairKey);
+        } else if (expectedReady && selectedDocumentPairs.has(actualPairKey)) {
+            documentStaleMetadataAppearances++;
+        }
+
+        const transitionRequestedTarget = document.querySelector(
+            "[data-testid='transition-requested-target']",
+        )?.textContent.trim() || "";
+        const transitionCommittedTarget = document.querySelector(
+            "[data-testid='transition-committed-target']",
+        )?.textContent.trim() || "";
+        const requestedName = transitionNameFromTarget(
+            transitionRequestedTarget,
+        );
+        const committedName = transitionNameFromTarget(
+            transitionCommittedTarget,
+        );
+        if (requestedName &&
+            committedName &&
+            requestedName !== committedName &&
+            (actualTitle.includes(requestedName) ||
+                actualDescription.includes(requestedName))) {
+            documentTransitionRequestedMetadataAppearances++;
+        }
+
+        const snapshot = {
+            phase,
+            hash: window.location.hash,
+            renderedRoute: renderedRouteName(),
+            transitionRequestedTarget,
+            transitionCommittedTarget,
+            transitionCommittedMessage: document.querySelector(
+                "[data-testid='transition-message']",
+            )?.textContent.trim() || "",
+            savedCommittedValue: document.querySelector(
+                "[data-testid='saved-greeting-committed']",
+            )?.textContent.trim() || "",
+            savedMutationStatus: document.querySelector(
+                "[data-testid='saved-greeting-mutation-status']",
+            )?.textContent.trim() || "",
+            activeOwner: owner,
+            expectedTitle,
+            expectedDescription,
+            actualTitle,
+            actualDescription,
+            descriptionCount,
+            viewportContent,
+            titleIdentityStable,
+            descriptionIdentityStable,
+            viewportIdentityStable,
+            valid,
+        };
+        documentSnapshots.push(snapshot);
+        return { ...snapshot };
+    }
+
+    function documentEvidenceState() {
+        const title = document.querySelector("head title");
+        const description = document.querySelector(
+            "head meta[name='description']",
+        );
+        const viewport = document.querySelector(
+            "head meta[name='viewport']",
+        );
+        return {
+            preBootCaptured: Boolean(authoredHead),
+            authoredTitle: authoredHead?.titleText || "",
+            authoredDescription: authoredHead?.descriptionText || "",
+            authoredDescriptionCount: authoredHead?.descriptionCount || 0,
+            authoredViewportContent: authoredHead?.viewportContent || "",
+            titleIdentityStable: Boolean(
+                authoredHead &&
+                title === authoredHead.title &&
+                title?.isConnected,
+            ),
+            descriptionIdentityStable: Boolean(
+                authoredHead &&
+                description === authoredHead.description &&
+                description?.isConnected,
+            ),
+            viewportIdentityStable: Boolean(
+                authoredHead &&
+                viewport === authoredHead.viewport &&
+                viewport?.isConnected,
+            ),
+            titleMutationBatches: documentTitleMutationBatches,
+            descriptionMutationBatches: documentDescriptionMutationBatches,
+            headSnapshots: documentSnapshots.length,
+            invalidPairs: documentInvalidPairs,
+            duplicateDescriptionObservations:
+                documentDuplicateDescriptionObservations,
+            viewportMutations: documentViewportMutations,
+            titleNodeReplacements: documentTitleNodeReplacements,
+            descriptionNodeReplacements:
+                documentDescriptionNodeReplacements,
+            transitionRequestedMetadataAppearances:
+                documentTransitionRequestedMetadataAppearances,
+            staleMetadataAppearances: documentStaleMetadataAppearances,
+            baselineRestorations: documentBaselineRestorations,
+            scopeUnmounts: documentScopeUnmounts,
+            scopeRemounts: documentScopeRemounts,
+            savedEditorActivations,
+            savedEditorReleases,
+        };
+    }
+
+    function renderedRouteName() {
+        if (document.querySelector("[data-testid='server-backed-home']")) {
+            return "home";
+        }
+        if (document.querySelector("[data-testid='server-backed-greeting-route']")) {
+            return "greeting";
+        }
+        if (document.querySelector("[data-testid='server-backed-transition-route']")) {
+            return "transitionGreeting";
+        }
+        if (document.querySelector("[data-testid='server-backed-saved-route']")) {
+            return "savedGreeting";
+        }
+        if (document.querySelector("[data-testid='server-backed-not-found']")) {
+            return "notFound";
+        }
+        return "missing";
+    }
+
+    function captureGreetingLoadingState() {
+        if (!document.querySelector("[data-testid='greeting-loading']")) {
+            return;
+        }
+        const target = document.querySelector(
+            "[data-testid='server-backed-route-target']",
+        )?.textContent.trim() || "";
+        if (target) {
+            greetingLoadingTargetsObserved.add(target);
         }
     }
 


### PR DESCRIPTION
## Summary

Extends `examples/server-backed` into an integrated Application Model II
reference combining route-owned data, retained async transitions,
server-confirmed mutations, and document title/description ownership using the
current public GoFrame APIs.

This PR does not change the runtime or introduce a public document-state,
transition, loader, or mutation API.

## What changed

- Adds an authored document baseline and an example-local ordered ownership
  coordinator for `<title>` and `meta[name="description"]`.
- Keeps transition metadata aligned with the committed visible screen while a
  newer route target is pending, failed, retrying, or moving through browser
  history.
- Adds a nested saved-editor owner that reveals the latest committed route state
  when released.
- Separates the mutable draft, immutable submitted target, and actual
  server-confirmed response so metadata cannot be reassigned by later input.
- Preserves authored head-node identity, prevents duplicate description
  elements, and restores the baseline when route owners unmount.
- Extends pure tests, Chrome/CDP evidence, and the server-backed reference
  documentation.

## Findings

Independent captured-value cleanup is insufficient for the demonstrated nested
ownership flow. The integrated example repeats the same ordered-owner contract
found by the isolated pressure fixture:

- new owners receive priority;
- updates preserve existing priority;
- releasing an owner reveals the latest remaining state;
- releasing the final owner restores the authored baseline.

This is **Result B**. The repeated contract supports a separate narrow API
design stage, but no public API is selected here.

## Validation

- repeated and race-enabled ownership and mutation-attribution tests;
- standard Go and TinyGo packaging;
- two deterministic browser runs with identical behavioral counters;
- zero invalid document pairs, stale metadata observations, target mismatches,
  false confirmations, duplicate descriptions, or head-node replacements;
- unchanged existing request, cancellation, transition, and mutation evidence;
- full tests, race checks, debug-tag tests, `go vet`, aggregate browser smoke,
  size budgets, documentation, artifact, and module-path checks;
- byte-identical output for all existing budgeted examples.

## Scope

The evidence covers one browser document, route-driven title and description
metadata, retained transitions, nested mutation ownership, Back/Forward,
unmount cleanup, and authored baseline restoration.

It does not establish arbitrary head management, canonical or social metadata,
SSR, hydration, production SEO, broad browser compatibility, or full
URL/screen/data atomicity.