### PR TITLE
fix(runtime): make ErrorBoundary subtree lifecycle transactional

### DIFF
--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -58,8 +58,46 @@ If no match exists, it reports the default missing path
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
 | router | 116736 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 230400 B | 77824 B | 94208 B | 81920 B |
-| resource | 153600 B | 57344 B | 67584 B | 61440 B |
+| router-dashboard | 233472 B | 77824 B | 94208 B | 81920 B |
+| resource | 156672 B | 57344 B | 68608 B | 61440 B |
+
+## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
+
+This targeted rebaseline covers complete mounted-subtree teardown ownership
+during protected ErrorBoundary reconciliation. The frozen main base is
+`15a0b8fe4f5d3f0da79b57acc10e1fab4e6cbac5`; the PR head before this
+correction is `ee68d49296586a42d142b9b4031fcb173f127b2d`. The runtime correction
+is `a3463d9d88837a3adb46d30f1d03e1e8c1947d1c`, and the browser evidence is
+`481d8ea5945caec08ac57668af49e3dc456e2762`.
+
+Measurements use Go `1.22.12` and TinyGo `0.41.1` on Linux amd64. Compression
+uses the unchanged budget-script commands. Head-to-final deltas compare
+artifacts with the same `bundle.wasm` basename.
+
+| app/format | PR head size | final size | delta | old budget | new budget | final headroom |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| router-dashboard raw | 230316 B | 232586 B | +2270 B | 230400 B | 233472 B | 886 B |
+| router-dashboard gzip | 92577 B | 93271 B | +694 B | 94208 B | 94208 B | 937 B |
+| router-dashboard br | 76183 B | 76703 B | +520 B | 77824 B | 77824 B | 1121 B |
+| router-dashboard zstd | 81281 B | 81813 B | +532 B | 81920 B | 81920 B | 107 B |
+| resource raw | 153200 B | 155484 B | +2284 B | 153600 B | 156672 B | 1188 B |
+| resource gzip | 67158 B | 67897 B | +739 B | 67584 B | 68608 B | 711 B |
+| resource br | 56578 B | 57182 B | +604 B | 57344 B | 57344 B | 162 B |
+| resource zstd | 59968 B | 60748 B | +780 B | 61440 B | 61440 B | 692 B |
+
+The nine non-ErrorBoundary applications (`counter`, `components`, `todo`,
+`dashboard`, `context`, `virtualized`, `multipackage`, `cmdapp`, and `router`)
+remain byte-identical at the raw WASM SHA-256 boundary; their compressed sizes
+are also unchanged. The final compression ratios remain within the existing
+limits: gzip `52.00%`, Brotli `38.00%`, and Zstandard `46.00%`.
+
+The earlier recommendation to keep budgets unchanged is superseded only for
+this accepted ErrorBoundary correctness guarantee. Raw budgets increase by
+3 KiB for `router-dashboard` and `resource`. Resource gzip increases by 1 KiB
+under the aligned compressed-budget rule; the other compressed budgets remain
+unchanged because their final artifacts fit. No workflow or ratio limit
+changes, no unrelated application budget changes, and no general runtime
+headroom are authorized by this rebaseline.
 
 ## Toolchain Matrix
 

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -211,7 +211,7 @@ func renderComponentLifecycle(instance *componentInstance, contextFinalizationSt
 	*contextFinalizationStarted = true
 	finishComponentContextRender(instance)
 	rendered := Child(node)
-	completeLifecycleRenderAttempt(instance)
+	commitLifecycleRenderAttempt(instance)
 	return rendered
 }
 
@@ -225,9 +225,21 @@ func markComponentDirty(instance *componentInstance) {
 		}
 		instance.dirtyCounted = true
 	}
+	scheduled := instance
+	if beginProtectedLifecycle != nil {
+		for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
+			state := ancestor.errorBoundary
+			if state == nil || state.phase != errorBoundaryProtected {
+				continue
+			}
+			ancestor.dirty = true
+			scheduled = ancestor
+			break
+		}
+	}
 	instance.dirty = true
 	if instance.scheduleUpdate != nil {
-		instance.scheduleUpdate(instance)
+		instance.scheduleUpdate(scheduled)
 	}
 }
 

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -211,7 +211,7 @@ func renderComponentLifecycle(instance *componentInstance, contextFinalizationSt
 	*contextFinalizationStarted = true
 	finishComponentContextRender(instance)
 	rendered := Child(node)
-	commitLifecycleRenderAttempt(instance)
+	completeLifecycleRenderAttempt(instance)
 	return rendered
 }
 

--- a/pkg/goframe/component.go
+++ b/pkg/goframe/component.go
@@ -225,21 +225,9 @@ func markComponentDirty(instance *componentInstance) {
 		}
 		instance.dirtyCounted = true
 	}
-	scheduled := instance
-	if beginProtectedLifecycle != nil {
-		for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
-			state := ancestor.errorBoundary
-			if state == nil || state.phase != errorBoundaryProtected {
-				continue
-			}
-			ancestor.dirty = true
-			scheduled = ancestor
-			break
-		}
-	}
 	instance.dirty = true
-	if instance.scheduleUpdate != nil {
-		instance.scheduleUpdate(scheduled)
+	if schedule := instance.scheduleUpdate; schedule != nil {
+		schedule(instance)
 	}
 }
 

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -324,6 +324,15 @@ func commitLifecycleRenderAttempt(instance *componentInstance) {
 	finishLifecycleRenderAttempt(attempt)
 }
 
+func completeLifecycleRenderAttempt(instance *componentInstance) {
+	attempt := requireLifecycleRenderAttempt(instance)
+	if (attempt.commitHooks != nil || len(attempt.participants) != 0) &&
+		stageProtectedSubtreeLifecycleAttempt(instance) {
+		return
+	}
+	commitLifecycleRenderAttempt(instance)
+}
+
 func commitLifecycleHooks(instance *componentInstance) {
 	attempt := &instance.lifecycleAttempt
 	for index := range attempt.effects {

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -198,22 +198,23 @@ type effectRenderUpdate struct {
 }
 
 type lifecycleRenderParticipant interface {
-	commitLifecycleRender(*renderLifecycleAttempt)
-	rollbackLifecycleRender(*renderLifecycleAttempt)
+	finishRender(attempt *renderLifecycleAttempt, commit bool)
 }
 
 type renderLifecycleAttempt struct {
 	active       bool
+	hooks        bool
 	effects      []effectRenderUpdate
 	unmounts     []Cleanup
 	participants []lifecycleRenderParticipant
-	// Keep hook commit indirect so hook-free TinyGo apps discard effect machinery.
-	commitHooks func(*componentInstance)
 }
 
 var (
-	pendingEffects  []*effectSlot
-	flushingEffects bool
+	pendingEffects                    []*effectSlot
+	flushingEffects                   bool
+	currentProtectedLifecycleBoundary *errorBoundaryState
+	// Keep hook commit indirect so hook-free TinyGo apps discard effect machinery.
+	commitLifecycleHook func(*componentInstance)
 )
 
 // UseMount runs effect once after this component instance is first mounted.
@@ -233,7 +234,8 @@ func UseUnmount(cleanup Cleanup) {
 	if index != len(attempt.unmounts) {
 		panic("goframe: invalid unmount hook index")
 	}
-	attempt.commitHooks = commitLifecycleHooks
+	commitLifecycleHook = commitLifecycleHooks
+	attempt.hooks = true
 	attempt.unmounts = append(attempt.unmounts, cleanup)
 }
 
@@ -264,7 +266,8 @@ func useEffect(kind effectKind, effect func() Cleanup, deps EffectDeps) {
 	if index != len(attempt.effects) {
 		panic("goframe: invalid effect hook index")
 	}
-	attempt.commitHooks = commitLifecycleHooks
+	commitLifecycleHook = commitLifecycleHooks
+	attempt.hooks = true
 
 	update := effectRenderUpdate{
 		kind:   kind,
@@ -314,23 +317,18 @@ func requireLifecycleRenderAttempt(instance *componentInstance) *renderLifecycle
 }
 
 func commitLifecycleRenderAttempt(instance *componentInstance) {
-	attempt := requireLifecycleRenderAttempt(instance)
-	for _, participant := range attempt.participants {
-		participant.commitLifecycleRender(attempt)
-	}
-	if attempt.commitHooks != nil {
-		attempt.commitHooks(instance)
-	}
-	finishLifecycleRenderAttempt(attempt)
-}
-
-func completeLifecycleRenderAttempt(instance *componentInstance) {
-	attempt := requireLifecycleRenderAttempt(instance)
-	if (attempt.commitHooks != nil || len(attempt.participants) != 0) &&
-		stageProtectedSubtreeLifecycleAttempt(instance) {
+	if boundary := currentProtectedLifecycleBoundary; boundary != nil {
+		boundary.attempts = append(boundary.attempts, instance)
 		return
 	}
-	commitLifecycleRenderAttempt(instance)
+	attempt := requireLifecycleRenderAttempt(instance)
+	for _, participant := range attempt.participants {
+		participant.finishRender(attempt, true)
+	}
+	if attempt.hooks {
+		commitLifecycleHook(instance)
+	}
+	finishLifecycleRenderAttempt(attempt)
 }
 
 func commitLifecycleHooks(instance *componentInstance) {
@@ -369,7 +367,7 @@ func rollbackLifecycleRenderAttempt(instance *componentInstance) {
 	}
 	attempt := &instance.lifecycleAttempt
 	for _, participant := range attempt.participants {
-		participant.rollbackLifecycleRender(attempt)
+		participant.finishRender(attempt, false)
 	}
 	finishLifecycleRenderAttempt(attempt)
 }
@@ -378,7 +376,7 @@ func finishLifecycleRenderAttempt(attempt *renderLifecycleAttempt) {
 	clear(attempt.effects)
 	clear(attempt.unmounts)
 	clear(attempt.participants)
-	attempt.commitHooks = nil
+	attempt.hooks = false
 	attempt.effects = attempt.effects[:0]
 	attempt.unmounts = attempt.unmounts[:0]
 	attempt.participants = attempt.participants[:0]

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -23,12 +23,17 @@ const (
 
 type errorBoundaryState struct {
 	phase       errorBoundaryPhase
+	hasResetKey bool
 	info        ErrorInfo
 	generation  int
 	resetKey    string
-	hasResetKey bool
-	transaction protectedSubtreeTransaction
+	attempts    []*componentInstance
 }
+
+var (
+	beginProtectedLifecycle  func(*errorBoundaryState) *errorBoundaryState
+	finishProtectedLifecycle func(*errorBoundaryState, *errorBoundaryState)
+)
 
 var errorBoundaryComponentType = NewComponentType("goframe.ErrorBoundary", "ErrorBoundary")
 
@@ -62,6 +67,8 @@ func renderErrorBoundary(props ErrorBoundaryProps) Node {
 
 func ensureErrorBoundaryState(instance *componentInstance) *errorBoundaryState {
 	if instance.errorBoundary == nil {
+		beginProtectedLifecycle = beginProtectedSubtreeLifecycle
+		finishProtectedLifecycle = finishProtectedSubtreeLifecycle
 		instance.errorBoundary = &errorBoundaryState{}
 	}
 	return instance.errorBoundary
@@ -101,9 +108,8 @@ func captureRenderErrorBoundary(failing *componentInstance, info ErrorInfo) {
 	if boundary == nil || boundary.errorBoundary == nil {
 		return
 	}
-	failProtectedSubtreeLifecycleTransaction(boundary)
-	cancelPendingEffectsUnderBoundary(boundary)
 	state := boundary.errorBoundary
+	cancelPendingEffectsUnderBoundary(boundary)
 	if state.phase == errorBoundaryProtected {
 		state.phase = errorBoundaryCaptured
 		state.info = info

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -77,7 +77,11 @@ func ensureErrorBoundaryState(instance *componentInstance) *errorBoundaryState {
 }
 
 func nearestProtectedLifecycleState(instance *componentInstance) *errorBoundaryState {
-	if instance == nil || instance.errorBoundary != nil {
+	if instance == nil {
+		return nil
+	}
+	if state := instance.errorBoundary; state != nil &&
+		state.phase == errorBoundaryProtected {
 		return nil
 	}
 	for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -33,7 +33,6 @@ type errorBoundaryState struct {
 var (
 	beginProtectedLifecycle  func(*errorBoundaryState) *errorBoundaryState
 	finishProtectedLifecycle func(*errorBoundaryState, *errorBoundaryState)
-	protectedDirtyUpdates    bool
 )
 
 var errorBoundaryComponentType = NewComponentType("goframe.ErrorBoundary", "ErrorBoundary")
@@ -70,27 +69,30 @@ func ensureErrorBoundaryState(instance *componentInstance) *errorBoundaryState {
 	if instance.errorBoundary == nil {
 		beginProtectedLifecycle = beginProtectedSubtreeLifecycle
 		finishProtectedLifecycle = finishProtectedSubtreeLifecycle
-		protectedDirtyUpdates = true
 		instance.errorBoundary = &errorBoundaryState{}
 	}
 	return instance.errorBoundary
 }
 
-func nearestProtectedLifecycleState(instance *componentInstance) *errorBoundaryState {
-	if instance == nil {
-		return nil
-	}
-	if state := instance.errorBoundary; state != nil &&
-		state.phase == errorBoundaryProtected {
-		return nil
-	}
-	for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
-		state := ancestor.errorBoundary
-		if state != nil && state.phase == errorBoundaryProtected {
+//go:noinline
+func lifecycleStateForDirtyUpdate(instance *componentInstance) *errorBoundaryState {
+	var nearest *errorBoundaryState
+	for current := instance; current != nil; current = current.parent {
+		state := current.errorBoundary
+		if state == nil {
+			continue
+		}
+		if current != instance && state.phase == errorBoundaryCaptured {
 			return state
 		}
+		if nearest == nil && state.phase == errorBoundaryProtected {
+			nearest = state
+		}
 	}
-	return nil
+	if instance != nil && nearest == instance.errorBoundary {
+		return nil
+	}
+	return nearest
 }
 
 func updateErrorBoundaryResetKey(state *errorBoundaryState, resetKey string) {

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -28,6 +28,7 @@ type errorBoundaryState struct {
 	generation  int
 	resetKey    string
 	attempts    []*componentInstance
+	teardown    protectedTeardownState
 }
 
 var (
@@ -60,7 +61,9 @@ func renderErrorBoundary(props ErrorBoundaryProps) Node {
 				resetErrorBoundary(instance, state)
 			},
 		}
-		return Key(errorBoundaryFallbackKey(state.generation), Child(props.Fallback(context)))
+		fallback := Child(props.Fallback(context))
+		prepareProtectedFallbackReconcile(state)
+		return Key(errorBoundaryFallbackKey(state.generation), fallback)
 	}
 	return Key(errorBoundaryProtectedKey(state.generation), Fragment(props.Children...))
 }
@@ -69,7 +72,12 @@ func ensureErrorBoundaryState(instance *componentInstance) *errorBoundaryState {
 	if instance.errorBoundary == nil {
 		beginProtectedLifecycle = beginProtectedSubtreeLifecycle
 		finishProtectedLifecycle = finishProtectedSubtreeLifecycle
-		instance.errorBoundary = &errorBoundaryState{}
+		installProtectedMountedTeardown()
+		state := &errorBoundaryState{}
+		instance.errorBoundary = state
+		instance.unmountSlots = append(instance.unmountSlots, func() {
+			state.teardown.release()
+		})
 	}
 	return instance.errorBoundary
 }
@@ -141,7 +149,11 @@ func captureRenderErrorBoundary(failing *componentInstance, info ErrorInfo) {
 
 func nearestErrorBoundary(instance *componentInstance) *componentInstance {
 	for current := instance.parent; current != nil; current = current.parent {
-		if current.active && current.errorBoundary != nil && current.errorBoundary.phase != errorBoundaryFallback {
+		if current.active &&
+			current.errorBoundary != nil &&
+			current.errorBoundary.phase != errorBoundaryFallback &&
+			(current.errorBoundary.phase != errorBoundaryProtected ||
+				current.errorBoundary.info.Phase == 0) {
 			return current
 		}
 	}

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -27,6 +27,7 @@ type errorBoundaryState struct {
 	generation  int
 	resetKey    string
 	hasResetKey bool
+	transaction protectedSubtreeTransaction
 }
 
 var errorBoundaryComponentType = NewComponentType("goframe.ErrorBoundary", "ErrorBoundary")
@@ -100,6 +101,7 @@ func captureRenderErrorBoundary(failing *componentInstance, info ErrorInfo) {
 	if boundary == nil || boundary.errorBoundary == nil {
 		return
 	}
+	failProtectedSubtreeLifecycleTransaction(boundary)
 	cancelPendingEffectsUnderBoundary(boundary)
 	state := boundary.errorBoundary
 	if state.phase == errorBoundaryProtected {

--- a/pkg/goframe/error_boundary.go
+++ b/pkg/goframe/error_boundary.go
@@ -33,6 +33,7 @@ type errorBoundaryState struct {
 var (
 	beginProtectedLifecycle  func(*errorBoundaryState) *errorBoundaryState
 	finishProtectedLifecycle func(*errorBoundaryState, *errorBoundaryState)
+	protectedDirtyUpdates    bool
 )
 
 var errorBoundaryComponentType = NewComponentType("goframe.ErrorBoundary", "ErrorBoundary")
@@ -69,9 +70,23 @@ func ensureErrorBoundaryState(instance *componentInstance) *errorBoundaryState {
 	if instance.errorBoundary == nil {
 		beginProtectedLifecycle = beginProtectedSubtreeLifecycle
 		finishProtectedLifecycle = finishProtectedSubtreeLifecycle
+		protectedDirtyUpdates = true
 		instance.errorBoundary = &errorBoundaryState{}
 	}
 	return instance.errorBoundary
+}
+
+func nearestProtectedLifecycleState(instance *componentInstance) *errorBoundaryState {
+	if instance == nil || instance.errorBoundary != nil {
+		return nil
+	}
+	for ancestor := instance.parent; ancestor != nil; ancestor = ancestor.parent {
+		state := ancestor.errorBoundary
+		if state != nil && state.phase == errorBoundaryProtected {
+			return state
+		}
+	}
+	return nil
 }
 
 func updateErrorBoundaryResetKey(state *errorBoundaryState, resetKey string) {

--- a/pkg/goframe/error_boundary_test.go
+++ b/pkg/goframe/error_boundary_test.go
@@ -560,4 +560,5 @@ func testComponentInstanceWithParent(name string, parent *componentInstance, ren
 func resetRuntimeBoundaryTestState() {
 	resetEffectsForTest()
 	contextSubscriptionsByID = nil
+	currentProtectedSubtreeTransaction = nil
 }

--- a/pkg/goframe/error_boundary_test.go
+++ b/pkg/goframe/error_boundary_test.go
@@ -560,5 +560,7 @@ func testComponentInstanceWithParent(name string, parent *componentInstance, ren
 func resetRuntimeBoundaryTestState() {
 	resetEffectsForTest()
 	contextSubscriptionsByID = nil
-	currentProtectedSubtreeTransaction = nil
+	currentProtectedLifecycleBoundary = nil
+	beginProtectedLifecycle = nil
+	finishProtectedLifecycle = nil
 }

--- a/pkg/goframe/error_boundary_test.go
+++ b/pkg/goframe/error_boundary_test.go
@@ -563,5 +563,4 @@ func resetRuntimeBoundaryTestState() {
 	currentProtectedLifecycleBoundary = nil
 	beginProtectedLifecycle = nil
 	finishProtectedLifecycle = nil
-	protectedDirtyUpdates = false
 }

--- a/pkg/goframe/error_boundary_test.go
+++ b/pkg/goframe/error_boundary_test.go
@@ -563,4 +563,5 @@ func resetRuntimeBoundaryTestState() {
 	currentProtectedLifecycleBoundary = nil
 	beginProtectedLifecycle = nil
 	finishProtectedLifecycle = nil
+	protectedDirtyUpdates = false
 }

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -94,6 +94,162 @@ func TestDirtyFallbackChildRemainsScheduledBelowCapturedBoundary(t *testing.T) {
 	}
 }
 
+func TestNestedFallbackTransactionSelectsProtectedAncestorByPhase(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		phase errorBoundaryPhase
+		outer bool
+	}{
+		{name: "protected", phase: errorBoundaryProtected},
+		{name: "captured", phase: errorBoundaryCaptured, outer: true},
+		{name: "fallback", phase: errorBoundaryFallback, outer: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			outer := transactionTestBoundary()
+			inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+				return Text("inner fallback")
+			}, nil)
+			renderComponentInstance(inner)
+			inner.errorBoundary.phase = test.phase
+
+			want := (*errorBoundaryState)(nil)
+			if test.outer {
+				want = outer.errorBoundary
+			}
+			if got := nearestProtectedLifecycleState(inner); got != want {
+				t.Fatalf("%s inner boundary selected state %p, want %p",
+					test.name, got, want)
+			}
+		})
+	}
+}
+
+func TestNestedFallbackTransactionWithoutProtectedAncestorSelectsNil(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	for _, phase := range []errorBoundaryPhase{
+		errorBoundaryCaptured,
+		errorBoundaryFallback,
+	} {
+		boundary.errorBoundary.phase = phase
+		if got := nearestProtectedLifecycleState(boundary); got != nil {
+			t.Fatalf("boundary phase %d selected state %p without protected ancestor, want nil",
+				phase, got)
+		}
+	}
+}
+
+func TestNestedFallbackTransactionSelectsNearestProtectedAncestor(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	middle := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+		return Text("middle fallback")
+	}, nil)
+	renderComponentInstance(middle)
+	middle.errorBoundary.phase = errorBoundaryFallback
+	inner := testErrorBoundaryInstanceWithParent(middle, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	renderComponentInstance(inner)
+	inner.errorBoundary.phase = errorBoundaryCaptured
+
+	if got := nearestProtectedLifecycleState(inner); got != outer.errorBoundary {
+		t.Fatalf("captured inner selected state %p through fallback middle, want outer %p",
+			got, outer.errorBoundary)
+	}
+
+	nearer := testErrorBoundaryInstanceWithParent(middle, "", func(ErrorBoundaryContext) Node {
+		return Text("nearer fallback")
+	}, nil)
+	renderComponentInstance(nearer)
+	inner.parent = nearer
+	if got := nearestProtectedLifecycleState(inner); got != nearer.errorBoundary {
+		t.Fatalf("captured inner selected state %p, want nearest protected %p",
+			got, nearer.errorBoundary)
+	}
+}
+
+func TestNestedFallbackTransactionRestoresSelectedOuterState(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		isolateLifecycleTestState(t)
+		outer := transactionTestBoundary()
+		inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+			return Text("inner fallback")
+		}, nil)
+		renderComponentInstance(inner)
+		inner.errorBoundary.phase = errorBoundaryFallback
+		owner := testComponentInstanceWithParent("FallbackOwner", inner, func() Node {
+			UseEffect(func() Cleanup { return nil })
+			return Empty()
+		})
+
+		state := nearestProtectedLifecycleState(inner)
+		if state != outer.errorBoundary {
+			t.Fatalf("selected state = %p, want outer %p", state, outer.errorBoundary)
+		}
+		runProtectedLifecycleStateTestAttempt(state, func() {
+			renderComponentInstance(owner)
+		})
+
+		if currentProtectedLifecycleBoundary != nil {
+			t.Fatal("successful nested fallback transaction left current state installed")
+		}
+		if state.attempts != nil {
+			t.Fatalf("successful nested fallback transaction retained attempts: %#v", state.attempts)
+		}
+		if owner.lifecycleAttempt.active {
+			t.Fatal("successful nested fallback transaction left owner attempt active")
+		}
+		if len(owner.effectSlots) != 1 || len(pendingEffects) != 1 {
+			t.Fatalf("successful nested fallback commit slots=%d pending=%d, want 1/1",
+				len(owner.effectSlots), len(pendingEffects))
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		isolateLifecycleTestState(t)
+		outer := transactionTestBoundary()
+		inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+			return Text("inner fallback")
+		}, nil)
+		renderComponentInstance(inner)
+		inner.errorBoundary.phase = errorBoundaryFallback
+		owner := testComponentInstanceWithParent("FallbackOwner", inner, func() Node {
+			UseEffect(func() Cleanup { return nil })
+			UseUnmount(func() {})
+			return Empty()
+		})
+
+		state := nearestProtectedLifecycleState(inner)
+		if state != outer.errorBoundary {
+			t.Fatalf("selected state = %p, want outer %p", state, outer.errorBoundary)
+		}
+		runProtectedLifecycleStateTestAttempt(state, func() {
+			renderComponentInstance(owner)
+			renderComponentInstance(transactionTestRisky(inner, "nested fallback descendant boom"))
+		})
+
+		if outer.errorBoundary.phase != errorBoundaryCaptured {
+			t.Fatalf("outer phase = %d, want captured", outer.errorBoundary.phase)
+		}
+		if currentProtectedLifecycleBoundary != nil {
+			t.Fatal("failed nested fallback transaction left current state installed")
+		}
+		if state.attempts != nil {
+			t.Fatalf("failed nested fallback transaction retained attempts: %#v", state.attempts)
+		}
+		if owner.lifecycleAttempt.active {
+			t.Fatal("failed nested fallback transaction left owner attempt active")
+		}
+		if len(owner.effectSlots) != 0 || len(owner.unmountSlots) != 0 || len(pendingEffects) != 0 {
+			t.Fatalf("failed nested fallback committed effects=%d unmounts=%d pending=%d, want 0/0/0",
+				len(owner.effectSlots), len(owner.unmountSlots), len(pendingEffects))
+		}
+	})
+}
+
 func TestProtectedSubtreeEffectStateRollsBackAfterDescendantFailure(t *testing.T) {
 	isolateLifecycleTestState(t)
 	boundary := transactionTestBoundary()
@@ -698,6 +854,12 @@ func runProtectedSubtreeTestAttempt(boundary *componentInstance, reconcile func(
 	if state == nil {
 		panic("goframe: test boundary has no protected lifecycle reconcile hook")
 	}
+	previous := beginProtectedLifecycle(state)
+	defer finishProtectedLifecycle(state, previous)
+	reconcile()
+}
+
+func runProtectedLifecycleStateTestAttempt(state *errorBoundaryState, reconcile func()) {
 	previous := beginProtectedLifecycle(state)
 	defer finishProtectedLifecycle(state, previous)
 	reconcile()

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -1,0 +1,567 @@
+package goframe
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProtectedSubtreeEffectStateRollsBackAfterDescendantFailure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	setupA := 0
+	setupB := 0
+	cleanupA := 0
+	effectA := func() Cleanup {
+		setupA++
+		return func() {
+			cleanupA++
+		}
+	}
+	effectB := func() Cleanup {
+		setupB++
+		return nil
+	}
+	currentEffect := effectA
+	currentDep := "A"
+	owner := testComponentInstanceWithParent("EffectOwner", boundary, func() Node {
+		UseEffect(currentEffect, Deps(currentDep))
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+	if setupA != 1 {
+		t.Fatalf("A effect setups = %d, want 1", setupA)
+	}
+
+	currentEffect = effectB
+	currentDep = "B"
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "effect descendant boom"))
+	})
+
+	if len(owner.effectSlots) != 1 {
+		t.Fatalf("effect slots = %d, want 1", len(owner.effectSlots))
+	}
+	slot := owner.effectSlots[0]
+	if !depsEqual(slot.deps, Deps("A")) {
+		t.Fatalf("committed effect deps changed A -> B: %#v", slot.deps)
+	}
+	if reflect.ValueOf(slot.effect).Pointer() != reflect.ValueOf(effectA).Pointer() {
+		t.Fatal("committed effect closure changed A -> B")
+	}
+	if slot.pending || slot.queued || len(pendingEffects) != 0 {
+		t.Fatalf("failed B effect pending=%v queued=%v global=%d, want false/false/0",
+			slot.pending, slot.queued, len(pendingEffects))
+	}
+	flushPendingEffects()
+	if setupB != 0 || cleanupA != 0 {
+		t.Fatalf("after rollback setupB=%d cleanupA=%d, want 0/0", setupB, cleanupA)
+	}
+
+	deactivateComponent(owner)
+	if cleanupA != 1 {
+		t.Fatalf("A cleanup after fallback release = %d, want 1", cleanupA)
+	}
+}
+
+func TestProtectedSubtreeUnmountStateRollsBackAfterDescendantFailure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	events := []string{}
+	cleanupA := func() {
+		events = append(events, "unmount A")
+	}
+	cleanupB := func() {
+		events = append(events, "unmount B")
+	}
+	currentCleanup := Cleanup(cleanupA)
+	owner := testComponentInstanceWithParent("UnmountOwner", boundary, func() Node {
+		UseUnmount(currentCleanup)
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	currentCleanup = cleanupB
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "unmount descendant boom"))
+	})
+
+	if len(owner.unmountSlots) != 1 {
+		t.Fatalf("unmount slots = %d, want 1", len(owner.unmountSlots))
+	}
+	if reflect.ValueOf(owner.unmountSlots[0]).Pointer() != reflect.ValueOf(cleanupA).Pointer() {
+		t.Fatal("committed UseUnmount callback changed A -> B")
+	}
+	deactivateComponent(owner)
+	assertEffectEvents(t, events, []string{"unmount A"})
+}
+
+func TestProtectedSubtreeResourceStateRollsBackAfterDescendantFailure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	loader := &resourceTestLoader{}
+	key := "a"
+	var resource Resource[string]
+	owner := testComponentInstanceWithParent("ResourceOwner", boundary, func() Node {
+		resource, _ = UseResource(key, loader.load)
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+
+	control := resourceControlForTest[string](t, owner)
+	generationA := control.generation
+	runA := control.current
+	if !resource.Loading() || runA == nil || !runA.active {
+		t.Fatalf("committed A resource=%#v run=%#v, want loading active A", resource, runA)
+	}
+
+	key = "b"
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "resource descendant boom"))
+	})
+
+	if control.key != "a" {
+		t.Fatalf("committed resource key changed a -> %q", control.key)
+	}
+	if control.generation != generationA {
+		t.Fatalf("committed resource generation changed %d -> %d", generationA, control.generation)
+	}
+	if !control.snapshot.Loading() {
+		t.Fatalf("committed resource snapshot changed from loading A: %#v", control.snapshot)
+	}
+	if control.current != runA || !runA.active {
+		t.Fatalf("committed A run current=%p active=%v, want %p/true",
+			control.current, runA.active, runA)
+	}
+	if control.pending.attempt != nil {
+		t.Fatalf("resource pending attempt retained after rollback: %#v", control.pending)
+	}
+	if loader.cleanups != 0 {
+		t.Fatalf("A cleanup during rollback = %d, want 0", loader.cleanups)
+	}
+	if got := loader.starts; len(got) != 1 || got[0] != "a" {
+		t.Fatalf("loader starts after failed B = %#v, want [a]", got)
+	}
+
+	deactivateComponent(owner)
+	if loader.cleanups != 1 {
+		t.Fatalf("A cleanup after fallback release = %d, want 1", loader.cleanups)
+	}
+	if len(loader.starts) != 1 {
+		t.Fatalf("B loader starts after fallback release = %d, want 0", len(loader.starts)-1)
+	}
+}
+
+func TestProtectedSubtreeLaterSiblingEffectCannotFlushAfterCapture(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	laterSetups := 0
+	later := testComponentInstanceWithParent("LaterEffect", boundary, func() Node {
+		UseEffect(func() Cleanup {
+			laterSetups++
+			return nil
+		})
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(transactionTestRisky(boundary, "early descendant boom"))
+		renderComponentInstance(later)
+	})
+	flushPendingEffects()
+
+	if laterSetups != 0 {
+		t.Fatalf("later protected sibling effect ran %d time(s), want 0", laterSetups)
+	}
+	if len(later.effectSlots) != 0 {
+		t.Fatalf("later sibling committed effect slots = %d, want 0", len(later.effectSlots))
+	}
+}
+
+func TestProtectedSubtreeManualResetRetryCommitsHealthyLifecycleOnce(t *testing.T) {
+	isolateLifecycleTestState(t)
+
+	var reset func()
+	boundary := testErrorBoundaryInstance("", func(ctx ErrorBoundaryContext) Node {
+		reset = ctx.Reset
+		return Text("fallback")
+	}, nil)
+	renderComponentInstance(boundary)
+
+	events := []string{}
+	loader := &resourceTestLoader{}
+	version := "A"
+	owner := transactionTestLifecycleOwner(boundary, &version, &events, loader)
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+
+	version = "B"
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "retry descendant boom"))
+	})
+	renderComponentInstance(boundary)
+	if reset == nil {
+		t.Fatal("fallback did not provide reset")
+	}
+	deactivateComponent(owner)
+
+	assertEffectEvents(t, events, []string{"effect A", "effect cleanup A", "unmount A"})
+	if got := loader.starts; len(got) != 1 || got[0] != "A" {
+		t.Fatalf("loader starts before retry = %#v, want [A]", got)
+	}
+	if loader.cleanups != 1 {
+		t.Fatalf("A resource cleanups before retry = %d, want 1", loader.cleanups)
+	}
+
+	reset()
+	renderComponentInstance(boundary)
+	retry := transactionTestLifecycleOwner(boundary, &version, &events, loader)
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(retry)
+	})
+	flushPendingEffects()
+
+	assertEffectEvents(t, events, []string{
+		"effect A",
+		"effect cleanup A",
+		"unmount A",
+		"effect B",
+	})
+	if got := loader.starts; len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("loader starts after retry = %#v, want [A B]", got)
+	}
+	if retry.lifecycleAttempt.active || len(pendingEffects) != 0 {
+		t.Fatalf("retry left lifecycle active=%v pending=%d, want false/0",
+			retry.lifecycleAttempt.active, len(pendingEffects))
+	}
+}
+
+func TestBoundaryTransactionNestedCaptureRollsBackInnerOnly(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+
+	events := []string{}
+	outerOwner := testComponentInstanceWithParent("OuterOwner", outer, func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "outer owner")
+			return nil
+		})
+		return Empty()
+	})
+	inner := testErrorBoundaryInstanceWithParent(outerOwner, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	innerOwner := testComponentInstanceWithParent("InnerOwner", inner, func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "inner owner")
+			return nil
+		})
+		return Empty()
+	})
+	outerSibling := testComponentInstanceWithParent("OuterSibling", outerOwner, func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "outer sibling")
+			return nil
+		})
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		renderComponentInstance(outerOwner)
+		renderComponentInstance(inner)
+		runProtectedSubtreeTestAttempt(inner, func() {
+			renderComponentInstance(innerOwner)
+			renderComponentInstance(transactionTestRisky(inner, "inner descendant boom"))
+		})
+		renderComponentInstance(outerSibling)
+	})
+	flushPendingEffects()
+
+	if inner.errorBoundary.phase != errorBoundaryCaptured {
+		t.Fatalf("inner boundary phase = %d, want captured", inner.errorBoundary.phase)
+	}
+	if outer.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("outer boundary phase = %d, want protected", outer.errorBoundary.phase)
+	}
+	if len(innerOwner.effectSlots) != 0 {
+		t.Fatalf("inner committed effect slots = %d, want 0", len(innerOwner.effectSlots))
+	}
+	assertEffectEvents(t, events, []string{"outer owner", "outer sibling"})
+}
+
+func TestBoundaryTransactionSuccessfulInnerRollsBackWithOuterFailure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+
+	innerSetups := 0
+	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	innerOwner := testComponentInstanceWithParent("InnerOwner", inner, func() Node {
+		UseEffect(func() Cleanup {
+			innerSetups++
+			return nil
+		})
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		renderComponentInstance(inner)
+		runProtectedSubtreeTestAttempt(inner, func() {
+			renderComponentInstance(innerOwner)
+		})
+		renderComponentInstance(transactionTestRisky(outer, "outer descendant boom"))
+	})
+	flushPendingEffects()
+
+	if outer.errorBoundary.phase != errorBoundaryCaptured {
+		t.Fatalf("outer boundary phase = %d, want captured", outer.errorBoundary.phase)
+	}
+	if inner.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("inner boundary phase = %d, want protected", inner.errorBoundary.phase)
+	}
+	if len(innerOwner.effectSlots) != 0 {
+		t.Fatalf("inner effect slots after outer rollback = %d, want 0", len(innerOwner.effectSlots))
+	}
+	if innerSetups != 0 {
+		t.Fatalf("inner effect setups after outer rollback = %d, want 0", innerSetups)
+	}
+}
+
+func TestBoundaryTransactionInvariantEscapeRollsBackAndRestoresState(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	events := []string{}
+	label := "A"
+	dep := 1
+	owner := testComponentInstanceWithParent("InvariantOwner", boundary, func() Node {
+		committedLabel := label
+		UseEffect(func() Cleanup {
+			events = append(events, "setup "+committedLabel)
+			return func() {
+				events = append(events, "cleanup "+committedLabel)
+			}
+		}, Deps(dep))
+		return Empty()
+	})
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+
+	label = "B"
+	dep = 2
+	invariant := testComponentInstanceWithParent("InvariantDescendant", boundary, func() Node {
+		UseEffect(func() Cleanup { return nil }, Deps(struct{}{}))
+		return Empty()
+	})
+	assertPanic(t,
+		"goframe: unsupported effect dependency type; reduce complex values to string, id, version, or counter",
+		func() {
+			runProtectedSubtreeTestAttempt(boundary, func() {
+				renderComponentInstance(owner)
+				renderComponentInstance(invariant)
+			})
+		})
+
+	if currentComponent != nil {
+		t.Fatalf("current component after invariant escape = %p, want nil", currentComponent)
+	}
+	if currentProtectedSubtreeTransaction != nil {
+		t.Fatalf("protected transaction after invariant escape = %p, want nil",
+			currentProtectedSubtreeTransaction)
+	}
+	if owner.lifecycleAttempt.active || len(owner.lifecycleAttempt.effects) != 0 {
+		t.Fatalf("owner lifecycle attempt after invariant escape = %#v, want cleared", owner.lifecycleAttempt)
+	}
+	if len(owner.effectSlots) != 1 || !depsEqual(owner.effectSlots[0].deps, Deps(1)) {
+		t.Fatalf("committed owner effect changed after invariant escape: %#v", owner.effectSlots)
+	}
+	if len(pendingEffects) != 0 {
+		t.Fatalf("pending effects after invariant escape = %d, want 0", len(pendingEffects))
+	}
+	if boundary.errorBoundary.phase != errorBoundaryProtected {
+		t.Fatalf("boundary captured invariant, phase=%d", boundary.errorBoundary.phase)
+	}
+
+	label = "C"
+	dep = 3
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+	deactivateComponent(owner)
+	assertEffectEvents(t, events, []string{
+		"setup A",
+		"cleanup A",
+		"setup C",
+		"cleanup C",
+	})
+}
+
+func TestProtectedSubtreeSuccessfulUpdatePreservesLifecycleTiming(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	events := []string{}
+	loader := &resourceTestLoader{}
+	version := "A"
+	owner := testComponentInstanceWithParent("SuccessfulOwner", boundary, func() Node {
+		committedVersion := version
+		UseEffect(func() Cleanup {
+			events = append(events, "effect "+committedVersion)
+			return func() {
+				events = append(events, "effect cleanup "+committedVersion)
+			}
+		}, Deps(committedVersion))
+		UseUnmount(func() {
+			events = append(events, "unmount "+committedVersion)
+		})
+		_, _ = UseResource(committedVersion, loader.load)
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	flushPendingEffects()
+	control := resourceControlForTest[string](t, owner)
+	runA := control.current
+
+	version = "B"
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		if control.key != "A" || control.current != runA || !runA.active {
+			t.Fatalf("resource committed before subtree success: key=%q current=%p active=%v",
+				control.key, control.current, runA.active)
+		}
+		if len(events) != 1 || loader.cleanups != 0 || len(loader.starts) != 1 {
+			t.Fatalf("lifecycle ran during reconciliation events=%#v cleanups=%d starts=%#v",
+				events, loader.cleanups, loader.starts)
+		}
+	})
+
+	if control.key != "B" || control.generation != 1 || runA.active {
+		t.Fatalf("resource after successful commit key=%q generation=%d old active=%v, want B/1/false",
+			control.key, control.generation, runA.active)
+	}
+	if len(events) != 1 || loader.cleanups != 0 || len(loader.starts) != 1 {
+		t.Fatalf("lifecycle ran before effect flush events=%#v cleanups=%d starts=%#v",
+			events, loader.cleanups, loader.starts)
+	}
+
+	flushPendingEffects()
+	assertEffectEvents(t, events, []string{"effect A", "effect cleanup A", "effect B"})
+	if loader.cleanups != 1 {
+		t.Fatalf("resource cleanups after successful update = %d, want 1", loader.cleanups)
+	}
+	if got := loader.starts; len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("resource starts after successful update = %#v, want [A B]", got)
+	}
+
+	deactivateComponent(owner)
+	assertEffectEvents(t, events, []string{
+		"effect A",
+		"effect cleanup A",
+		"effect B",
+		"effect cleanup B",
+		"unmount B",
+	})
+	if loader.cleanups != 2 {
+		t.Fatalf("resource cleanups after unmount = %d, want 2", loader.cleanups)
+	}
+}
+
+func TestProtectedSubtreeSuccessfulLifecycleOrderRemainsParentFirst(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+
+	events := []string{}
+	parent := testComponentInstanceWithParent("EffectParent", boundary, func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "parent")
+			return nil
+		})
+		return Empty()
+	})
+	child := testComponentInstanceWithParent("EffectChild", parent, func() Node {
+		UseEffect(func() Cleanup {
+			events = append(events, "child")
+			return nil
+		})
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(parent)
+		renderComponentInstance(child)
+	})
+	if len(pendingEffects) != 2 ||
+		pendingEffects[0].owner != parent ||
+		pendingEffects[1].owner != child {
+		t.Fatalf("successful transaction effect order = %#v, want parent then child", pendingEffects)
+	}
+	flushPendingEffects()
+	assertEffectEvents(t, events, []string{"parent", "child"})
+}
+
+func runProtectedSubtreeTestAttempt(boundary *componentInstance, reconcile func()) {
+	runProtectedSubtreeLifecycleTransaction(boundary, reconcile)
+}
+
+func transactionTestBoundary() *componentInstance {
+	boundary := testErrorBoundaryInstance("", func(ErrorBoundaryContext) Node {
+		return Text("fallback")
+	}, nil)
+	renderComponentInstance(boundary)
+	return boundary
+}
+
+func transactionTestRisky(parent *componentInstance, panicValue string) *componentInstance {
+	return testComponentInstanceWithParent("RiskyDescendant", parent, func() Node {
+		panic(panicValue)
+	})
+}
+
+func transactionTestLifecycleOwner(
+	parent *componentInstance,
+	version *string,
+	events *[]string,
+	loader *resourceTestLoader,
+) *componentInstance {
+	return testComponentInstanceWithParent("LifecycleOwner", parent, func() Node {
+		committedVersion := *version
+		UseEffect(func() Cleanup {
+			*events = append(*events, "effect "+committedVersion)
+			return func() {
+				*events = append(*events, "effect cleanup "+committedVersion)
+			}
+		}, Deps(committedVersion))
+		UseUnmount(func() {
+			*events = append(*events, "unmount "+committedVersion)
+		})
+		_, _ = UseResource(committedVersion, loader.load)
+		return Empty()
+	})
+}

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -5,6 +5,95 @@ import (
 	"testing"
 )
 
+func TestDirtyOwnerBelowProtectedBoundaryRemainsScheduled(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	owner := dirtyCleanInstance("DirtyOwner", boundary)
+
+	var scheduled []*componentInstance
+	owner.scheduleUpdate = func(instance *componentInstance) {
+		scheduled = append(scheduled, instance)
+	}
+
+	markComponentDirty(owner)
+
+	assertInstances(t, scheduled, []*componentInstance{owner})
+	if got := nearestProtectedLifecycleState(owner); got != boundary.errorBoundary {
+		t.Fatalf("protected lifecycle state = %p, want boundary %p", got, boundary.errorBoundary)
+	}
+	if !owner.dirty || !owner.dirtyCounted {
+		t.Fatalf("owner dirty=%v counted=%v, want true/true", owner.dirty, owner.dirtyCounted)
+	}
+	if boundary.dirty {
+		t.Fatal("protected boundary was marked dirty for a descendant update")
+	}
+	if boundary.dirtyDescendants != 1 {
+		t.Fatalf("boundary dirty descendants = %d, want 1", boundary.dirtyDescendants)
+	}
+}
+
+func TestNestedDirtyOwnerRemainsScheduled(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	renderComponentInstance(inner)
+	owner := dirtyCleanInstance("NestedDirtyOwner", inner)
+
+	var scheduled []*componentInstance
+	owner.scheduleUpdate = func(instance *componentInstance) {
+		scheduled = append(scheduled, instance)
+	}
+
+	markComponentDirty(owner)
+
+	assertInstances(t, scheduled, []*componentInstance{owner})
+	if got := nearestProtectedLifecycleState(owner); got != inner.errorBoundary {
+		t.Fatalf("protected lifecycle state = %p, want inner boundary %p", got, inner.errorBoundary)
+	}
+	if got := nearestProtectedLifecycleState(inner); got != nil {
+		t.Fatalf("dirty boundary selected ancestor lifecycle state %p, want nil", got)
+	}
+	if outer.dirty || inner.dirty {
+		t.Fatalf("boundaries dirty outer=%v inner=%v, want false/false", outer.dirty, inner.dirty)
+	}
+	if outer.dirtyDescendants != 1 || inner.dirtyDescendants != 1 {
+		t.Fatalf("dirty descendants outer=%d inner=%d, want 1/1",
+			outer.dirtyDescendants, inner.dirtyDescendants)
+	}
+}
+
+func TestDirtyFallbackChildRemainsScheduledBelowCapturedBoundary(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	renderComponentInstance(inner)
+	inner.errorBoundary.phase = errorBoundaryFallback
+	owner := dirtyCleanInstance("FallbackDirtyOwner", inner)
+
+	var scheduled []*componentInstance
+	owner.scheduleUpdate = func(instance *componentInstance) {
+		scheduled = append(scheduled, instance)
+	}
+
+	markComponentDirty(owner)
+
+	assertInstances(t, scheduled, []*componentInstance{owner})
+	if got := nearestProtectedLifecycleState(owner); got != outer.errorBoundary {
+		t.Fatalf("protected lifecycle state = %p, want outer boundary %p", got, outer.errorBoundary)
+	}
+	if outer.dirty || inner.dirty {
+		t.Fatalf("boundaries dirty outer=%v inner=%v, want false/false", outer.dirty, inner.dirty)
+	}
+	if outer.dirtyDescendants != 1 || inner.dirtyDescendants != 1 {
+		t.Fatalf("dirty descendants outer=%d inner=%d, want 1/1",
+			outer.dirtyDescendants, inner.dirtyDescendants)
+	}
+}
+
 func TestProtectedSubtreeEffectStateRollsBackAfterDescendantFailure(t *testing.T) {
 	isolateLifecycleTestState(t)
 	boundary := transactionTestBoundary()
@@ -424,15 +513,20 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 	previousCurrent := currentProtectedLifecycleBoundary
 	previousBegin := beginProtectedLifecycle
 	previousFinish := finishProtectedLifecycle
+	previousDirtyUpdates := protectedDirtyUpdates
 	currentProtectedLifecycleBoundary = nil
 	beginProtectedLifecycle = nil
 	finishProtectedLifecycle = nil
+	protectedDirtyUpdates = false
 	t.Cleanup(func() {
 		currentProtectedLifecycleBoundary = previousCurrent
 		beginProtectedLifecycle = previousBegin
 		finishProtectedLifecycle = previousFinish
+		protectedDirtyUpdates = previousDirtyUpdates
 	})
-	if beginProtectedLifecycle != nil || finishProtectedLifecycle != nil {
+	if beginProtectedLifecycle != nil ||
+		finishProtectedLifecycle != nil ||
+		protectedDirtyUpdates {
 		t.Fatal("protected lifecycle hooks installed before an ErrorBoundary")
 	}
 
@@ -447,7 +541,9 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 	if currentProtectedLifecycleBoundary != nil {
 		t.Fatal("ordinary component render installed protected lifecycle boundary")
 	}
-	if beginProtectedLifecycle != nil || finishProtectedLifecycle != nil {
+	if beginProtectedLifecycle != nil ||
+		finishProtectedLifecycle != nil ||
+		protectedDirtyUpdates {
 		t.Fatal("ordinary component render installed protected lifecycle hooks")
 	}
 	if len(ordinary.effectSlots) != 1 {
@@ -455,7 +551,9 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 	}
 
 	outer := transactionTestBoundary()
-	if beginProtectedLifecycle == nil || finishProtectedLifecycle == nil {
+	if beginProtectedLifecycle == nil ||
+		finishProtectedLifecycle == nil ||
+		!protectedDirtyUpdates {
 		t.Fatal("ErrorBoundary did not install protected lifecycle hooks")
 	}
 	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -388,9 +388,8 @@ func TestBoundaryTransactionInvariantEscapeRollsBackAndRestoresState(t *testing.
 	if currentComponent != nil {
 		t.Fatalf("current component after invariant escape = %p, want nil", currentComponent)
 	}
-	if currentProtectedSubtreeTransaction != nil {
-		t.Fatalf("protected transaction after invariant escape = %p, want nil",
-			currentProtectedSubtreeTransaction)
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("protected lifecycle boundary remained installed after invariant escape")
 	}
 	if owner.lifecycleAttempt.active || len(owner.lifecycleAttempt.effects) != 0 {
 		t.Fatalf("owner lifecycle attempt after invariant escape = %#v, want cleared", owner.lifecycleAttempt)
@@ -418,6 +417,71 @@ func TestBoundaryTransactionInvariantEscapeRollsBackAndRestoresState(t *testing.
 		"setup C",
 		"cleanup C",
 	})
+}
+
+func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
+	isolateLifecycleTestState(t)
+	previousCurrent := currentProtectedLifecycleBoundary
+	previousBegin := beginProtectedLifecycle
+	previousFinish := finishProtectedLifecycle
+	currentProtectedLifecycleBoundary = nil
+	beginProtectedLifecycle = nil
+	finishProtectedLifecycle = nil
+	t.Cleanup(func() {
+		currentProtectedLifecycleBoundary = previousCurrent
+		beginProtectedLifecycle = previousBegin
+		finishProtectedLifecycle = previousFinish
+	})
+	if beginProtectedLifecycle != nil || finishProtectedLifecycle != nil {
+		t.Fatal("protected lifecycle hooks installed before an ErrorBoundary")
+	}
+
+	ordinary := testComponentInstance("Ordinary", func() Node {
+		UseEffect(func() Cleanup { return nil })
+		return Empty()
+	}, nil)
+	renderComponentInstance(ordinary)
+	if ordinary.errorBoundary != nil {
+		t.Fatal("ordinary component installed protected lifecycle hooks")
+	}
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("ordinary component render installed protected lifecycle boundary")
+	}
+	if beginProtectedLifecycle != nil || finishProtectedLifecycle != nil {
+		t.Fatal("ordinary component render installed protected lifecycle hooks")
+	}
+	if len(ordinary.effectSlots) != 1 {
+		t.Fatalf("ordinary component effect slots = %d, want immediate commit", len(ordinary.effectSlots))
+	}
+
+	outer := transactionTestBoundary()
+	if beginProtectedLifecycle == nil || finishProtectedLifecycle == nil {
+		t.Fatal("ErrorBoundary did not install protected lifecycle hooks")
+	}
+	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
+		return Text("inner fallback")
+	}, nil)
+	renderComponentInstance(inner)
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("idle ErrorBoundary left protected lifecycle boundary installed")
+	}
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		if currentProtectedLifecycleBoundary != outer.errorBoundary {
+			t.Fatal("outer transaction did not install its protected lifecycle boundary")
+		}
+		runProtectedSubtreeTestAttempt(inner, func() {
+			if currentProtectedLifecycleBoundary != inner.errorBoundary {
+				t.Fatal("inner transaction did not install its protected lifecycle boundary")
+			}
+		})
+		if currentProtectedLifecycleBoundary != outer.errorBoundary {
+			t.Fatal("inner transaction did not restore outer protected lifecycle boundary")
+		}
+	})
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("outer transaction did not restore default protected lifecycle boundary")
+	}
 }
 
 func TestProtectedSubtreeSuccessfulUpdatePreservesLifecycleTiming(t *testing.T) {
@@ -527,7 +591,18 @@ func TestProtectedSubtreeSuccessfulLifecycleOrderRemainsParentFirst(t *testing.T
 }
 
 func runProtectedSubtreeTestAttempt(boundary *componentInstance, reconcile func()) {
-	runProtectedSubtreeLifecycleTransaction(boundary, reconcile)
+	var state *errorBoundaryState
+	if boundary != nil &&
+		boundary.errorBoundary != nil &&
+		boundary.errorBoundary.phase == errorBoundaryProtected {
+		state = boundary.errorBoundary
+	}
+	if state == nil {
+		panic("goframe: test boundary has no protected lifecycle reconcile hook")
+	}
+	previous := beginProtectedLifecycle(state)
+	defer finishProtectedLifecycle(state, previous)
+	reconcile()
 }
 
 func transactionTestBoundary() *componentInstance {

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -18,7 +18,7 @@ func TestDirtyOwnerBelowProtectedBoundaryRemainsScheduled(t *testing.T) {
 	markComponentDirty(owner)
 
 	assertInstances(t, scheduled, []*componentInstance{owner})
-	if got := nearestProtectedLifecycleState(owner); got != boundary.errorBoundary {
+	if got := lifecycleStateForDirtyUpdate(owner); got != boundary.errorBoundary {
 		t.Fatalf("protected lifecycle state = %p, want boundary %p", got, boundary.errorBoundary)
 	}
 	if !owner.dirty || !owner.dirtyCounted {
@@ -49,10 +49,10 @@ func TestNestedDirtyOwnerRemainsScheduled(t *testing.T) {
 	markComponentDirty(owner)
 
 	assertInstances(t, scheduled, []*componentInstance{owner})
-	if got := nearestProtectedLifecycleState(owner); got != inner.errorBoundary {
+	if got := lifecycleStateForDirtyUpdate(owner); got != inner.errorBoundary {
 		t.Fatalf("protected lifecycle state = %p, want inner boundary %p", got, inner.errorBoundary)
 	}
-	if got := nearestProtectedLifecycleState(inner); got != nil {
+	if got := lifecycleStateForDirtyUpdate(inner); got != nil {
 		t.Fatalf("dirty boundary selected ancestor lifecycle state %p, want nil", got)
 	}
 	if outer.dirty || inner.dirty {
@@ -82,7 +82,7 @@ func TestDirtyFallbackChildRemainsScheduledBelowCapturedBoundary(t *testing.T) {
 	markComponentDirty(owner)
 
 	assertInstances(t, scheduled, []*componentInstance{owner})
-	if got := nearestProtectedLifecycleState(owner); got != outer.errorBoundary {
+	if got := lifecycleStateForDirtyUpdate(owner); got != outer.errorBoundary {
 		t.Fatalf("protected lifecycle state = %p, want outer boundary %p", got, outer.errorBoundary)
 	}
 	if outer.dirty || inner.dirty {
@@ -91,6 +91,135 @@ func TestDirtyFallbackChildRemainsScheduledBelowCapturedBoundary(t *testing.T) {
 	if outer.dirtyDescendants != 1 || inner.dirtyDescendants != 1 {
 		t.Fatalf("dirty descendants outer=%d inner=%d, want 1/1",
 			outer.dirtyDescendants, inner.dirtyDescendants)
+	}
+}
+
+func TestCapturedDirtyBatchLifecycleStateSelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func() (*componentInstance, *errorBoundaryState)
+	}{
+		{
+			name: "owner under captured boundary",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				boundary := transactionTestBoundary()
+				boundary.errorBoundary.phase = errorBoundaryCaptured
+				return dirtyCleanInstance("DirtyOwner", boundary), boundary.errorBoundary
+			},
+		},
+		{
+			name: "protected inner under captured outer",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				outer := transactionTestBoundary()
+				outer.errorBoundary.phase = errorBoundaryCaptured
+				inner := transactionTestBoundaryWithParent(outer)
+				return dirtyCleanInstance("DirtyOwner", inner), outer.errorBoundary
+			},
+		},
+		{
+			name: "owner under captured inner and protected outer",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				outer := transactionTestBoundary()
+				inner := transactionTestBoundaryWithParent(outer)
+				inner.errorBoundary.phase = errorBoundaryCaptured
+				return dirtyCleanInstance("DirtyOwner", inner), inner.errorBoundary
+			},
+		},
+		{
+			name: "captured boundary instance under protected outer",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				outer := transactionTestBoundary()
+				inner := transactionTestBoundaryWithParent(outer)
+				inner.errorBoundary.phase = errorBoundaryCaptured
+				return inner, outer.errorBoundary
+			},
+		},
+		{
+			name: "protected boundary instance under captured outer",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				outer := transactionTestBoundary()
+				outer.errorBoundary.phase = errorBoundaryCaptured
+				inner := transactionTestBoundaryWithParent(outer)
+				return inner, outer.errorBoundary
+			},
+		},
+		{
+			name: "fallback child under protected outer",
+			build: func() (*componentInstance, *errorBoundaryState) {
+				outer := transactionTestBoundary()
+				inner := transactionTestBoundaryWithParent(outer)
+				inner.errorBoundary.phase = errorBoundaryFallback
+				return dirtyCleanInstance("DirtyFallbackChild", inner), outer.errorBoundary
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			instance, want := test.build()
+			if got := lifecycleStateForDirtyUpdate(instance); got != want {
+				t.Fatalf("dirty lifecycle state = %p phase=%v, want %p phase=%v",
+					got, boundaryPhaseForTest(got), want, boundaryPhaseForTest(want))
+			}
+		})
+	}
+}
+
+func TestCapturedDirtyBatchIndependentBranchRemainsRunnable(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	boundary.errorBoundary.phase = errorBoundaryCaptured
+	stale := dirtyCleanInstance("StaleOwner", boundary)
+	independent := dirtyCleanInstance("IndependentOwner", nil)
+
+	if got := lifecycleStateForDirtyUpdate(stale); got != boundary.errorBoundary {
+		t.Fatalf("stale owner state = %p, want captured boundary %p",
+			got, boundary.errorBoundary)
+	}
+	if got := lifecycleStateForDirtyUpdate(independent); got != nil {
+		t.Fatalf("independent owner state = %p, want nil", got)
+	}
+}
+
+func TestCapturedDirtyBatchDiscardBalancesBookkeeping(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	boundary.errorBoundary.phase = errorBoundaryCaptured
+	markComponentDirty(boundary)
+
+	owner := dirtyCleanInstance("StaleOwner", boundary)
+	renders := 0
+	owner.update = func() {
+		renders++
+	}
+	markComponentDirty(owner)
+
+	state := lifecycleStateForDirtyUpdate(owner)
+	if state != boundary.errorBoundary || state.phase != errorBoundaryCaptured {
+		t.Fatalf("dirty lifecycle state = %p phase=%v, want captured boundary %p",
+			state, boundaryPhaseForTest(state), boundary.errorBoundary)
+	}
+	if state.phase == errorBoundaryCaptured {
+		clearComponentDirty(owner)
+	} else {
+		owner.update()
+	}
+
+	if renders != 0 {
+		t.Fatalf("discarded owner renders = %d, want 0", renders)
+	}
+	if owner.dirty || owner.dirtyCounted {
+		t.Fatalf("discarded owner dirty=%v counted=%v, want false/false",
+			owner.dirty, owner.dirtyCounted)
+	}
+	if boundary.dirtyDescendants != 0 {
+		t.Fatalf("captured boundary dirty descendants = %d, want 0",
+			boundary.dirtyDescendants)
+	}
+	if !boundary.dirty || !boundary.dirtyCounted {
+		t.Fatalf("captured boundary dirty=%v counted=%v, want true/true",
+			boundary.dirty, boundary.dirtyCounted)
 	}
 }
 
@@ -117,7 +246,7 @@ func TestNestedFallbackTransactionSelectsProtectedAncestorByPhase(t *testing.T) 
 			if test.outer {
 				want = outer.errorBoundary
 			}
-			if got := nearestProtectedLifecycleState(inner); got != want {
+			if got := lifecycleStateForDirtyUpdate(inner); got != want {
 				t.Fatalf("%s inner boundary selected state %p, want %p",
 					test.name, got, want)
 			}
@@ -134,7 +263,7 @@ func TestNestedFallbackTransactionWithoutProtectedAncestorSelectsNil(t *testing.
 		errorBoundaryFallback,
 	} {
 		boundary.errorBoundary.phase = phase
-		if got := nearestProtectedLifecycleState(boundary); got != nil {
+		if got := lifecycleStateForDirtyUpdate(boundary); got != nil {
 			t.Fatalf("boundary phase %d selected state %p without protected ancestor, want nil",
 				phase, got)
 		}
@@ -155,7 +284,7 @@ func TestNestedFallbackTransactionSelectsNearestProtectedAncestor(t *testing.T) 
 	renderComponentInstance(inner)
 	inner.errorBoundary.phase = errorBoundaryCaptured
 
-	if got := nearestProtectedLifecycleState(inner); got != outer.errorBoundary {
+	if got := lifecycleStateForDirtyUpdate(inner); got != outer.errorBoundary {
 		t.Fatalf("captured inner selected state %p through fallback middle, want outer %p",
 			got, outer.errorBoundary)
 	}
@@ -165,7 +294,7 @@ func TestNestedFallbackTransactionSelectsNearestProtectedAncestor(t *testing.T) 
 	}, nil)
 	renderComponentInstance(nearer)
 	inner.parent = nearer
-	if got := nearestProtectedLifecycleState(inner); got != nearer.errorBoundary {
+	if got := lifecycleStateForDirtyUpdate(inner); got != nearer.errorBoundary {
 		t.Fatalf("captured inner selected state %p, want nearest protected %p",
 			got, nearer.errorBoundary)
 	}
@@ -185,7 +314,7 @@ func TestNestedFallbackTransactionRestoresSelectedOuterState(t *testing.T) {
 			return Empty()
 		})
 
-		state := nearestProtectedLifecycleState(inner)
+		state := lifecycleStateForDirtyUpdate(inner)
 		if state != outer.errorBoundary {
 			t.Fatalf("selected state = %p, want outer %p", state, outer.errorBoundary)
 		}
@@ -222,7 +351,7 @@ func TestNestedFallbackTransactionRestoresSelectedOuterState(t *testing.T) {
 			return Empty()
 		})
 
-		state := nearestProtectedLifecycleState(inner)
+		state := lifecycleStateForDirtyUpdate(inner)
 		if state != outer.errorBoundary {
 			t.Fatalf("selected state = %p, want outer %p", state, outer.errorBoundary)
 		}
@@ -669,20 +798,16 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 	previousCurrent := currentProtectedLifecycleBoundary
 	previousBegin := beginProtectedLifecycle
 	previousFinish := finishProtectedLifecycle
-	previousDirtyUpdates := protectedDirtyUpdates
 	currentProtectedLifecycleBoundary = nil
 	beginProtectedLifecycle = nil
 	finishProtectedLifecycle = nil
-	protectedDirtyUpdates = false
 	t.Cleanup(func() {
 		currentProtectedLifecycleBoundary = previousCurrent
 		beginProtectedLifecycle = previousBegin
 		finishProtectedLifecycle = previousFinish
-		protectedDirtyUpdates = previousDirtyUpdates
 	})
 	if beginProtectedLifecycle != nil ||
-		finishProtectedLifecycle != nil ||
-		protectedDirtyUpdates {
+		finishProtectedLifecycle != nil {
 		t.Fatal("protected lifecycle hooks installed before an ErrorBoundary")
 	}
 
@@ -698,8 +823,7 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 		t.Fatal("ordinary component render installed protected lifecycle boundary")
 	}
 	if beginProtectedLifecycle != nil ||
-		finishProtectedLifecycle != nil ||
-		protectedDirtyUpdates {
+		finishProtectedLifecycle != nil {
 		t.Fatal("ordinary component render installed protected lifecycle hooks")
 	}
 	if len(ordinary.effectSlots) != 1 {
@@ -708,8 +832,7 @@ func TestProtectedSubtreeLifecycleHooksInstallAndRestoreLazily(t *testing.T) {
 
 	outer := transactionTestBoundary()
 	if beginProtectedLifecycle == nil ||
-		finishProtectedLifecycle == nil ||
-		!protectedDirtyUpdates {
+		finishProtectedLifecycle == nil {
 		t.Fatal("ErrorBoundary did not install protected lifecycle hooks")
 	}
 	inner := testErrorBoundaryInstanceWithParent(outer, "", func(ErrorBoundaryContext) Node {
@@ -871,6 +994,21 @@ func transactionTestBoundary() *componentInstance {
 	}, nil)
 	renderComponentInstance(boundary)
 	return boundary
+}
+
+func transactionTestBoundaryWithParent(parent *componentInstance) *componentInstance {
+	boundary := testErrorBoundaryInstanceWithParent(parent, "", func(ErrorBoundaryContext) Node {
+		return Text("fallback")
+	}, nil)
+	renderComponentInstance(boundary)
+	return boundary
+}
+
+func boundaryPhaseForTest(state *errorBoundaryState) any {
+	if state == nil {
+		return nil
+	}
+	return state.phase
 }
 
 func transactionTestRisky(parent *componentInstance, panicValue string) *componentInstance {

--- a/pkg/goframe/protected_teardown_test.go
+++ b/pkg/goframe/protected_teardown_test.go
@@ -1,0 +1,312 @@
+package goframe
+
+import "testing"
+
+func TestProtectedTeardownSuccessfulTransactionReleasesInOrder(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	first := protectedTeardownForTest(&events, "first")
+	second := protectedTeardownForTest(&events, "second")
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		if !stageProtectedSubtreeTeardownForTest(first) ||
+			!stageProtectedSubtreeTeardownForTest(second) {
+			t.Fatal("active protected transaction did not accept teardown")
+		}
+		if len(events) != 0 {
+			t.Fatalf("teardown ran during reconciliation: %#v", events)
+		}
+		assertProtectedTeardownState(t, boundary.errorBoundary, 2, 0)
+	})
+
+	assertEffectEvents(t, events, []string{"first", "second"})
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 0)
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("successful teardown transaction left current boundary installed")
+	}
+}
+
+func TestProtectedTeardownCaptureRetainsOwnership(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "retained")
+	owner := testComponentInstanceWithParent("AttemptOwner", boundary, func() Node {
+		UseEffect(func() Cleanup { return nil })
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		stageProtectedSubtreeTeardownForTest(teardown)
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "capture teardown"))
+	})
+
+	if len(events) != 0 {
+		t.Fatalf("captured transaction released teardown: %#v", events)
+	}
+	if len(owner.effectSlots) != 0 || owner.lifecycleAttempt.active {
+		t.Fatalf("captured owner committed lifecycle: slots=%d attempt=%#v",
+			len(owner.effectSlots), owner.lifecycleAttempt)
+	}
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 1)
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("captured teardown transaction left current boundary installed")
+	}
+}
+
+func TestProtectedTeardownSuccessfulRetryFinalizesRetainedOnce(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "retained")
+	retainProtectedTeardownForTest(t, boundary, teardown)
+
+	clearErrorBoundary(boundary.errorBoundary)
+	runProtectedSubtreeTestAttempt(boundary, func() {})
+
+	assertEffectEvents(t, events, []string{"retained"})
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 0)
+
+	runProtectedSubtreeTestAttempt(boundary, func() {})
+	assertEffectEvents(t, events, []string{"retained"})
+}
+
+func TestProtectedTeardownRepeatedFailureDoesNotDuplicateOwnership(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "retained")
+	retainProtectedTeardownForTest(t, boundary, teardown)
+
+	clearErrorBoundary(boundary.errorBoundary)
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		if !stageProtectedSubtreeTeardownForTest(teardown) {
+			t.Fatal("repeated failed attempt did not retain existing teardown")
+		}
+		renderComponentInstance(transactionTestRisky(boundary, "repeat capture teardown"))
+	})
+
+	if len(events) != 0 {
+		t.Fatalf("repeated failed attempt released teardown: %#v", events)
+	}
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 1)
+
+	deactivateComponent(boundary)
+	assertEffectEvents(t, events, []string{"retained"})
+}
+
+func TestProtectedTeardownNestedSuccessMergesIntoOuter(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	inner := transactionTestBoundaryWithParent(outer)
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "inner")
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		runProtectedSubtreeTestAttempt(inner, func() {
+			stageProtectedSubtreeTeardownForTest(teardown)
+		})
+		if len(events) != 0 {
+			t.Fatalf("inner success released before outer commit: %#v", events)
+		}
+		assertProtectedTeardownState(t, inner.errorBoundary, 0, 0)
+		assertProtectedTeardownState(t, outer.errorBoundary, 1, 0)
+	})
+
+	assertEffectEvents(t, events, []string{"inner"})
+	assertProtectedTeardownState(t, outer.errorBoundary, 0, 0)
+}
+
+func TestProtectedTeardownOuterCaptureRetainsMergedInnerOwnership(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	inner := transactionTestBoundaryWithParent(outer)
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "inner")
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		runProtectedSubtreeTestAttempt(inner, func() {
+			stageProtectedSubtreeTeardownForTest(teardown)
+		})
+		renderComponentInstance(transactionTestRisky(outer, "outer capture teardown"))
+	})
+
+	if len(events) != 0 {
+		t.Fatalf("outer capture released merged teardown: %#v", events)
+	}
+	assertProtectedTeardownState(t, outer.errorBoundary, 0, 1)
+
+	deactivateComponent(outer)
+	assertEffectEvents(t, events, []string{"inner"})
+}
+
+func TestProtectedTeardownFallbackWithoutOuterFinalizesPending(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "fallback")
+	retainProtectedTeardownForTest(t, boundary, teardown)
+	boundary.errorBoundary.phase = errorBoundaryFallback
+
+	finalizePendingProtectedSubtreeTeardownForTest(boundary.errorBoundary)
+
+	assertEffectEvents(t, events, []string{"fallback"})
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 0)
+}
+
+func TestProtectedTeardownFallbackTransfersToOuter(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		capture bool
+	}{
+		{name: "outer success"},
+		{name: "outer capture", capture: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			outer := transactionTestBoundary()
+			inner := transactionTestBoundaryWithParent(outer)
+			events := []string{}
+			teardown := protectedTeardownForTest(&events, "fallback")
+			retainProtectedTeardownForTest(t, inner, teardown)
+			inner.errorBoundary.phase = errorBoundaryFallback
+
+			runProtectedSubtreeTestAttempt(outer, func() {
+				finalizePendingProtectedSubtreeTeardownForTest(inner.errorBoundary)
+				if len(events) != 0 {
+					t.Fatalf("fallback released before outer outcome: %#v", events)
+				}
+				assertProtectedTeardownState(t, inner.errorBoundary, 0, 0)
+				assertProtectedTeardownState(t, outer.errorBoundary, 1, 0)
+				if test.capture {
+					renderComponentInstance(transactionTestRisky(outer, "outer fallback capture"))
+				}
+			})
+
+			if test.capture {
+				if len(events) != 0 {
+					t.Fatalf("captured outer released fallback teardown: %#v", events)
+				}
+				assertProtectedTeardownState(t, outer.errorBoundary, 0, 1)
+				deactivateComponent(outer)
+			}
+			assertEffectEvents(t, events, []string{"fallback"})
+		})
+	}
+}
+
+func TestProtectedTeardownBoundaryDestructionReleasesPendingOnce(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "destroy")
+	retainProtectedTeardownForTest(t, boundary, teardown)
+
+	deactivateComponent(boundary)
+	deactivateComponent(boundary)
+
+	assertEffectEvents(t, events, []string{"destroy"})
+	if boundary.errorBoundary != nil {
+		t.Fatal("destroyed boundary retained error boundary state")
+	}
+}
+
+func TestProtectedTeardownInvariantEscapeRetainsOwnership(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "invariant")
+
+	assertPanic(t, "goframe: protected teardown invariant", func() {
+		runProtectedSubtreeTestAttempt(boundary, func() {
+			stageProtectedSubtreeTeardownForTest(teardown)
+			panic("goframe: protected teardown invariant")
+		})
+	})
+
+	if len(events) != 0 {
+		t.Fatalf("invariant escape released teardown: %#v", events)
+	}
+	if currentProtectedLifecycleBoundary != nil {
+		t.Fatal("invariant escape left current boundary installed")
+	}
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 1)
+
+	deactivateComponent(boundary)
+	assertEffectEvents(t, events, []string{"invariant"})
+}
+
+func TestProtectedTeardownReleaseDetachesJournalBeforeCallbacks(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	first := protectedTeardownForTestCallback(func() {
+		assertProtectedTeardownState(t, boundary.errorBoundary, 0, 0)
+		events = append(events, "first")
+	})
+	second := protectedTeardownForTest(&events, "second")
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		stageProtectedSubtreeTeardownForTest(first)
+		stageProtectedSubtreeTeardownForTest(second)
+	})
+
+	assertEffectEvents(t, events, []string{"first", "second"})
+}
+
+func TestProtectedTeardownRepeatedStagingReleasesOnce(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	events := []string{}
+	teardown := protectedTeardownForTest(&events, "once")
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		stageProtectedSubtreeTeardownForTest(teardown)
+		stageProtectedSubtreeTeardownForTest(teardown)
+		stageProtectedSubtreeTeardownForTest(teardown)
+	})
+
+	assertEffectEvents(t, events, []string{"once"})
+}
+
+func protectedTeardownForTest(events *[]string, label string) *protectedSubtreeTeardown {
+	return protectedTeardownForTestCallback(func() {
+		*events = append(*events, label)
+	})
+}
+
+func retainProtectedTeardownForTest(
+	t *testing.T,
+	boundary *componentInstance,
+	teardown *protectedSubtreeTeardown,
+) {
+	t.Helper()
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		if !stageProtectedSubtreeTeardownForTest(teardown) {
+			t.Fatal("active protected transaction did not accept teardown")
+		}
+		renderComponentInstance(transactionTestRisky(boundary, "retain teardown"))
+	})
+	if boundary.errorBoundary.phase != errorBoundaryCaptured {
+		t.Fatalf("boundary phase = %d, want captured", boundary.errorBoundary.phase)
+	}
+	assertProtectedTeardownState(t, boundary.errorBoundary, 0, 1)
+}
+
+func assertProtectedTeardownState(
+	t *testing.T,
+	state *errorBoundaryState,
+	active int,
+	pending int,
+) {
+	t.Helper()
+	gotActive, gotPending := protectedTeardownStateForTest(state)
+	if gotActive != active {
+		t.Fatalf("active teardown journal length = %d, want %d", gotActive, active)
+	}
+	if gotPending != pending {
+		t.Fatalf("pending teardown journal length = %d, want %d", gotPending, pending)
+	}
+}

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -131,7 +131,15 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 	end := document.Call("createComment", "/goframe-component")
 	fragment := document.Call("createDocumentFragment")
 	fragment.Call("appendChild", start)
-	child := mountNode(document, renderComponentInstance(instance), instance)
+	rendered := renderComponentInstance(instance)
+	var child *mountedNode
+	if componentHasProtectedErrorBoundary(instance) {
+		runProtectedSubtreeLifecycleTransaction(instance, func() {
+			child = mountNode(document, rendered, instance)
+		})
+	} else {
+		child = mountNode(document, rendered, instance)
+	}
 	placeMountedBefore(fragment, child, js.Null())
 	fragment.Call("appendChild", end)
 	mounted.componentChild = child
@@ -147,7 +155,9 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 		if parent.IsUndefined() || parent.IsNull() {
 			return
 		}
-		patchComponent(document, parent, mounted, instance.node, instance.parent)
+		runProtectedDescendantLifecycleTransaction(instance, func() {
+			patchComponent(document, parent, mounted, instance.node, instance.parent)
+		})
 	}
 }
 
@@ -162,7 +172,15 @@ func patchComponent(document, parent js.Value, mounted *mountedNode, newNode Com
 		return
 	}
 	instance.node = newNode
-	child := patchMounted(document, parent, mounted.componentChild, renderComponentInstance(instance), instance)
+	rendered := renderComponentInstance(instance)
+	var child *mountedNode
+	if componentHasProtectedErrorBoundary(instance) {
+		runProtectedSubtreeLifecycleTransaction(instance, func() {
+			child = patchMounted(document, parent, mounted.componentChild, rendered, instance)
+		})
+	} else {
+		child = patchMounted(document, parent, mounted.componentChild, rendered, instance)
+	}
 	mounted.componentChild = child
 }
 

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -151,6 +151,13 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 		if parent.IsUndefined() || parent.IsNull() {
 			return
 		}
+		if protectedDirtyUpdates {
+			if state := nearestProtectedLifecycleState(instance); state != nil {
+				// Dirty flushes are non-reentrant, so no owner update can
+				// begin while this boundary transaction is already active.
+				defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
+			}
+		}
 		patchComponent(document, parent, mounted, instance.node, instance.parent)
 	}
 }

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -151,11 +151,18 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 		if parent.IsUndefined() || parent.IsNull() {
 			return
 		}
-		if protectedDirtyUpdates {
-			if state := nearestProtectedLifecycleState(instance); state != nil {
+		if beginProtectedLifecycle != nil {
+			if state := lifecycleStateForDirtyUpdate(instance); state != nil {
+				if state.phase != errorBoundaryProtected {
+					clearComponentDirty(instance)
+					return
+				}
 				// Dirty flushes are non-reentrant, so no owner update can
 				// begin while this boundary transaction is already active.
-				defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
+				defer finishProtectedSubtreeLifecycle(
+					state,
+					beginProtectedSubtreeLifecycle(state),
+				)
 			}
 		}
 		patchComponent(document, parent, mounted, instance.node, instance.parent)

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -265,6 +265,10 @@ func removeMounted(parent js.Value, mounted *mountedNode) {
 }
 
 func releaseMounted(mounted *mountedNode) {
+	if stageProtectedMountedTeardown != nil &&
+		stageProtectedMountedTeardown(mounted) {
+		return
+	}
 	if mounted.component != nil {
 		releaseMounted(mounted.componentChild)
 		deactivateComponent(mounted.component)

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -132,14 +132,10 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 	fragment := document.Call("createDocumentFragment")
 	fragment.Call("appendChild", start)
 	rendered := renderComponentInstance(instance)
-	var child *mountedNode
-	if componentHasProtectedErrorBoundary(instance) {
-		runProtectedSubtreeLifecycleTransaction(instance, func() {
-			child = mountNode(document, rendered, instance)
-		})
-	} else {
-		child = mountNode(document, rendered, instance)
+	if state := instance.errorBoundary; state != nil {
+		defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
 	}
+	child := mountNode(document, rendered, instance)
 	placeMountedBefore(fragment, child, js.Null())
 	fragment.Call("appendChild", end)
 	mounted.componentChild = child
@@ -155,9 +151,7 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 		if parent.IsUndefined() || parent.IsNull() {
 			return
 		}
-		runProtectedDescendantLifecycleTransaction(instance, func() {
-			patchComponent(document, parent, mounted, instance.node, instance.parent)
-		})
+		patchComponent(document, parent, mounted, instance.node, instance.parent)
 	}
 }
 
@@ -173,15 +167,11 @@ func patchComponent(document, parent js.Value, mounted *mountedNode, newNode Com
 	}
 	instance.node = newNode
 	rendered := renderComponentInstance(instance)
-	var child *mountedNode
-	if componentHasProtectedErrorBoundary(instance) {
-		runProtectedSubtreeLifecycleTransaction(instance, func() {
-			child = patchMounted(document, parent, mounted.componentChild, rendered, instance)
-		})
-	} else {
-		child = patchMounted(document, parent, mounted.componentChild, rendered, instance)
+	if state := instance.errorBoundary; state != nil &&
+		state.phase == errorBoundaryProtected {
+		defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
 	}
-	mounted.componentChild = child
+	mounted.componentChild = patchMounted(document, parent, mounted.componentChild, rendered, instance)
 }
 
 func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNodes []Node, boundary js.Value, owner *componentInstance) []*mountedNode {

--- a/pkg/goframe/render_teardown_js.go
+++ b/pkg/goframe/render_teardown_js.go
@@ -1,0 +1,56 @@
+//go:build js && wasm
+
+package goframe
+
+import "syscall/js"
+
+var stageProtectedMountedTeardown func(*mountedNode) bool
+
+func installProtectedMountedTeardown() {
+	stageProtectedMountedTeardown = stageMountedTeardown
+}
+
+func prepareProtectedFallbackReconcile(state *errorBoundaryState) {
+	state.phase = errorBoundaryProtected
+}
+
+func stageMountedTeardown(mounted *mountedNode) bool {
+	state := currentProtectedLifecycleBoundary
+	if state == nil {
+		return false
+	}
+	return state.teardown.stage(mounted)
+}
+
+type protectedTeardownState []*mountedNode
+
+func (state *protectedTeardownState) begin() {}
+
+func (state *protectedTeardownState) stage(
+	mounted *mountedNode,
+) bool {
+	if mounted == nil {
+		return false
+	}
+	if mounted.pending.Type() == js.TypeNull {
+		return true
+	}
+	mounted.pending = js.Null()
+	*state = append(*state, mounted)
+	return true
+}
+
+func (state *protectedTeardownState) retain() {}
+
+func (state *protectedTeardownState) merge(target *protectedTeardownState) {
+	*target = append(*target, *state...)
+	*state = nil
+}
+
+func (state *protectedTeardownState) release() {
+	entries := *state
+	*state = nil
+	for _, teardown := range entries {
+		releaseMounted(teardown)
+	}
+}

--- a/pkg/goframe/render_teardown_nonjs.go
+++ b/pkg/goframe/render_teardown_nonjs.go
@@ -1,0 +1,94 @@
+//go:build !js || !wasm
+
+package goframe
+
+func installProtectedMountedTeardown() {}
+
+func prepareProtectedFallbackReconcile(*errorBoundaryState) {}
+
+type protectedSubtreeTeardown struct {
+	release func()
+	owned   bool
+}
+
+type protectedTeardownState struct {
+	entries  []*protectedSubtreeTeardown
+	retained int
+}
+
+func (state *protectedTeardownState) begin() {
+	if state.retained != len(state.entries) {
+		panic("goframe: invalid protected subtree transaction")
+	}
+}
+
+func (state *protectedTeardownState) stage(
+	teardown *protectedSubtreeTeardown,
+) bool {
+	if teardown == nil {
+		return false
+	}
+	if teardown.owned {
+		return true
+	}
+	teardown.owned = true
+	state.entries = append(state.entries, teardown)
+	return true
+}
+
+func (state *protectedTeardownState) retain() {
+	state.retained = len(state.entries)
+}
+
+func (state *protectedTeardownState) merge(target *protectedTeardownState) {
+	target.entries = append(target.entries, state.entries...)
+	state.entries = nil
+	state.retained = 0
+}
+
+func (state *protectedTeardownState) release() {
+	entries := state.entries
+	state.entries = nil
+	state.retained = 0
+	for _, entry := range entries {
+		if entry == nil || entry.release == nil {
+			continue
+		}
+		release := entry.release
+		entry.release = nil
+		entry.owned = false
+		release()
+	}
+}
+
+func stageProtectedSubtreeTeardownForTest(
+	teardown *protectedSubtreeTeardown,
+) bool {
+	state := currentProtectedLifecycleBoundary
+	if state == nil {
+		return false
+	}
+	return state.teardown.stage(teardown)
+}
+
+func protectedTeardownForTestCallback(
+	release func(),
+) *protectedSubtreeTeardown {
+	return &protectedSubtreeTeardown{release: release}
+}
+
+func protectedTeardownStateForTest(
+	state *errorBoundaryState,
+) (active int, pending int) {
+	if state == nil {
+		return 0, 0
+	}
+	return len(state.teardown.entries) - state.teardown.retained,
+		state.teardown.retained
+}
+
+func finalizePendingProtectedSubtreeTeardownForTest(
+	state *errorBoundaryState,
+) {
+	finalizePendingProtectedSubtreeTeardown(state)
+}

--- a/pkg/goframe/render_transaction.go
+++ b/pkg/goframe/render_transaction.go
@@ -6,6 +6,7 @@ func beginProtectedSubtreeLifecycle(state *errorBoundaryState) *errorBoundarySta
 	}
 	previous := currentProtectedLifecycleBoundary
 	state.attempts = make([]*componentInstance, 0)
+	state.teardown.begin()
 	currentProtectedLifecycleBoundary = state
 	return previous
 }
@@ -23,22 +24,43 @@ func finishProtectedSubtreeLifecycle(
 	currentProtectedLifecycleBoundary = previous
 	attempts := state.attempts
 	state.attempts = nil
+	if state.phase == errorBoundaryProtected &&
+		state.info.Phase != 0 {
+		state.phase = errorBoundaryFallback
+	}
 
 	if recovered != nil {
 		rollbackProtectedSubtreeLifecycleAttempts(attempts)
+		state.teardown.retain()
 		panic(recovered)
 	}
-	if state.phase != errorBoundaryProtected {
+	if state.phase != errorBoundaryProtected &&
+		state.phase != errorBoundaryFallback {
 		rollbackProtectedSubtreeLifecycleAttempts(attempts)
+		state.teardown.retain()
 		return
 	}
 	if previous != nil {
 		// The outer boundary still owns commit: a later outer failure must be
 		// able to roll back work from this successful nested subtree.
 		previous.attempts = append(previous.attempts, attempts...)
+		state.teardown.merge(&previous.teardown)
 		return
 	}
+	state.teardown.retain()
 	commitProtectedSubtreeLifecycleAttempts(attempts)
+	state.teardown.release()
+}
+
+func finalizePendingProtectedSubtreeTeardown(state *errorBoundaryState) {
+	if state == nil {
+		return
+	}
+	if currentProtectedLifecycleBoundary != nil {
+		state.teardown.merge(&currentProtectedLifecycleBoundary.teardown)
+		return
+	}
+	state.teardown.release()
 }
 
 func commitProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {

--- a/pkg/goframe/render_transaction.go
+++ b/pkg/goframe/render_transaction.go
@@ -1,0 +1,148 @@
+package goframe
+
+type protectedSubtreeTransaction struct {
+	boundary *componentInstance
+	parent   *protectedSubtreeTransaction
+	attempts []*componentInstance
+	failed   bool
+	active   bool
+}
+
+var currentProtectedSubtreeTransaction *protectedSubtreeTransaction
+
+func runProtectedSubtreeLifecycleTransaction(boundary *componentInstance, reconcile func()) {
+	transaction := beginProtectedSubtreeLifecycleTransaction(boundary)
+	completed := false
+	defer func() {
+		finishProtectedSubtreeLifecycleTransaction(transaction, completed)
+	}()
+	reconcile()
+	completed = true
+}
+
+func beginProtectedSubtreeLifecycleTransaction(boundary *componentInstance) *protectedSubtreeTransaction {
+	if !componentHasProtectedErrorBoundary(boundary) {
+		panic("goframe: protected subtree transaction requires an active error boundary")
+	}
+	transaction := &boundary.errorBoundary.transaction
+	if transaction.active {
+		panic("goframe: error boundary transaction is already active")
+	}
+	if len(transaction.attempts) != 0 {
+		panic("goframe: error boundary transaction retained lifecycle attempts")
+	}
+	transaction.boundary = boundary
+	transaction.parent = currentProtectedSubtreeTransaction
+	transaction.failed = false
+	transaction.active = true
+	currentProtectedSubtreeTransaction = transaction
+	return transaction
+}
+
+func finishProtectedSubtreeLifecycleTransaction(
+	transaction *protectedSubtreeTransaction,
+	completed bool,
+) {
+	if transaction == nil || !transaction.active {
+		panic("goframe: protected subtree transaction is not active")
+	}
+	if currentProtectedSubtreeTransaction != transaction {
+		panic("goframe: protected subtree transaction stack mismatch")
+	}
+
+	parent := transaction.parent
+	currentProtectedSubtreeTransaction = parent
+	transaction.parent = nil
+	transaction.active = false
+
+	if !completed || transaction.failed {
+		rollbackProtectedSubtreeLifecycleAttempts(transaction.attempts)
+		clearProtectedSubtreeLifecycleAttempts(transaction)
+		return
+	}
+	if parent != nil {
+		// The outer boundary still owns commit: a later outer failure must be
+		// able to roll back work from this successful nested subtree.
+		parent.attempts = append(parent.attempts, transaction.attempts...)
+		clearProtectedSubtreeLifecycleAttempts(transaction)
+		return
+	}
+
+	commitProtectedSubtreeLifecycleAttempts(transaction.attempts)
+	clearProtectedSubtreeLifecycleAttempts(transaction)
+}
+
+func stageProtectedSubtreeLifecycleAttempt(instance *componentInstance) bool {
+	transaction := currentProtectedSubtreeTransaction
+	if transaction == nil {
+		return false
+	}
+	transaction.attempts = append(transaction.attempts, instance)
+	return true
+}
+
+func failProtectedSubtreeLifecycleTransaction(boundary *componentInstance) {
+	for transaction := currentProtectedSubtreeTransaction; transaction != nil; transaction = transaction.parent {
+		if transaction.boundary == boundary {
+			transaction.failed = true
+			return
+		}
+	}
+}
+
+func componentHasProtectedErrorBoundary(instance *componentInstance) bool {
+	return instance != nil &&
+		instance.errorBoundary != nil &&
+		instance.errorBoundary.phase == errorBoundaryProtected
+}
+
+func nearestProtectedErrorBoundary(instance *componentInstance) *componentInstance {
+	for current := instance.parent; current != nil; current = current.parent {
+		if componentHasProtectedErrorBoundary(current) {
+			return current
+		}
+	}
+	return nil
+}
+
+func runProtectedDescendantLifecycleTransaction(instance *componentInstance, reconcile func()) {
+	if currentProtectedSubtreeTransaction != nil {
+		reconcile()
+		return
+	}
+	// Dirty component updates can enter below a boundary without rerendering
+	// the boundary component itself, so establish the missing protected scope.
+	boundary := nearestProtectedErrorBoundary(instance)
+	if boundary == nil {
+		reconcile()
+		return
+	}
+	runProtectedSubtreeLifecycleTransaction(boundary, reconcile)
+}
+
+func commitProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {
+	next := 0
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			rollbackProtectedSubtreeLifecycleAttempts(attempts[next:])
+			panic(recovered)
+		}
+	}()
+	for next < len(attempts) {
+		commitLifecycleRenderAttempt(attempts[next])
+		next++
+	}
+}
+
+func rollbackProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {
+	for index := len(attempts) - 1; index >= 0; index-- {
+		rollbackLifecycleRenderAttempt(attempts[index])
+	}
+}
+
+func clearProtectedSubtreeLifecycleAttempts(transaction *protectedSubtreeTransaction) {
+	clear(transaction.attempts)
+	transaction.attempts = transaction.attempts[:0]
+	transaction.boundary = nil
+	transaction.failed = false
+}

--- a/pkg/goframe/render_transaction.go
+++ b/pkg/goframe/render_transaction.go
@@ -1,148 +1,62 @@
 package goframe
 
-type protectedSubtreeTransaction struct {
-	boundary *componentInstance
-	parent   *protectedSubtreeTransaction
-	attempts []*componentInstance
-	failed   bool
-	active   bool
+func beginProtectedSubtreeLifecycle(state *errorBoundaryState) *errorBoundaryState {
+	if state.phase != errorBoundaryProtected || state.attempts != nil {
+		panic("goframe: invalid protected subtree transaction")
+	}
+	previous := currentProtectedLifecycleBoundary
+	state.attempts = make([]*componentInstance, 0)
+	currentProtectedLifecycleBoundary = state
+	return previous
 }
 
-var currentProtectedSubtreeTransaction *protectedSubtreeTransaction
-
-func runProtectedSubtreeLifecycleTransaction(boundary *componentInstance, reconcile func()) {
-	transaction := beginProtectedSubtreeLifecycleTransaction(boundary)
-	completed := false
-	defer func() {
-		finishProtectedSubtreeLifecycleTransaction(transaction, completed)
-	}()
-	reconcile()
-	completed = true
-}
-
-func beginProtectedSubtreeLifecycleTransaction(boundary *componentInstance) *protectedSubtreeTransaction {
-	if !componentHasProtectedErrorBoundary(boundary) {
-		panic("goframe: protected subtree transaction requires an active error boundary")
-	}
-	transaction := &boundary.errorBoundary.transaction
-	if transaction.active {
-		panic("goframe: error boundary transaction is already active")
-	}
-	if len(transaction.attempts) != 0 {
-		panic("goframe: error boundary transaction retained lifecycle attempts")
-	}
-	transaction.boundary = boundary
-	transaction.parent = currentProtectedSubtreeTransaction
-	transaction.failed = false
-	transaction.active = true
-	currentProtectedSubtreeTransaction = transaction
-	return transaction
-}
-
-func finishProtectedSubtreeLifecycleTransaction(
-	transaction *protectedSubtreeTransaction,
-	completed bool,
+func finishProtectedSubtreeLifecycle(
+	state *errorBoundaryState,
+	previous *errorBoundaryState,
 ) {
-	if transaction == nil || !transaction.active {
-		panic("goframe: protected subtree transaction is not active")
-	}
-	if currentProtectedSubtreeTransaction != transaction {
-		panic("goframe: protected subtree transaction stack mismatch")
+	recovered := recover()
+	if state.attempts == nil ||
+		currentProtectedLifecycleBoundary != state {
+		panic("goframe: invalid protected subtree transaction")
 	}
 
-	parent := transaction.parent
-	currentProtectedSubtreeTransaction = parent
-	transaction.parent = nil
-	transaction.active = false
+	currentProtectedLifecycleBoundary = previous
+	attempts := state.attempts
+	state.attempts = nil
 
-	if !completed || transaction.failed {
-		rollbackProtectedSubtreeLifecycleAttempts(transaction.attempts)
-		clearProtectedSubtreeLifecycleAttempts(transaction)
+	if recovered != nil {
+		rollbackProtectedSubtreeLifecycleAttempts(attempts)
+		panic(recovered)
+	}
+	if state.phase != errorBoundaryProtected {
+		rollbackProtectedSubtreeLifecycleAttempts(attempts)
 		return
 	}
-	if parent != nil {
+	if previous != nil {
 		// The outer boundary still owns commit: a later outer failure must be
 		// able to roll back work from this successful nested subtree.
-		parent.attempts = append(parent.attempts, transaction.attempts...)
-		clearProtectedSubtreeLifecycleAttempts(transaction)
+		previous.attempts = append(previous.attempts, attempts...)
 		return
 	}
-
-	commitProtectedSubtreeLifecycleAttempts(transaction.attempts)
-	clearProtectedSubtreeLifecycleAttempts(transaction)
-}
-
-func stageProtectedSubtreeLifecycleAttempt(instance *componentInstance) bool {
-	transaction := currentProtectedSubtreeTransaction
-	if transaction == nil {
-		return false
-	}
-	transaction.attempts = append(transaction.attempts, instance)
-	return true
-}
-
-func failProtectedSubtreeLifecycleTransaction(boundary *componentInstance) {
-	for transaction := currentProtectedSubtreeTransaction; transaction != nil; transaction = transaction.parent {
-		if transaction.boundary == boundary {
-			transaction.failed = true
-			return
-		}
-	}
-}
-
-func componentHasProtectedErrorBoundary(instance *componentInstance) bool {
-	return instance != nil &&
-		instance.errorBoundary != nil &&
-		instance.errorBoundary.phase == errorBoundaryProtected
-}
-
-func nearestProtectedErrorBoundary(instance *componentInstance) *componentInstance {
-	for current := instance.parent; current != nil; current = current.parent {
-		if componentHasProtectedErrorBoundary(current) {
-			return current
-		}
-	}
-	return nil
-}
-
-func runProtectedDescendantLifecycleTransaction(instance *componentInstance, reconcile func()) {
-	if currentProtectedSubtreeTransaction != nil {
-		reconcile()
-		return
-	}
-	// Dirty component updates can enter below a boundary without rerendering
-	// the boundary component itself, so establish the missing protected scope.
-	boundary := nearestProtectedErrorBoundary(instance)
-	if boundary == nil {
-		reconcile()
-		return
-	}
-	runProtectedSubtreeLifecycleTransaction(boundary, reconcile)
+	commitProtectedSubtreeLifecycleAttempts(attempts)
 }
 
 func commitProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {
-	next := 0
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			rollbackProtectedSubtreeLifecycleAttempts(attempts[next:])
-			panic(recovered)
-		}
-	}()
-	for next < len(attempts) {
-		commitLifecycleRenderAttempt(attempts[next])
-		next++
+	defer recoverProtectedSubtreeLifecycleAttempts(attempts)
+	for _, attempt := range attempts {
+		commitLifecycleRenderAttempt(attempt)
+	}
+}
+
+func recoverProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {
+	if recovered := recover(); recovered != nil {
+		rollbackProtectedSubtreeLifecycleAttempts(attempts)
+		panic(recovered)
 	}
 }
 
 func rollbackProtectedSubtreeLifecycleAttempts(attempts []*componentInstance) {
-	for index := len(attempts) - 1; index >= 0; index-- {
-		rollbackLifecycleRenderAttempt(attempts[index])
+	for index := len(attempts); index > 0; index-- {
+		rollbackLifecycleRenderAttempt(attempts[index-1])
 	}
-}
-
-func clearProtectedSubtreeLifecycleAttempts(transaction *protectedSubtreeTransaction) {
-	clear(transaction.attempts)
-	transaction.attempts = transaction.attempts[:0]
-	transaction.boundary = nil
-	transaction.failed = false
 }

--- a/pkg/goframe/resource.go
+++ b/pkg/goframe/resource.go
@@ -141,9 +141,13 @@ func (control *resourceControl[T]) prepareRender(
 	return pending.snapshot, pending.generation
 }
 
-func (control *resourceControl[T]) commitLifecycleRender(attempt *renderLifecycleAttempt) {
+func (control *resourceControl[T]) finishRender(attempt *renderLifecycleAttempt, commit bool) {
 	pending := control.pending
 	if pending.attempt != attempt {
+		return
+	}
+	if !commit {
+		control.pending = resourceRenderState[T]{}
 		return
 	}
 	control.owner = pending.owner
@@ -160,12 +164,6 @@ func (control *resourceControl[T]) commitLifecycleRender(attempt *renderLifecycl
 		control.snapshot = pending.snapshot
 	}
 	control.pending = resourceRenderState[T]{}
-}
-
-func (control *resourceControl[T]) rollbackLifecycleRender(attempt *renderLifecycleAttempt) {
-	if control.pending.attempt == attempt {
-		control.pending = resourceRenderState[T]{}
-	}
 }
 
 func (control *resourceControl[T]) reload() {

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -99,6 +99,60 @@ try {
     await assertShellSame(client, "shell after nested fallback panic");
     await assertListenerNetStable(client, "nested fallback panic");
 
+    await waitForText(client, "[data-testid='eb-transaction-version']", "A", "initial transaction version");
+    await waitForProbe(client, (current) =>
+        current.transaction.aEffectSetups === 1 &&
+        current.transaction.aResourceStarts === 1 &&
+        current.transaction.aLaterSiblingSetups === 1 &&
+        current.transaction.aEffectCleanups === 0 &&
+        current.transaction.aUnmountCallbacks === 0 &&
+        current.transaction.aResourceCleanups === 0,
+    "initial protected transaction lifecycle");
+    const beforeTransactionFailure = await probe(client);
+
+    await click(client, "[data-testid='eb-trigger-transaction-error']");
+    await waitForSelector(client, "[data-testid='eb-transaction-fallback']", "transaction boundary fallback");
+    await waitForAbsent(client, "[data-testid='eb-transaction-owner']", "failed transaction owner removed");
+    await waitForText(
+        client,
+        "[data-testid='eb-transaction-error-component']",
+        "TransactionRiskyDescendant",
+        "transaction descendant component",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeTransactionFailure.reports.length + 1 &&
+        current.reports.at(-1).phase === "render" &&
+        current.reports.at(-1).component === "TransactionRiskyDescendant" &&
+        current.transaction.attemptedBEffectSetups === 0 &&
+        current.transaction.attemptedBUnmountCallbacks === 0 &&
+        current.transaction.attemptedBResourceStarts === 0 &&
+        current.transaction.attemptedBResourceCleanups === 0 &&
+        current.transaction.attemptedBLaterSetups === 0 &&
+        current.transaction.aEffectCleanups === 1 &&
+        current.transaction.aUnmountCallbacks === 1 &&
+        current.transaction.aResourceCleanups === 1,
+    "failed protected transaction rollback");
+    await assertShellSame(client, "protected transaction fallback");
+
+    const afterTransactionFailure = await probe(client);
+    const transactionBoundaryReports =
+        afterTransactionFailure.reports.length - beforeTransactionFailure.reports.length;
+    await click(client, "[data-testid='eb-transaction-retry']");
+    await waitForText(client, "[data-testid='eb-transaction-version']", "B", "transaction retry version");
+    await waitForAbsent(client, "[data-testid='eb-transaction-fallback']", "transaction fallback cleared");
+    await waitForProbe(client, (current) =>
+        current.reports.length === afterTransactionFailure.reports.length &&
+        current.transaction.retryBEffectSetups === 1 &&
+        current.transaction.retryBResourceStarts === 1 &&
+        current.transaction.retryBLaterSetups === 1 &&
+        current.transaction.attemptedBEffectSetups === 0 &&
+        current.transaction.attemptedBUnmountCallbacks === 0 &&
+        current.transaction.attemptedBResourceStarts === 0 &&
+        current.transaction.attemptedBLaterSetups === 0 &&
+        current.listenerAudit.add === current.listenerAudit.remove,
+    "healthy protected transaction retry");
+    await assertShellSame(client, "protected transaction retry");
+
     const beforeNoBoundary = await probe(client);
     await click(client, "[data-testid='eb-trigger-no-boundary-error']");
     await waitForAbsent(client, "[data-testid='eb-no-boundary-healthy']", "no-boundary subtree default Empty fallback");
@@ -108,6 +162,14 @@ try {
     "no-boundary render report");
     await assertShellSame(client, "shell after no-boundary failure");
 
+    const finalProbe = await probe(client);
+    console.log(`Error boundary protected transaction counters: ${JSON.stringify({
+        ...finalProbe.transaction,
+        boundaryReports: transactionBoundaryReports,
+        shellIdentityChanges: finalProbe.shellIdentityChanges,
+        listenerAdditions: finalProbe.listenerAudit.add,
+        listenerRemovals: finalProbe.listenerAudit.remove,
+    })}`);
     client.close();
     console.log("Error boundary browser smoke: ok");
 } finally {
@@ -139,6 +201,7 @@ async function installListenerAudit(client) {
 async function captureShell(client) {
     const ok = await client.evaluate(`(() => {
         window.__errorBoundaryShell = document.querySelector("[data-testid='eb-shell']");
+        window.__errorBoundaryShellIdentityChanges = 0;
         return Boolean(window.__errorBoundaryShell);
     })()`);
     if (!ok) {
@@ -147,7 +210,11 @@ async function captureShell(client) {
 }
 
 async function assertShellSame(client, label) {
-    const same = await client.evaluate(`(() => window.__errorBoundaryShell === document.querySelector("[data-testid='eb-shell']"))()`);
+    const same = await client.evaluate(`(() => {
+        const same = window.__errorBoundaryShell === document.querySelector("[data-testid='eb-shell']");
+        if (!same) window.__errorBoundaryShellIdentityChanges++;
+        return same;
+    })()`);
     if (!same) {
         throw new Error(`APP FAILURE: shell identity changed during ${label}`);
     }
@@ -158,6 +225,8 @@ async function probe(client) {
         effectCount: globalThis.goframeErrorBoundaryEffectCount ?? 0,
         cleanupCount: globalThis.goframeErrorBoundaryCleanupCount ?? 0,
         reports: Array.from(globalThis.goframeErrorBoundaryReports || []),
+        transaction: globalThis.goframeProtectedTransactionProbe || {},
+        shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);
 }

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -44,6 +44,155 @@ try {
     await captureShell(client);
     await installListenerAudit(client);
 
+    await waitForProbe(client, (current) =>
+        current.local.ownerRenders >= 1 &&
+        current.local.siblingRenders >= 1 &&
+        current.local.siblingEffectSetups >= 1 &&
+        current.local.nestedInnerOwnerRenders >= 1 &&
+        current.local.nestedInnerSiblingRenders >= 1 &&
+        current.local.nestedInnerSiblingSetups >= 1 &&
+        current.local.nestedOuterSiblingRenders >= 1 &&
+        current.local.nestedOuterSiblingSetups >= 1,
+    "initial local update probes");
+
+    const localEvidence = {};
+    const beforeLocalUpdate = await probe(client);
+    await click(client, "[data-testid='eb-local-owner-update']");
+    await waitForText(client, "[data-testid='eb-local-owner-state']", "1", "local owner state update");
+    const afterLocalUpdate = await probe(client);
+    localEvidence.ownerRenderDelta = counterDelta(
+        afterLocalUpdate.local.ownerRenders,
+        beforeLocalUpdate.local.ownerRenders,
+        1,
+        "local owner render",
+    );
+    localEvidence.siblingRenderDelta = counterDelta(
+        afterLocalUpdate.local.siblingRenders,
+        beforeLocalUpdate.local.siblingRenders,
+        0,
+        "unrelated sibling render",
+    );
+    localEvidence.siblingEveryRenderDelta = counterDelta(
+        afterLocalUpdate.local.siblingEffectSetups,
+        beforeLocalUpdate.local.siblingEffectSetups,
+        0,
+        "unrelated sibling EveryRender setup",
+    );
+    counterDelta(
+        afterLocalUpdate.reports.length,
+        beforeLocalUpdate.reports.length,
+        0,
+        "local update boundary report",
+    );
+    counterDelta(
+        afterLocalUpdate.listenerAudit.add,
+        beforeLocalUpdate.listenerAudit.add,
+        0,
+        "local update listener addition",
+    );
+    counterDelta(
+        afterLocalUpdate.listenerAudit.remove,
+        beforeLocalUpdate.listenerAudit.remove,
+        0,
+        "local update listener removal",
+    );
+    await waitForAbsent(client, "[data-testid='eb-local-unexpected-fallback']", "local update fallback stays inactive");
+    await assertShellSame(client, "successful local owner update");
+
+    const beforeNestedLocalUpdate = await probe(client);
+    await click(client, "[data-testid='eb-nested-local-owner-update']");
+    await waitForText(client, "[data-testid='eb-nested-local-owner-state']", "1", "nested local owner state update");
+    const afterNestedLocalUpdate = await probe(client);
+    localEvidence.nestedInnerOwnerRenderDelta = counterDelta(
+        afterNestedLocalUpdate.local.nestedInnerOwnerRenders,
+        beforeNestedLocalUpdate.local.nestedInnerOwnerRenders,
+        1,
+        "nested inner owner render",
+    );
+    localEvidence.nestedInnerSiblingRenderDelta = counterDelta(
+        afterNestedLocalUpdate.local.nestedInnerSiblingRenders,
+        beforeNestedLocalUpdate.local.nestedInnerSiblingRenders,
+        0,
+        "nested inner sibling render",
+    );
+    localEvidence.nestedInnerSiblingEveryRenderDelta = counterDelta(
+        afterNestedLocalUpdate.local.nestedInnerSiblingSetups,
+        beforeNestedLocalUpdate.local.nestedInnerSiblingSetups,
+        0,
+        "nested inner sibling EveryRender setup",
+    );
+    localEvidence.nestedOuterSiblingRenderDelta = counterDelta(
+        afterNestedLocalUpdate.local.nestedOuterSiblingRenders,
+        beforeNestedLocalUpdate.local.nestedOuterSiblingRenders,
+        0,
+        "nested outer sibling render",
+    );
+    counterDelta(
+        afterNestedLocalUpdate.reports.length,
+        beforeNestedLocalUpdate.reports.length,
+        0,
+        "nested local update boundary report",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-nested-local-unexpected-fallback']",
+        "nested local update fallback stays inactive",
+    );
+    await assertShellSame(client, "successful nested local owner update");
+
+    await waitForText(client, "[data-testid='eb-local-transaction-version']", "A", "initial local transaction version");
+    await waitForProbe(client, (current) =>
+        current.localTransaction.aEffectSetups === 1 &&
+        current.localTransaction.aResourceStarts === 1 &&
+        current.localTransaction.aLaterSiblingSetups === 1 &&
+        current.localTransaction.aEffectCleanups === 0 &&
+        current.localTransaction.aUnmountCallbacks === 0 &&
+        current.localTransaction.aResourceCleanups === 0,
+    "initial local protected transaction lifecycle");
+    const beforeLocalTransactionFailure = await probe(client);
+
+    await click(client, "[data-testid='eb-local-transaction-trigger']");
+    await waitForSelector(client, "[data-testid='eb-local-transaction-fallback']", "local transaction boundary fallback");
+    await waitForAbsent(client, "[data-testid='eb-local-transaction-owner']", "failed local transaction owner removed");
+    await waitForText(
+        client,
+        "[data-testid='eb-local-transaction-error-component']",
+        "LocalTransactionRiskyDescendant",
+        "local transaction descendant component",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeLocalTransactionFailure.reports.length + 1 &&
+        current.reports.at(-1).phase === "render" &&
+        current.reports.at(-1).component === "LocalTransactionRiskyDescendant" &&
+        current.localTransaction.attemptedBEffectSetups === 0 &&
+        current.localTransaction.attemptedBUnmountCallbacks === 0 &&
+        current.localTransaction.attemptedBResourceStarts === 0 &&
+        current.localTransaction.attemptedBResourceCleanups === 0 &&
+        current.localTransaction.attemptedBLaterSetups === 0 &&
+        current.localTransaction.aEffectCleanups === 1 &&
+        current.localTransaction.aUnmountCallbacks === 1 &&
+        current.localTransaction.aResourceCleanups === 1,
+    "failed local protected transaction rollback");
+    await assertShellSame(client, "local protected transaction fallback");
+
+    const afterLocalTransactionFailure = await probe(client);
+    localEvidence.localTransactionBoundaryReports =
+        afterLocalTransactionFailure.reports.length - beforeLocalTransactionFailure.reports.length;
+    await click(client, "[data-testid='eb-local-transaction-retry']");
+    await waitForText(client, "[data-testid='eb-local-transaction-version']", "B", "local transaction retry version");
+    await waitForAbsent(client, "[data-testid='eb-local-transaction-fallback']", "local transaction fallback cleared");
+    await waitForProbe(client, (current) =>
+        current.reports.length === afterLocalTransactionFailure.reports.length &&
+        current.localTransaction.retryBEffectSetups === 1 &&
+        current.localTransaction.retryBResourceStarts === 1 &&
+        current.localTransaction.retryBLaterSetups === 1 &&
+        current.localTransaction.attemptedBEffectSetups === 0 &&
+        current.localTransaction.attemptedBUnmountCallbacks === 0 &&
+        current.localTransaction.attemptedBResourceStarts === 0 &&
+        current.localTransaction.attemptedBLaterSetups === 0,
+    "healthy local protected transaction retry");
+    await assertShellSame(client, "local protected transaction retry");
+
     await click(client, "[data-testid='eb-protected-increment']");
     await waitForText(client, "[data-testid='eb-protected-state']", "1", "protected state before failure");
     await waitForProbe(client, (probe) => probe.effectCount === 2 && probe.cleanupCount === 1, "effect rerun before failure");
@@ -165,6 +314,9 @@ try {
     const finalProbe = await probe(client);
     console.log(`Error boundary protected transaction counters: ${JSON.stringify({
         ...finalProbe.transaction,
+        localEvidence,
+        localUpdate: finalProbe.local,
+        localTransaction: finalProbe.localTransaction,
         boundaryReports: transactionBoundaryReports,
         shellIdentityChanges: finalProbe.shellIdentityChanges,
         listenerAdditions: finalProbe.listenerAudit.add,
@@ -226,9 +378,19 @@ async function probe(client) {
         cleanupCount: globalThis.goframeErrorBoundaryCleanupCount ?? 0,
         reports: Array.from(globalThis.goframeErrorBoundaryReports || []),
         transaction: globalThis.goframeProtectedTransactionProbe || {},
+        local: globalThis.goframeLocalUpdateProbe || {},
+        localTransaction: globalThis.goframeLocalTransactionProbe || {},
         shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);
+}
+
+function counterDelta(after, before, expected, label) {
+    const delta = after - before;
+    if (delta !== expected) {
+        throw new Error(`APP FAILURE: ${label} delta = ${delta}, want ${expected}`);
+    }
+    return delta;
 }
 
 async function click(client, selector) {

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -100,6 +100,122 @@ try {
         current.nestedFallback.laterSiblingSetups === 0,
     "initial nested fallback transaction counters");
 
+    await waitForSelector(
+        client,
+        "[data-testid='eb-teardown-removed']",
+        "initial removable lifecycle child",
+    );
+    await waitForText(
+        client,
+        "[data-testid='eb-teardown-replaced']",
+        "replaced A",
+        "initial replaceable lifecycle child",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-teardown-fallback']",
+        "initial teardown fallback absent",
+    );
+    await waitForProbe(client, (current) =>
+        current.teardown.ownerRenders === 1 &&
+        current.teardown.removedEffectSetups === 1 &&
+        current.teardown.removedEffectCleanups === 0 &&
+        current.teardown.removedUnmountCallbacks === 0 &&
+        current.teardown.removedResourceStarts === 1 &&
+        current.teardown.removedResourceCleanups === 0 &&
+        current.teardown.replacedEffectSetups === 1 &&
+        current.teardown.replacedEffectCleanups === 0 &&
+        current.teardown.replacedUnmountCallbacks === 0 &&
+        current.teardown.replacedResourceStarts === 1 &&
+        current.teardown.replacedResourceCleanups === 0 &&
+        current.teardown.fallbackRenders === 0 &&
+        current.teardown.boundaryReports === 0 &&
+        current.teardown.order === "",
+    "initial protected teardown lifecycle");
+
+    const beforeTeardownFailure = await probe(client);
+    await click(client, "[data-testid='eb-trigger-teardown-error']");
+    await waitForSelector(
+        client,
+        "[data-testid='eb-teardown-fallback']",
+        "protected teardown fallback",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-teardown-owner']",
+        "failed teardown owner removed",
+    );
+    await waitForText(
+        client,
+        "[data-testid='eb-teardown-error-component']",
+        "TeardownRiskyDescendant",
+        "protected teardown report component",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeTeardownFailure.reports.length + 1 &&
+        current.reports.at(-1).component === "TeardownRiskyDescendant" &&
+        current.teardown.ownerRenders === 2 &&
+        current.teardown.removedEffectSetups === 1 &&
+        current.teardown.removedEffectCleanups === 1 &&
+        current.teardown.removedUnmountCallbacks === 1 &&
+        current.teardown.removedResourceStarts === 1 &&
+        current.teardown.removedResourceCleanups === 1 &&
+        current.teardown.replacedEffectSetups === 1 &&
+        current.teardown.replacedEffectCleanups === 1 &&
+        current.teardown.replacedUnmountCallbacks === 1 &&
+        current.teardown.replacedResourceStarts === 1 &&
+        current.teardown.replacedResourceCleanups === 1 &&
+        current.teardown.fallbackRenders === 1 &&
+        current.teardown.boundaryReports === 1,
+    "protected teardown cleanup");
+    const afterTeardownFailure = await probe(client);
+    const teardownOrdering = assertProtectedTeardownOrdering(
+        afterTeardownFailure.teardown.order,
+        "protected teardown fallback",
+    );
+    await assertShellSame(client, "protected teardown fallback");
+
+    await click(client, "[data-testid='eb-teardown-retry']");
+    await waitForText(
+        client,
+        "[data-testid='eb-teardown-replaced']",
+        "replaced B",
+        "healthy teardown retry",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-teardown-fallback']",
+        "teardown fallback cleared",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === afterTeardownFailure.reports.length &&
+        current.teardown.ownerRenders === 3 &&
+        current.teardown.removedEffectSetups === 1 &&
+        current.teardown.removedEffectCleanups === 1 &&
+        current.teardown.removedUnmountCallbacks === 1 &&
+        current.teardown.removedResourceStarts === 1 &&
+        current.teardown.removedResourceCleanups === 1 &&
+        current.teardown.replacedEffectSetups === 2 &&
+        current.teardown.replacedEffectCleanups === 1 &&
+        current.teardown.replacedUnmountCallbacks === 1 &&
+        current.teardown.replacedResourceStarts === 2 &&
+        current.teardown.replacedResourceCleanups === 1 &&
+        current.teardown.fallbackRenders === 1 &&
+        current.teardown.boundaryReports === 1 &&
+        current.teardown.order === afterTeardownFailure.teardown.order &&
+        current.listenerAudit.add === current.listenerAudit.remove,
+    "healthy protected teardown retry");
+    await assertShellSame(client, "protected teardown retry");
+    const afterTeardownRetry = await probe(client);
+    const protectedTeardownEvidence = {
+        ...afterTeardownRetry.teardown,
+        boundaryReportDelta:
+            afterTeardownRetry.reports.length -
+            beforeTeardownFailure.reports.length,
+        fallbackIndex: teardownOrdering.fallbackIndex,
+        earliestTeardownIndex: teardownOrdering.earliestTeardownIndex,
+    };
+
     const beforeDirtyBatch = await probe(client);
     await click(client, "[data-testid='eb-trigger-dirty-batch']");
     await waitForSelector(
@@ -456,6 +572,7 @@ try {
         localTransaction: finalProbe.localTransaction,
         nestedFallback: nestedFallbackEvidence,
         capturedDirtyBatch: dirtyBatchEvidence,
+        protectedTeardown: protectedTeardownEvidence,
         boundaryReports: transactionBoundaryReports,
         shellIdentityChanges: finalProbe.shellIdentityChanges,
         listenerAdditions: finalProbe.listenerAudit.add,
@@ -521,6 +638,7 @@ async function probe(client) {
         localTransaction: globalThis.goframeLocalTransactionProbe || {},
         nestedFallback: globalThis.goframeNestedFallbackTransactionProbe || {},
         dirtyBatch: globalThis.goframeCapturedDirtyBatchProbe || {},
+        teardown: globalThis.goframeProtectedTeardownProbe || {},
         shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);
@@ -532,6 +650,42 @@ function counterDelta(after, before, expected, label) {
         throw new Error(`APP FAILURE: ${label} delta = ${delta}, want ${expected}`);
     }
     return delta;
+}
+
+function assertProtectedTeardownOrdering(order, label) {
+    const events = order.split(",").filter(Boolean);
+    const fallbackIndex = events.indexOf("fallback-render");
+    const teardownMarkers = [
+        "removed-effect-cleanup",
+        "removed-resource-cleanup",
+        "removed-unmount",
+        "replaced-effect-cleanup",
+        "replaced-resource-cleanup",
+        "replaced-unmount",
+    ];
+    const teardownIndices = teardownMarkers.map((marker) => {
+        const index = events.indexOf(marker);
+        if (index < 0) {
+            throw new Error(
+                `APP FAILURE: missing ${marker} during ${label}; order=${JSON.stringify(events)}`,
+            );
+        }
+        if (events.indexOf(marker, index + 1) >= 0) {
+            throw new Error(
+                `APP FAILURE: duplicate ${marker} during ${label}; order=${JSON.stringify(events)}`,
+            );
+        }
+        return index;
+    });
+    const earliestTeardownIndex = Math.min(...teardownIndices);
+    if (fallbackIndex < 0 || teardownIndices.some((index) => index <= fallbackIndex)) {
+        throw new Error(
+            `APP FAILURE: protected teardown ran before fallback render during ${label}; ` +
+            `fallbackIndex=${fallbackIndex}; earliestTeardownIndex=${earliestTeardownIndex}; ` +
+            `order=${JSON.stringify(events)}`,
+        );
+    }
+    return { fallbackIndex, earliestTeardownIndex };
 }
 
 async function click(client, selector) {

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -55,6 +55,26 @@ try {
         current.local.nestedOuterSiblingSetups >= 1,
     "initial local update probes");
 
+    await waitForText(
+        client,
+        "[data-testid='eb-dirty-batch-later-version']",
+        "A",
+        "initial captured dirty batch later owner",
+    );
+    await waitForText(
+        client,
+        "[data-testid='eb-dirty-batch-independent']",
+        "0",
+        "initial captured dirty batch independent owner",
+    );
+    await waitForProbe(client, (current) =>
+        current.dirtyBatch.failingOwnerRenders === 1 &&
+        current.dirtyBatch.laterARenders === 1 &&
+        current.dirtyBatch.aEffectSetups === 1 &&
+        current.dirtyBatch.aResourceStarts === 1 &&
+        current.dirtyBatch.independentOwnerRenders === 1,
+    "initial captured dirty batch lifecycle");
+
     await waitForSelector(
         client,
         "[data-testid='eb-nested-fallback-protected']",
@@ -79,6 +99,53 @@ try {
         current.nestedFallback.resourceCleanups === 0 &&
         current.nestedFallback.laterSiblingSetups === 0,
     "initial nested fallback transaction counters");
+
+    const beforeDirtyBatch = await probe(client);
+    await click(client, "[data-testid='eb-trigger-dirty-batch']");
+    await waitForSelector(
+        client,
+        "[data-testid='eb-dirty-batch-fallback']",
+        "captured dirty batch fallback",
+    );
+    await waitForText(
+        client,
+        "[data-testid='eb-dirty-batch-error-component']",
+        "DirtyBatchRiskyDescendant",
+        "captured dirty batch report component",
+    );
+    await waitForText(
+        client,
+        "[data-testid='eb-dirty-batch-independent']",
+        "1",
+        "captured dirty batch independent update",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeDirtyBatch.reports.length + 1 &&
+        current.reports.at(-1).component === "DirtyBatchRiskyDescendant" &&
+        current.dirtyBatch.setterOrder === "failing B,later B,independent 1" &&
+        current.dirtyBatch.renderOrder === "failing B,risky B,independent 1" &&
+        current.dirtyBatch.attemptedBRenders === 0 &&
+        current.dirtyBatch.attemptedBEffectSetups === 0 &&
+        current.dirtyBatch.attemptedBEffectCleanups === 0 &&
+        current.dirtyBatch.attemptedBUnmounts === 0 &&
+        current.dirtyBatch.attemptedBResourceStarts === 0 &&
+        current.dirtyBatch.attemptedBResourceCleanups === 0 &&
+        current.dirtyBatch.aEffectCleanups === 1 &&
+        current.dirtyBatch.aUnmountCallbacks === 1 &&
+        current.dirtyBatch.aResourceCleanups === 1 &&
+        current.dirtyBatch.independentOwnerRenders ===
+            beforeDirtyBatch.dirtyBatch.independentOwnerRenders + 1,
+    "captured dirty batch discard");
+    await assertShellSame(client, "captured dirty batch fallback");
+    const afterDirtyBatch = await probe(client);
+    const dirtyBatchEvidence = {
+        ...afterDirtyBatch.dirtyBatch,
+        boundaryReports:
+            afterDirtyBatch.reports.length - beforeDirtyBatch.reports.length,
+        independentRenderDelta:
+            afterDirtyBatch.dirtyBatch.independentOwnerRenders -
+            beforeDirtyBatch.dirtyBatch.independentOwnerRenders,
+    };
 
     const localEvidence = {};
     const beforeLocalUpdate = await probe(client);
@@ -388,6 +455,7 @@ try {
         localUpdate: finalProbe.local,
         localTransaction: finalProbe.localTransaction,
         nestedFallback: nestedFallbackEvidence,
+        capturedDirtyBatch: dirtyBatchEvidence,
         boundaryReports: transactionBoundaryReports,
         shellIdentityChanges: finalProbe.shellIdentityChanges,
         listenerAdditions: finalProbe.listenerAudit.add,
@@ -452,6 +520,7 @@ async function probe(client) {
         local: globalThis.goframeLocalUpdateProbe || {},
         localTransaction: globalThis.goframeLocalTransactionProbe || {},
         nestedFallback: globalThis.goframeNestedFallbackTransactionProbe || {},
+        dirtyBatch: globalThis.goframeCapturedDirtyBatchProbe || {},
         shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -55,6 +55,31 @@ try {
         current.local.nestedOuterSiblingSetups >= 1,
     "initial local update probes");
 
+    await waitForSelector(
+        client,
+        "[data-testid='eb-nested-fallback-protected']",
+        "initial nested fallback protected child",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-nested-fallback-owner']",
+        "initial nested fallback owner absent",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-nested-fallback-outer']",
+        "initial nested fallback outer absent",
+    );
+    await waitForProbe(client, (current) =>
+        current.nestedFallback.ownerRenders === 0 &&
+        current.nestedFallback.effectSetups === 0 &&
+        current.nestedFallback.effectCleanups === 0 &&
+        current.nestedFallback.unmountCallbacks === 0 &&
+        current.nestedFallback.resourceStarts === 0 &&
+        current.nestedFallback.resourceCleanups === 0 &&
+        current.nestedFallback.laterSiblingSetups === 0,
+    "initial nested fallback transaction counters");
+
     const localEvidence = {};
     const beforeLocalUpdate = await probe(client);
     await click(client, "[data-testid='eb-local-owner-update']");
@@ -248,6 +273,51 @@ try {
     await assertShellSame(client, "shell after nested fallback panic");
     await assertListenerNetStable(client, "nested fallback panic");
 
+    const beforeNestedFallbackTransaction = await probe(client);
+    await click(client, "[data-testid='eb-trigger-nested-fallback-transaction']");
+    await waitForSelector(
+        client,
+        "[data-testid='eb-nested-fallback-outer']",
+        "nested fallback descendant bubbles to outer",
+    );
+    await waitForAbsent(
+        client,
+        "[data-testid='eb-nested-fallback-owner']",
+        "failed nested fallback lifecycle owner removed",
+    );
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeNestedFallbackTransaction.reports.length + 2 &&
+        current.reports.at(-2).component === "InitialRiskyChild" &&
+        current.reports.at(-1).component === "FallbackRiskyDescendant" &&
+        current.nestedFallback.ownerRenders === 1 &&
+        current.nestedFallback.effectSetups === 0 &&
+        current.nestedFallback.effectCleanups === 0 &&
+        current.nestedFallback.unmountCallbacks === 0 &&
+        current.nestedFallback.resourceStarts === 0 &&
+        current.nestedFallback.resourceCleanups === 0 &&
+        current.nestedFallback.laterSiblingSetups === 0,
+    "nested fallback transaction rollback");
+    await waitForStableReportCount(
+        client,
+        beforeNestedFallbackTransaction.reports.length + 2,
+        "nested fallback transaction",
+    );
+    await assertShellSame(client, "nested fallback transaction");
+    await assertListenerNetStable(client, "nested fallback transaction");
+    const afterNestedFallbackTransaction = await probe(client);
+    const nestedFallbackReports = afterNestedFallbackTransaction.reports.slice(
+        beforeNestedFallbackTransaction.reports.length,
+    );
+    const nestedFallbackEvidence = {
+        ...afterNestedFallbackTransaction.nestedFallback,
+        innerReports: nestedFallbackReports.filter(
+            (report) => report.component === "InitialRiskyChild",
+        ).length,
+        outerReports: nestedFallbackReports.filter(
+            (report) => report.component === "FallbackRiskyDescendant",
+        ).length,
+    };
+
     await waitForText(client, "[data-testid='eb-transaction-version']", "A", "initial transaction version");
     await waitForProbe(client, (current) =>
         current.transaction.aEffectSetups === 1 &&
@@ -317,6 +387,7 @@ try {
         localEvidence,
         localUpdate: finalProbe.local,
         localTransaction: finalProbe.localTransaction,
+        nestedFallback: nestedFallbackEvidence,
         boundaryReports: transactionBoundaryReports,
         shellIdentityChanges: finalProbe.shellIdentityChanges,
         listenerAdditions: finalProbe.listenerAudit.add,
@@ -380,6 +451,7 @@ async function probe(client) {
         transaction: globalThis.goframeProtectedTransactionProbe || {},
         local: globalThis.goframeLocalUpdateProbe || {},
         localTransaction: globalThis.goframeLocalTransactionProbe || {},
+        nestedFallback: globalThis.goframeNestedFallbackTransactionProbe || {},
         shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -10,6 +10,7 @@ func App() gf.Node {
 	noBoundaryBroken, setNoBoundaryBroken := gf.UseState(false)
 	transactionVersion, setTransactionVersion := gf.UseState("A")
 	transactionBroken, setTransactionBroken := gf.UseState(false)
+	nestedFallbackBroken, setNestedFallbackBroken := gf.UseState(false)
 
 	return (
 		<main data-testid="eb-shell">
@@ -56,6 +57,16 @@ func App() gf.Node {
 				Trigger inner fallback panic
 			</button>
 			<NestedBoundaryScenario Broken={nestedBroken} FallbackCrash={innerFallbackCrash} />
+
+			<button
+				data-testid="eb-trigger-nested-fallback-transaction"
+				OnClick={func() {
+					setNestedFallbackBroken(true)
+				}}
+			>
+				Trigger nested fallback transaction
+			</button>
+			<NestedFallbackTransactionScenario Broken={nestedFallbackBroken} />
 
 			<button
 				data-testid="eb-trigger-transaction-error"

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -82,6 +82,8 @@ func App() gf.Node {
 				<TransactionOwner Version={transactionVersion} Broken={transactionBroken} />
 			</gf.ErrorBoundary>
 
+			<ProtectedTeardownScenario />
+
 			<gf.ErrorBoundary Fallback={localUpdateFallback}>
 				<LocalStateOwner />
 				<LocalUpdateSibling />
@@ -121,5 +123,27 @@ func App() gf.Node {
 			</button>
 			<NoBoundaryRisky Broken={noBoundaryBroken} />
 		</main>
+	)
+}
+
+func ProtectedTeardownScenario(ProtectedTeardownScenarioProps) gf.Node {
+	version, setVersion := gf.UseState("A")
+	broken, setBroken := gf.UseState(false)
+
+	return (
+		<section data-testid="eb-teardown-scenario">
+			<button
+				data-testid="eb-trigger-teardown-error"
+				OnClick={func() {
+					setVersion("B")
+					setBroken(true)
+				}}
+			>
+				Trigger protected teardown error
+			</button>
+			<gf.ErrorBoundary Fallback={makeTeardownFallback(setBroken)}>
+				<TeardownOwner Version={version} Broken={broken} />
+			</gf.ErrorBoundary>
+		</section>
 	)
 }

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -8,6 +8,8 @@ func App() gf.Node {
 	nestedBroken, setNestedBroken := gf.UseState(false)
 	innerFallbackCrash, setInnerFallbackCrash := gf.UseState(false)
 	noBoundaryBroken, setNoBoundaryBroken := gf.UseState(false)
+	transactionVersion, setTransactionVersion := gf.UseState("A")
+	transactionBroken, setTransactionBroken := gf.UseState(false)
 
 	return (
 		<main data-testid="eb-shell">
@@ -54,6 +56,20 @@ func App() gf.Node {
 				Trigger inner fallback panic
 			</button>
 			<NestedBoundaryScenario Broken={nestedBroken} FallbackCrash={innerFallbackCrash} />
+
+			<button
+				data-testid="eb-trigger-transaction-error"
+				OnClick={func() {
+					transactionAttemptPhase = "attempt"
+					setTransactionVersion("B")
+					setTransactionBroken(true)
+				}}
+			>
+				Trigger protected transaction error
+			</button>
+			<gf.ErrorBoundary Fallback={makeTransactionFallback(setTransactionBroken)}>
+				<TransactionOwner Version={transactionVersion} Broken={transactionBroken} />
+			</gf.ErrorBoundary>
 
 			<button
 				data-testid="eb-trigger-no-boundary-error"

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -71,6 +71,23 @@ func App() gf.Node {
 				<TransactionOwner Version={transactionVersion} Broken={transactionBroken} />
 			</gf.ErrorBoundary>
 
+			<gf.ErrorBoundary Fallback={localUpdateFallback}>
+				<LocalStateOwner />
+				<LocalUpdateSibling />
+			</gf.ErrorBoundary>
+
+			<gf.ErrorBoundary Fallback={nestedLocalUpdateFallback}>
+				<NestedOuterSibling />
+				<gf.ErrorBoundary Fallback={nestedLocalUpdateFallback}>
+					<LocalInnerOwner />
+					<NestedInnerSibling />
+				</gf.ErrorBoundary>
+			</gf.ErrorBoundary>
+
+			<gf.ErrorBoundary Fallback={localTransactionFallback}>
+				<LocalTransactionOwner />
+			</gf.ErrorBoundary>
+
 			<button
 				data-testid="eb-trigger-no-boundary-error"
 				OnClick={func() {

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -100,6 +100,18 @@ func App() gf.Node {
 			</gf.ErrorBoundary>
 
 			<button
+				data-testid="eb-trigger-dirty-batch"
+				OnClick={triggerDirtyBatch}
+			>
+				Trigger captured dirty batch
+			</button>
+			<gf.ErrorBoundary Fallback={dirtyBatchFallback}>
+				<DirtyBatchFailingOwner />
+				<DirtyBatchLaterOwner />
+			</gf.ErrorBoundary>
+			<DirtyBatchIndependentOwner />
+
+			<button
 				data-testid="eb-trigger-no-boundary-error"
 				OnClick={func() {
 					setNoBoundaryBroken(true)

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -13,6 +13,7 @@ var (
 	protectedCleanupCount        int
 	transactionAttemptPhase      = "initial"
 	transactionProbe             protectedTransactionProbe
+	teardownProbe                protectedTeardownProbe
 	localTransactionVersion      = "A"
 	localTransactionAttemptPhase = "initial"
 	localUpdateProbe             localUpdateLifecycleProbe
@@ -40,6 +41,23 @@ type protectedTransactionProbe struct {
 	retryBResourceStarts       int
 	retryBResourceCleanups     int
 	retryBLaterSetups          int
+}
+
+type protectedTeardownProbe struct {
+	ownerRenders             int
+	removedEffectSetups      int
+	removedEffectCleanups    int
+	removedUnmountCallbacks  int
+	removedResourceStarts    int
+	removedResourceCleanups  int
+	replacedEffectSetups     int
+	replacedEffectCleanups   int
+	replacedUnmountCallbacks int
+	replacedResourceStarts   int
+	replacedResourceCleanups int
+	fallbackRenders          int
+	boundaryReports          int
+	order                    string
 }
 
 type localUpdateLifecycleProbe struct {
@@ -132,6 +150,21 @@ type TransactionRiskyProps struct {
 type TransactionLaterEffectProps struct {
 	Version string
 	Phase   string
+}
+
+type ProtectedTeardownScenarioProps struct{}
+
+type TeardownOwnerProps struct {
+	Version string
+	Broken  bool
+}
+
+type TeardownLifecycleChildProps struct {
+	Version string
+}
+
+type TeardownRiskyDescendantProps struct {
+	Broken bool
 }
 
 type LocalStateOwnerProps struct{}
@@ -390,6 +423,169 @@ func TransactionLaterEffect(props TransactionLaterEffectProps) gf.Node {
 		return nil
 	}, gf.Deps(props.Version))
 	return gf.Empty()
+}
+
+func TeardownOwner(props TeardownOwnerProps) gf.Node {
+	teardownProbe.ownerRenders++
+	syncBoundaryProbe()
+
+	children := make([]gf.Node, 0, 3)
+	if props.Version == "A" {
+		children = append(children, gf.Key(
+			"removed",
+			gf.Component(
+				"RemovedLifecycleChild",
+				TeardownLifecycleChildProps{Version: "A"},
+				RemovedLifecycleChild,
+			),
+		))
+	}
+
+	replaced := gf.Component(
+		"ReplacedLifecycleChildA",
+		TeardownLifecycleChildProps{Version: props.Version},
+		ReplacedLifecycleChildA,
+	)
+	if props.Version == "B" {
+		replaced = gf.Component(
+			"ReplacedLifecycleChildB",
+			TeardownLifecycleChildProps{Version: props.Version},
+			ReplacedLifecycleChildB,
+		)
+	}
+	children = append(
+		children,
+		gf.Key("replaced", replaced),
+		gf.Component(
+			"TeardownRiskyDescendant",
+			TeardownRiskyDescendantProps{Broken: props.Broken},
+			TeardownRiskyDescendant,
+		),
+	)
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-teardown-owner"},
+		children...,
+	)
+}
+
+func RemovedLifecycleChild(props TeardownLifecycleChildProps) gf.Node {
+	gf.UseEffect(func() gf.Cleanup {
+		teardownProbe.removedEffectSetups++
+		syncBoundaryProbe()
+		return func() {
+			teardownProbe.removedEffectCleanups++
+			recordTeardownEvent("removed-effect-cleanup")
+		}
+	})
+	gf.UseUnmount(func() {
+		teardownProbe.removedUnmountCallbacks++
+		recordTeardownEvent("removed-unmount")
+	})
+	_, _ = gf.UseResource("removed-"+props.Version, func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		teardownProbe.removedResourceStarts++
+		syncBoundaryProbe()
+		return func() {
+			teardownProbe.removedResourceCleanups++
+			recordTeardownEvent("removed-resource-cleanup")
+		}
+	})
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-teardown-removed"},
+		gf.Text("removed "+props.Version),
+	)
+}
+
+func ReplacedLifecycleChildA(props TeardownLifecycleChildProps) gf.Node {
+	return replacedLifecycleChild(props)
+}
+
+func ReplacedLifecycleChildB(props TeardownLifecycleChildProps) gf.Node {
+	return replacedLifecycleChild(props)
+}
+
+func replacedLifecycleChild(props TeardownLifecycleChildProps) gf.Node {
+	gf.UseEffect(func() gf.Cleanup {
+		teardownProbe.replacedEffectSetups++
+		syncBoundaryProbe()
+		return func() {
+			teardownProbe.replacedEffectCleanups++
+			recordTeardownEvent("replaced-effect-cleanup")
+		}
+	})
+	gf.UseUnmount(func() {
+		teardownProbe.replacedUnmountCallbacks++
+		recordTeardownEvent("replaced-unmount")
+	})
+	_, _ = gf.UseResource("replaced-"+props.Version, func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		teardownProbe.replacedResourceStarts++
+		syncBoundaryProbe()
+		return func() {
+			teardownProbe.replacedResourceCleanups++
+			recordTeardownEvent("replaced-resource-cleanup")
+		}
+	})
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-teardown-replaced"},
+		gf.Text("replaced "+props.Version),
+	)
+}
+
+func TeardownRiskyDescendant(props TeardownRiskyDescendantProps) gf.Node {
+	if props.Broken {
+		recordTeardownEvent("risky-panic")
+		panic("protected teardown descendant boom")
+	}
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-teardown-risky"},
+		gf.Text("healthy"),
+	)
+}
+
+func makeTeardownFallback(
+	setBroken func(bool),
+) func(gf.ErrorBoundaryContext) gf.Node {
+	return func(ctx gf.ErrorBoundaryContext) gf.Node {
+		teardownProbe.fallbackRenders++
+		teardownProbe.boundaryReports++
+		recordTeardownEvent("fallback-render")
+		return gf.El(
+			"section",
+			gf.Props{"data-testid": "eb-teardown-fallback"},
+			gf.El(
+				"p",
+				gf.Props{"data-testid": "eb-teardown-error-component"},
+				gf.Text(ctx.Info.Component),
+			),
+			gf.El(
+				"button",
+				gf.Props{
+					"data-testid": "eb-teardown-retry",
+					"OnClick": func() {
+						setBroken(false)
+						ctx.Reset()
+					},
+				},
+				gf.Text("Retry teardown transaction"),
+			),
+		)
+	}
+}
+
+func recordTeardownEvent(event string) {
+	teardownProbe.order = appendDirtyBatchStep(teardownProbe.order, event)
+	syncBoundaryProbe()
 }
 
 func LocalStateOwner(LocalStateOwnerProps) gf.Node {
@@ -844,6 +1040,7 @@ func initBoundaryProbe() {
 	protectedCleanupCount = 0
 	transactionAttemptPhase = "initial"
 	transactionProbe = protectedTransactionProbe{}
+	teardownProbe = protectedTeardownProbe{}
 	localTransactionVersion = "A"
 	localTransactionAttemptPhase = "initial"
 	localUpdateProbe = localUpdateLifecycleProbe{}
@@ -877,6 +1074,23 @@ func syncBoundaryProbe() {
 	probe.Set("retryBResourceCleanups", transactionProbe.retryBResourceCleanups)
 	probe.Set("retryBLaterSetups", transactionProbe.retryBLaterSetups)
 	js.Global().Set("goframeProtectedTransactionProbe", probe)
+
+	teardown := js.Global().Get("Object").New()
+	teardown.Set("ownerRenders", teardownProbe.ownerRenders)
+	teardown.Set("removedEffectSetups", teardownProbe.removedEffectSetups)
+	teardown.Set("removedEffectCleanups", teardownProbe.removedEffectCleanups)
+	teardown.Set("removedUnmountCallbacks", teardownProbe.removedUnmountCallbacks)
+	teardown.Set("removedResourceStarts", teardownProbe.removedResourceStarts)
+	teardown.Set("removedResourceCleanups", teardownProbe.removedResourceCleanups)
+	teardown.Set("replacedEffectSetups", teardownProbe.replacedEffectSetups)
+	teardown.Set("replacedEffectCleanups", teardownProbe.replacedEffectCleanups)
+	teardown.Set("replacedUnmountCallbacks", teardownProbe.replacedUnmountCallbacks)
+	teardown.Set("replacedResourceStarts", teardownProbe.replacedResourceStarts)
+	teardown.Set("replacedResourceCleanups", teardownProbe.replacedResourceCleanups)
+	teardown.Set("fallbackRenders", teardownProbe.fallbackRenders)
+	teardown.Set("boundaryReports", teardownProbe.boundaryReports)
+	teardown.Set("order", teardownProbe.order)
+	js.Global().Set("goframeProtectedTeardownProbe", teardown)
 
 	local := js.Global().Get("Object").New()
 	local.Set("ownerRenders", localUpdateProbe.ownerRenders)

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -9,9 +9,29 @@ import (
 )
 
 var (
-	protectedEffectCount  int
-	protectedCleanupCount int
+	protectedEffectCount    int
+	protectedCleanupCount   int
+	transactionAttemptPhase = "initial"
+	transactionProbe        protectedTransactionProbe
 )
+
+type protectedTransactionProbe struct {
+	aEffectSetups              int
+	aEffectCleanups            int
+	aUnmountCallbacks          int
+	aResourceStarts            int
+	aResourceCleanups          int
+	aLaterSiblingSetups        int
+	attemptedBEffectSetups     int
+	attemptedBUnmountCallbacks int
+	attemptedBResourceStarts   int
+	attemptedBResourceCleanups int
+	attemptedBLaterSetups      int
+	retryBEffectSetups         int
+	retryBResourceStarts       int
+	retryBResourceCleanups     int
+	retryBLaterSetups          int
+}
 
 type RiskyPanelProps struct {
 	Broken bool
@@ -37,6 +57,20 @@ type InnerFallbackProps struct {
 
 type NoBoundaryRiskyProps struct {
 	Broken bool
+}
+
+type TransactionOwnerProps struct {
+	Version string
+	Broken  bool
+}
+
+type TransactionRiskyProps struct {
+	Broken bool
+}
+
+type TransactionLaterEffectProps struct {
+	Version string
+	Phase   string
 }
 
 func RiskyPanel(props RiskyPanelProps) gf.Node {
@@ -127,9 +161,141 @@ func NoBoundaryRisky(props NoBoundaryRiskyProps) gf.Node {
 	return gf.El("section", gf.Props{"data-testid": "eb-no-boundary-healthy"}, gf.Text("no boundary healthy"))
 }
 
+func TransactionOwner(props TransactionOwnerProps) gf.Node {
+	version := props.Version
+	phase := transactionAttemptPhase
+	gf.UseEffect(func() gf.Cleanup {
+		recordTransactionEffectSetup(version, phase)
+		return func() {
+			recordTransactionEffectCleanup(version, phase)
+		}
+	}, gf.Deps(version))
+	gf.UseUnmount(func() {
+		recordTransactionUnmount(version, phase)
+	})
+	_, _ = gf.UseResource(version, func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		recordTransactionResourceStart(key, phase)
+		return func() {
+			recordTransactionResourceCleanup(key, phase)
+		}
+	})
+	return gf.El("section", gf.Props{"data-testid": "eb-transaction-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-transaction-version"}, gf.Text(version)),
+		gf.Component("TransactionRiskyDescendant", TransactionRiskyProps{
+			Broken: props.Broken,
+		}, TransactionRiskyDescendant),
+		gf.Component("TransactionLaterEffect", TransactionLaterEffectProps{
+			Version: version,
+			Phase:   phase,
+		}, TransactionLaterEffect),
+	)
+}
+
+func TransactionRiskyDescendant(props TransactionRiskyProps) gf.Node {
+	if props.Broken {
+		panic("protected transaction descendant boom")
+	}
+	return gf.El("p", gf.Props{"data-testid": "eb-transaction-descendant"}, gf.Text("healthy"))
+}
+
+func TransactionLaterEffect(props TransactionLaterEffectProps) gf.Node {
+	gf.UseEffect(func() gf.Cleanup {
+		recordTransactionLaterSetup(props.Version, props.Phase)
+		return nil
+	}, gf.Deps(props.Version))
+	return gf.Empty()
+}
+
+func makeTransactionFallback(setBroken func(bool)) func(gf.ErrorBoundaryContext) gf.Node {
+	return func(ctx gf.ErrorBoundaryContext) gf.Node {
+		return gf.El("section", gf.Props{"data-testid": "eb-transaction-fallback"},
+			gf.El("p", gf.Props{"data-testid": "eb-transaction-error-component"}, gf.Text(ctx.Info.Component)),
+			gf.El("button", gf.Props{
+				"data-testid": "eb-transaction-retry",
+				"OnClick": func() {
+					transactionAttemptPhase = "retry"
+					setBroken(false)
+					ctx.Reset()
+				},
+			}, gf.Text("Retry transaction")),
+		)
+	}
+}
+
+func recordTransactionEffectSetup(version, phase string) {
+	switch {
+	case version == "A":
+		transactionProbe.aEffectSetups++
+	case phase == "attempt":
+		transactionProbe.attemptedBEffectSetups++
+	case phase == "retry":
+		transactionProbe.retryBEffectSetups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordTransactionEffectCleanup(version, phase string) {
+	if version == "A" {
+		transactionProbe.aEffectCleanups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordTransactionUnmount(version, phase string) {
+	switch {
+	case version == "A":
+		transactionProbe.aUnmountCallbacks++
+	case phase == "attempt":
+		transactionProbe.attemptedBUnmountCallbacks++
+	}
+	syncBoundaryProbe()
+}
+
+func recordTransactionResourceStart(version, phase string) {
+	switch {
+	case version == "A":
+		transactionProbe.aResourceStarts++
+	case phase == "attempt":
+		transactionProbe.attemptedBResourceStarts++
+	case phase == "retry":
+		transactionProbe.retryBResourceStarts++
+	}
+	syncBoundaryProbe()
+}
+
+func recordTransactionResourceCleanup(version, phase string) {
+	switch {
+	case version == "A":
+		transactionProbe.aResourceCleanups++
+	case phase == "attempt":
+		transactionProbe.attemptedBResourceCleanups++
+	case phase == "retry":
+		transactionProbe.retryBResourceCleanups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordTransactionLaterSetup(version, phase string) {
+	switch {
+	case version == "A":
+		transactionProbe.aLaterSiblingSetups++
+	case phase == "attempt":
+		transactionProbe.attemptedBLaterSetups++
+	case phase == "retry":
+		transactionProbe.retryBLaterSetups++
+	}
+	syncBoundaryProbe()
+}
+
 func initBoundaryProbe() {
 	protectedEffectCount = 0
 	protectedCleanupCount = 0
+	transactionAttemptPhase = "initial"
+	transactionProbe = protectedTransactionProbe{}
 	js.Global().Set("goframeErrorBoundaryReports", js.Global().Get("Array").New())
 	syncBoundaryProbe()
 }
@@ -137,4 +303,21 @@ func initBoundaryProbe() {
 func syncBoundaryProbe() {
 	js.Global().Set("goframeErrorBoundaryEffectCount", protectedEffectCount)
 	js.Global().Set("goframeErrorBoundaryCleanupCount", protectedCleanupCount)
+	probe := js.Global().Get("Object").New()
+	probe.Set("aEffectSetups", transactionProbe.aEffectSetups)
+	probe.Set("aEffectCleanups", transactionProbe.aEffectCleanups)
+	probe.Set("aUnmountCallbacks", transactionProbe.aUnmountCallbacks)
+	probe.Set("aResourceStarts", transactionProbe.aResourceStarts)
+	probe.Set("aResourceCleanups", transactionProbe.aResourceCleanups)
+	probe.Set("aLaterSiblingSetups", transactionProbe.aLaterSiblingSetups)
+	probe.Set("attemptedBEffectSetups", transactionProbe.attemptedBEffectSetups)
+	probe.Set("attemptedBUnmountCallbacks", transactionProbe.attemptedBUnmountCallbacks)
+	probe.Set("attemptedBResourceStarts", transactionProbe.attemptedBResourceStarts)
+	probe.Set("attemptedBResourceCleanups", transactionProbe.attemptedBResourceCleanups)
+	probe.Set("attemptedBLaterSetups", transactionProbe.attemptedBLaterSetups)
+	probe.Set("retryBEffectSetups", transactionProbe.retryBEffectSetups)
+	probe.Set("retryBResourceStarts", transactionProbe.retryBResourceStarts)
+	probe.Set("retryBResourceCleanups", transactionProbe.retryBResourceCleanups)
+	probe.Set("retryBLaterSetups", transactionProbe.retryBLaterSetups)
+	js.Global().Set("goframeProtectedTransactionProbe", probe)
 }

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -17,6 +17,7 @@ var (
 	localTransactionAttemptPhase = "initial"
 	localUpdateProbe             localUpdateLifecycleProbe
 	localTransactionProbe        protectedTransactionProbe
+	nestedFallbackProbe          nestedFallbackTransactionProbe
 )
 
 type protectedTransactionProbe struct {
@@ -52,6 +53,16 @@ type localUpdateLifecycleProbe struct {
 	localTransactionOwnerRenders int
 }
 
+type nestedFallbackTransactionProbe struct {
+	ownerRenders       int
+	effectSetups       int
+	effectCleanups     int
+	unmountCallbacks   int
+	resourceStarts     int
+	resourceCleanups   int
+	laterSiblingSetups int
+}
+
 type RiskyPanelProps struct {
 	Broken bool
 }
@@ -68,6 +79,14 @@ type NestedRiskyProps struct {
 type NestedBoundaryScenarioProps struct {
 	Broken        bool
 	FallbackCrash bool
+}
+
+type NestedFallbackTransactionScenarioProps struct {
+	Broken bool
+}
+
+type NestedFallbackInitialRiskyProps struct {
+	Broken bool
 }
 
 type InnerFallbackProps struct {
@@ -183,6 +202,105 @@ func InnerFallback(props InnerFallbackProps) gf.Node {
 
 func OuterFallback(gf.ErrorBoundaryContext) gf.Node {
 	return gf.El("section", gf.Props{"data-testid": "eb-nested-outer-fallback"}, gf.Text("outer fallback"))
+}
+
+func NestedFallbackTransactionScenario(props NestedFallbackTransactionScenarioProps) gf.Node {
+	return gf.ErrorBoundary(gf.ErrorBoundaryProps{
+		Fallback: nestedFallbackTransactionOuterFallback,
+		Children: []gf.Node{
+			gf.ErrorBoundary(gf.ErrorBoundaryProps{
+				Fallback: func(gf.ErrorBoundaryContext) gf.Node {
+					return gf.Component(
+						"FallbackLifecycleOwner",
+						struct{}{},
+						FallbackLifecycleOwner,
+					)
+				},
+				Children: []gf.Node{
+					gf.Component(
+						"InitialRiskyChild",
+						NestedFallbackInitialRiskyProps{Broken: props.Broken},
+						NestedFallbackInitialRiskyChild,
+					),
+				},
+			}),
+		},
+	})
+}
+
+func NestedFallbackInitialRiskyChild(props NestedFallbackInitialRiskyProps) gf.Node {
+	if props.Broken {
+		panic("nested fallback initial protected boom")
+	}
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-nested-fallback-protected"},
+		gf.Text("nested fallback protected"),
+	)
+}
+
+func FallbackLifecycleOwner(struct{}) gf.Node {
+	nestedFallbackProbe.ownerRenders++
+	syncBoundaryProbe()
+	gf.UseEffect(func() gf.Cleanup {
+		nestedFallbackProbe.effectSetups++
+		syncBoundaryProbe()
+		return func() {
+			nestedFallbackProbe.effectCleanups++
+			syncBoundaryProbe()
+		}
+	})
+	gf.UseUnmount(func() {
+		nestedFallbackProbe.unmountCallbacks++
+		syncBoundaryProbe()
+	})
+	_, _ = gf.UseResource("nested-fallback", func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		nestedFallbackProbe.resourceStarts++
+		syncBoundaryProbe()
+		return func() {
+			nestedFallbackProbe.resourceCleanups++
+			syncBoundaryProbe()
+		}
+	})
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-nested-fallback-owner"},
+		gf.Component(
+			"FallbackRiskyDescendant",
+			struct{}{},
+			FallbackRiskyDescendant,
+		),
+		gf.Component(
+			"FallbackLaterEffect",
+			struct{}{},
+			FallbackLaterEffect,
+		),
+	)
+}
+
+func FallbackRiskyDescendant(struct{}) gf.Node {
+	panic("nested fallback descendant boom")
+}
+
+func FallbackLaterEffect(struct{}) gf.Node {
+	gf.UseEffect(func() gf.Cleanup {
+		nestedFallbackProbe.laterSiblingSetups++
+		syncBoundaryProbe()
+		return nil
+	})
+	return gf.Empty()
+}
+
+func nestedFallbackTransactionOuterFallback(gf.ErrorBoundaryContext) gf.Node {
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-nested-fallback-outer"},
+		gf.Text("nested fallback outer"),
+	)
 }
 
 func NoBoundaryRisky(props NoBoundaryRiskyProps) gf.Node {
@@ -545,6 +663,7 @@ func initBoundaryProbe() {
 	localTransactionAttemptPhase = "initial"
 	localUpdateProbe = localUpdateLifecycleProbe{}
 	localTransactionProbe = protectedTransactionProbe{}
+	nestedFallbackProbe = nestedFallbackTransactionProbe{}
 	js.Global().Set("goframeErrorBoundaryReports", js.Global().Get("Array").New())
 	syncBoundaryProbe()
 }
@@ -602,4 +721,14 @@ func syncBoundaryProbe() {
 	localTransaction.Set("retryBResourceCleanups", localTransactionProbe.retryBResourceCleanups)
 	localTransaction.Set("retryBLaterSetups", localTransactionProbe.retryBLaterSetups)
 	js.Global().Set("goframeLocalTransactionProbe", localTransaction)
+
+	nestedFallback := js.Global().Get("Object").New()
+	nestedFallback.Set("ownerRenders", nestedFallbackProbe.ownerRenders)
+	nestedFallback.Set("effectSetups", nestedFallbackProbe.effectSetups)
+	nestedFallback.Set("effectCleanups", nestedFallbackProbe.effectCleanups)
+	nestedFallback.Set("unmountCallbacks", nestedFallbackProbe.unmountCallbacks)
+	nestedFallback.Set("resourceStarts", nestedFallbackProbe.resourceStarts)
+	nestedFallback.Set("resourceCleanups", nestedFallbackProbe.resourceCleanups)
+	nestedFallback.Set("laterSiblingSetups", nestedFallbackProbe.laterSiblingSetups)
+	js.Global().Set("goframeNestedFallbackTransactionProbe", nestedFallback)
 }

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -18,6 +18,10 @@ var (
 	localUpdateProbe             localUpdateLifecycleProbe
 	localTransactionProbe        protectedTransactionProbe
 	nestedFallbackProbe          nestedFallbackTransactionProbe
+	dirtyBatchProbe              capturedDirtyBatchProbe
+	setDirtyBatchFailingVersion  func(string)
+	setDirtyBatchLaterVersion    func(string)
+	setDirtyBatchIndependent     func(int)
 )
 
 type protectedTransactionProbe struct {
@@ -61,6 +65,25 @@ type nestedFallbackTransactionProbe struct {
 	resourceStarts     int
 	resourceCleanups   int
 	laterSiblingSetups int
+}
+
+type capturedDirtyBatchProbe struct {
+	setterOrder                string
+	renderOrder                string
+	failingOwnerRenders        int
+	laterARenders              int
+	attemptedBRenders          int
+	aEffectSetups              int
+	aEffectCleanups            int
+	aUnmountCallbacks          int
+	aResourceStarts            int
+	aResourceCleanups          int
+	attemptedBEffectSetups     int
+	attemptedBEffectCleanups   int
+	attemptedBUnmounts         int
+	attemptedBResourceStarts   int
+	attemptedBResourceCleanups int
+	independentOwnerRenders    int
 }
 
 type RiskyPanelProps struct {
@@ -122,6 +145,16 @@ type NestedInnerSiblingProps struct{}
 type NestedOuterSiblingProps struct{}
 
 type LocalTransactionOwnerProps struct{}
+
+type DirtyBatchFailingOwnerProps struct{}
+
+type DirtyBatchLaterOwnerProps struct{}
+
+type DirtyBatchIndependentOwnerProps struct{}
+
+type DirtyBatchRiskyDescendantProps struct {
+	Broken bool
+}
 
 func RiskyPanel(props RiskyPanelProps) gf.Node {
 	count, setCount := gf.UseState(0)
@@ -483,6 +516,158 @@ func LocalTransactionLaterEffect(props TransactionLaterEffectProps) gf.Node {
 	return gf.Empty()
 }
 
+func DirtyBatchFailingOwner(DirtyBatchFailingOwnerProps) gf.Node {
+	version, setVersion := gf.UseState("A")
+	setDirtyBatchFailingVersion = setVersion
+	dirtyBatchProbe.failingOwnerRenders++
+	if version == "B" {
+		recordDirtyBatchRender("failing B")
+	}
+	syncBoundaryProbe()
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-dirty-batch-failing-owner"},
+		gf.Component(
+			"DirtyBatchRiskyDescendant",
+			DirtyBatchRiskyDescendantProps{Broken: version == "B"},
+			DirtyBatchRiskyDescendant,
+		),
+	)
+}
+
+func DirtyBatchRiskyDescendant(props DirtyBatchRiskyDescendantProps) gf.Node {
+	if props.Broken {
+		recordDirtyBatchRender("risky B")
+		panic("captured dirty batch descendant boom")
+	}
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-dirty-batch-risky"},
+		gf.Text("healthy"),
+	)
+}
+
+func DirtyBatchLaterOwner(DirtyBatchLaterOwnerProps) gf.Node {
+	version, setVersion := gf.UseState("A")
+	setDirtyBatchLaterVersion = setVersion
+	if version == "A" {
+		dirtyBatchProbe.laterARenders++
+	} else {
+		dirtyBatchProbe.attemptedBRenders++
+		recordDirtyBatchRender("later B")
+	}
+	syncBoundaryProbe()
+
+	gf.UseEffect(func() gf.Cleanup {
+		if version == "A" {
+			dirtyBatchProbe.aEffectSetups++
+		} else {
+			dirtyBatchProbe.attemptedBEffectSetups++
+		}
+		syncBoundaryProbe()
+		return func() {
+			if version == "A" {
+				dirtyBatchProbe.aEffectCleanups++
+			} else {
+				dirtyBatchProbe.attemptedBEffectCleanups++
+			}
+			syncBoundaryProbe()
+		}
+	}, gf.Deps(version))
+	gf.UseUnmount(func() {
+		if version == "A" {
+			dirtyBatchProbe.aUnmountCallbacks++
+		} else {
+			dirtyBatchProbe.attemptedBUnmounts++
+		}
+		syncBoundaryProbe()
+	})
+	_, _ = gf.UseResource(version, func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		if key == "A" {
+			dirtyBatchProbe.aResourceStarts++
+		} else {
+			dirtyBatchProbe.attemptedBResourceStarts++
+		}
+		syncBoundaryProbe()
+		return func() {
+			if key == "A" {
+				dirtyBatchProbe.aResourceCleanups++
+			} else {
+				dirtyBatchProbe.attemptedBResourceCleanups++
+			}
+			syncBoundaryProbe()
+		}
+	})
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-dirty-batch-later-owner"},
+		gf.El(
+			"p",
+			gf.Props{"data-testid": "eb-dirty-batch-later-version"},
+			gf.Text(version),
+		),
+	)
+}
+
+func DirtyBatchIndependentOwner(DirtyBatchIndependentOwnerProps) gf.Node {
+	value, setValue := gf.UseState(0)
+	setDirtyBatchIndependent = setValue
+	dirtyBatchProbe.independentOwnerRenders++
+	if value == 1 {
+		recordDirtyBatchRender("independent 1")
+	}
+	syncBoundaryProbe()
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-dirty-batch-independent"},
+		gf.Text(gf.ToString(value)),
+	)
+}
+
+func triggerDirtyBatch() {
+	dirtyBatchProbe.setterOrder = ""
+	dirtyBatchProbe.renderOrder = ""
+	recordDirtyBatchSetter("failing B")
+	setDirtyBatchFailingVersion("B")
+	recordDirtyBatchSetter("later B")
+	setDirtyBatchLaterVersion("B")
+	recordDirtyBatchSetter("independent 1")
+	setDirtyBatchIndependent(1)
+}
+
+func recordDirtyBatchSetter(step string) {
+	dirtyBatchProbe.setterOrder = appendDirtyBatchStep(dirtyBatchProbe.setterOrder, step)
+	syncBoundaryProbe()
+}
+
+func recordDirtyBatchRender(step string) {
+	dirtyBatchProbe.renderOrder = appendDirtyBatchStep(dirtyBatchProbe.renderOrder, step)
+	syncBoundaryProbe()
+}
+
+func appendDirtyBatchStep(order, step string) string {
+	if order == "" {
+		return step
+	}
+	return order + "," + step
+}
+
+func dirtyBatchFallback(ctx gf.ErrorBoundaryContext) gf.Node {
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-dirty-batch-fallback"},
+		gf.El(
+			"p",
+			gf.Props{"data-testid": "eb-dirty-batch-error-component"},
+			gf.Text(ctx.Info.Component),
+		),
+	)
+}
+
 func localUpdateFallback(gf.ErrorBoundaryContext) gf.Node {
 	return gf.El("section", gf.Props{"data-testid": "eb-local-unexpected-fallback"},
 		gf.Text("unexpected local update fallback"),
@@ -664,6 +849,10 @@ func initBoundaryProbe() {
 	localUpdateProbe = localUpdateLifecycleProbe{}
 	localTransactionProbe = protectedTransactionProbe{}
 	nestedFallbackProbe = nestedFallbackTransactionProbe{}
+	dirtyBatchProbe = capturedDirtyBatchProbe{}
+	setDirtyBatchFailingVersion = nil
+	setDirtyBatchLaterVersion = nil
+	setDirtyBatchIndependent = nil
 	js.Global().Set("goframeErrorBoundaryReports", js.Global().Get("Array").New())
 	syncBoundaryProbe()
 }
@@ -731,4 +920,23 @@ func syncBoundaryProbe() {
 	nestedFallback.Set("resourceCleanups", nestedFallbackProbe.resourceCleanups)
 	nestedFallback.Set("laterSiblingSetups", nestedFallbackProbe.laterSiblingSetups)
 	js.Global().Set("goframeNestedFallbackTransactionProbe", nestedFallback)
+
+	dirtyBatch := js.Global().Get("Object").New()
+	dirtyBatch.Set("setterOrder", dirtyBatchProbe.setterOrder)
+	dirtyBatch.Set("renderOrder", dirtyBatchProbe.renderOrder)
+	dirtyBatch.Set("failingOwnerRenders", dirtyBatchProbe.failingOwnerRenders)
+	dirtyBatch.Set("laterARenders", dirtyBatchProbe.laterARenders)
+	dirtyBatch.Set("attemptedBRenders", dirtyBatchProbe.attemptedBRenders)
+	dirtyBatch.Set("aEffectSetups", dirtyBatchProbe.aEffectSetups)
+	dirtyBatch.Set("aEffectCleanups", dirtyBatchProbe.aEffectCleanups)
+	dirtyBatch.Set("aUnmountCallbacks", dirtyBatchProbe.aUnmountCallbacks)
+	dirtyBatch.Set("aResourceStarts", dirtyBatchProbe.aResourceStarts)
+	dirtyBatch.Set("aResourceCleanups", dirtyBatchProbe.aResourceCleanups)
+	dirtyBatch.Set("attemptedBEffectSetups", dirtyBatchProbe.attemptedBEffectSetups)
+	dirtyBatch.Set("attemptedBEffectCleanups", dirtyBatchProbe.attemptedBEffectCleanups)
+	dirtyBatch.Set("attemptedBUnmounts", dirtyBatchProbe.attemptedBUnmounts)
+	dirtyBatch.Set("attemptedBResourceStarts", dirtyBatchProbe.attemptedBResourceStarts)
+	dirtyBatch.Set("attemptedBResourceCleanups", dirtyBatchProbe.attemptedBResourceCleanups)
+	dirtyBatch.Set("independentOwnerRenders", dirtyBatchProbe.independentOwnerRenders)
+	js.Global().Set("goframeCapturedDirtyBatchProbe", dirtyBatch)
 }

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -9,10 +9,14 @@ import (
 )
 
 var (
-	protectedEffectCount    int
-	protectedCleanupCount   int
-	transactionAttemptPhase = "initial"
-	transactionProbe        protectedTransactionProbe
+	protectedEffectCount         int
+	protectedCleanupCount        int
+	transactionAttemptPhase      = "initial"
+	transactionProbe             protectedTransactionProbe
+	localTransactionVersion      = "A"
+	localTransactionAttemptPhase = "initial"
+	localUpdateProbe             localUpdateLifecycleProbe
+	localTransactionProbe        protectedTransactionProbe
 )
 
 type protectedTransactionProbe struct {
@@ -31,6 +35,21 @@ type protectedTransactionProbe struct {
 	retryBResourceStarts       int
 	retryBResourceCleanups     int
 	retryBLaterSetups          int
+}
+
+type localUpdateLifecycleProbe struct {
+	ownerRenders                 int
+	siblingRenders               int
+	siblingEffectSetups          int
+	siblingEffectCleanups        int
+	nestedInnerOwnerRenders      int
+	nestedInnerSiblingRenders    int
+	nestedOuterSiblingRenders    int
+	nestedInnerSiblingSetups     int
+	nestedInnerSiblingCleanups   int
+	nestedOuterSiblingSetups     int
+	nestedOuterSiblingCleanups   int
+	localTransactionOwnerRenders int
 }
 
 type RiskyPanelProps struct {
@@ -72,6 +91,18 @@ type TransactionLaterEffectProps struct {
 	Version string
 	Phase   string
 }
+
+type LocalStateOwnerProps struct{}
+
+type LocalUpdateSiblingProps struct{}
+
+type LocalInnerOwnerProps struct{}
+
+type NestedInnerSiblingProps struct{}
+
+type NestedOuterSiblingProps struct{}
+
+type LocalTransactionOwnerProps struct{}
 
 func RiskyPanel(props RiskyPanelProps) gf.Node {
 	count, setCount := gf.UseState(0)
@@ -210,6 +241,155 @@ func TransactionLaterEffect(props TransactionLaterEffectProps) gf.Node {
 	return gf.Empty()
 }
 
+func LocalStateOwner(LocalStateOwnerProps) gf.Node {
+	localUpdateProbe.ownerRenders++
+	syncBoundaryProbe()
+	count, setCount := gf.UseState(0)
+	return gf.El("section", gf.Props{"data-testid": "eb-local-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-local-owner-state"}, gf.Text(gf.ToString(count))),
+		gf.El("button", gf.Props{
+			"data-testid": "eb-local-owner-update",
+			"OnClick": func() {
+				setCount(count + 1)
+			},
+		}, gf.Text("Update local owner")),
+	)
+}
+
+func LocalUpdateSibling(LocalUpdateSiblingProps) gf.Node {
+	localUpdateProbe.siblingRenders++
+	syncBoundaryProbe()
+	gf.UseEffect(func() gf.Cleanup {
+		localUpdateProbe.siblingEffectSetups++
+		syncBoundaryProbe()
+		return func() {
+			localUpdateProbe.siblingEffectCleanups++
+			syncBoundaryProbe()
+		}
+	}, gf.EveryRender())
+	return gf.El("p", gf.Props{"data-testid": "eb-local-sibling"}, gf.Text("local sibling"))
+}
+
+func LocalInnerOwner(LocalInnerOwnerProps) gf.Node {
+	localUpdateProbe.nestedInnerOwnerRenders++
+	syncBoundaryProbe()
+	count, setCount := gf.UseState(0)
+	return gf.El("section", gf.Props{"data-testid": "eb-nested-local-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-nested-local-owner-state"}, gf.Text(gf.ToString(count))),
+		gf.El("button", gf.Props{
+			"data-testid": "eb-nested-local-owner-update",
+			"OnClick": func() {
+				setCount(count + 1)
+			},
+		}, gf.Text("Update nested local owner")),
+	)
+}
+
+func NestedInnerSibling(NestedInnerSiblingProps) gf.Node {
+	localUpdateProbe.nestedInnerSiblingRenders++
+	syncBoundaryProbe()
+	gf.UseEffect(func() gf.Cleanup {
+		localUpdateProbe.nestedInnerSiblingSetups++
+		syncBoundaryProbe()
+		return func() {
+			localUpdateProbe.nestedInnerSiblingCleanups++
+			syncBoundaryProbe()
+		}
+	}, gf.EveryRender())
+	return gf.El("p", gf.Props{"data-testid": "eb-nested-inner-sibling"}, gf.Text("nested inner sibling"))
+}
+
+func NestedOuterSibling(NestedOuterSiblingProps) gf.Node {
+	localUpdateProbe.nestedOuterSiblingRenders++
+	syncBoundaryProbe()
+	gf.UseEffect(func() gf.Cleanup {
+		localUpdateProbe.nestedOuterSiblingSetups++
+		syncBoundaryProbe()
+		return func() {
+			localUpdateProbe.nestedOuterSiblingCleanups++
+			syncBoundaryProbe()
+		}
+	}, gf.EveryRender())
+	return gf.El("p", gf.Props{"data-testid": "eb-nested-outer-sibling"}, gf.Text("nested outer sibling"))
+}
+
+func LocalTransactionOwner(LocalTransactionOwnerProps) gf.Node {
+	localUpdateProbe.localTransactionOwnerRenders++
+	syncBoundaryProbe()
+	version, setVersion := gf.UseState(localTransactionVersion)
+	phase := localTransactionAttemptPhase
+	gf.UseEffect(func() gf.Cleanup {
+		recordLocalTransactionEffectSetup(version, phase)
+		return func() {
+			recordLocalTransactionEffectCleanup(version, phase)
+		}
+	}, gf.Deps(version))
+	gf.UseUnmount(func() {
+		recordLocalTransactionUnmount(version, phase)
+	})
+	_, _ = gf.UseResource(version, func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		recordLocalTransactionResourceStart(key, phase)
+		return func() {
+			recordLocalTransactionResourceCleanup(key, phase)
+		}
+	})
+	return gf.El("section", gf.Props{"data-testid": "eb-local-transaction-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-local-transaction-version"}, gf.Text(version)),
+		gf.El("button", gf.Props{
+			"data-testid": "eb-local-transaction-trigger",
+			"OnClick": func() {
+				localTransactionVersion = "B"
+				localTransactionAttemptPhase = "attempt"
+				setVersion("B")
+			},
+		}, gf.Text("Trigger local transaction error")),
+		gf.Component("LocalTransactionRiskyDescendant", TransactionRiskyProps{
+			Broken: version == "B" && phase == "attempt",
+		}, TransactionRiskyDescendant),
+		gf.Component("LocalTransactionLaterEffect", TransactionLaterEffectProps{
+			Version: version,
+			Phase:   phase,
+		}, LocalTransactionLaterEffect),
+	)
+}
+
+func LocalTransactionLaterEffect(props TransactionLaterEffectProps) gf.Node {
+	gf.UseEffect(func() gf.Cleanup {
+		recordLocalTransactionLaterSetup(props.Version, props.Phase)
+		return nil
+	}, gf.Deps(props.Version))
+	return gf.Empty()
+}
+
+func localUpdateFallback(gf.ErrorBoundaryContext) gf.Node {
+	return gf.El("section", gf.Props{"data-testid": "eb-local-unexpected-fallback"},
+		gf.Text("unexpected local update fallback"),
+	)
+}
+
+func nestedLocalUpdateFallback(gf.ErrorBoundaryContext) gf.Node {
+	return gf.El("section", gf.Props{"data-testid": "eb-nested-local-unexpected-fallback"},
+		gf.Text("unexpected nested local update fallback"),
+	)
+}
+
+func localTransactionFallback(ctx gf.ErrorBoundaryContext) gf.Node {
+	return gf.El("section", gf.Props{"data-testid": "eb-local-transaction-fallback"},
+		gf.El("p", gf.Props{"data-testid": "eb-local-transaction-error-component"}, gf.Text(ctx.Info.Component)),
+		gf.El("button", gf.Props{
+			"data-testid": "eb-local-transaction-retry",
+			"OnClick": func() {
+				localTransactionAttemptPhase = "retry"
+				ctx.Reset()
+			},
+		}, gf.Text("Retry local transaction")),
+	)
+}
+
 func makeTransactionFallback(setBroken func(bool)) func(gf.ErrorBoundaryContext) gf.Node {
 	return func(ctx gf.ErrorBoundaryContext) gf.Node {
 		return gf.El("section", gf.Props{"data-testid": "eb-transaction-fallback"},
@@ -291,11 +471,80 @@ func recordTransactionLaterSetup(version, phase string) {
 	syncBoundaryProbe()
 }
 
+func recordLocalTransactionEffectSetup(version, phase string) {
+	switch {
+	case version == "A":
+		localTransactionProbe.aEffectSetups++
+	case phase == "attempt":
+		localTransactionProbe.attemptedBEffectSetups++
+	case phase == "retry":
+		localTransactionProbe.retryBEffectSetups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordLocalTransactionEffectCleanup(version, phase string) {
+	if version == "A" {
+		localTransactionProbe.aEffectCleanups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordLocalTransactionUnmount(version, phase string) {
+	switch {
+	case version == "A":
+		localTransactionProbe.aUnmountCallbacks++
+	case phase == "attempt":
+		localTransactionProbe.attemptedBUnmountCallbacks++
+	}
+	syncBoundaryProbe()
+}
+
+func recordLocalTransactionResourceStart(version, phase string) {
+	switch {
+	case version == "A":
+		localTransactionProbe.aResourceStarts++
+	case phase == "attempt":
+		localTransactionProbe.attemptedBResourceStarts++
+	case phase == "retry":
+		localTransactionProbe.retryBResourceStarts++
+	}
+	syncBoundaryProbe()
+}
+
+func recordLocalTransactionResourceCleanup(version, phase string) {
+	switch {
+	case version == "A":
+		localTransactionProbe.aResourceCleanups++
+	case phase == "attempt":
+		localTransactionProbe.attemptedBResourceCleanups++
+	case phase == "retry":
+		localTransactionProbe.retryBResourceCleanups++
+	}
+	syncBoundaryProbe()
+}
+
+func recordLocalTransactionLaterSetup(version, phase string) {
+	switch {
+	case version == "A":
+		localTransactionProbe.aLaterSiblingSetups++
+	case phase == "attempt":
+		localTransactionProbe.attemptedBLaterSetups++
+	case phase == "retry":
+		localTransactionProbe.retryBLaterSetups++
+	}
+	syncBoundaryProbe()
+}
+
 func initBoundaryProbe() {
 	protectedEffectCount = 0
 	protectedCleanupCount = 0
 	transactionAttemptPhase = "initial"
 	transactionProbe = protectedTransactionProbe{}
+	localTransactionVersion = "A"
+	localTransactionAttemptPhase = "initial"
+	localUpdateProbe = localUpdateLifecycleProbe{}
+	localTransactionProbe = protectedTransactionProbe{}
 	js.Global().Set("goframeErrorBoundaryReports", js.Global().Get("Array").New())
 	syncBoundaryProbe()
 }
@@ -320,4 +569,37 @@ func syncBoundaryProbe() {
 	probe.Set("retryBResourceCleanups", transactionProbe.retryBResourceCleanups)
 	probe.Set("retryBLaterSetups", transactionProbe.retryBLaterSetups)
 	js.Global().Set("goframeProtectedTransactionProbe", probe)
+
+	local := js.Global().Get("Object").New()
+	local.Set("ownerRenders", localUpdateProbe.ownerRenders)
+	local.Set("siblingRenders", localUpdateProbe.siblingRenders)
+	local.Set("siblingEffectSetups", localUpdateProbe.siblingEffectSetups)
+	local.Set("siblingEffectCleanups", localUpdateProbe.siblingEffectCleanups)
+	local.Set("nestedInnerOwnerRenders", localUpdateProbe.nestedInnerOwnerRenders)
+	local.Set("nestedInnerSiblingRenders", localUpdateProbe.nestedInnerSiblingRenders)
+	local.Set("nestedOuterSiblingRenders", localUpdateProbe.nestedOuterSiblingRenders)
+	local.Set("nestedInnerSiblingSetups", localUpdateProbe.nestedInnerSiblingSetups)
+	local.Set("nestedInnerSiblingCleanups", localUpdateProbe.nestedInnerSiblingCleanups)
+	local.Set("nestedOuterSiblingSetups", localUpdateProbe.nestedOuterSiblingSetups)
+	local.Set("nestedOuterSiblingCleanups", localUpdateProbe.nestedOuterSiblingCleanups)
+	local.Set("localTransactionOwnerRenders", localUpdateProbe.localTransactionOwnerRenders)
+	js.Global().Set("goframeLocalUpdateProbe", local)
+
+	localTransaction := js.Global().Get("Object").New()
+	localTransaction.Set("aEffectSetups", localTransactionProbe.aEffectSetups)
+	localTransaction.Set("aEffectCleanups", localTransactionProbe.aEffectCleanups)
+	localTransaction.Set("aUnmountCallbacks", localTransactionProbe.aUnmountCallbacks)
+	localTransaction.Set("aResourceStarts", localTransactionProbe.aResourceStarts)
+	localTransaction.Set("aResourceCleanups", localTransactionProbe.aResourceCleanups)
+	localTransaction.Set("aLaterSiblingSetups", localTransactionProbe.aLaterSiblingSetups)
+	localTransaction.Set("attemptedBEffectSetups", localTransactionProbe.attemptedBEffectSetups)
+	localTransaction.Set("attemptedBUnmountCallbacks", localTransactionProbe.attemptedBUnmountCallbacks)
+	localTransaction.Set("attemptedBResourceStarts", localTransactionProbe.attemptedBResourceStarts)
+	localTransaction.Set("attemptedBResourceCleanups", localTransactionProbe.attemptedBResourceCleanups)
+	localTransaction.Set("attemptedBLaterSetups", localTransactionProbe.attemptedBLaterSetups)
+	localTransaction.Set("retryBEffectSetups", localTransactionProbe.retryBEffectSetups)
+	localTransaction.Set("retryBResourceStarts", localTransactionProbe.retryBResourceStarts)
+	localTransaction.Set("retryBResourceCleanups", localTransactionProbe.retryBResourceCleanups)
+	localTransaction.Set("retryBLaterSetups", localTransactionProbe.retryBLaterSetups)
+	js.Global().Set("goframeLocalTransactionProbe", localTransaction)
 }

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -137,7 +137,7 @@ check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 ||
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 230400 77824 94208 81920 || status=1
-check_app "resource" "$(bundle_path resource)" 153600 57344 67584 61440 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 233472 77824 94208 81920 || status=1
+check_app "resource" "$(bundle_path resource)" 156672 57344 68608 61440 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Makes lifecycle and resource updates beneath `ErrorBoundary` transactional
across complete recursive subtree reconciliation, including teardown of removed
and replaced mounted subtrees.

When a descendant render fails, the runtime now preserves:

- the last committed effect state;
- `UseUnmount` callbacks;
- active `UseResource` runs;
- lifecycle ownership of removed or replaced mounted subtrees.

Speculative lifecycle work is rolled back, while committed subtree teardown is
deferred until fallback, retry, an outer protected transaction, or boundary
destruction owns the final release.

No public API or DOM rollback is introduced.

## What changed

- Stages effect, unmount, and resource lifecycle changes until the complete
  protected subtree reconciles successfully.
- Rolls failed attempts back in reverse order and prevents later protected
  siblings from committing effects after capture.
- Preserves nearest-boundary isolation across nested boundaries and fallback
  reconciliation.
- Keeps local dirty updates scoped to their original component instead of
  rerendering the complete boundary subtree.
- Skips stale dirty work that was snapshotted before an ancestor boundary became
  captured, while unrelated dirty work continues normally.
- Stages lifecycle teardown for removed and identity-replaced mounted subtrees
  instead of releasing committed ownership during a failed reconciliation.
- Keeps DOM ranges on the existing non-transactional reconciliation path while
  deferring component, effect, resource, listener, and context release.
- Transfers staged teardown through nested protected transactions and retains it
  across capture, failed retries, and outer-boundary failure.
- Releases staged mounted subtrees exactly once after successful fallback,
  successful retry, outer transaction commit, or boundary destruction.
- Installs transaction and teardown machinery lazily so applications without
  `ErrorBoundary` do not retain its TinyGo/WASM cost.
- Extends the existing Error Boundary fixture and browser harness with:
  - descendant-failure rollback;
  - successful retry TinyGo/WASM cost.
- Extends the existing Error Boundary fixture and browser harness;
  - component-local dirty updates;
  - nested fallback transactions;
  - same-batch stale dirty-owner discard;
  - removed-child teardown after capture;
  - identity replacement before a later descendant panic;
  - deterministic teardown-order evidence.

## Teardown guarantees

For a failed protected reconciliation:

```text
descendant panic
→ boundary fallback renders
→ committed removed/replaced subtree teardown runs
```

Effect cleanup, resource cleanup, and `UseUnmount` callbacks from the last
committed subtree no longer run during the failed attempt.

Staged teardown ownership is:

- retained when the boundary captures;
- committed after a healthy retry;
- transferred into an outer protected transaction when nested;
- retained when that outer transaction later captures;
- finalized when the owning boundary is destroyed;
- released in deterministic staging order;
- detached from transaction state before callbacks execute to prevent duplicate
  release.

## Validation

- Repeated, race-enabled, and `goframe_debug` runtime tests.
- Focused teardown tests covering:
  - successful commit;
  - capture retention;
  - successful and repeated retries;
  - nested transaction transfer;
  - outer capture;
  - fallback reconciliation;
  - boundary destruction;
  - escaping runtime invariants;
  - deterministic release order;
  - duplicate-staging protection.
- Full validation on Go `1.22.12` and Go `1.25.12`.
- Focused runtime and GOX validation on Go `1.26.5`; only the existing browser
  source-selection incompatibility remains separate.
- Standard Go and TinyGo fixture packaging.
- Two deterministic focused browser runs with identical lifecycle counters and
  ordering logs.
- Full repository checks, aggregate browser smoke, vet, Windows
  cross-compilation, documentation, artifact, and module-path validation.
- All GitHub Actions workflows pass:
  - Core;
  - Browser Smoke;
  - WASM Size;
  - VS Code Extension.

## WASM size

The completed teardown transaction is retained only by the two measured
applications that author `ErrorBoundary`.

Nine non-boundary applications remain byte-identical to the previous PR head.

| Application | Previous raw | Final raw | Delta | New budget |
|---|---:|---:|---:|---:|
| `router-dashboard` | 230,316 B | 232,586 B | +2,270 B | 233,472 B |
| `resource` | 153,200 B | 155,484 B | +2,284 B | 156,672 B |

The targeted correctness rebaseline changes only:

- `router-dashboard` raw: `230,400 B → 233,472 B`;
- `resource` raw: `153,600 B → 156,672 B`;
- `resource` gzip: `67,584 B → 68,608 B`.

All other raw and compressed budgets remain unchanged.

The existing compression-ratio limits also remain unchanged:

- gzip: `52.00%`;
- Brotli: `38.00%`;
- Zstandard: `46.00%`.

This rebaseline records the measured cost of the completed `ErrorBoundary`
correctness contract; it does not grant general runtime headroom.

## Scope

This PR changes internal render-lifecycle behavior only.

It does not:

- add DOM rollback or state rollback;
- change the `ErrorBoundary` public API;
- change scheduler or dirty-queue public semantics;
- change public effect, resource, or context APIs;
- modify GOX or `goxc`;
- add dependencies;
- change workflows or compression commands;
- change compression-ratio limits;
- claim recover-based Error Boundary containment for TinyGo's default
  panic-trap profile.