### PR TITLE
test(document): compare metadata ownership API shapes

### DIFF
--- a/docs/document-metadata-api-design.md
+++ b/docs/document-metadata-api-design.md
@@ -46,9 +46,10 @@ release, and error behavior. They do not execute hook, component, or handle
 lifecycle wrappers through a host renderer.
 
 The browser harness executes the actual wrappers in one Chrome process. A
-pre-boot observer records the authored title, description, viewport metadata,
-node identities, managed mutations, coordinator statistics, owner IDs, and
-candidate-specific lifetime events before WASM starts.
+pre-boot observer records the authored title and description, their node
+identities, managed title and description mutations, coordinator statistics,
+owner IDs, and candidate-specific lifetime events before WASM starts. One
+unrelated authored metadata node remains outside the managed pair.
 
 Temporary candidate-only copies provide TinyGo size evidence. Temporary copies
 of `examples/server-backed` test package-level integration. None of those
@@ -201,8 +202,13 @@ gf.UseOwnedDocumentMetadata(owner, gf.DocumentMetadata{
 The private prototype retains a nil handle slot and a nil publication slot.
 Committed initialization effects create them. A later publication effect
 activates the owner. Passing the handle through a helper preserves identity.
-Identical duplicate publications coalesce, while conflicting simultaneous
-publications are rejected.
+The first publication becomes primary. An identical duplicate coalesces without
+another coordinator publication. While multiple publications coexist, their
+metadata is immutable: changing either one is rejected before coordinator,
+document, handle, or publication state changes. Releasing the duplicate leaves
+the primary active, after which that sole primary can update through the same
+owner. The prototype does not transfer primary status when the primary itself
+is released first.
 
 The handle supports helper composition explicitly, but requires two calls,
 three effect sites, and split handle/publication lifetime rules. It also has the
@@ -229,6 +235,22 @@ actual candidate wrappers.
 The focused pure suite passed 100 repetitions and 20 race-detector
 repetitions.
 
+The handle publication state machine has separate focused coverage:
+
+| Scenario | Corrected result |
+|---|---|
+| first publication | primary, count one |
+| identical duplicate | coalesced, count two, no coordinator write |
+| conflicting duplicate activation | rejected before mutation |
+| primary update while duplicated | rejected before mutation |
+| duplicate release | count one, owner remains active |
+| sole-primary update after duplicate release | same owner, one update |
+| final release | exactly one coordinator release |
+| repeated release | no-op |
+| publication-count underflow | rejected |
+
+Those tests also passed 100 repetitions and 20 race-detector repetitions.
+
 ## Candidate Wrapper Lifecycle Evidence
 
 Actual hook, component, and handle lifecycle wrappers are exercised in the
@@ -246,8 +268,13 @@ Candidate-specific browser evidence showed:
   exactly once;
 - component: five successful mounts matched four unmounts with one active
   remount, and no wrapper DOM element appeared;
-- handle: six handle/token/ID lifetimes and seven publication lifetimes were
-  committed; one forwarded duplicate coalesced through owner ID 5;
+- handle: seven handle/token/ID lifetimes and nine publication lifetimes were
+  committed; one forwarded duplicate and one conflict-probe duplicate
+  coalesced through owner IDs 5 and 6;
+- handle conflict probe: changing the primary while its identical duplicate
+  remained active produced the precise conflict diagnostic with no coordinator,
+  document, handle-count, or publication-state change; after duplicate release,
+  the primary published metadata C through the same owner ID;
 - all candidates: the failed-render token, ID, and active-owner deltas were
   zero.
 
@@ -267,17 +294,35 @@ Candidate-specific browser evidence showed:
 | node identity | pass | pass | pass | pass |
 | duplicate description prevention | pass | pass | pass | pass |
 
+The harness requires positive observer evidence for every mode. Exact counts
+below are deterministic evidence for the pinned toolchain, not compatibility
+requirements:
+
+| Mode | Title batches | Description batches | Head snapshots | Snapshot length | Invalid pairs |
+|---|---:|---:|---:|---:|---:|
+| control | 7 | 7 | 7 | 7 | 0 |
+| hook | 9 | 9 | 9 | 9 | 0 |
+| component | 7 | 7 | 7 | 7 | 0 |
+| handle | 12 | 12 | 12 | 12 | 0 |
+
+Every mode requires title batches, description batches, and head snapshots to
+be positive, and requires snapshot length to equal the head-snapshot count. A
+temporary fault injection that classified managed title and description nodes
+as unrelated failed with `control observer liveness: no title mutation
+batches`; the injected copy was removed.
+
 Two focused browser runs produced byte-identical normalized evidence after
 excluding elapsed time:
 
 ```text
 SHA-256:
-8a6df8a2eab01b652405c861d66609299c6f67f122d6d3cf1429428f9a5dc058
+1bf05e4c9b3f0cb26f0835146d6440f9850eb380d4b8f1eb1b35458b16b2b03b
 ```
 
-The runs took 5,908 ms and 5,674 ms. Transition counters, coordinator
+The runs took 7,580 ms and 7,486 ms. Transition counters, coordinator
 statistics, committed owner-ID sequences, mutation logs, baseline restoration,
-node identity, and failure counters were identical.
+node identity, handle-conflict evidence, full-navigation evidence, and failure
+counters were identical.
 
 Final focused statistics were:
 
@@ -286,7 +331,20 @@ Final focused statistics were:
 | control | 5 | 5 | 5 | 1 | 4 | 1 | 5 |
 | hook | 7 | 7 | 7 | 1 | 6 | 1 | 7 |
 | component | 5 | 5 | 5 | 1 | 4 | 1 | 5 |
-| handle | 6 | 6 | 6 | 1 | 5 | 1 | 6 |
+| handle | 7 | 7 | 7 | 2 | 6 | 1 | 7 |
+
+Candidate mode links preserve boot-time mode selection by navigating the full
+document to `./?candidate=<mode>#/<mode>`. The browser sequence control -> hook
+-> component -> handle -> control increased the document boot count from 1 to
+5. Every navigation updated the query and hash, rendered the target mode, and
+recaptured the authored baseline. The fixture adds no router or `hashchange`
+listener.
+
+Browser command validation is awaited before fixture packaging, temporary
+browser roots, or the detached fixture server are created. The actual Chrome
+spawn is also awaited. A missing absolute browser command returned its original
+`ENOENT` spawn diagnostic, left the selected port closed, created no fixture
+package or task-owned temporary root, and settled without a leaked server.
 
 ## Candidate Measurements
 
@@ -305,13 +363,14 @@ fixture evidence calls.
 | token creations | 1 | 1 | 1 | 1 |
 | committed owner IDs | 1 | 1 | 1 | 1 |
 | unmount callbacks | 1 | 1 | 1 | 1 |
-| ownership support lines | 34 | 44 | 61 | 147 |
+| ownership support lines | 34 | 44 | 61 | 280 |
 | application-visible owner keys | 2 | 0 | 0 | 0 |
 | positional-hook restriction at caller | yes | yes | no | yes |
 
 All candidates require one more effect site than the eager versions. Hook and
-component support grew from 21 and 36 lines to 44 and 61. Handle support grew
-from 90 to 147 lines.
+component support grew from 21 and 36 lines to 44 and 61. The corrected
+duplicate-publication state machine grows handle support from the earlier 147
+lines to 280.
 
 ## TinyGo Size Evidence
 
@@ -322,25 +381,28 @@ wrapper and its candidate-specific probe reachable.
 
 | Fixture | Raw | gzip | Brotli | Zstandard | Raw delta from control |
 |---|---:|---:|---:|---:|---:|
-| control only | 307,235 B | 130,835 B | 107,144 B | 113,214 B | 0 B |
-| hook only | 313,588 B | 132,352 B | 108,503 B | 114,483 B | +6,353 B |
-| component only | 314,758 B | 132,782 B | 108,507 B | 114,976 B | +7,523 B |
-| handle only | 319,836 B | 135,242 B | 109,902 B | 116,914 B | +12,601 B |
-| combined comparison fixture | 341,382 B | 142,089 B | 114,833 B | 121,807 B | not comparable |
+| control only | 307,855 B | 131,023 B | 107,380 B | 113,305 B | 0 B |
+| hook only | 314,220 B | 132,653 B | 108,452 B | 114,642 B | +6,365 B |
+| component only | 315,374 B | 133,030 B | 108,848 B | 115,222 B | +7,519 B |
+| handle only | 331,049 B | 139,465 B | 112,706 B | 119,471 B | +23,194 B |
+| combined comparison fixture | 352,383 B | 146,161 B | 117,522 B | 124,598 B | not comparable |
 
-The corrected component costs 1,170 raw bytes more than the hook. The corrected
-combined fixture is 9,973 raw bytes, 2,908 gzip bytes, 2,432 Brotli bytes, and
-2,599 Zstandard bytes larger than the old eager-allocation head. The previous
-candidate-only and combined measurements are superseded.
+The corrected component costs 1,154 raw bytes more than the hook. The handle
+measurement includes the corrected conflict state machine and its focused
+probe. The previous candidate-only and combined values are superseded.
 
 ## Candidate Size Reproduction
 
-The measurement source is commit
-`7eb2f01804876c317e652e7b48f90dc9c36d90bb`. A reproducible temporary layout is:
+The pinned pre-review measurement source remains
+`7eb2f01804876c317e652e7b48f90dc9c36d90bb`, a direct ancestor of this record.
+The current measurements require the corrected handle and browser evidence, so
+their source is commit
+`2e197aec7fa52e2c3cf8799371af401eeb9bbf41`. A reproducible temporary layout for
+the current values is:
 
 ```bash
 root="$(mktemp -d)"
-git archive 7eb2f01804876c317e652e7b48f90dc9c36d90bb \
+git archive 2e197aec7fa52e2c3cf8799371af401eeb9bbf41 \
   | tar -x -C "$root"
 
 for mode in control hook component handle combined; do
@@ -354,17 +416,18 @@ the common failure and render recording after the direct hook/control/handle
 call; the component dispatch returns the component directly. In
 `candidateProbeNode`, retain only the hook two-slot probe for `hook`, only the
 forwarded duplicate probe for `handle`, and return `gf.Empty()` for `control`
-and `component`. The `combined` copy is unchanged. Run `gofmt` on
-`candidates.go`.
+and `component`. Retain `handleConflictProbeNode` and its controls only for the
+`handle` copy; make them unreachable in the other candidate-only copies. The
+`combined` copy is unchanged. Run `gofmt` on `candidates.go`.
 
 Normalized projection patch hashes are:
 
 | Copy | Patch SHA-256 |
 |---|---|
-| control | `62d6193bbb811d50a1719407a960cf1effa7dfd0ee2548c155461db986ec7d64` |
-| hook | `85cc1776b00a6467354a58f8ab1b8a52f4443f2449560054367d3089e0a10bde` |
-| component | `afd9195392a7eb70bb5794b877bc30677076d6ef74b909cb82e5564c73799ee6` |
-| handle | `436687cc326028c6d951dab38437299f4c6676f7825380424f440b29d51d6614` |
+| control | `c2d31c8ec7c8cd6595ded28918765460510d604c4ce0ab448712efe512c36066` |
+| hook | `41957c7fea1321f6f110e7407ff6c04cdbb6711827edccea3d3d25181bdd513f` |
+| component | `da9cb9c8d313c22bccf8808bcb41c525968c7e1b75f2de37418dd5782d978b39` |
+| handle | `76ed7dd79004f524ed9d49763ba83b6ff5381d46f443d4161495df17fadb1e05` |
 | combined | no patch |
 
 Each patch is a unified diff with repository-relative labels for
@@ -404,17 +467,20 @@ Each temporary projection:
 
 | Candidate | Patch SHA-256 | Added | Removed | Total changed | Generate/tests/build/package |
 |---|---|---:|---:|---:|---|
-| hook | `0f559023f210fda6697722cab125c3f4c8d795e671cbf394e00dfdffe0d79ec7` | 159 | 99 | 258 | pass |
-| component | `a9dc2653d80932bd178e4ad28dc235b987006e5c336e1b8c2c6eab00c3673970` | 128 | 69 | 197 | pass |
-| handle | `5dc404d16abaf5958660e9121956fe6317c5527abbe485cde691917e90702bb4` | 244 | 99 | 343 | pass |
+| hook | `1558632036e4e7e8ea0cf9c0f0fd93495bef10b7dc9a83c44512f1b4add4bb57` | 189 | 98 | 287 | pass |
+| component | `0611546ba45c3bfc5ffc36a8db794e1c58d68277ae1c1bf849e6f81f5f88bbb2` | 144 | 70 | 214 | pass |
+| handle | `f0c7c1f84e5a2eb77df50caec653b41de49b902512547b2e205e897f3b994ae8` | 349 | 100 | 449 | pass |
 
-The evidence-label adapter maps zero active owners to the authored baseline,
-one active owner to `route`, and a deeper active owner to `saved-editor`.
-Those labels are not identity and do not appear at candidate call sites.
+Opaque owner identity and evidence labels are stored separately. A token's first
+publication labels the first active candidate owner as `route` and a deeper
+owner as `saved-editor`; the existing string-key coordinator path retains its
+exact labels for pure-test compatibility. Labels are not identity and do not
+appear at candidate call sites.
 
-The full existing server-backed browser harness was run against all three
-corrected projections. Each reached the final document assertion with the
-request and safety evidence intact:
+The earlier corrected projection ran the full existing server-backed browser
+harness against all three candidates. The refreshed handle projection includes
+the corrected duplicate-publication state machine and again reached the final
+document assertion with request and safety evidence intact:
 
 ```text
 ordinary greeting requests: 11
@@ -427,7 +493,7 @@ duplicate descriptions: 0
 saved-editor activations/releases: 5/5
 ```
 
-Each projection failed the existing lifecycle counters in the same way:
+The refreshed handle result matches the prior shared lifecycle failure:
 
 | Counter | Reference | Hook | Component | Handle |
 |---|---:|---:|---:|---:|
@@ -442,11 +508,13 @@ observable completed states, not invalid title/description pairs.
 
 ## Server Projection Reproduction
 
-Use the same source commit and one temporary copy per candidate:
+Use corrected evidence commit
+`2e197aec7fa52e2c3cf8799371af401eeb9bbf41` and one temporary copy per
+candidate:
 
 ```bash
 root="$(mktemp -d)"
-git archive 7eb2f01804876c317e652e7b48f90dc9c36d90bb \
+git archive 2e197aec7fa52e2c3cf8799371af401eeb9bbf41 \
   | tar -x -C "$root"
 
 for mode in hook component handle; do
@@ -462,9 +530,10 @@ Apply these exact transformation rules to each copy:
    to `serverBackedDocumentState`. Store `coordinator` and `key` on the token,
    add `nextID uint64`, and set the key to
    `"owner-"+strconv.FormatUint(nextID, 10)` only in first `Publish`. Preserve
-   the existing string `Set`, `Remove`, `Snapshot`, and pure tests. Map the
-   candidate result label to empty at count 0, `route` at count 1, and
-   `saved-editor` above count 1.
+   the existing string `Set`, `Remove`, `Snapshot`, and pure tests. Store opaque
+   owner identity separately from the evidence label; label the first candidate
+   owner `route` and a deeper candidate owner `saved-editor` when its token
+   first publishes.
 2. In `app.gox`, remove `DocumentOwnerProps`, the two string-owner constants,
    `DocumentOwner`, and `useServerBackedDocumentState`.
 3. Add `document_candidate.go` with `//go:build js && wasm`. For hook,
@@ -481,9 +550,9 @@ Apply these exact transformation rules to each copy:
 5. Do not modify tests, the browser harness, backend protocol, document
    adapter, or committer.
 
-Create repository-relative unified diffs for `app.gox`,
-`document_state.go`, and the added `document_candidate.go`; their hashes must
-match the table above. Run from each temporary root:
+Create repository-relative unified diffs in `app.gox`, added
+`document_candidate.go`, then `document_state.go` order; their hashes must match
+the table above. Run from each temporary root:
 
 ```bash
 goxc generate ./examples/server-backed

--- a/docs/document-metadata-api-design.md
+++ b/docs/document-metadata-api-design.md
@@ -1,0 +1,396 @@
+# Document Metadata API Design
+
+## Status
+
+Accepted — Component Candidate
+
+This record selects the non-DOM component form as the implementation candidate.
+No public API is added by this branch.
+
+## Context
+
+The document-state fixture and the server-backed example independently implement
+the same title and description ownership model. Each application currently owns
+an ordered coordinator, stable owner identity, publication and release
+lifecycle, selected-snapshot state, browser bindings, and a central document
+committer.
+
+The repeated value is one pair:
+
+```go
+type DocumentMetadata struct {
+	Title       string
+	Description string
+}
+```
+
+The design comparison asks which application-facing shape can hide owner keys
+and coordinator plumbing while retaining component-scoped ownership. The
+comparison does not add a general head manager or change runtime lifecycle
+semantics.
+
+## Evidence Surfaces
+
+The executable comparison uses
+`scripts/fixtures/document-state-api-design`. It contains one common ordered
+model, one explicit string-owner control, and separate hook, component, and
+owner-handle implementations.
+
+The browser harness loads control, hook, component, and handle modes in one
+Chrome process. A pre-boot observer records the authored title, description,
+viewport metadata, node identities, and every managed mutation before WASM
+starts.
+
+Temporary copies of `examples/server-backed` project each candidate onto route
+metadata and the saved-editor override. Those copies are measurement artifacts;
+none is part of this branch.
+
+## Current Application-Local Pattern
+
+The control keeps the current application responsibilities:
+
+- string owner keys;
+- coordinator and snapshot callback bindings;
+- one publication effect and one unmount callback;
+- selected-snapshot state;
+- one central browser committer;
+- explicit route and nested-editor owner wrappers.
+
+This pattern implements the required behavior, but ownership identity and
+coordination remain application code.
+
+## Fixed Ownership Contract
+
+The candidates use the same contract:
+
+1. The authored title and description are captured before the first owner.
+2. A newly committed owner receives the highest priority.
+3. Updating an active owner changes its pair without changing priority.
+4. Releasing the selected owner reveals the latest remaining owner.
+5. Releasing a non-selected owner does not change the selected pair.
+6. Releasing the final owner restores the authored baseline.
+7. Failed speculative renders publish no owner.
+8. Title and description are committed as one selected pair.
+9. Identical selected values cause no document write.
+10. Existing title, description, and unrelated head-node identities remain
+    stable.
+
+Owner activation is lifecycle-committed. None of the candidates mutates the
+document during render.
+
+## Non-Goals
+
+This comparison does not define:
+
+- independent title and description ownership;
+- arbitrary head elements;
+- router-specific metadata;
+- a public coordinator or global registry;
+- SSR or hydration behavior;
+- SEO guarantees;
+- cross-document ownership;
+- a public API in this branch.
+
+## Candidate A — Implicit Hook
+
+The proposed shape is:
+
+```go
+gf.UseDocumentMetadata(gf.DocumentMetadata{
+	Title:       "...",
+	Description: "...",
+})
+```
+
+The private prototype allocates one opaque owner per hook slot. Its effect
+publishes after commit, updates retain priority, and its unmount callback
+releases the owner. Two calls in one component produce two distinct owners.
+
+The hook has the smallest candidate-specific TinyGo result and the shortest
+ordinary route call site. Ownership is not visible in the returned node tree,
+however. Conditional ownership requires an additional component boundary or an
+unconditional hook call with separately defined inactive semantics. Moving a
+call across a condition can change owner-slot identity without a visible tree
+change.
+
+## Candidate B — Non-DOM Component
+
+The proposed shape is:
+
+```gox
+<gf.DocumentMetadata
+	Metadata={gf.DocumentMetadata{
+		Title:       "...",
+		Description: "...",
+	}}
+>
+	{content}
+</gf.DocumentMetadata>
+```
+
+The exact props spelling remains open. One mounted component instance owns one
+metadata pair. The component returns its children as a fragment and emits no DOM
+element. Prop updates retain owner identity and priority. Conditional component
+mounting expresses activation and unmount expresses release.
+
+This form makes the ownership boundary visible in GOX and avoids positional-hook
+conditions in application components. Its main surprise is that a component
+with children owns browser state but adds no layout or DOM node. Documentation
+and naming must state that behavior directly.
+
+## Candidate C — Explicit Owner Handle
+
+The proposed shape is:
+
+```go
+owner := gf.UseDocumentMetadataOwner()
+gf.UseOwnedDocumentMetadata(owner, gf.DocumentMetadata{
+	Title:       "...",
+	Description: "...",
+})
+```
+
+The private prototype keeps a stable opaque handle and a separate publication
+slot. Passing the handle through a helper preserves owner identity. Identical
+duplicate publications coalesce, while conflicting simultaneous publications
+are rejected.
+
+The handle supports helper composition explicitly, but requires two calls and
+two lifecycle state values for ordinary ownership. Its misuse surface includes
+escaping a handle, reusing it across unrelated component lifetimes, and
+confusing handle creation with active publication.
+
+## Behavioral Evidence
+
+All candidates pass the same host and browser scenarios:
+
+| Scenario | Control | Hook | Component | Handle |
+|---|---:|---:|---:|---:|
+| route activation | pass | pass | pass | pass |
+| nested activation | pass | pass | pass | pass |
+| parent update beneath nested owner | pass | pass | pass | pass |
+| selected release reveals updated parent | pass | pass | pass | pass |
+| non-selected release | pass | pass | pass | pass |
+| identical selected update | pass | pass | pass | pass |
+| failed speculative render | pass | pass | pass | pass |
+| final release restores baseline | pass | pass | pass | pass |
+| scope remount | pass | pass | pass | pass |
+
+Two focused browser runs produced identical normalized transition, candidate,
+and mutation evidence. Every mode reported:
+
+- zero invalid title/description pairs;
+- zero duplicate descriptions;
+- zero speculative metadata appearances;
+- zero unrelated metadata mutations;
+- zero title-node replacements;
+- zero description-node replacements;
+- one authored-baseline restoration;
+- one captured speculative render failure.
+
+Candidate-specific evidence also showed:
+
+- hook: two calls in one component had distinct owner identities and added no
+  DOM element;
+- component: conditional mount and release matched owner lifetime and added no
+  wrapper element;
+- handle: forwarding retained one owner, and one identical duplicate
+  publication coalesced.
+
+## Call-Site Measurements
+
+The common hidden support is one coordinator, one selected-snapshot state, one
+context binding, and one central committer. Candidate numbers below count
+ownership-specific application shape, not browser evidence.
+
+| Measure | Control | Hook | Component | Handle |
+|---|---:|---:|---:|---:|
+| metadata arguments per owner | 2 fields plus key | 1 value | 1 value | handle plus 1 value |
+| application-visible owner keys | 2 | 0 | 0 | 0 |
+| owner state slots | 0 | 1 | 1 | 2 |
+| owner publication effects | 1 | 1 | 1 | 1 |
+| owner unmount callbacks | 1 | 1 | 1 | 1 |
+| owner helper types | 1 adapter | 0 | 1 props type | 2 |
+| owner helper functions | 1 | 1 | 1 | 3 |
+| coordinator methods visible to caller | 2 | 0 | 0 | 0 |
+| explicit caller cleanup callbacks | 1 | 0 | 0 | 0 |
+| positional-hook restriction at caller | yes | yes | no | yes |
+
+The temporary server-backed projections contained six ownership sites: five
+route owners and one saved-editor override.
+
+| Measure | Current control | Hook | Component | Handle |
+|---|---:|---:|---:|---:|
+| ownership expression lines | 18 | 8 | 14 | 13 |
+| route-owner lines | 14 | 5 | 11 | 10 |
+| nested-override lines | 4 | 3 | 3 | 3 |
+| owner-key props | 6 | 0 | 0 | 0 |
+| candidate-specific route helper needed | no | no | no | no |
+| conditional editor helper needed | existing wrapper | yes | no | yes |
+
+The central committer and selected-snapshot plumbing remain common hidden costs;
+they are not evidence for one candidate over another.
+
+## Misuse Analysis
+
+| Risk | Hook | Component | Handle |
+|---|---|---|---|
+| accidental conditional use | positional slot can change | ordinary conditional mount is valid | either handle or publication call can become conditional |
+| duplicate owner creation | one owner per accidental extra hook call | one owner per extra mounted component | extra handle creates an owner; repeated publication needs validation |
+| stale cleanup | hidden by hook implementation | tied to component unmount | split handle/publication lifetimes require checks |
+| token escape or reuse | no token exposed | no token exposed | handle can escape or be reused |
+| invisible ownership | high | ownership appears in tree | handle calls are visible but not in tree |
+| non-DOM surprise | none | component adds no DOM node | none |
+| repeated publication | another hook call means another owner | another component means another owner | same handle needs duplicate/conflict rules |
+| missing root binding | runtime diagnostic required | runtime diagnostic required | runtime diagnostic required |
+| multiple mounted apps | binding must remain mount-local | binding must remain mount-local | handle must not cross mounts |
+| non-browser use | should be an inert lifecycle contract or diagnosed | same | same |
+| testing ergonomics | render a hook owner | mount a visible ownership boundary | create and publish a handle |
+
+Concrete invalid forms include calling the hook only inside `if open`, mounting
+two metadata components for one logical owner, and retaining a handle after its
+publishing component unmounts. A future implementation must diagnose missing
+root bindings and reject a handle from another mounted application.
+
+The decision rubric scores 0 as weakest and 3 as strongest:
+
+| Category | Hook | Component | Handle |
+|---|---:|---:|---:|
+| semantic fit | 3 | 3 | 3 |
+| call-site clarity | 2 | 3 | 2 |
+| nested-owner ergonomics | 2 | 3 | 2 |
+| update ergonomics | 3 | 3 | 3 |
+| lifecycle safety | 2 | 3 | 2 |
+| positional-hook burden | 1 | 3 | 2 |
+| GOX ergonomics | 2 | 3 | 1 |
+| helper composition | 3 | 2 | 3 |
+| testability | 2 | 3 | 2 |
+| misuse resistance | 2 | 2 | 1 |
+| implementation narrowness | 3 | 3 | 2 |
+| DCE feasibility | 3 | 3 | 3 |
+| TinyGo cost | 3 | 2 | 1 |
+| integrated projection | 2 | 3 | 1 |
+| **Total** | **33** | **39** | **28** |
+
+The score does not override hard rejection conditions. No candidate triggered a
+hard rejection; the component lead is supported by the integrated projection,
+not aesthetics alone.
+
+## TinyGo Size Evidence
+
+Measurements use Go 1.22.12, TinyGo 0.41.1, Linux amd64, `gzip -n -9`,
+Brotli quality 11, and Zstandard level 19. Each candidate-only copy retains the
+same coordinator, adapter, and scenario UI, with only one ownership candidate
+reachable.
+
+| Fixture | Ownership support lines | Raw | gzip | Brotli | Zstandard | Raw delta from control |
+|---|---:|---:|---:|---:|---:|---:|
+| control only | 22 | 302,625 B | 129,291 B | 105,829 B | 112,125 B | 0 B |
+| hook only | 21 | 307,577 B | 130,542 B | 106,997 B | 112,916 B | +4,952 B |
+| component only | 36 | 308,669 B | 130,780 B | 107,106 B | 113,326 B | +6,044 B |
+| handle only | 90 | 311,210 B | 131,896 B | 107,898 B | 114,266 B | +8,585 B |
+| combined comparison fixture | not applicable | 331,409 B | 139,181 B | 112,401 B | 119,208 B | not comparable |
+
+The component costs 1,092 raw bytes more than the hook in this fixture. This
+difference does not outweigh its explicit lifecycle boundary and simpler
+conditional ownership in the integrated projection.
+
+Ownership support lines count each candidate's lifecycle wrapper and private
+owner/publication types. They exclude the shared coordinator, adapter, scenario,
+browser evidence, and dispatch used only to host all candidates in one fixture.
+
+## Integrated Server-Backed Projection
+
+Every temporary projection:
+
+- generated successfully;
+- passed `examples/server-backed/...` pure tests;
+- completed a Go/WASM build;
+- produced a standard-Go standalone package;
+- retained route metadata, nested saved-editor ownership, metadata updates
+  beneath the editor, validation, pending and confirmed states, editor release,
+  and route-scope unmount code paths.
+
+| Candidate | Added | Removed | Total changed lines | Result |
+|---|---:|---:|---:|---|
+| hook | 29 | 44 | 73 | compile, tests, build, package pass |
+| component | 21 | 27 | 48 | compile, tests, build, package pass |
+| handle | 53 | 44 | 97 | compile, tests, build, package pass |
+
+The selected component projection also passed the existing focused
+server-backed browser harness. It retained 11 ordinary greeting requests, 10
+transition requests, 4 saved GETs, 4 saved POSTs, 43 title mutation batches, 43
+description mutation batches, 139 document snapshots, one baseline restoration,
+and five saved-editor activations and releases. Invalid pairs, stale metadata,
+duplicate descriptions, node replacements, false confirmations, and ownership
+mismatches remained zero.
+
+The evidence-label adapter in the temporary projection derived the existing
+`route` and `saved-editor` labels from owner depth. Those labels were not owner
+identity and were not supplied at component call sites.
+
+## Decision
+
+The component candidate is selected for a possible later implementation stage.
+It satisfies the fixed contract, makes owner lifetime visible in GOX, expresses
+conditional overrides through ordinary component mounting, removes string owner
+keys and coordinator methods from call sites, and creates the smallest
+server-backed projection.
+
+The hook is smaller, but its invisible ownership and positional conditional-use
+burden are material for route and editor composition. The handle preserves
+explicit identity through helpers, but its extra ceremony and token-lifetime
+rules are not justified by the current evidence.
+
+Selection here means only that the component form is the implementation
+candidate. No production API, compatibility promise, or implementation schedule
+is established.
+
+## Rejected Alternatives
+
+- The explicit string-owner control remains application-local and exposes the
+  machinery this design intends to hide.
+- Independent title and description APIs can create mixed document pairs and
+  are outside the fixed contract.
+- Render-time setters or direct DOM writes violate lifecycle commit semantics.
+- A public coordinator, global registry, router integration, or general head
+  manager broadens the current evidence boundary.
+- The hook and handle remain documented comparison candidates, not alternate
+  public spellings to ship together.
+
+## Proposed Stability Tier
+
+If implemented later, the candidate belongs in **Experimental Frontier**.
+
+The exact exported name, props shape, root binding, diagnostics, and non-browser
+behavior require implementation evidence. The candidate is not stable and is
+not classified as Public-Candidate by this record.
+
+## Implementation Boundary
+
+A later implementation would need a private mount-local coordinator and browser
+adapter, stable opaque owner identity per component instance, lifecycle-committed
+publication, release on unmount, selected-pair state, baseline capture, and one
+document committer.
+
+The application-facing component must not accept a coordinator, callback,
+browser adapter, string owner key, owner index, or global registry. Generated
+DOM must contain only its children.
+
+## Remaining Limits
+
+The evidence covers one browser document, one authored title, one authored
+description element, nested component owners, route ownership, editor
+overrides, failed-render isolation, and baseline restoration.
+
+It does not establish:
+
+- SSR, hydration, or server metadata behavior;
+- multiple browser documents or portals;
+- arbitrary head-element ownership;
+- concurrent independently mounted apps targeting one document;
+- interaction with authored scripts that mutate the same nodes;
+- a stable diagnostic or testing API;
+- production SEO behavior.
+
+Those limits must not be inferred from the private prototype.

--- a/docs/document-metadata-api-design.md
+++ b/docs/document-metadata-api-design.md
@@ -2,18 +2,24 @@
 
 ## Status
 
-Accepted — Component Candidate
+Corrected - Result D: no implementation candidate selected.
 
-This record selects the non-DOM component form as the implementation candidate.
-No public API is added by this branch.
+The hook, non-DOM component, and owner-handle prototypes satisfy the focused
+coordinator and wrapper-lifecycle contract. After owner creation was moved out
+of render, however, all three corrected server-backed projections exposed an
+extra committed initialization phase between route-owner lifetimes. That phase
+temporarily restored the authored baseline during ordinary route changes.
+
+No public API is added by this branch. The previous Component Candidate result
+and its measurements are superseded by this record.
 
 ## Context
 
-The document-state fixture and the server-backed example independently implement
-the same title and description ownership model. Each application currently owns
-an ordered coordinator, stable owner identity, publication and release
-lifecycle, selected-snapshot state, browser bindings, and a central document
-committer.
+The document-state fixture and the server-backed example independently
+implement the same title and description ownership model. Each application
+currently owns an ordered coordinator, stable owner identity, publication and
+release lifecycle, selected-snapshot state, browser bindings, and a central
+document committer.
 
 The repeated value is one pair:
 
@@ -24,59 +30,102 @@ type DocumentMetadata struct {
 }
 ```
 
-The design comparison asks which application-facing shape can hide owner keys
-and coordinator plumbing while retaining component-scoped ownership. The
-comparison does not add a general head manager or change runtime lifecycle
-semantics.
+The comparison asks which application-facing shape can hide owner keys and
+coordinator plumbing while retaining component-scoped ownership. It does not
+add a general head manager or change runtime lifecycle semantics.
 
 ## Evidence Surfaces
 
 The executable comparison uses
-`scripts/fixtures/document-state-api-design`. It contains one common ordered
-model, one explicit string-owner control, and separate hook, component, and
-owner-handle implementations.
+`scripts/fixtures/document-state-api-design`. It contains one ordered
+coordinator model, one explicit string-owner control, and private hook,
+component, and owner-handle wrappers.
 
-The browser harness loads control, hook, component, and handle modes in one
-Chrome process. A pre-boot observer records the authored title, description,
-viewport metadata, node identities, and every managed mutation before WASM
-starts.
+Pure Go tests exercise coordinator ordering, token identity, publication,
+release, and error behavior. They do not execute hook, component, or handle
+lifecycle wrappers through a host renderer.
 
-Temporary copies of `examples/server-backed` project each candidate onto route
-metadata and the saved-editor override. Those copies are measurement artifacts;
-none is part of this branch.
+The browser harness executes the actual wrappers in one Chrome process. A
+pre-boot observer records the authored title, description, viewport metadata,
+node identities, managed mutations, coordinator statistics, owner IDs, and
+candidate-specific lifetime events before WASM starts.
 
-## Current Application-Local Pattern
+Temporary candidate-only copies provide TinyGo size evidence. Temporary copies
+of `examples/server-backed` test package-level integration. None of those
+measurement copies is committed.
 
-The control keeps the current application responsibilities:
+## Previous Allocation Defect
 
-- string owner keys;
-- coordinator and snapshot callback bindings;
-- one publication effect and one unmount callback;
-- selected-snapshot state;
-- one central browser committer;
-- explicit route and nested-editor owner wrappers.
+The old wrappers passed side-effectful expressions to `UseState`:
 
-This pattern implements the required behavior, but ownership identity and
-coordination remain application code.
+```go
+owner, _ := gf.UseState(bindings.coordinator.NewOwner())
+```
+
+```go
+handle, _ := gf.UseState(&documentMetadataOwnerHandle{
+	owner: bindings.coordinator.NewOwner(),
+})
+```
+
+The handle publication used the same eager pattern. Go evaluates those
+arguments on every render even when `UseState` retains the existing slot.
+`NewOwner` also assigned an ID immediately. Ordinary rerenders and failed
+speculative renders therefore created discarded objects and consumed IDs.
+
+A temporary old-head probe observed the route committed as ID 1 while the same
+initial route pass evaluated a discarded ID 2. An ordinary update evaluated
+discarded IDs 7 and 8 while the active route remained ID 1. A same-value
+rerender evaluated discarded IDs 25 and 26. A failed speculative hook render
+evaluated ID 41 without adding an active owner. Component and handle modes
+showed the same class of discarded allocation.
+
+## Corrected Identity Contract
+
+An owner token begins inactive:
+
+```text
+ID = 0
+not in active order
+does not reserve the next committed ID
+```
+
+`NewOwner` creates only that inactive token. The first successful
+`Coordinator.Publish` assigns the next numeric ID, appends the owner, and does
+so from committed effect work. Updating the same owner retains its ID and
+priority. Releasing an unpublished token is a no-op. IDs are never recycled.
+
+The candidate wrappers use two committed phases:
+
+```text
+render with nil private state
+-> initialization effect creates and installs token/handle/publication
+-> next committed render publishes through the stable token
+```
+
+No candidate setter runs during render. A render that fails before commit
+creates no token, handle, publication, ID, or active owner.
 
 ## Fixed Ownership Contract
 
-The candidates use the same contract:
+The corrected prototypes retain these requirements:
 
-1. The authored title and description are captured before the first owner.
-2. A newly committed owner receives the highest priority.
+1. Title and description are one value.
+2. A newly committed owner receives highest priority.
 3. Updating an active owner changes its pair without changing priority.
 4. Releasing the selected owner reveals the latest remaining owner.
 5. Releasing a non-selected owner does not change the selected pair.
 6. Releasing the final owner restores the authored baseline.
-7. Failed speculative renders publish no owner.
-8. Title and description are committed as one selected pair.
-9. Identical selected values cause no document write.
-10. Existing title, description, and unrelated head-node identities remain
-    stable.
+7. Remount creates a new ownership lifetime.
+8. Failed speculative renders publish no owner.
+9. Identical selected metadata causes no document write.
+10. Authored title and description node identities remain stable.
+11. Unrelated authored head elements remain unchanged.
+12. No document mutation occurs during render.
 
-Owner activation is lifecycle-committed. None of the candidates mutates the
-document during render.
+The browser evidence establishes pair consistency at committed application and
+MutationObserver boundaries. It does not claim one atomic browser operation for
+both DOM writes.
 
 ## Non-Goals
 
@@ -91,9 +140,9 @@ This comparison does not define:
 - cross-document ownership;
 - a public API in this branch.
 
-## Candidate A — Implicit Hook
+## Candidate A - Implicit Hook
 
-The proposed shape is:
+The compared shape is:
 
 ```go
 gf.UseDocumentMetadata(gf.DocumentMetadata{
@@ -102,20 +151,20 @@ gf.UseDocumentMetadata(gf.DocumentMetadata{
 })
 ```
 
-The private prototype allocates one opaque owner per hook slot. Its effect
-publishes after commit, updates retain priority, and its unmount callback
-releases the owner. Two calls in one component produce two distinct owners.
+The private hook retains one nil token state slot. Its initialization effect
+creates the token, its publication effect activates or updates it, and its
+unmount callback releases it. Two calls in one component create two committed
+owners. Failed initial render creates neither.
 
-The hook has the smallest candidate-specific TinyGo result and the shortest
-ordinary route call site. Ownership is not visible in the returned node tree,
-however. Conditional ownership requires an additional component boundary or an
-unconditional hook call with separately defined inactive semantics. Moving a
-call across a condition can change owner-slot identity without a visible tree
-change.
+The hook has the smallest corrected candidate-only TinyGo result and the
+shortest ordinary route call site. Ownership is not visible in the returned
+node tree. Conditional ownership still needs another component boundary, and
+the extra committed initialization phase is visible when one route component
+replaces another.
 
-## Candidate B — Non-DOM Component
+## Candidate B - Non-DOM Component
 
-The proposed shape is:
+The compared shape is:
 
 ```gox
 <gf.DocumentMetadata
@@ -128,19 +177,18 @@ The proposed shape is:
 </gf.DocumentMetadata>
 ```
 
-The exact props spelling remains open. One mounted component instance owns one
-metadata pair. The component returns its children as a fragment and emits no DOM
-element. Prop updates retain owner identity and priority. Conditional component
-mounting expresses activation and unmount expresses release.
+One mounted component instance retains one nil token state slot. Conditional
+mounting expresses activation and unmount expresses release. Prop updates
+retain owner identity and priority. The component returns children as a
+fragment and emits no wrapper element.
 
-This form makes the ownership boundary visible in GOX and avoids positional-hook
-conditions in application components. Its main surprise is that a component
-with children owns browser state but adds no layout or DOM node. Documentation
-and naming must state that behavior directly.
+This shape still makes ownership most visible in GOX and avoids positional-hook
+conditions in application components. Its corrected server-backed projection
+nevertheless has the same committed initialization gap as the hook.
 
-## Candidate C — Explicit Owner Handle
+## Candidate C - Explicit Owner Handle
 
-The proposed shape is:
+The compared shape is:
 
 ```go
 owner := gf.UseDocumentMetadataOwner()
@@ -150,19 +198,60 @@ gf.UseOwnedDocumentMetadata(owner, gf.DocumentMetadata{
 })
 ```
 
-The private prototype keeps a stable opaque handle and a separate publication
-slot. Passing the handle through a helper preserves owner identity. Identical
-duplicate publications coalesce, while conflicting simultaneous publications
-are rejected.
+The private prototype retains a nil handle slot and a nil publication slot.
+Committed initialization effects create them. A later publication effect
+activates the owner. Passing the handle through a helper preserves identity.
+Identical duplicate publications coalesce, while conflicting simultaneous
+publications are rejected.
 
-The handle supports helper composition explicitly, but requires two calls and
-two lifecycle state values for ordinary ownership. Its misuse surface includes
-escaping a handle, reusing it across unrelated component lifetimes, and
-confusing handle creation with active publication.
+The handle supports helper composition explicitly, but requires two calls,
+three effect sites, and split handle/publication lifetime rules. It also has the
+largest corrected source and TinyGo cost, while retaining the same integration
+gap.
 
-## Behavioral Evidence
+## Pure Coordinator Conformance
 
-All candidates pass the same host and browser scenarios:
+Pure host tests cover the control and opaque-token coordinator models, not the
+actual candidate wrappers.
+
+| Scenario | Required result | Corrected result |
+|---|---|---|
+| inactive token | ID 0 | pass |
+| unpublished token before published token | no ID gap | pass |
+| first publication | ID 1 | pass |
+| existing-owner update | same ID and priority | pass |
+| identical publication | no transition | pass |
+| unpublished release | no-op | pass |
+| release and remount | exactly next ID | pass |
+| foreign token | rejected before and after publication | pass |
+| title-only and description-only updates | compare the complete pair | pass |
+
+The focused pure suite passed 100 repetitions and 20 race-detector
+repetitions.
+
+## Candidate Wrapper Lifecycle Evidence
+
+Actual hook, component, and handle lifecycle wrappers are exercised in the
+browser renderer. Pure host tests cover their shared coordinator model and
+identity allocation rules.
+
+The ordinary route lifetime for each candidate produced one token, one
+committed ID, and one active addition. Metadata and identical rerenders created
+no token or ID. A speculative failed owner created none. Scope remount created
+exactly one next lifetime.
+
+Candidate-specific browser evidence showed:
+
+- hook: the two-slot probe created tokens and IDs 5 and 6, then released both
+  exactly once;
+- component: five successful mounts matched four unmounts with one active
+  remount, and no wrapper DOM element appeared;
+- handle: six handle/token/ID lifetimes and seven publication lifetimes were
+  committed; one forwarded duplicate coalesced through owner ID 5;
+- all candidates: the failed-render token, ID, and active-owner deltas were
+  zero.
+
+## Focused Browser Evidence
 
 | Scenario | Control | Hook | Component | Handle |
 |---|---:|---:|---:|---:|
@@ -171,226 +260,350 @@ All candidates pass the same host and browser scenarios:
 | parent update beneath nested owner | pass | pass | pass | pass |
 | selected release reveals updated parent | pass | pass | pass | pass |
 | non-selected release | pass | pass | pass | pass |
-| identical selected update | pass | pass | pass | pass |
+| identical selected rerender | pass | pass | pass | pass |
 | failed speculative render | pass | pass | pass | pass |
 | final release restores baseline | pass | pass | pass | pass |
 | scope remount | pass | pass | pass | pass |
+| node identity | pass | pass | pass | pass |
+| duplicate description prevention | pass | pass | pass | pass |
 
-Two focused browser runs produced identical normalized transition, candidate,
-and mutation evidence. Every mode reported:
+Two focused browser runs produced byte-identical normalized evidence after
+excluding elapsed time:
 
-- zero invalid title/description pairs;
-- zero duplicate descriptions;
-- zero speculative metadata appearances;
-- zero unrelated metadata mutations;
-- zero title-node replacements;
-- zero description-node replacements;
-- one authored-baseline restoration;
-- one captured speculative render failure.
+```text
+SHA-256:
+8a6df8a2eab01b652405c861d66609299c6f67f122d6d3cf1429428f9a5dc058
+```
 
-Candidate-specific evidence also showed:
+The runs took 5,908 ms and 5,674 ms. Transition counters, coordinator
+statistics, committed owner-ID sequences, mutation logs, baseline restoration,
+node identity, and failure counters were identical.
 
-- hook: two calls in one component had distinct owner identities and added no
-  DOM element;
-- component: conditional mount and release matched owner lifetime and added no
-  wrapper element;
-- handle: forwarding retained one owner, and one identical duplicate
-  publication coalesced.
+Final focused statistics were:
 
-## Call-Site Measurements
+| Mode | Tokens | IDs | Adds | Updates | Releases | Active | Last ID |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| control | 5 | 5 | 5 | 1 | 4 | 1 | 5 |
+| hook | 7 | 7 | 7 | 1 | 6 | 1 | 7 |
+| component | 5 | 5 | 5 | 1 | 4 | 1 | 5 |
+| handle | 6 | 6 | 6 | 1 | 5 | 1 | 6 |
 
-The common hidden support is one coordinator, one selected-snapshot state, one
-context binding, and one central committer. Candidate numbers below count
-ownership-specific application shape, not browser evidence.
+## Candidate Measurements
+
+Counts below cover one ordinary owner. Initialization renders count committed
+renders from mount through the first publication. Effect sites count
+`UseEffect` calls; unmount callbacks are listed separately. Support lines use
+the same source-span rule as the superseded measurements: the complete private
+lifecycle wrapper and its private owner/publication types, including embedded
+fixture evidence calls.
 
 | Measure | Control | Hook | Component | Handle |
 |---|---:|---:|---:|---:|
-| metadata arguments per owner | 2 fields plus key | 1 value | 1 value | handle plus 1 value |
+| private state slots | 0 | 1 | 1 | 2 |
+| effect sites | 1 | 2 | 2 | 3 |
+| initialization renders | 1 | 2 | 2 | 2 |
+| token creations | 1 | 1 | 1 | 1 |
+| committed owner IDs | 1 | 1 | 1 | 1 |
+| unmount callbacks | 1 | 1 | 1 | 1 |
+| ownership support lines | 34 | 44 | 61 | 147 |
 | application-visible owner keys | 2 | 0 | 0 | 0 |
-| owner state slots | 0 | 1 | 1 | 2 |
-| owner publication effects | 1 | 1 | 1 | 1 |
-| owner unmount callbacks | 1 | 1 | 1 | 1 |
-| owner helper types | 1 adapter | 0 | 1 props type | 2 |
-| owner helper functions | 1 | 1 | 1 | 3 |
-| coordinator methods visible to caller | 2 | 0 | 0 | 0 |
-| explicit caller cleanup callbacks | 1 | 0 | 0 | 0 |
 | positional-hook restriction at caller | yes | yes | no | yes |
 
-The temporary server-backed projections contained six ownership sites: five
-route owners and one saved-editor override.
-
-| Measure | Current control | Hook | Component | Handle |
-|---|---:|---:|---:|---:|
-| ownership expression lines | 18 | 8 | 14 | 13 |
-| route-owner lines | 14 | 5 | 11 | 10 |
-| nested-override lines | 4 | 3 | 3 | 3 |
-| owner-key props | 6 | 0 | 0 | 0 |
-| candidate-specific route helper needed | no | no | no | no |
-| conditional editor helper needed | existing wrapper | yes | no | yes |
-
-The central committer and selected-snapshot plumbing remain common hidden costs;
-they are not evidence for one candidate over another.
-
-## Misuse Analysis
-
-| Risk | Hook | Component | Handle |
-|---|---|---|---|
-| accidental conditional use | positional slot can change | ordinary conditional mount is valid | either handle or publication call can become conditional |
-| duplicate owner creation | one owner per accidental extra hook call | one owner per extra mounted component | extra handle creates an owner; repeated publication needs validation |
-| stale cleanup | hidden by hook implementation | tied to component unmount | split handle/publication lifetimes require checks |
-| token escape or reuse | no token exposed | no token exposed | handle can escape or be reused |
-| invisible ownership | high | ownership appears in tree | handle calls are visible but not in tree |
-| non-DOM surprise | none | component adds no DOM node | none |
-| repeated publication | another hook call means another owner | another component means another owner | same handle needs duplicate/conflict rules |
-| missing root binding | runtime diagnostic required | runtime diagnostic required | runtime diagnostic required |
-| multiple mounted apps | binding must remain mount-local | binding must remain mount-local | handle must not cross mounts |
-| non-browser use | should be an inert lifecycle contract or diagnosed | same | same |
-| testing ergonomics | render a hook owner | mount a visible ownership boundary | create and publish a handle |
-
-Concrete invalid forms include calling the hook only inside `if open`, mounting
-two metadata components for one logical owner, and retaining a handle after its
-publishing component unmounts. A future implementation must diagnose missing
-root bindings and reject a handle from another mounted application.
-
-The decision rubric scores 0 as weakest and 3 as strongest:
-
-| Category | Hook | Component | Handle |
-|---|---:|---:|---:|
-| semantic fit | 3 | 3 | 3 |
-| call-site clarity | 2 | 3 | 2 |
-| nested-owner ergonomics | 2 | 3 | 2 |
-| update ergonomics | 3 | 3 | 3 |
-| lifecycle safety | 2 | 3 | 2 |
-| positional-hook burden | 1 | 3 | 2 |
-| GOX ergonomics | 2 | 3 | 1 |
-| helper composition | 3 | 2 | 3 |
-| testability | 2 | 3 | 2 |
-| misuse resistance | 2 | 2 | 1 |
-| implementation narrowness | 3 | 3 | 2 |
-| DCE feasibility | 3 | 3 | 3 |
-| TinyGo cost | 3 | 2 | 1 |
-| integrated projection | 2 | 3 | 1 |
-| **Total** | **33** | **39** | **28** |
-
-The score does not override hard rejection conditions. No candidate triggered a
-hard rejection; the component lead is supported by the integrated projection,
-not aesthetics alone.
+All candidates require one more effect site than the eager versions. Hook and
+component support grew from 21 and 36 lines to 44 and 61. Handle support grew
+from 90 to 147 lines.
 
 ## TinyGo Size Evidence
 
 Measurements use Go 1.22.12, TinyGo 0.41.1, Linux amd64, `gzip -n -9`,
 Brotli quality 11, and Zstandard level 19. Each candidate-only copy retains the
-same coordinator, adapter, and scenario UI, with only one ownership candidate
-reachable.
+same scenario UI, coordinator, and browser adapter, with only one candidate
+wrapper and its candidate-specific probe reachable.
 
-| Fixture | Ownership support lines | Raw | gzip | Brotli | Zstandard | Raw delta from control |
-|---|---:|---:|---:|---:|---:|---:|
-| control only | 22 | 302,625 B | 129,291 B | 105,829 B | 112,125 B | 0 B |
-| hook only | 21 | 307,577 B | 130,542 B | 106,997 B | 112,916 B | +4,952 B |
-| component only | 36 | 308,669 B | 130,780 B | 107,106 B | 113,326 B | +6,044 B |
-| handle only | 90 | 311,210 B | 131,896 B | 107,898 B | 114,266 B | +8,585 B |
-| combined comparison fixture | not applicable | 331,409 B | 139,181 B | 112,401 B | 119,208 B | not comparable |
+| Fixture | Raw | gzip | Brotli | Zstandard | Raw delta from control |
+|---|---:|---:|---:|---:|---:|
+| control only | 307,235 B | 130,835 B | 107,144 B | 113,214 B | 0 B |
+| hook only | 313,588 B | 132,352 B | 108,503 B | 114,483 B | +6,353 B |
+| component only | 314,758 B | 132,782 B | 108,507 B | 114,976 B | +7,523 B |
+| handle only | 319,836 B | 135,242 B | 109,902 B | 116,914 B | +12,601 B |
+| combined comparison fixture | 341,382 B | 142,089 B | 114,833 B | 121,807 B | not comparable |
 
-The component costs 1,092 raw bytes more than the hook in this fixture. This
-difference does not outweigh its explicit lifecycle boundary and simpler
-conditional ownership in the integrated projection.
+The corrected component costs 1,170 raw bytes more than the hook. The corrected
+combined fixture is 9,973 raw bytes, 2,908 gzip bytes, 2,432 Brotli bytes, and
+2,599 Zstandard bytes larger than the old eager-allocation head. The previous
+candidate-only and combined measurements are superseded.
 
-Ownership support lines count each candidate's lifecycle wrapper and private
-owner/publication types. They exclude the shared coordinator, adapter, scenario,
-browser evidence, and dispatch used only to host all candidates in one fixture.
+## Candidate Size Reproduction
+
+The measurement source is commit
+`7eb2f01804876c317e652e7b48f90dc9c36d90bb`. A reproducible temporary layout is:
+
+```bash
+root="$(mktemp -d)"
+git archive 7eb2f01804876c317e652e7b48f90dc9c36d90bb \
+  | tar -x -C "$root"
+
+for mode in control hook component handle combined; do
+  cp -a "$root" "$root-$mode"
+done
+```
+
+For `control`, `hook`, `component`, and `handle`, replace the
+`CandidateOwner` mode switch with the corresponding direct wrapper call. Keep
+the common failure and render recording after the direct hook/control/handle
+call; the component dispatch returns the component directly. In
+`candidateProbeNode`, retain only the hook two-slot probe for `hook`, only the
+forwarded duplicate probe for `handle`, and return `gf.Empty()` for `control`
+and `component`. The `combined` copy is unchanged. Run `gofmt` on
+`candidates.go`.
+
+Normalized projection patch hashes are:
+
+| Copy | Patch SHA-256 |
+|---|---|
+| control | `62d6193bbb811d50a1719407a960cf1effa7dfd0ee2548c155461db986ec7d64` |
+| hook | `85cc1776b00a6467354a58f8ab1b8a52f4443f2449560054367d3089e0a10bde` |
+| component | `afd9195392a7eb70bb5794b877bc30677076d6ef74b909cb82e5564c73799ee6` |
+| handle | `436687cc326028c6d951dab38437299f4c6676f7825380424f440b29d51d6614` |
+| combined | no patch |
+
+Each patch is a unified diff with repository-relative labels for
+`candidates.go` and `app.gox`, created before generation. Build and measure each
+copy with:
+
+```bash
+goxc build ./scripts/fixtures/document-state-api-design --compiler=tinygo
+
+wasm="./scripts/fixtures/document-state-api-design/.goframe/build/tinygo/dev/bundle.wasm"
+wc -c "$wasm"
+gzip -n -9 -c "$wasm" | wc -c
+brotli -q 11 -c "$wasm" | wc -c
+zstd -19 -q -c "$wasm" | wc -c
+sha256sum "$wasm"
+```
+
+Remove the copies and owned caches with:
+
+```bash
+rm -rf "$root" "$root-control" "$root-hook" "$root-component" \
+  "$root-handle" "$root-combined"
+```
 
 ## Integrated Server-Backed Projection
 
-Every temporary projection:
+Each temporary projection:
 
 - generated successfully;
 - passed `examples/server-backed/...` pure tests;
-- completed a Go/WASM build;
+- completed a TinyGo WASM build;
 - produced a standard-Go standalone package;
-- retained route metadata, nested saved-editor ownership, metadata updates
-  beneath the editor, validation, pending and confirmed states, editor release,
-  and route-scope unmount code paths.
+- removed six caller-supplied owner-key props and the application
+  `DocumentOwner`/`useServerBackedDocumentState` adapter;
+- added an inactive opaque token path whose ID is assigned on first committed
+  publication.
 
-| Candidate | Added | Removed | Total changed lines | Result |
-|---|---:|---:|---:|---|
-| hook | 29 | 44 | 73 | compile, tests, build, package pass |
-| component | 21 | 27 | 48 | compile, tests, build, package pass |
-| handle | 53 | 44 | 97 | compile, tests, build, package pass |
+| Candidate | Patch SHA-256 | Added | Removed | Total changed | Generate/tests/build/package |
+|---|---|---:|---:|---:|---|
+| hook | `0f559023f210fda6697722cab125c3f4c8d795e671cbf394e00dfdffe0d79ec7` | 159 | 99 | 258 | pass |
+| component | `a9dc2653d80932bd178e4ad28dc235b987006e5c336e1b8c2c6eab00c3673970` | 128 | 69 | 197 | pass |
+| handle | `5dc404d16abaf5958660e9121956fe6317c5527abbe485cde691917e90702bb4` | 244 | 99 | 343 | pass |
 
-The selected component projection also passed the existing focused
-server-backed browser harness. It retained 11 ordinary greeting requests, 10
-transition requests, 4 saved GETs, 4 saved POSTs, 43 title mutation batches, 43
-description mutation batches, 139 document snapshots, one baseline restoration,
-and five saved-editor activations and releases. Invalid pairs, stale metadata,
-duplicate descriptions, node replacements, false confirmations, and ownership
-mismatches remained zero.
+The evidence-label adapter maps zero active owners to the authored baseline,
+one active owner to `route`, and a deeper active owner to `saved-editor`.
+Those labels are not identity and do not appear at candidate call sites.
 
-The evidence-label adapter in the temporary projection derived the existing
-`route` and `saved-editor` labels from owner depth. Those labels were not owner
-identity and were not supplied at component call sites.
+The full existing server-backed browser harness was run against all three
+corrected projections. Each reached the final document assertion with the
+request and safety evidence intact:
+
+```text
+ordinary greeting requests: 11
+retained-transition requests: 10
+saved GET requests: 4
+saved POST requests: 4
+invalid metadata pairs: 0
+stale metadata appearances: 0
+duplicate descriptions: 0
+saved-editor activations/releases: 5/5
+```
+
+Each projection failed the existing lifecycle counters in the same way:
+
+| Counter | Reference | Hook | Component | Handle |
+|---|---:|---:|---:|---:|
+| authored-baseline restorations | 1 | 9 | 9 | 9 |
+| title mutation batches | 43 | 51 | 51 | 51 |
+| description mutation batches | 43 | 51 | 51 | 51 |
+| document snapshots | 139 | 147 | 147 | 147 |
+
+The eight extra restorations occur when an old route owner releases before the
+replacement wrapper reaches its second committed publication phase. They are
+observable completed states, not invalid title/description pairs.
+
+## Server Projection Reproduction
+
+Use the same source commit and one temporary copy per candidate:
+
+```bash
+root="$(mktemp -d)"
+git archive 7eb2f01804876c317e652e7b48f90dc9c36d90bb \
+  | tar -x -C "$root"
+
+for mode in hook component handle; do
+  cp -a "$root" "$root-$mode"
+done
+```
+
+Apply these exact transformation rules to each copy:
+
+1. In `document_state.go`, adapt the `Owner`, `NewOwner`, `Publish`, `Release`,
+   and foreign-owner validation from
+   `scripts/fixtures/document-state-api-design/internal/documentmeta/model.go`
+   to `serverBackedDocumentState`. Store `coordinator` and `key` on the token,
+   add `nextID uint64`, and set the key to
+   `"owner-"+strconv.FormatUint(nextID, 10)` only in first `Publish`. Preserve
+   the existing string `Set`, `Remove`, `Snapshot`, and pure tests. Map the
+   candidate result label to empty at count 0, `route` at count 1, and
+   `saved-editor` above count 1.
+2. In `app.gox`, remove `DocumentOwnerProps`, the two string-owner constants,
+   `DocumentOwner`, and `useServerBackedDocumentState`.
+3. Add `document_candidate.go` with `//go:build js && wasm`. For hook,
+   component, or handle respectively, copy the corrected lifecycle structure
+   of `useHookDocumentMetadata`, `ComponentDocumentMetadata`, or the
+   `documentMetadataOwnerHandle`/`documentMetadataPublication` block from
+   `scripts/fixtures/document-state-api-design/cmd/app/candidates.go`. Remove
+   roles and fixture evidence calls, substitute the server-backed types, and
+   call `OnSnapshot` only when the coordinator reports a change.
+4. Replace the five route ownership sites and one saved-editor site. Hook and
+   handle projections add a conditional `SavedGreetingEditor` component;
+   component projection directly replaces `DocumentOwner` with
+   `DocumentMetadata`.
+5. Do not modify tests, the browser harness, backend protocol, document
+   adapter, or committer.
+
+Create repository-relative unified diffs for `app.gox`,
+`document_state.go`, and the added `document_candidate.go`; their hashes must
+match the table above. Run from each temporary root:
+
+```bash
+goxc generate ./examples/server-backed
+go test -count=1 ./examples/server-backed/...
+goxc build ./examples/server-backed --compiler=tinygo
+goxc package ./examples/server-backed --compiler=go
+```
+
+Browser evidence uses:
+
+```bash
+node --experimental-websocket scripts/server-backed-browser-smoke.mjs
+```
+
+The expected corrected-projection result is the final lifecycle-counter
+failure shown above. Cleanup is:
+
+```bash
+rm -rf "$root" "$root-hook" "$root-component" "$root-handle"
+```
+
+## Misuse Analysis
+
+| Risk | Hook | Component | Handle |
+|---|---|---|---|
+| conditional use | positional slot can change | ordinary conditional mount is valid | handle or publication call can become conditional |
+| initialization | hidden two-phase activation | visible owner still activates in two phases | handle and publication initialize separately |
+| route replacement | baseline gap before publication | baseline gap before publication | baseline gap before publication |
+| duplicate owner creation | extra hook call creates owner | extra mounted component creates owner | extra handle creates owner |
+| token escape or reuse | no token exposed | no token exposed | handle can escape or be reused |
+| helper composition | implicit slot survives helper only through caller shape | requires component composition | explicit handle forwarding |
+| publication conflict | another hook means another owner | another component means another owner | duplicate/conflicting publication rules required |
+| missing root binding | diagnostic required | diagnostic required | diagnostic required |
+| multiple mounted apps | binding must remain mount-local | binding must remain mount-local | handle must not cross mounts |
+| testing ergonomics | render hook owner | mount non-DOM owner component | create handle and publication |
+
+## Decision Matrix
+
+The score uses 0 as weakest and 3 as strongest. Integration receives zero for
+all candidates because the corrected projections do not preserve the reference
+owner-handoff counters.
+
+| Category | Hook | Component | Handle |
+|---|---:|---:|---:|
+| semantic fit | 2 | 2 | 2 |
+| call-site clarity | 2 | 3 | 2 |
+| nested-owner ergonomics | 2 | 3 | 2 |
+| update ergonomics | 3 | 3 | 3 |
+| lifecycle safety | 1 | 1 | 1 |
+| initialization complexity | 2 | 2 | 1 |
+| positional-hook burden | 1 | 3 | 2 |
+| GOX ergonomics | 2 | 3 | 1 |
+| helper composition | 3 | 2 | 3 |
+| testability | 2 | 3 | 2 |
+| misuse resistance | 2 | 2 | 1 |
+| implementation narrowness | 2 | 2 | 1 |
+| DCE feasibility | 3 | 3 | 3 |
+| TinyGo cost | 3 | 2 | 1 |
+| integrated projection | 0 | 0 | 0 |
+| **Total** | **30** | **34** | **25** |
 
 ## Decision
 
-The component candidate is selected for a possible later implementation stage.
-It satisfies the fixed contract, makes owner lifetime visible in GOX, expresses
-conditional overrides through ordinary component mounting, removes string owner
-keys and coordinator methods from call sites, and creates the smallest
-server-backed projection.
+Result D is selected: no implementation candidate.
 
-The hook is smaller, but its invisible ownership and positional conditional-use
-burden are material for route and editor composition. The handle preserves
-explicit identity through helpers, but its extra ceremony and token-lifetime
-rules are not justified by the current evidence.
+The component remains the clearest call-site shape and the narrowest integrated
+patch, but that relative lead does not override the shared lifecycle
+regression. A component, hook, or handle API should not be selected until
+committed owner activation can hand off between component lifetimes without an
+observable authored-baseline interval and without moving owner creation back
+into render.
 
-Selection here means only that the component form is the implementation
-candidate. No production API, compatibility promise, or implementation schedule
-is established.
+No proposed public spelling or stability tier is assigned. If a later design
+produces a viable candidate, it remains an Experimental Frontier question, not
+a Public-Candidate or compatibility promise.
 
 ## Rejected Alternatives
 
 - The explicit string-owner control remains application-local and exposes the
   machinery this design intends to hide.
-- Independent title and description APIs can create mixed document pairs and
-  are outside the fixed contract.
+- Moving `NewOwner` back into a `UseState` argument recreates discarded
+  per-render allocations and failed-render ID gaps.
 - Render-time setters or direct DOM writes violate lifecycle commit semantics.
-- A public coordinator, global registry, router integration, or general head
-  manager broadens the current evidence boundary.
-- The hook and handle remain documented comparison candidates, not alternate
-  public spellings to ship together.
+- Accepting the eight extra baseline restorations weakens existing
+  server-backed ownership evidence.
+- Independent title and description APIs can create mixed pairs and are outside
+  the fixed contract.
+- A public coordinator, global registry, router integration, transactional
+  lifecycle redesign, or general head manager broadens this stage.
 
-## Proposed Stability Tier
+## Public Surface Boundary
 
-If implemented later, the candidate belongs in **Experimental Frontier**.
+This branch does not add:
 
-The exact exported name, props shape, root binding, diagnostics, and non-browser
-behavior require implementation evidence. The candidate is not stable and is
-not classified as Public-Candidate by this record.
+```text
+gf.DocumentMetadata
+gf.UseDocumentMetadata
+gf.UseDocumentMetadataOwner
+gf.UseOwnedDocumentMetadata
+```
 
-## Implementation Boundary
-
-A later implementation would need a private mount-local coordinator and browser
-adapter, stable opaque owner identity per component instance, lifecycle-committed
-publication, release on unmount, selected-pair state, baseline capture, and one
-document committer.
-
-The application-facing component must not accept a coordinator, callback,
-browser adapter, string owner key, owner index, or global registry. Generated
-DOM must contain only its children.
+No production implementation is authorized by this record.
 
 ## Remaining Limits
 
 The evidence covers one browser document, one authored title, one authored
 description element, nested component owners, route ownership, editor
-overrides, failed-render isolation, and baseline restoration.
+overrides, failed-render isolation, baseline restoration, and one real
+server-backed route workflow.
 
 It does not establish:
 
-- SSR, hydration, or server metadata behavior;
-- multiple browser documents or portals;
 - arbitrary head-element ownership;
+- SSR or hydration behavior;
+- multiple browser documents or portals;
 - concurrent independently mounted apps targeting one document;
-- interaction with authored scripts that mutate the same nodes;
+- interaction with external scripts that mutate the same head nodes;
+- one atomic browser operation for title and description;
 - a stable diagnostic or testing API;
-- production SEO behavior.
+- production SEO behavior;
+- TinyGo panic/recover containment.
 
 Those limits must not be inferred from the private prototype.

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -403,6 +403,11 @@ export GOFRAME_DOCUMENT_STATE_CHROME_DEBUG_PORT="${GOFRAME_DOCUMENT_STATE_CHROME
 GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/document-state-browser-smoke.mjs
 
 echo
+echo "== Document metadata API design comparison =="
+export GOFRAME_DOCUMENT_API_DESIGN_CHROME_DEBUG_PORT="${GOFRAME_DOCUMENT_API_DESIGN_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+GOXC="$GOXC" CHROME="$CHROME_BIN" node --experimental-websocket scripts/document-state-api-design-browser-smoke.mjs
+
+echo
 echo "== Restore Todo production bundle =="
 "$GOXC" package ./examples/todo --compiler=tinygo
 "$GOXC" package ./examples/dashboard --compiler=tinygo

--- a/scripts/document-state-api-design-browser-smoke.mjs
+++ b/scripts/document-state-api-design-browser-smoke.mjs
@@ -17,8 +17,6 @@ const fixtureDir = join(
     "document-state-api-design",
 );
 const chrome = process.env.CHROME ?? "google-chrome";
-const tempRoot = await mkdtemp(join(tmpdir(), "goframe-document-api-design-"));
-const profile = await mkdtemp(join(tmpdir(), "goframe-document-api-design-chrome-"));
 const appPort = Number(
     process.env.GOFRAME_DOCUMENT_API_DESIGN_PORT ?? await pickFreePort(),
 );
@@ -48,6 +46,18 @@ const metadataC = {
     title: "Dialog C · GoFrame",
     description: "Nested dialog metadata C.",
 };
+const handleConflictA = {
+    title: "Handle conflict A · GoFrame",
+    description: "Coalesced handle metadata A.",
+};
+const handleConflictB = {
+    title: "Handle conflict B · GoFrame",
+    description: "Rejected handle metadata B.",
+};
+const handleConflictC = {
+    title: "Handle conflict C · GoFrame",
+    description: "Sole-primary handle metadata C.",
+};
 const speculative = {
     title: "Speculative failure · GoFrame",
     description: "This pair must never commit.",
@@ -57,11 +67,17 @@ let browser = null;
 let browserError = "";
 let client = null;
 let server = null;
+let tempRoot = null;
+let profile = null;
 const commandOutput = [];
 const results = {};
+let modeLinks = null;
 const startedAt = Date.now();
 
 try {
+    await validateBrowserCommand(chrome);
+    tempRoot = await mkdtemp(join(tmpdir(), "goframe-document-api-design-"));
+    profile = await mkdtemp(join(tmpdir(), "goframe-document-api-design-chrome-"));
     const goxc = await prepareTools();
     await runCommand(goxc, ["package", fixtureDir, "--compiler=go"]);
     server = await startServer(
@@ -71,19 +87,14 @@ try {
         "document-state API design fixture",
     );
 
-    browser = spawn(chrome, [
+    browser = await startBrowser(chrome, [
         "--headless",
         "--no-sandbox",
         "--disable-gpu",
         `--remote-debugging-port=${debugPort}`,
         `--user-data-dir=${profile}`,
         "about:blank",
-    ], {
-        stdio: ["ignore", "ignore", "pipe"],
-    });
-    browser.stderr.on("data", (chunk) => {
-        browserError += chunk;
-    });
+    ]);
 
     const page = await waitForPage(debugPort);
     client = await connect(page.webSocketDebuggerUrl);
@@ -93,6 +104,7 @@ try {
         source: `(${installHeadObserver.toString()})()`,
     });
 
+    modeLinks = await runModeLinkProbe(client);
     for (const mode of modes) {
         results[mode] = await runMode(client, mode);
     }
@@ -105,6 +117,7 @@ try {
     console.log(
         `document API design evidence: ${JSON.stringify({
             modes: results,
+            modeLinks,
             elapsedMilliseconds,
         })}`,
     );
@@ -118,24 +131,100 @@ try {
     client?.close();
     await stopProcess(browser, false);
     await stopProcess(server?.child, true);
-    await rm(profile, {
-        recursive: true,
-        force: true,
-        maxRetries: 5,
-        retryDelay: 100,
-    });
-    await rm(tempRoot, {
-        recursive: true,
-        force: true,
-        maxRetries: 5,
-        retryDelay: 100,
-    });
+    if (profile) {
+        await rm(profile, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+        });
+    }
+    if (tempRoot) {
+        await rm(tempRoot, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+        });
+    }
     await rm(join(fixtureDir, ".goframe"), {
         recursive: true,
         force: true,
         maxRetries: 5,
         retryDelay: 100,
     });
+}
+
+async function runModeLinkProbe(browserClient) {
+    const transitions = [];
+    const initialURL = `${origin}/?candidate=control&mode-link-smoke=1#/control`;
+    await browserClient.call("Page.navigate", { url: initialURL });
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return state.app && state.mode === "control" &&
+            state.baselineCaptured && state.documentBootCount > 0;
+    }, "mode-link control fixture boot");
+
+    let current = await pageState(browserClient);
+    assertModeLinkState(current, "control", "mode-link initial control");
+    const initialBootCount = current.documentBootCount;
+    for (const target of ["hook", "component", "handle", "control"]) {
+        const previous = current;
+        await click(browserClient, `candidate-mode-${target}`);
+        await waitForCondition(async () => {
+            const state = await pageState(browserClient);
+            return state.app &&
+                state.mode === target &&
+                state.runtime.mode === target &&
+                state.hash === `#/${target}` &&
+                state.candidateQuery === target &&
+                state.documentBootCount > previous.documentBootCount &&
+                state.baselineCaptured;
+        }, `mode-link ${previous.mode} to ${target}`);
+        current = await pageState(browserClient);
+        assertModeLinkState(
+            current,
+            target,
+            `mode-link ${previous.mode} to ${target}`,
+        );
+        transitions.push({
+            from: previous.mode,
+            to: target,
+            beforeBootCount: previous.documentBootCount,
+            afterBootCount: current.documentBootCount,
+            hash: current.hash,
+            candidateQuery: current.candidateQuery,
+            renderedMode: current.mode,
+            baselineRecaptured: current.baselineCaptured,
+        });
+    }
+
+    return {
+        initialBootCount,
+        finalBootCount: current.documentBootCount,
+        transitions,
+    };
+}
+
+function assertModeLinkState(state, mode, label) {
+    assert(state.hash === `#/${mode}`, `${label} hash = ${state.hash}`);
+    assert(
+        state.candidateQuery === mode,
+        `${label} candidate query = ${state.candidateQuery}`,
+    );
+    assert(state.mode === mode, `${label} displayed mode = ${state.mode}`);
+    assert(state.runtime.mode === mode, `${label} runtime mode = ${state.runtime.mode}`);
+    assert(
+        state.authoredTitle === baseline.title &&
+            state.authoredDescription === baseline.description &&
+            state.authoredDescriptionCount === 1,
+        `${label} authored baseline was not recaptured`,
+    );
+    assert(pairMatches(state, baseline), `${label} did not begin at the baseline`);
+    assert(
+        state.titleNodeSame && state.descriptionNodeSame,
+        `${label} authored node identity was not recaptured`,
+    );
 }
 
 async function runMode(browserClient, mode) {
@@ -260,8 +349,15 @@ async function runMode(browserClient, mode) {
     });
 
     const candidateProbe = await runCandidateProbe(browserClient, mode);
-    const candidateChecks = candidateProbe.checks;
-    boundaries.candidateProbe = candidateProbe.boundary;
+    const handleConflict = mode === "handle"
+        ? await runHandleConflictProbe(browserClient)
+        : null;
+    const candidateChecks = {
+        ...candidateProbe.checks,
+        ...(handleConflict ? { handleConflict } : {}),
+    };
+    boundaries.candidateProbe =
+        handleConflict?.boundary ?? candidateProbe.boundary;
 
     await setPhase(browserClient, "speculative-failure");
     const beforeFailure = await pageState(browserClient);
@@ -336,6 +432,31 @@ async function runMode(browserClient, mode) {
     );
     assert(final.titleNodeSame, `${mode} title identity changed`);
     assert(final.descriptionNodeSame, `${mode} description identity changed`);
+    assert(
+        final.titleMutationBatches > 0,
+        `${mode} observer liveness: no title mutation batches`,
+    );
+    assert(
+        final.descriptionMutationBatches > 0,
+        `${mode} observer liveness: no description mutation batches`,
+    );
+    assert(
+        final.headSnapshots > 0,
+        `${mode} observer liveness: no managed head snapshots`,
+    );
+    assert(
+        final.snapshots.length === final.headSnapshots,
+        `${mode} observer liveness: snapshot length ${final.snapshots.length}, ` +
+            `head snapshots ${final.headSnapshots}`,
+    );
+    assert(
+        final.snapshots.some((snapshot) =>
+            snapshot.descriptionCount === 1 &&
+            snapshot.title !== baseline.title &&
+            snapshot.description !== baseline.description
+        ),
+        `${mode} observer liveness: no managed title/description snapshot`,
+    );
     assertGenericLifecycleEvidence(mode, boundaries, routeOwnerID);
     assertCandidateLifecycleEvidence(mode, boundaries, candidateProbe);
 
@@ -471,6 +592,168 @@ async function runCandidateProbe(browserClient, mode) {
         };
     }
     throw new Error(`APP FAILURE: unsupported candidate probe mode ${mode}`);
+}
+
+async function runHandleConflictProbe(browserClient) {
+    await setPhase(browserClient, "handle-conflict-activation");
+    await click(browserClient, "activate-handle-conflict-probe");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        const publications = state.runtime.handlePublicationEvents.filter(
+            (event) => event.role.startsWith("handle-conflict-"),
+        );
+        return pairMatches(state, handleConflictA) &&
+            state.ownerCount === 3 &&
+            publications.length >= 2 &&
+            publications.at(-1)?.activePublications === 2;
+    }, "handle conflict duplicate activation");
+    const duplicated = await pageState(browserClient);
+    const added = duplicated.runtime.events.filter((event) =>
+        event.role === "handle-conflict-primary" &&
+        event.change === "added"
+    );
+    assert(added.length === 1, `handle conflict owner additions = ${added.length}`);
+    const ownerID = Number(added[0].ownerID);
+    const activePublicationsBefore = duplicated.runtime.handlePublicationEvents
+        .filter((event) => event.role.startsWith("handle-conflict-"))
+        .at(-1).activePublications;
+    const publicationsBeforeConflict =
+        duplicated.runtime.handlePublicationEvents.length;
+
+    await setPhase(browserClient, "handle-conflict-primary-b");
+    await click(browserClient, "handle-conflict-primary-b");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return state.runtime.runtimeErrors.length ===
+            duplicated.runtime.runtimeErrors.length + 1;
+    }, "handle conflict report");
+    const conflicted = await pageState(browserClient);
+    const conflictErrors = conflicted.runtime.runtimeErrors.slice(
+        duplicated.runtime.runtimeErrors.length,
+    );
+    assert(conflictErrors.length === 1, `handle conflict errors = ${conflictErrors.length}`);
+    assert(
+        conflictErrors[0].panic ===
+            "document-state API design: one owner handle has conflicting active publications",
+        `handle conflict diagnostic = ${JSON.stringify(conflictErrors[0].panic)}`,
+    );
+    assert(pairMatches(conflicted, handleConflictA), "handle conflict changed selected pair");
+    assert(conflicted.ownerCount === 3, "handle conflict changed active owner count");
+    assert(
+        conflicted.handleConflictPublicationCount === 2,
+        `handle conflict publication count = ${conflicted.handleConflictPublicationCount}`,
+    );
+    assert(
+        Number(conflicted.handleConflictOwnerID) === ownerID,
+        `handle conflict owner ID = ${conflicted.handleConflictOwnerID}, want ${ownerID}`,
+    );
+    assert(
+        conflicted.runtime.handlePublicationEvents.length ===
+            publicationsBeforeConflict,
+        "handle conflict changed publication evidence before rejection",
+    );
+    assertStatisticsDelta(
+        "handle conflict rejection",
+        lifecycleBoundary(duplicated),
+        lifecycleBoundary(conflicted),
+        zeroStatisticsDelta(),
+    );
+    assertNoDocumentDelta(
+        "handle conflict rejection",
+        lifecycleBoundary(duplicated),
+        lifecycleBoundary(conflicted),
+    );
+    assert(
+        !conflicted.runtime.events.some((event) =>
+            event.title === handleConflictB.title ||
+            event.description === handleConflictB.description
+        ),
+        "rejected handle metadata reached the coordinator",
+    );
+    assert(
+        !conflicted.snapshots.some((snapshot) =>
+            snapshot.title === handleConflictB.title ||
+            snapshot.description === handleConflictB.description
+        ),
+        "rejected handle metadata reached the document",
+    );
+
+    await setPhase(browserClient, "handle-conflict-duplicate-release");
+    await click(browserClient, "handle-conflict-release-duplicate");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        const publication = state.runtime.handlePublicationEvents.at(-1);
+        return publication?.role === "handle-conflict-duplicate" &&
+            publication.action === "release" &&
+            publication.activePublications === 1;
+    }, "handle conflict duplicate release");
+    const duplicateReleased = await pageState(browserClient);
+    assert(pairMatches(duplicateReleased, handleConflictA), "duplicate release changed pair");
+    assert(duplicateReleased.ownerCount === 3, "duplicate release changed owner count");
+    assertStatisticsDelta(
+        "handle duplicate release",
+        lifecycleBoundary(conflicted),
+        lifecycleBoundary(duplicateReleased),
+        zeroStatisticsDelta(),
+    );
+
+    await setPhase(browserClient, "handle-conflict-primary-c");
+    await click(browserClient, "handle-conflict-primary-c");
+    await waitForState(browserClient, handleConflictC, {
+        label: "handle sole-primary update",
+        ownerCount: 3,
+    });
+    const updated = await pageState(browserClient);
+    const updateEvents = updated.runtime.events.filter((event) =>
+        event.role === "handle-conflict-primary" &&
+        event.change === "updated"
+    );
+    assert(updateEvents.length === 1, `handle conflict updates = ${updateEvents.length}`);
+    assert(
+        Number(updateEvents[0].ownerID) === ownerID,
+        `handle conflict update owner = ${updateEvents[0].ownerID}, want ${ownerID}`,
+    );
+    assert(
+        updated.handleConflictPublicationCount === 1,
+        `sole-primary publication count = ${updated.handleConflictPublicationCount}`,
+    );
+    assertStatisticsDelta(
+        "handle sole-primary update",
+        lifecycleBoundary(duplicateReleased),
+        lifecycleBoundary(updated),
+        {
+            ...zeroStatisticsDelta(),
+            updates: 1,
+        },
+    );
+
+    await setPhase(browserClient, "handle-conflict-probe-release");
+    await click(browserClient, "release-handle-conflict-probe");
+    await waitForState(browserClient, metadataC, {
+        label: "handle conflict probe release",
+        ownerCount: 2,
+    });
+    const released = await pageState(browserClient);
+    assert(
+        released.runtime.runtimeErrors.length ===
+            duplicated.runtime.runtimeErrors.length + 1,
+        "handle conflict probe reported more than one runtime error",
+    );
+
+    return {
+        ownerID,
+        conflictDiagnostic: conflictErrors[0].panic,
+        activeOwnerCountBefore: duplicated.ownerCount,
+        activeOwnerCountAfter: conflicted.ownerCount,
+        activePublicationsBefore,
+        activePublicationsAfter: conflicted.handleConflictPublicationCount,
+        coordinatorUnchanged: true,
+        documentUnchanged: true,
+        duplicateReleased: true,
+        solePrimaryUpdate: handleConflictC,
+        sameOwnerUpdated: Number(updateEvents[0].ownerID) === ownerID,
+        boundary: lifecycleBoundary(released),
+    };
 }
 
 function lifecycleBoundary(state) {
@@ -797,6 +1080,8 @@ function collectModeEvidence(state, candidateChecks, boundaries) {
                 state.runtime.publicationCreationEvents,
             coordinatorStatisticsEvents:
                 state.runtime.coordinatorStatisticsEvents,
+            handlePublicationEvents:
+                state.runtime.handlePublicationEvents,
             runtimeErrors: state.runtime.runtimeErrors,
         },
         candidateChecks,
@@ -805,6 +1090,7 @@ function collectModeEvidence(state, candidateChecks, boundaries) {
             titleMutationBatches: state.titleMutationBatches,
             descriptionMutationBatches: state.descriptionMutationBatches,
             headSnapshots: state.headSnapshots,
+            snapshotLength: state.snapshots.length,
             invalidPairs: state.invalidPairs,
             duplicateDescriptions: state.duplicateDescriptions,
             speculativeAppearances: state.speculativeAppearances,
@@ -885,8 +1171,11 @@ async function pageState(browserClient) {
         );
         const titleNode = document.querySelector("head title");
         const descriptionNode = descriptions[0] || null;
+        const currentURL = new URL(location.href);
         return {
             href: location.href,
+            hash: location.hash,
+            candidateQuery: currentURL.searchParams.get("candidate") ?? "",
             mode: text("design-mode").replace(/^Mode:\\s*/, ""),
             app: Boolean(document.querySelector("[data-testid='design-app']")),
             scopeActive: Boolean(document.querySelector(
@@ -902,6 +1191,10 @@ async function pageState(browserClient) {
             ownerCount: Number(text("active-owner-count") || 0),
             expectedTitle: text("expected-title"),
             expectedDescription: text("expected-description"),
+            handleConflictOwnerID: text("handle-conflict-owner-id"),
+            handleConflictPublicationCount: Number(
+                text("handle-conflict-publication-count") || 0
+            ),
             title: document.title,
             description: descriptionNode?.getAttribute("content") ?? "",
             descriptionCount: descriptions.length,
@@ -909,6 +1202,7 @@ async function pageState(browserClient) {
                 'head meta[name="fixture-unrelated"]'
             )?.getAttribute("content") ?? "",
             baselineCaptured: Boolean(head.baselineCaptured),
+            documentBootCount: head.documentBootCount ?? 0,
             authoredTitle: head.authoredTitle ?? "",
             authoredDescription: head.authoredDescription ?? "",
             authoredDescriptionCount: head.authoredDescriptionCount ?? 0,
@@ -977,6 +1271,8 @@ async function pageState(browserClient) {
                     runtime.publicationCreationEvents ?? [],
                 coordinatorStatisticsEvents:
                     runtime.coordinatorStatisticsEvents ?? [],
+                handlePublicationEvents:
+                    runtime.handlePublicationEvents ?? [],
                 runtimeErrors: runtime.runtimeErrors ?? [],
             },
         };
@@ -1005,8 +1301,17 @@ async function click(browserClient, testID) {
 }
 
 function installHeadObserver() {
+    let documentBootCount = 1;
+    try {
+        const key = "goframe-document-api-design-boot-count";
+        documentBootCount = Number(sessionStorage.getItem(key) || 0) + 1;
+        sessionStorage.setItem(key, String(documentBootCount));
+    } catch {
+        // The fixture assertions still require a positive per-document count.
+    }
     const evidence = {
         baselineCaptured: false,
+        documentBootCount,
         authoredTitle: "",
         authoredDescription: "",
         authoredDescriptionCount: 0,
@@ -1134,6 +1439,48 @@ function installHeadObserver() {
     queueMicrotask(captureBaseline);
     document.addEventListener("DOMContentLoaded", captureBaseline, {
         once: true,
+    });
+}
+
+function validateBrowserCommand(command) {
+    return new Promise((resolveValidation, reject) => {
+        const child = spawn(command, ["--version"], {
+            cwd: rootDir,
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+            output += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+            output += chunk;
+        });
+        child.once("error", reject);
+        child.once("exit", (code, signal) => {
+            if (code === 0) {
+                resolveValidation();
+                return;
+            }
+            reject(new Error(
+                `HARNESS FAILURE: browser command ${JSON.stringify(command)} ` +
+                `validation failed with ${signal ?? code}\n${output}`,
+            ));
+        });
+    });
+}
+
+function startBrowser(command, args) {
+    return new Promise((resolveBrowser, reject) => {
+        const child = spawn(command, args, {
+            stdio: ["ignore", "ignore", "pipe"],
+        });
+        child.stderr.on("data", (chunk) => {
+            browserError += chunk;
+        });
+        child.once("error", reject);
+        child.once("spawn", () => {
+            resolveBrowser(child);
+        });
     });
 }
 

--- a/scripts/document-state-api-design-browser-smoke.mjs
+++ b/scripts/document-state-api-design-browser-smoke.mjs
@@ -1,0 +1,1043 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:net";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixtureDir = join(
+    rootDir,
+    "scripts",
+    "fixtures",
+    "document-state-api-design",
+);
+const chrome = process.env.CHROME ?? "google-chrome";
+const tempRoot = await mkdtemp(join(tmpdir(), "goframe-document-api-design-"));
+const profile = await mkdtemp(join(tmpdir(), "goframe-document-api-design-chrome-"));
+const appPort = Number(
+    process.env.GOFRAME_DOCUMENT_API_DESIGN_PORT ?? await pickFreePort(),
+);
+const debugPort = Number(
+    process.env.GOFRAME_DOCUMENT_API_DESIGN_CHROME_DEBUG_PORT ??
+        await pickFreePort(),
+);
+const origin = `http://127.0.0.1:${appPort}`;
+const modes = ["control", "hook", "component", "handle"];
+const baseline = {
+    title: "GoFrame document API design fixture",
+    description: "Authored document API design baseline",
+};
+const routeA = {
+    title: "Route A · GoFrame",
+    description: "Route metadata A.",
+};
+const routeA2 = {
+    title: "Route A2 · GoFrame",
+    description: "Route metadata A2.",
+};
+const metadataB = {
+    title: "Editor B · GoFrame",
+    description: "Nested editor metadata B.",
+};
+const metadataC = {
+    title: "Dialog C · GoFrame",
+    description: "Nested dialog metadata C.",
+};
+const speculative = {
+    title: "Speculative failure · GoFrame",
+    description: "This pair must never commit.",
+};
+
+let browser = null;
+let browserError = "";
+let client = null;
+let server = null;
+const commandOutput = [];
+const results = {};
+const startedAt = Date.now();
+
+try {
+    const goxc = await prepareTools();
+    await runCommand(goxc, ["package", fixtureDir, "--compiler=go"]);
+    server = await startServer(
+        goxc,
+        ["serve", fixtureDir, `--port=${appPort}`],
+        `${origin}/`,
+        "document-state API design fixture",
+    );
+
+    browser = spawn(chrome, [
+        "--headless",
+        "--no-sandbox",
+        "--disable-gpu",
+        `--remote-debugging-port=${debugPort}`,
+        `--user-data-dir=${profile}`,
+        "about:blank",
+    ], {
+        stdio: ["ignore", "ignore", "pipe"],
+    });
+    browser.stderr.on("data", (chunk) => {
+        browserError += chunk;
+    });
+
+    const page = await waitForPage(debugPort);
+    client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Page.addScriptToEvaluateOnNewDocument", {
+        source: `(${installHeadObserver.toString()})()`,
+    });
+
+    for (const mode of modes) {
+        results[mode] = await runMode(client, mode);
+    }
+
+    const elapsedMilliseconds = Date.now() - startedAt;
+    assert(
+        elapsedMilliseconds <= 60_000,
+        `focused comparison took ${elapsedMilliseconds}ms, limit is 60000ms`,
+    );
+    console.log(
+        `document API design evidence: ${JSON.stringify({
+            modes: results,
+            elapsedMilliseconds,
+        })}`,
+    );
+    console.log("document state API design browser smoke: ok");
+} catch (error) {
+    const diagnostics = await collectDiagnostics();
+    throw new Error(`${error.message}\n${JSON.stringify(diagnostics, null, 2)}`, {
+        cause: error,
+    });
+} finally {
+    client?.close();
+    await stopProcess(browser, false);
+    await stopProcess(server?.child, true);
+    await rm(profile, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+    });
+    await rm(tempRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+    });
+    await rm(join(fixtureDir, ".goframe"), {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+    });
+}
+
+async function runMode(browserClient, mode) {
+    const appURL = `${origin}/?smoke=${Date.now()}#/${mode}`;
+    await browserClient.call("Page.navigate", { url: appURL });
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return state.app && state.mode === mode && state.baselineCaptured;
+    }, `${mode} fixture boot`);
+    await assertState(browserClient, baseline, {
+        label: `${mode} initial baseline`,
+        ownerCount: 0,
+        scopeActive: true,
+    });
+
+    const initial = await pageState(browserClient);
+    assert(initial.authoredTitle === baseline.title, `${mode} authored title changed`);
+    assert(
+        initial.authoredDescription === baseline.description,
+        `${mode} authored description changed`,
+    );
+    assert(initial.authoredDescriptionCount === 1, `${mode} authored description count`);
+    assert(initial.unrelated === "preserve-me", `${mode} unrelated metadata changed`);
+    assert(initial.titleNodeSame, `${mode} title identity was not captured`);
+    assert(initial.descriptionNodeSame, `${mode} description identity was not captured`);
+
+    await setPhase(browserClient, "route-a");
+    await click(browserClient, "activate-route-a");
+    await waitForState(browserClient, routeA, {
+        label: `${mode} route A`,
+        ownerCount: 1,
+    });
+    const routeOwnerID = (await pageState(browserClient)).activeOwnerID;
+
+    await setPhase(browserClient, "nested-b");
+    await click(browserClient, "activate-b");
+    await waitForState(browserClient, metadataB, {
+        label: `${mode} nested B`,
+        ownerCount: 2,
+    });
+
+    await setPhase(browserClient, "route-a2-beneath-b");
+    await click(browserClient, "update-route-a2");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return pairMatches(state, metadataB) &&
+            state.runtime.events.some((event) =>
+                event.role === "route" &&
+                event.change === "updated" &&
+                event.title === metadataB.title
+            );
+    }, `${mode} route A2 retained beneath B`);
+    await assertState(browserClient, metadataB, {
+        label: `${mode} A2 beneath B`,
+        ownerCount: 2,
+    });
+
+    await setPhase(browserClient, "release-selected-b");
+    await click(browserClient, "release-b");
+    await waitForState(browserClient, routeA2, {
+        label: `${mode} release B reveals A2`,
+        ownerCount: 1,
+    });
+
+    await setPhase(browserClient, "non-top-release");
+    await click(browserClient, "activate-b");
+    await waitForState(browserClient, metadataB, {
+        label: `${mode} B reactivation`,
+        ownerCount: 2,
+    });
+    await click(browserClient, "activate-c");
+    await waitForState(browserClient, metadataC, {
+        label: `${mode} C activation`,
+        ownerCount: 3,
+    });
+    const beforeNonTop = await pageState(browserClient);
+    await click(browserClient, "release-b");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return pairMatches(state, metadataC) && state.ownerCount === 2;
+    }, `${mode} non-top B release`);
+    const afterNonTop = await pageState(browserClient);
+    assert(
+        afterNonTop.titleMutationBatches === beforeNonTop.titleMutationBatches &&
+            afterNonTop.descriptionMutationBatches ===
+                beforeNonTop.descriptionMutationBatches,
+        `${mode} non-top release caused a document write`,
+    );
+
+    await setPhase(browserClient, "same-value-rerender");
+    const beforeSame = await pageState(browserClient);
+    await click(browserClient, "same-value-update");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return state.runtime.renders > beforeSame.runtime.renders;
+    }, `${mode} selected owner rerender`);
+    const afterSame = await pageState(browserClient);
+    assert(
+        afterSame.runtime.transitions === beforeSame.runtime.transitions,
+        `${mode} identical rerender reached the coordinator`,
+    );
+    assert(
+        afterSame.titleMutationBatches === beforeSame.titleMutationBatches &&
+            afterSame.descriptionMutationBatches ===
+                beforeSame.descriptionMutationBatches,
+        `${mode} identical rerender caused a document write`,
+    );
+    await assertState(browserClient, metadataC, {
+        label: `${mode} identical update no-op`,
+        ownerCount: 2,
+    });
+
+    const candidateChecks = await runCandidateProbe(browserClient, mode);
+
+    await setPhase(browserClient, "speculative-failure");
+    const beforeFailure = await pageState(browserClient);
+    await click(browserClient, "activate-failure");
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return state.failureFallback &&
+            state.runtime.errorBoundaryCaptures ===
+                beforeFailure.runtime.errorBoundaryCaptures + 1;
+    }, `${mode} speculative fallback`);
+    const failed = await pageState(browserClient);
+    assert(pairMatches(failed, metadataC), `${mode} speculative owner changed selected pair`);
+    assert(
+        !failed.runtime.events.some((event) => event.role === "speculative"),
+        `${mode} speculative owner reached the coordinator`,
+    );
+    assert(
+        failed.speculativeAppearances === 0,
+        `${mode} speculative metadata appeared in the document`,
+    );
+    await click(browserClient, "reset-failure");
+    await waitForCondition(async () => {
+        return !(await pageState(browserClient)).failureFallback;
+    }, `${mode} speculative subtree reset`);
+
+    await setPhase(browserClient, "scope-unmount");
+    await click(browserClient, "unmount-scope");
+    await waitForState(browserClient, baseline, {
+        label: `${mode} authored baseline restoration`,
+        ownerCount: 0,
+        scopeActive: false,
+    });
+    const unmounted = await pageState(browserClient);
+    assert(
+        unmounted.runtime.baselineRestorations === 1,
+        `${mode} baseline restorations = ${unmounted.runtime.baselineRestorations}`,
+    );
+
+    await setPhase(browserClient, "scope-remount");
+    await click(browserClient, "remount-scope");
+    await waitForState(browserClient, routeA2, {
+        label: `${mode} scope remount`,
+        ownerCount: 1,
+        scopeActive: true,
+    });
+    const final = await pageState(browserClient);
+    assert(
+        final.activeOwnerID !== routeOwnerID,
+        `${mode} remount reused owner lifetime ${routeOwnerID}`,
+    );
+    assert(final.runtime.scopeMounts === 2, `${mode} scope mounts = ${final.runtime.scopeMounts}`);
+    assert(
+        final.runtime.scopeUnmounts === 1,
+        `${mode} scope unmounts = ${final.runtime.scopeUnmounts}`,
+    );
+    assert(final.invalidPairs === 0, `${mode} invalid pairs = ${final.invalidPairs}`);
+    assert(
+        final.duplicateDescriptions === 0,
+        `${mode} duplicate descriptions = ${final.duplicateDescriptions}`,
+    );
+    assert(
+        final.unrelatedMetaMutations === 0,
+        `${mode} unrelated mutations = ${final.unrelatedMetaMutations}`,
+    );
+    assert(final.titleNodeReplacements === 0, `${mode} title node was replaced`);
+    assert(
+        final.descriptionNodeReplacements === 0,
+        `${mode} description node was replaced`,
+    );
+    assert(final.titleNodeSame, `${mode} title identity changed`);
+    assert(final.descriptionNodeSame, `${mode} description identity changed`);
+
+    console.log(`${mode} document metadata ownership: ok`);
+    return collectModeEvidence(final, candidateChecks);
+}
+
+async function runCandidateProbe(browserClient, mode) {
+    if (mode === "control") {
+        return {};
+    }
+    if (mode === "component") {
+        const state = await pageState(browserClient);
+        const nestedBLifetimes = state.runtime.componentLifetimes.filter(
+            (event) => event.role === "nested-b",
+        );
+        assert(
+            nestedBLifetimes.some((event) => event.action === "mount") &&
+                nestedBLifetimes.some((event) => event.action === "unmount"),
+            "component conditional ownership did not mount and unmount",
+        );
+        const directChild = await browserClient.evaluate(`(() => {
+            const scope = document.querySelector(
+                "[data-testid='candidate-scope']"
+            );
+            const route = document.querySelector(
+                "[data-testid='route-owner-content']"
+            );
+            return Boolean(scope && route && route.parentElement === scope);
+        })()`);
+        assert(directChild, "component ownership added a wrapper element");
+        return {
+            conditionalMountRelease: true,
+            wrapperElementsAdded: 0,
+        };
+    }
+
+    await setPhase(browserClient, `${mode}-identity-probe`);
+    const before = await pageState(browserClient);
+    const elementCount = await browserClient.evaluate(
+        "document.querySelector('[data-testid=\"candidate-scope\"]')?.querySelectorAll('*').length ?? -1",
+    );
+    await click(browserClient, "activate-probe");
+
+    if (mode === "hook") {
+        const expected = {
+            title: "Hook probe two · GoFrame",
+            description: "Hook slot two metadata.",
+        };
+        await waitForState(browserClient, expected, {
+            label: "hook two-slot probe",
+            ownerCount: 4,
+        });
+        const state = await pageState(browserClient);
+        const events = state.runtime.events.filter((event) =>
+            event.role === "hook-probe-one" ||
+            event.role === "hook-probe-two"
+        );
+        assert(events.length === 2, `hook probe events = ${events.length}, want 2`);
+        assert(
+            events[0].ownerID !== events[1].ownerID,
+            `hook slots shared owner ${events[0].ownerID}`,
+        );
+        const nextElementCount = await browserClient.evaluate(
+            "document.querySelector('[data-testid=\"candidate-scope\"]')?.querySelectorAll('*').length ?? -1",
+        );
+        assert(
+            nextElementCount === elementCount,
+            `hook ownership added an element: ${elementCount} -> ${nextElementCount}`,
+        );
+        await click(browserClient, "release-probe");
+        await waitForState(browserClient, metadataC, {
+            label: `${mode} identity probe release`,
+            ownerCount: 2,
+        });
+        return {
+            hookSlotsDistinct: true,
+            ownershipElementsAdded: 0,
+        };
+    }
+
+    if (mode === "handle") {
+        const expected = {
+            title: "Handle probe · GoFrame",
+            description: "One forwarded handle publication.",
+        };
+        await waitForState(browserClient, expected, {
+            label: "handle forwarded duplicate probe",
+            ownerCount: 3,
+        });
+        const state = await pageState(browserClient);
+        assert(state.runtime.handleForwards > 0, "handle forwarding was not observed");
+        assert(
+            state.runtime.handleDuplicateCoalesces === 1,
+            `handle duplicate coalesces = ${state.runtime.handleDuplicateCoalesces}`,
+        );
+        const probeAdds = state.runtime.events.filter((event) =>
+            event.role === "handle-duplicate-probe" &&
+            event.change === "added"
+        );
+        assert(probeAdds.length === 1, `handle probe owner additions = ${probeAdds.length}`);
+        assert(state.runtime.handleForwardedOwnerIDs.every(
+            (ownerID) => ownerID === probeAdds[0].ownerID,
+        ), "helper forwarding changed handle identity");
+        await click(browserClient, "release-probe");
+        await waitForState(browserClient, metadataC, {
+            label: `${mode} identity probe release`,
+            ownerCount: 2,
+        });
+        const after = await pageState(browserClient);
+        assert(after.runtime.adds > before.runtime.adds, `${mode} probe did not add an owner`);
+        return {
+            forwardedOwnerStable: true,
+            ownerRecordsAdded: 1,
+            duplicatePublicationsCoalesced:
+                state.runtime.handleDuplicateCoalesces,
+        };
+    }
+    throw new Error(`APP FAILURE: unsupported candidate probe mode ${mode}`);
+}
+
+function collectModeEvidence(state, candidateChecks) {
+    return {
+        runtime: {
+            transitions: state.runtime.transitions,
+            adds: state.runtime.adds,
+            updates: state.runtime.updates,
+            removes: state.runtime.removes,
+            noops: state.runtime.noops,
+            documentCommits: state.runtime.documentCommits,
+            baselineRestorations: state.runtime.baselineRestorations,
+            scopeMounts: state.runtime.scopeMounts,
+            scopeUnmounts: state.runtime.scopeUnmounts,
+            componentMounts: state.runtime.componentMounts,
+            componentUnmounts: state.runtime.componentUnmounts,
+            handleForwards: state.runtime.handleForwards,
+            handleDuplicateCoalesces:
+                state.runtime.handleDuplicateCoalesces,
+            errorBoundaryCaptures: state.runtime.errorBoundaryCaptures,
+            events: state.runtime.events.map((event) => ({
+                candidate: event.candidate,
+                role: event.role,
+                change: event.change,
+                ownerCount: event.ownerCount,
+                title: event.title,
+                description: event.description,
+            })),
+            runtimeErrors: state.runtime.runtimeErrors,
+        },
+        candidateChecks,
+        observer: {
+            titleMutationBatches: state.titleMutationBatches,
+            descriptionMutationBatches: state.descriptionMutationBatches,
+            headSnapshots: state.headSnapshots,
+            invalidPairs: state.invalidPairs,
+            duplicateDescriptions: state.duplicateDescriptions,
+            speculativeAppearances: state.speculativeAppearances,
+            unrelatedMetaMutations: state.unrelatedMetaMutations,
+            titleNodeReplacements: state.titleNodeReplacements,
+            descriptionNodeReplacements: state.descriptionNodeReplacements,
+            snapshots: state.snapshots,
+        },
+    };
+}
+
+async function waitForState(browserClient, metadata, options) {
+    await waitForCondition(async () => {
+        const state = await pageState(browserClient);
+        return pairMatches(state, metadata) &&
+            state.ownerCount === options.ownerCount &&
+            (options.scopeActive === undefined ||
+                state.scopeActive === options.scopeActive);
+    }, options.label);
+    await assertState(browserClient, metadata, options);
+}
+
+async function assertState(browserClient, metadata, options) {
+    const state = await pageState(browserClient);
+    const mismatches = [];
+    if (!pairMatches(state, metadata)) {
+        mismatches.push(
+            `actual=${JSON.stringify({
+                title: state.title,
+                description: state.description,
+                expectedTitle: state.expectedTitle,
+                expectedDescription: state.expectedDescription,
+            })}`,
+        );
+    }
+    if (state.ownerCount !== options.ownerCount) {
+        mismatches.push(`ownerCount=${state.ownerCount}, want ${options.ownerCount}`);
+    }
+    if (
+        options.scopeActive !== undefined &&
+        state.scopeActive !== options.scopeActive
+    ) {
+        mismatches.push(`scopeActive=${state.scopeActive}, want ${options.scopeActive}`);
+    }
+    if (state.descriptionCount !== 1) {
+        mismatches.push(`descriptionCount=${state.descriptionCount}, want 1`);
+    }
+    if (state.unrelated !== "preserve-me") {
+        mismatches.push(`unrelated=${JSON.stringify(state.unrelated)}`);
+    }
+    if (!state.titleNodeSame || !state.descriptionNodeSame) {
+        mismatches.push(
+            `node identity title=${state.titleNodeSame} description=${state.descriptionNodeSame}`,
+        );
+    }
+    if (mismatches.length > 0) {
+        throw new Error(`APP FAILURE: ${options.label}: ${mismatches.join("; ")}`);
+    }
+    console.log(`${options.label}: ok`);
+}
+
+function pairMatches(state, metadata) {
+    return state.title === metadata.title &&
+        state.description === metadata.description &&
+        state.expectedTitle === metadata.title &&
+        state.expectedDescription === metadata.description;
+}
+
+async function pageState(browserClient) {
+    return await browserClient.evaluate(`(() => {
+        const text = (testID) =>
+            document.querySelector("[data-testid='" + testID + "']")
+                ?.textContent.trim() ?? "";
+        const head = globalThis.__documentAPIDesignHeadEvidence || {};
+        const runtime = globalThis.goframeDocumentAPIDesignEvidence || {};
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const titleNode = document.querySelector("head title");
+        const descriptionNode = descriptions[0] || null;
+        return {
+            href: location.href,
+            mode: text("design-mode").replace(/^Mode:\\s*/, ""),
+            app: Boolean(document.querySelector("[data-testid='design-app']")),
+            scopeActive: Boolean(document.querySelector(
+                "[data-testid='candidate-scope']"
+            )),
+            scopeInactive: Boolean(document.querySelector(
+                "[data-testid='candidate-scope-inactive']"
+            )),
+            failureFallback: Boolean(document.querySelector(
+                "[data-testid='failure-fallback']"
+            )),
+            activeOwnerID: text("active-owner-id"),
+            ownerCount: Number(text("active-owner-count") || 0),
+            expectedTitle: text("expected-title"),
+            expectedDescription: text("expected-description"),
+            title: document.title,
+            description: descriptionNode?.getAttribute("content") ?? "",
+            descriptionCount: descriptions.length,
+            unrelated: document.querySelector(
+                'head meta[name="fixture-unrelated"]'
+            )?.getAttribute("content") ?? "",
+            baselineCaptured: Boolean(head.baselineCaptured),
+            authoredTitle: head.authoredTitle ?? "",
+            authoredDescription: head.authoredDescription ?? "",
+            authoredDescriptionCount: head.authoredDescriptionCount ?? 0,
+            titleNodeSame: Boolean(
+                head.titleNode && titleNode === head.titleNode
+            ),
+            descriptionNodeSame: Boolean(
+                head.descriptionNode &&
+                descriptionNode === head.descriptionNode
+            ),
+            titleMutationBatches: head.titleMutationBatches ?? 0,
+            descriptionMutationBatches: head.descriptionMutationBatches ?? 0,
+            headSnapshots: head.headSnapshots ?? 0,
+            invalidPairs: head.invalidPairs ?? 0,
+            duplicateDescriptions: head.duplicateDescriptions ?? 0,
+            speculativeAppearances: head.speculativeAppearances ?? 0,
+            unrelatedMetaMutations: head.unrelatedMetaMutations ?? 0,
+            titleNodeReplacements: head.titleNodeReplacements ?? 0,
+            descriptionNodeReplacements:
+                head.descriptionNodeReplacements ?? 0,
+            snapshots: head.snapshots ?? [],
+            runtime: {
+                mode: runtime.mode ?? "",
+                transitions: runtime.transitions ?? 0,
+                adds: runtime.adds ?? 0,
+                updates: runtime.updates ?? 0,
+                removes: runtime.removes ?? 0,
+                noops: runtime.noops ?? 0,
+                renders: runtime.renders ?? 0,
+                documentCommits: runtime.documentCommits ?? 0,
+                baselineRestorations: runtime.baselineRestorations ?? 0,
+                scopeMounts: runtime.scopeMounts ?? 0,
+                scopeUnmounts: runtime.scopeUnmounts ?? 0,
+                componentMounts: runtime.componentMounts ?? 0,
+                componentUnmounts: runtime.componentUnmounts ?? 0,
+                handleForwards: runtime.handleForwards ?? 0,
+                handleDuplicateCoalesces:
+                    runtime.handleDuplicateCoalesces ?? 0,
+                errorBoundaryCaptures:
+                    runtime.errorBoundaryCaptures ?? 0,
+                events: runtime.events ?? [],
+                ownerRenders: runtime.ownerRenders ?? [],
+                componentLifetimes: runtime.componentLifetimes ?? [],
+                handleForwardedOwnerIDs:
+                    runtime.handleForwardedOwnerIDs ?? [],
+                handleDuplicateOwnerIDs:
+                    runtime.handleDuplicateOwnerIDs ?? [],
+                runtimeErrors: runtime.runtimeErrors ?? [],
+            },
+        };
+    })()`);
+}
+
+async function setPhase(browserClient, phase) {
+    await browserClient.evaluate(`(() => {
+        const evidence = globalThis.__documentAPIDesignHeadEvidence;
+        if (!evidence) return false;
+        evidence.phase = ${JSON.stringify(phase)};
+        return true;
+    })()`);
+}
+
+async function click(browserClient, testID) {
+    const clicked = await browserClient.evaluate(`(() => {
+        const element = document.querySelector(
+            "[data-testid='${testID}']"
+        );
+        if (!element) return false;
+        element.click();
+        return true;
+    })()`);
+    assert(clicked, `missing element for click ${testID}`);
+}
+
+function installHeadObserver() {
+    const evidence = {
+        baselineCaptured: false,
+        authoredTitle: "",
+        authoredDescription: "",
+        authoredDescriptionCount: 0,
+        titleNode: null,
+        descriptionNode: null,
+        unrelatedNode: null,
+        titleMutationBatches: 0,
+        descriptionMutationBatches: 0,
+        headSnapshots: 0,
+        invalidPairs: 0,
+        duplicateDescriptions: 0,
+        speculativeAppearances: 0,
+        unrelatedMetaMutations: 0,
+        titleNodeReplacements: 0,
+        descriptionNodeReplacements: 0,
+        phase: "document-parse",
+        snapshots: [],
+    };
+    globalThis.__documentAPIDesignHeadEvidence = evidence;
+
+    const captureBaseline = () => {
+        if (evidence.baselineCaptured) return true;
+        const titles = document.querySelectorAll("head title");
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const unrelated = document.querySelector(
+            'head meta[name="fixture-unrelated"]'
+        );
+        if (titles.length !== 1 || descriptions.length !== 1 || !unrelated) {
+            return false;
+        }
+        evidence.titleNode = titles[0];
+        evidence.descriptionNode = descriptions[0];
+        evidence.unrelatedNode = unrelated;
+        evidence.authoredTitle = titles[0].textContent;
+        evidence.authoredDescription =
+            descriptions[0].getAttribute("content") ?? "";
+        evidence.authoredDescriptionCount = descriptions.length;
+        evidence.baselineCaptured = true;
+        return true;
+    };
+
+    const containsNode = (record, node) => {
+        if (!node) return false;
+        if (record.target === node || node.contains(record.target)) return true;
+        return [...record.addedNodes, ...record.removedNodes].some(
+            (changed) => changed === node ||
+                (changed.nodeType === Node.ELEMENT_NODE &&
+                    changed.contains(node))
+        );
+    };
+
+    const observer = new MutationObserver((records) => {
+        const capturedBeforeBatch = evidence.baselineCaptured;
+        if (!captureBaseline() || !capturedBeforeBatch) return;
+
+        const titleTouched = records.some((record) =>
+            containsNode(record, evidence.titleNode)
+        );
+        const descriptionTouched = records.some((record) =>
+            containsNode(record, evidence.descriptionNode)
+        );
+        if (titleTouched) evidence.titleMutationBatches++;
+        if (descriptionTouched) evidence.descriptionMutationBatches++;
+        if (
+            records.some((record) =>
+                containsNode(record, evidence.unrelatedNode)
+            )
+        ) {
+            evidence.unrelatedMetaMutations++;
+        }
+        for (const record of records) {
+            const changed = [...record.addedNodes, ...record.removedNodes];
+            if (changed.includes(evidence.titleNode)) {
+                evidence.titleNodeReplacements++;
+            }
+            if (changed.includes(evidence.descriptionNode)) {
+                evidence.descriptionNodeReplacements++;
+            }
+        }
+        if (!titleTouched && !descriptionTouched) return;
+
+        const descriptions = document.querySelectorAll(
+            'head meta[name="description"]'
+        );
+        const snapshot = {
+            phase: evidence.phase,
+            title: document.title,
+            description:
+                descriptions[0]?.getAttribute("content") ?? "",
+            descriptionCount: descriptions.length,
+        };
+        evidence.snapshots.push(snapshot);
+        evidence.headSnapshots++;
+        if (snapshot.descriptionCount !== 1) {
+            evidence.duplicateDescriptions++;
+        }
+        const expectedTitle = document.querySelector(
+            "[data-testid='expected-title']"
+        )?.textContent.trim() ?? "";
+        const expectedDescription = document.querySelector(
+            "[data-testid='expected-description']"
+        )?.textContent.trim() ?? "";
+        if (
+            expectedTitle &&
+            (snapshot.title !== expectedTitle ||
+                snapshot.description !== expectedDescription)
+        ) {
+            evidence.invalidPairs++;
+        }
+        if (
+            snapshot.title === "Speculative failure · GoFrame" ||
+            snapshot.description === "This pair must never commit."
+        ) {
+            evidence.speculativeAppearances++;
+        }
+    });
+    observer.observe(document, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+    });
+    queueMicrotask(captureBaseline);
+    document.addEventListener("DOMContentLoaded", captureBaseline, {
+        once: true,
+    });
+}
+
+async function prepareTools() {
+    if (process.env.GOXC) {
+        return process.env.GOXC;
+    }
+    const goxc = join(tempRoot, "goxc");
+    await runCommand("go", ["build", "-o", goxc, "./cmd/goxc"]);
+    return goxc;
+}
+
+async function collectDiagnostics() {
+    const diagnostics = {
+        appPort,
+        debugPort,
+        browserStderr: browserError.slice(-6000),
+        serverOutput: server?.output?.().slice(-6000) ?? "",
+        commandOutput: commandOutput.slice(-8),
+    };
+    if (client) {
+        try {
+            diagnostics.page = await pageState(client);
+        } catch (error) {
+            diagnostics.pageError = error.message;
+        }
+    }
+    return diagnostics;
+}
+
+async function startServer(command, args, readyURL, label) {
+    const child = spawn(command, args, {
+        cwd: rootDir,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+            ...process.env,
+            GOWORK: "off",
+        },
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => {
+        output += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+        output += chunk;
+    });
+    try {
+        await waitForHTTP(readyURL, child, label, () => output);
+    } catch (error) {
+        await stopProcess(child, true);
+        throw error;
+    }
+    return { child, output: () => output };
+}
+
+async function waitForHTTP(url, child, label, output) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 120; attempt++) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+            throw new Error(
+                `HARNESS FAILURE: ${label} exited before HTTP was available\n${output()}`,
+            );
+        }
+        try {
+            const response = await fetch(url);
+            if (response.ok) return;
+            lastError = new Error(`HTTP ${response.status}`);
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: ${label} did not become ready: ` +
+        `${lastError?.message ?? ""}\n${output()}`,
+    );
+}
+
+async function waitForPage(port) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        if (browser?.exitCode !== null) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome exited before CDP was ready\n${browserError}`,
+            );
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            const targets = await response.json();
+            const page = targets.find(
+                (entry) => entry.type === "page" &&
+                    entry.webSocketDebuggerUrl
+            );
+            if (page) return page;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: Chrome DevTools did not become ready: ` +
+        `${lastError?.message ?? ""}\n${browserError}`,
+    );
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolveOpen, reject) => {
+        socket.addEventListener("open", resolveOpen, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) return;
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result);
+        }
+    });
+    return {
+        call(method, params = {}) {
+            return new Promise((resolveCall, reject) => {
+                const id = nextID++;
+                pending.set(id, { resolve: resolveCall, reject });
+                socket.send(JSON.stringify({ id, method, params }));
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                returnByValue: true,
+                awaitPromise: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(
+                    "APP FAILURE: browser evaluation failed: " +
+                    JSON.stringify(result.exceptionDetails),
+                );
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+async function waitForCondition(check, label) {
+    let lastError = null;
+    for (let attempt = 0; attempt < 200; attempt++) {
+        try {
+            if (await check()) return;
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(
+        `HARNESS FAILURE: timed out waiting for ${label}` +
+        (lastError ? `: ${lastError.message}` : ""),
+    );
+}
+
+function runCommand(command, args) {
+    return new Promise((resolveCommand, reject) => {
+        const child = spawn(command, args, {
+            cwd: rootDir,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: {
+                ...process.env,
+                GOWORK: "off",
+            },
+        });
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+            output += chunk;
+            process.stdout.write(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+            output += chunk;
+            process.stderr.write(chunk);
+        });
+        child.on("error", reject);
+        child.on("exit", (code, signal) => {
+            commandOutput.push({
+                command,
+                args,
+                status: signal ?? code,
+                output: output.slice(-6000),
+            });
+            if (code === 0) {
+                resolveCommand();
+                return;
+            }
+            reject(
+                new Error(
+                    `${command} ${args.join(" ")} failed with ${signal ?? code}`,
+                ),
+            );
+        });
+    });
+}
+
+async function stopProcess(child, processGroup) {
+    if (!child || child.exitCode !== null || child.signalCode !== null) return;
+    const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
+    terminate(child, processGroup, "SIGTERM");
+    const stopped = await Promise.race([
+        exited.then(() => true),
+        wait(2000).then(() => false),
+    ]);
+    if (!stopped && child.exitCode === null && child.signalCode === null) {
+        terminate(child, processGroup, "SIGKILL");
+        await Promise.race([exited, wait(1000)]);
+    }
+}
+
+function terminate(child, processGroup, signal) {
+    try {
+        if (processGroup) {
+            process.kill(-child.pid, signal);
+            return;
+        }
+    } catch {
+        // Fall through to direct child termination.
+    }
+    try {
+        child.kill(signal);
+    } catch {
+        // The process may have exited between checks.
+    }
+}
+
+function pickFreePort() {
+    return new Promise((resolvePort, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            server.close(() => resolvePort(address.port));
+        });
+    });
+}
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(`APP FAILURE: ${message}`);
+    }
+}
+
+function wait(milliseconds) {
+    return new Promise((resolveWait) => {
+        setTimeout(resolveWait, milliseconds);
+    });
+}

--- a/scripts/document-state-api-design-browser-smoke.mjs
+++ b/scripts/document-state-api-design-browser-smoke.mjs
@@ -139,6 +139,7 @@ try {
 }
 
 async function runMode(browserClient, mode) {
+    const boundaries = {};
     const appURL = `${origin}/?smoke=${Date.now()}#/${mode}`;
     await browserClient.call("Page.navigate", { url: appURL });
     await waitForCondition(async () => {
@@ -152,6 +153,7 @@ async function runMode(browserClient, mode) {
     });
 
     const initial = await pageState(browserClient);
+    boundaries.initialBaseline = lifecycleBoundary(initial);
     assert(initial.authoredTitle === baseline.title, `${mode} authored title changed`);
     assert(
         initial.authoredDescription === baseline.description,
@@ -168,7 +170,9 @@ async function runMode(browserClient, mode) {
         label: `${mode} route A`,
         ownerCount: 1,
     });
-    const routeOwnerID = (await pageState(browserClient)).activeOwnerID;
+    const routeAState = await pageState(browserClient);
+    boundaries.routeA = lifecycleBoundary(routeAState);
+    const routeOwnerID = Number(routeAState.activeOwnerID);
 
     await setPhase(browserClient, "nested-b");
     await click(browserClient, "activate-b");
@@ -176,6 +180,7 @@ async function runMode(browserClient, mode) {
         label: `${mode} nested B`,
         ownerCount: 2,
     });
+    boundaries.nestedB = lifecycleBoundary(await pageState(browserClient));
 
     await setPhase(browserClient, "route-a2-beneath-b");
     await click(browserClient, "update-route-a2");
@@ -192,6 +197,7 @@ async function runMode(browserClient, mode) {
         label: `${mode} A2 beneath B`,
         ownerCount: 2,
     });
+    boundaries.routeA2 = lifecycleBoundary(await pageState(browserClient));
 
     await setPhase(browserClient, "release-selected-b");
     await click(browserClient, "release-b");
@@ -199,6 +205,7 @@ async function runMode(browserClient, mode) {
         label: `${mode} release B reveals A2`,
         ownerCount: 1,
     });
+    boundaries.selectedBRelease = lifecycleBoundary(await pageState(browserClient));
 
     await setPhase(browserClient, "non-top-release");
     await click(browserClient, "activate-b");
@@ -206,11 +213,13 @@ async function runMode(browserClient, mode) {
         label: `${mode} B reactivation`,
         ownerCount: 2,
     });
+    boundaries.bRemount = lifecycleBoundary(await pageState(browserClient));
     await click(browserClient, "activate-c");
     await waitForState(browserClient, metadataC, {
         label: `${mode} C activation`,
         ownerCount: 3,
     });
+    boundaries.cActivation = lifecycleBoundary(await pageState(browserClient));
     const beforeNonTop = await pageState(browserClient);
     await click(browserClient, "release-b");
     await waitForCondition(async () => {
@@ -218,6 +227,7 @@ async function runMode(browserClient, mode) {
         return pairMatches(state, metadataC) && state.ownerCount === 2;
     }, `${mode} non-top B release`);
     const afterNonTop = await pageState(browserClient);
+    boundaries.nonTopBRelease = lifecycleBoundary(afterNonTop);
     assert(
         afterNonTop.titleMutationBatches === beforeNonTop.titleMutationBatches &&
             afterNonTop.descriptionMutationBatches ===
@@ -233,6 +243,7 @@ async function runMode(browserClient, mode) {
         return state.runtime.renders > beforeSame.runtime.renders;
     }, `${mode} selected owner rerender`);
     const afterSame = await pageState(browserClient);
+    boundaries.identicalRerender = lifecycleBoundary(afterSame);
     assert(
         afterSame.runtime.transitions === beforeSame.runtime.transitions,
         `${mode} identical rerender reached the coordinator`,
@@ -248,7 +259,9 @@ async function runMode(browserClient, mode) {
         ownerCount: 2,
     });
 
-    const candidateChecks = await runCandidateProbe(browserClient, mode);
+    const candidateProbe = await runCandidateProbe(browserClient, mode);
+    const candidateChecks = candidateProbe.checks;
+    boundaries.candidateProbe = candidateProbe.boundary;
 
     await setPhase(browserClient, "speculative-failure");
     const beforeFailure = await pageState(browserClient);
@@ -260,6 +273,7 @@ async function runMode(browserClient, mode) {
                 beforeFailure.runtime.errorBoundaryCaptures + 1;
     }, `${mode} speculative fallback`);
     const failed = await pageState(browserClient);
+    boundaries.speculativeFailure = lifecycleBoundary(failed);
     assert(pairMatches(failed, metadataC), `${mode} speculative owner changed selected pair`);
     assert(
         !failed.runtime.events.some((event) => event.role === "speculative"),
@@ -282,6 +296,7 @@ async function runMode(browserClient, mode) {
         scopeActive: false,
     });
     const unmounted = await pageState(browserClient);
+    boundaries.scopeUnmount = lifecycleBoundary(unmounted);
     assert(
         unmounted.runtime.baselineRestorations === 1,
         `${mode} baseline restorations = ${unmounted.runtime.baselineRestorations}`,
@@ -295,8 +310,9 @@ async function runMode(browserClient, mode) {
         scopeActive: true,
     });
     const final = await pageState(browserClient);
+    boundaries.scopeRemount = lifecycleBoundary(final);
     assert(
-        final.activeOwnerID !== routeOwnerID,
+        Number(final.activeOwnerID) !== routeOwnerID,
         `${mode} remount reused owner lifetime ${routeOwnerID}`,
     );
     assert(final.runtime.scopeMounts === 2, `${mode} scope mounts = ${final.runtime.scopeMounts}`);
@@ -320,14 +336,19 @@ async function runMode(browserClient, mode) {
     );
     assert(final.titleNodeSame, `${mode} title identity changed`);
     assert(final.descriptionNodeSame, `${mode} description identity changed`);
+    assertGenericLifecycleEvidence(mode, boundaries, routeOwnerID);
+    assertCandidateLifecycleEvidence(mode, boundaries, candidateProbe);
 
     console.log(`${mode} document metadata ownership: ok`);
-    return collectModeEvidence(final, candidateChecks);
+    return collectModeEvidence(final, candidateChecks, boundaries);
 }
 
 async function runCandidateProbe(browserClient, mode) {
     if (mode === "control") {
-        return {};
+        return {
+            checks: {},
+            boundary: lifecycleBoundary(await pageState(browserClient)),
+        };
     }
     if (mode === "component") {
         const state = await pageState(browserClient);
@@ -350,8 +371,11 @@ async function runCandidateProbe(browserClient, mode) {
         })()`);
         assert(directChild, "component ownership added a wrapper element");
         return {
-            conditionalMountRelease: true,
-            wrapperElementsAdded: 0,
+            checks: {
+                conditionalMountRelease: true,
+                wrapperElementsAdded: 0,
+            },
+            boundary: lifecycleBoundary(state),
         };
     }
 
@@ -394,8 +418,13 @@ async function runCandidateProbe(browserClient, mode) {
             ownerCount: 2,
         });
         return {
-            hookSlotsDistinct: true,
-            ownershipElementsAdded: 0,
+            checks: {
+                hookSlotsDistinct: true,
+                ownershipElementsAdded: 0,
+            },
+            before: lifecycleBoundary(before),
+            committed: lifecycleBoundary(state),
+            boundary: lifecycleBoundary(await pageState(browserClient)),
         };
     }
 
@@ -430,16 +459,308 @@ async function runCandidateProbe(browserClient, mode) {
         const after = await pageState(browserClient);
         assert(after.runtime.adds > before.runtime.adds, `${mode} probe did not add an owner`);
         return {
-            forwardedOwnerStable: true,
-            ownerRecordsAdded: 1,
-            duplicatePublicationsCoalesced:
-                state.runtime.handleDuplicateCoalesces,
+            checks: {
+                forwardedOwnerStable: true,
+                ownerRecordsAdded: 1,
+                duplicatePublicationsCoalesced:
+                    state.runtime.handleDuplicateCoalesces,
+            },
+            before: lifecycleBoundary(before),
+            committed: lifecycleBoundary(state),
+            boundary: lifecycleBoundary(after),
         };
     }
     throw new Error(`APP FAILURE: unsupported candidate probe mode ${mode}`);
 }
 
-function collectModeEvidence(state, candidateChecks) {
+function lifecycleBoundary(state) {
+    return {
+        coordinator: { ...state.runtime.coordinatorStatistics },
+        transitions: state.runtime.transitions,
+        documentCommits: state.runtime.documentCommits,
+        titleMutationBatches: state.titleMutationBatches,
+        descriptionMutationBatches: state.descriptionMutationBatches,
+        activeOwnerID: numericOwnerID(state.activeOwnerID),
+        ownerCount: state.ownerCount,
+        title: state.title,
+        description: state.description,
+        componentMounts: state.runtime.componentMounts,
+        componentUnmounts: state.runtime.componentUnmounts,
+        handleCreations: state.runtime.handleCreations,
+        publicationCreations: state.runtime.publicationCreations,
+        handleForwards: state.runtime.handleForwards,
+        handleDuplicateCoalesces:
+            state.runtime.handleDuplicateCoalesces,
+        zeroIDOwnerRenders: state.runtime.zeroIDOwnerRenders,
+        committedOwnerIDs: state.runtime.events
+            .filter((event) => event.change === "added")
+            .map((event) => event.ownerID),
+    };
+}
+
+function numericOwnerID(value) {
+    const ownerID = Number(value);
+    return Number.isFinite(ownerID) ? ownerID : 0;
+}
+
+function assertGenericLifecycleEvidence(mode, boundaries, routeOwnerID) {
+    assertStatisticsDelta(
+        `${mode} route activation`,
+        boundaries.initialBaseline,
+        boundaries.routeA,
+        {
+            tokenCreations: 1,
+            committedIDAssignments: 1,
+            activeAdditions: 1,
+            updates: 0,
+            releases: 0,
+            activeOwnerCount: 1,
+            lastCommittedOwnerID: 1,
+        },
+    );
+    assertStatisticsDelta(
+        `${mode} metadata update`,
+        boundaries.nestedB,
+        boundaries.routeA2,
+        {
+            tokenCreations: 0,
+            committedIDAssignments: 0,
+            activeAdditions: 0,
+            updates: 1,
+            releases: 0,
+            activeOwnerCount: 0,
+            lastCommittedOwnerID: 0,
+        },
+    );
+    assertStatisticsDelta(
+        `${mode} identical rerender`,
+        boundaries.nonTopBRelease,
+        boundaries.identicalRerender,
+        zeroStatisticsDelta(),
+    );
+    assert(
+        boundaries.identicalRerender.transitions ===
+            boundaries.nonTopBRelease.transitions,
+        `${mode} identical rerender transition delta`,
+    );
+    assertNoDocumentDelta(
+        `${mode} identical rerender`,
+        boundaries.nonTopBRelease,
+        boundaries.identicalRerender,
+    );
+    assertStatisticsDelta(
+        `${mode} speculative failure`,
+        boundaries.candidateProbe,
+        boundaries.speculativeFailure,
+        zeroStatisticsDelta(),
+    );
+    assert(
+        boundaries.speculativeFailure.transitions ===
+            boundaries.candidateProbe.transitions,
+        `${mode} speculative failure transition delta`,
+    );
+    assertNoDocumentDelta(
+        `${mode} speculative failure`,
+        boundaries.candidateProbe,
+        boundaries.speculativeFailure,
+    );
+    assert(
+        boundaries.speculativeFailure.ownerCount ===
+            boundaries.candidateProbe.ownerCount &&
+            boundaries.speculativeFailure.activeOwnerID ===
+                boundaries.candidateProbe.activeOwnerID,
+        `${mode} speculative failure changed active ownership`,
+    );
+    assert(
+        boundaries.speculativeFailure.title ===
+            boundaries.candidateProbe.title &&
+            boundaries.speculativeFailure.description ===
+                boundaries.candidateProbe.description,
+        `${mode} speculative failure changed selected metadata`,
+    );
+    assertStatisticsDelta(
+        `${mode} scope remount`,
+        boundaries.scopeUnmount,
+        boundaries.scopeRemount,
+        {
+            tokenCreations: 1,
+            committedIDAssignments: 1,
+            activeAdditions: 1,
+            updates: 0,
+            releases: 0,
+            activeOwnerCount: 1,
+            lastCommittedOwnerID: 1,
+        },
+    );
+    assert(
+        boundaries.scopeRemount.activeOwnerID ===
+            boundaries.scopeRemount.coordinator.lastCommittedOwnerID,
+        `${mode} remount did not use the latest committed owner ID`,
+    );
+    assert(
+        boundaries.scopeRemount.activeOwnerID !== routeOwnerID,
+        `${mode} remount reused route owner ${routeOwnerID}`,
+    );
+}
+
+function assertCandidateLifecycleEvidence(mode, boundaries, probe) {
+    if (mode === "control") {
+        return;
+    }
+    assert(
+        boundaries.routeA.zeroIDOwnerRenders -
+            boundaries.initialBaseline.zeroIDOwnerRenders === 2,
+        `${mode} route initialization render count`,
+    );
+    assert(
+        boundaries.scopeRemount.zeroIDOwnerRenders -
+            boundaries.scopeUnmount.zeroIDOwnerRenders === 2,
+        `${mode} remount initialization render count`,
+    );
+
+    if (mode === "hook") {
+        assertStatisticsDelta(
+            "hook two-slot activation",
+            probe.before,
+            probe.committed,
+            {
+                tokenCreations: 2,
+                committedIDAssignments: 2,
+                activeAdditions: 2,
+                updates: 0,
+                releases: 0,
+                activeOwnerCount: 2,
+                lastCommittedOwnerID: 2,
+            },
+        );
+        assertStatisticsDelta(
+            "hook two-slot release",
+            probe.committed,
+            probe.boundary,
+            {
+                ...zeroStatisticsDelta(),
+                releases: 2,
+                activeOwnerCount: -2,
+            },
+        );
+        assert(
+            probe.committed.zeroIDOwnerRenders -
+                probe.before.zeroIDOwnerRenders === 4,
+            "hook two-slot initialization render count",
+        );
+        return;
+    }
+
+    if (mode === "component") {
+        assertStatisticsDelta(
+            "component conditional remount",
+            boundaries.selectedBRelease,
+            boundaries.bRemount,
+            {
+                tokenCreations: 1,
+                committedIDAssignments: 1,
+                activeAdditions: 1,
+                updates: 0,
+                releases: 0,
+                activeOwnerCount: 1,
+                lastCommittedOwnerID: 1,
+            },
+        );
+        assert(
+            boundaries.bRemount.componentMounts -
+                boundaries.selectedBRelease.componentMounts === 1,
+            "component conditional remount record count",
+        );
+        assert(
+            boundaries.nonTopBRelease.componentUnmounts -
+                boundaries.cActivation.componentUnmounts === 1,
+            "component conditional unmount record count",
+        );
+        return;
+    }
+
+    if (mode === "handle") {
+        assertStatisticsDelta(
+            "handle forwarded activation",
+            probe.before,
+            probe.committed,
+            {
+                tokenCreations: 1,
+                committedIDAssignments: 1,
+                activeAdditions: 1,
+                updates: 0,
+                releases: 0,
+                activeOwnerCount: 1,
+                lastCommittedOwnerID: 1,
+            },
+        );
+        assert(
+            probe.committed.handleCreations - probe.before.handleCreations === 1,
+            "handle probe creation count",
+        );
+        assert(
+            probe.committed.publicationCreations -
+                probe.before.publicationCreations === 2,
+            "handle probe publication creation count",
+        );
+        assert(
+            probe.committed.handleDuplicateCoalesces -
+                probe.before.handleDuplicateCoalesces === 1,
+            "handle probe duplicate coalescing count",
+        );
+        assertStatisticsDelta(
+            "handle forwarded release",
+            probe.committed,
+            probe.boundary,
+            {
+                ...zeroStatisticsDelta(),
+                releases: 1,
+                activeOwnerCount: -1,
+            },
+        );
+        assert(
+            boundaries.speculativeFailure.handleCreations ===
+                boundaries.candidateProbe.handleCreations &&
+            boundaries.speculativeFailure.publicationCreations ===
+                boundaries.candidateProbe.publicationCreations,
+            "failed handle owner created committed private state",
+        );
+    }
+}
+
+function assertStatisticsDelta(label, before, after, expected) {
+    for (const [field, value] of Object.entries(expected)) {
+        const actual = after.coordinator[field] - before.coordinator[field];
+        assert(
+            actual === value,
+            `${label} ${field} delta = ${actual}, want ${value}`,
+        );
+    }
+}
+
+function zeroStatisticsDelta() {
+    return {
+        tokenCreations: 0,
+        committedIDAssignments: 0,
+        activeAdditions: 0,
+        updates: 0,
+        releases: 0,
+        activeOwnerCount: 0,
+        lastCommittedOwnerID: 0,
+    };
+}
+
+function assertNoDocumentDelta(label, before, after) {
+    assert(
+        after.documentCommits === before.documentCommits &&
+            after.titleMutationBatches === before.titleMutationBatches &&
+            after.descriptionMutationBatches ===
+                before.descriptionMutationBatches,
+        `${label} changed document evidence`,
+    );
+}
+
+function collectModeEvidence(state, candidateChecks, boundaries) {
     return {
         runtime: {
             transitions: state.runtime.transitions,
@@ -456,18 +777,30 @@ function collectModeEvidence(state, candidateChecks) {
             handleForwards: state.runtime.handleForwards,
             handleDuplicateCoalesces:
                 state.runtime.handleDuplicateCoalesces,
+            handleCreations: state.runtime.handleCreations,
+            publicationCreations: state.runtime.publicationCreations,
+            zeroIDOwnerRenders: state.runtime.zeroIDOwnerRenders,
+            coordinatorStatistics: state.runtime.coordinatorStatistics,
             errorBoundaryCaptures: state.runtime.errorBoundaryCaptures,
             events: state.runtime.events.map((event) => ({
                 candidate: event.candidate,
                 role: event.role,
                 change: event.change,
+                ownerID: event.ownerID,
+                activeOwnerID: event.activeOwnerID,
                 ownerCount: event.ownerCount,
                 title: event.title,
                 description: event.description,
             })),
+            handleCreationEvents: state.runtime.handleCreationEvents,
+            publicationCreationEvents:
+                state.runtime.publicationCreationEvents,
+            coordinatorStatisticsEvents:
+                state.runtime.coordinatorStatisticsEvents,
             runtimeErrors: state.runtime.runtimeErrors,
         },
         candidateChecks,
+        boundaries,
         observer: {
             titleMutationBatches: state.titleMutationBatches,
             descriptionMutationBatches: state.descriptionMutationBatches,
@@ -614,6 +947,21 @@ async function pageState(browserClient) {
                 handleForwards: runtime.handleForwards ?? 0,
                 handleDuplicateCoalesces:
                     runtime.handleDuplicateCoalesces ?? 0,
+                handleCreations: runtime.handleCreations ?? 0,
+                publicationCreations:
+                    runtime.publicationCreations ?? 0,
+                zeroIDOwnerRenders:
+                    runtime.zeroIDOwnerRenders ?? 0,
+                coordinatorStatistics:
+                    runtime.coordinatorStatistics ?? {
+                        tokenCreations: 0,
+                        committedIDAssignments: 0,
+                        activeAdditions: 0,
+                        updates: 0,
+                        releases: 0,
+                        activeOwnerCount: 0,
+                        lastCommittedOwnerID: 0,
+                    },
                 errorBoundaryCaptures:
                     runtime.errorBoundaryCaptures ?? 0,
                 events: runtime.events ?? [],
@@ -623,6 +971,12 @@ async function pageState(browserClient) {
                     runtime.handleForwardedOwnerIDs ?? [],
                 handleDuplicateOwnerIDs:
                     runtime.handleDuplicateOwnerIDs ?? [],
+                handleCreationEvents:
+                    runtime.handleCreationEvents ?? [],
+                publicationCreationEvents:
+                    runtime.publicationCreationEvents ?? [],
+                coordinatorStatisticsEvents:
+                    runtime.coordinatorStatisticsEvents ?? [],
                 runtimeErrors: runtime.runtimeErrors ?? [],
             },
         };

--- a/scripts/fixtures/document-state-api-design/README.md
+++ b/scripts/fixtures/document-state-api-design/README.md
@@ -1,0 +1,11 @@
+# Document Metadata API Design Fixture
+
+This private fixture compares four application-local ownership surfaces against
+one ordered title and description coordinator:
+
+- `#/control` keeps explicit string owner keys and coordinator plumbing.
+- `#/hook` models one implicit owner per positional hook slot.
+- `#/component` models one owner per mounted non-visual component.
+- `#/handle` models explicit owner-handle creation plus lifecycle publication.
+
+The fixture is design evidence only. It does not add a public GoFrame API.

--- a/scripts/fixtures/document-state-api-design/assets/index.html
+++ b/scripts/fixtures/document-state-api-design/assets/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GoFrame document API design fixture</title>
+    <meta
+        name="description"
+        content="Authored document API design baseline"
+    />
+    <meta name="fixture-unrelated" content="preserve-me" />
+    <link rel="stylesheet" href="styles.css" />
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root">Loading...</div>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/document-state-api-design/assets/styles.css
+++ b/scripts/fixtures/document-state-api-design/assets/styles.css
@@ -1,0 +1,42 @@
+:root {
+    color-scheme: light dark;
+    font-family: system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+}
+
+.design-app {
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: 64rem;
+    padding: 2rem;
+}
+
+.design-card,
+.design-evidence {
+    border: 1px solid currentColor;
+    border-radius: 0.5rem;
+    padding: 1rem;
+}
+
+.design-controls,
+.design-modes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-block: 1rem;
+}
+
+.design-evidence {
+    display: grid;
+    gap: 0.35rem;
+    grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+}
+
+.nested-owner {
+    border-inline-start: 0.25rem solid currentColor;
+    margin-top: 0.75rem;
+    padding-inline-start: 0.75rem;
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/app.gox
+++ b/scripts/fixtures/document-state-api-design/cmd/app/app.gox
@@ -1,0 +1,416 @@
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+type AppProps struct {
+	Mode        string
+	Adapter     *browserDocumentAdapter
+	Coordinator *documentmeta.Coordinator
+	Control     *documentmeta.StringOwners
+}
+
+type DocumentCommitterProps struct {
+	Adapter  *browserDocumentAdapter
+	Snapshot documentmeta.Snapshot
+}
+
+type CandidateScopeProps struct {
+	Mode        string
+	Control     *documentmeta.StringOwners
+	OnSnapshot  func(documentmeta.Snapshot)
+	StartActive bool
+	StartA2     bool
+}
+
+type HookTwoSlotProbeProps struct {
+	Children []gf.Node
+}
+
+var (
+	candidateScopeType = gf.NewComponentType(
+		"fixture.document-state-api-design.CandidateScope",
+		"DocumentAPIDesignCandidateScope",
+	)
+	hookTwoSlotProbeType = gf.NewComponentType(
+		"fixture.document-state-api-design.HookTwoSlotProbe",
+		"DocumentAPIDesignHookTwoSlotProbe",
+	)
+)
+
+func App(props AppProps) gf.Node {
+	scopeActive, setScopeActive := gf.UseState(true)
+	scopeGeneration, setScopeGeneration := gf.UseState(0)
+	snapshot, setSnapshot := gf.UseState(props.Coordinator.Snapshot())
+	bindings, _ := gf.UseState(&documentBindings{
+		coordinator: props.Coordinator,
+		onSnapshot: func(next documentmeta.Snapshot) {
+			setSnapshot(next)
+		},
+	})
+	provideDocumentBindings(bindings)
+
+	scope := candidateScopeNode(
+		scopeActive,
+		scopeGeneration,
+		props,
+		bindings.onSnapshot,
+	)
+
+	return (
+		<main class="design-app" data-testid="design-app" data-mode={props.Mode}>
+			<header>
+				<h1>Document metadata API design</h1>
+				<p data-testid="design-mode">Mode: {props.Mode}</p>
+			</header>
+
+			<nav class="design-modes" aria-label="Candidate modes">
+				<a href="#/control">Control</a>
+				<a href="#/hook">Hook</a>
+				<a href="#/component">Component</a>
+				<a href="#/handle">Handle</a>
+			</nav>
+
+			<DocumentCommitter Adapter={props.Adapter} Snapshot={snapshot} />
+
+			<section class="design-evidence" data-testid="design-evidence">
+				<span data-testid="active-owner-id">{activeOwnerID(snapshot)}</span>
+				<span data-testid="active-owner-count">{gf.ToString(snapshot.OwnerCount)}</span>
+				<span data-testid="expected-title">{snapshot.Metadata.Title}</span>
+				<span data-testid="expected-description">{snapshot.Metadata.Description}</span>
+			</section>
+
+			<div class="design-controls">
+				{scopeToggle(
+					scopeActive,
+					scopeGeneration,
+					setScopeActive,
+					setScopeGeneration,
+				)}
+			</div>
+
+			{scope}
+		</main>
+	)
+}
+
+func DocumentCommitter(props DocumentCommitterProps) gf.Node {
+	metadata := props.Snapshot.Metadata
+	gf.UseEffect(func() gf.Cleanup {
+		if err := props.Adapter.Apply(metadata); err != nil {
+			panic("document-state API design apply: " + err.Error())
+		}
+		return nil
+	}, gf.Deps(metadata.Title, metadata.Description))
+	return gf.Empty()
+}
+
+func CandidateScope(props CandidateScopeProps) gf.Node {
+	routeActive, setRouteActive := gf.UseState(props.StartActive)
+	routeA2, setRouteA2 := gf.UseState(props.StartA2)
+	nestedB, setNestedB := gf.UseState(false)
+	nestedC, setNestedC := gf.UseState(false)
+	failureActive, setFailureActive := gf.UseState(false)
+	probeActive, setProbeActive := gf.UseState(false)
+	renderNonce, setRenderNonce := gf.UseState(0)
+
+	gf.UseEffect(func() gf.Cleanup {
+		recordScopeMount()
+		return nil
+	})
+	gf.UseUnmount(func() {
+		recordScopeUnmount()
+	})
+
+	routeMetadata := routeMetadataA(routeA2)
+	routeNode := conditionalCandidateOwner(
+		routeActive,
+		candidateOwnerProps{
+			Mode:        props.Mode,
+			Role:        "route",
+			Metadata:    routeMetadata,
+			Control:     props.Control,
+			OnSnapshot:  props.OnSnapshot,
+			RenderNonce: renderNonce,
+			Children: []gf.Node{
+				gf.El(
+					"section",
+					gf.Props{"data-testid": "route-owner-content"},
+					gf.El("h2", nil, gf.Text(routeMetadata.Title)),
+				),
+			},
+		},
+	)
+	nestedBNode := conditionalCandidateOwner(
+		nestedB,
+		candidateOwnerProps{
+			Mode:       props.Mode,
+			Role:       "nested-b",
+			Metadata:   metadataB(),
+			Control:    props.Control,
+			OnSnapshot: props.OnSnapshot,
+			Children: []gf.Node{
+				gf.El(
+					"aside",
+					gf.Props{
+						"class":       "nested-owner",
+						"data-testid": "nested-owner-b",
+					},
+					gf.Text("Nested owner B"),
+				),
+			},
+		},
+	)
+	nestedCNode := conditionalCandidateOwner(
+		nestedC,
+		candidateOwnerProps{
+			Mode:        props.Mode,
+			Role:        "nested-c",
+			Metadata:    metadataC(),
+			Control:     props.Control,
+			OnSnapshot:  props.OnSnapshot,
+			RenderNonce: renderNonce,
+			Children: []gf.Node{
+				gf.El(
+					"aside",
+					gf.Props{
+						"class":       "nested-owner",
+						"data-testid": "nested-owner-c",
+					},
+					gf.Text("Nested owner C"),
+				),
+			},
+		},
+	)
+	probe := candidateProbeNode(props, probeActive)
+	failure := speculativeOwnerNode(props, failureActive)
+
+	return (
+		<section class="design-card" data-testid="candidate-scope">
+			<div class="design-controls">
+				<button Type="button" data-testid="activate-route-a" OnClick={func() {
+					setRouteActive(true)
+				}}>Activate route A</button>
+				<button Type="button" data-testid="update-route-a2" OnClick={func() {
+					setRouteA2(true)
+				}}>Update route to A2</button>
+				<button Type="button" data-testid="activate-b" OnClick={func() {
+					setNestedB(true)
+				}}>Activate nested B</button>
+				<button Type="button" data-testid="release-b" OnClick={func() {
+					setNestedB(false)
+				}}>Release nested B</button>
+				<button Type="button" data-testid="activate-c" OnClick={func() {
+					setNestedC(true)
+				}}>Activate nested C</button>
+				<button Type="button" data-testid="same-value-update" OnClick={func() {
+					setRenderNonce(renderNonce + 1)
+				}}>Rerender selected value</button>
+				<button Type="button" data-testid="activate-probe" OnClick={func() {
+					setProbeActive(true)
+				}}>Activate candidate probe</button>
+				<button Type="button" data-testid="release-probe" OnClick={func() {
+					setProbeActive(false)
+				}}>Release candidate probe</button>
+				<button Type="button" data-testid="activate-failure" OnClick={func() {
+					setFailureActive(true)
+				}}>Activate speculative failure</button>
+			</div>
+
+			{routeNode}
+			{nestedBNode}
+			{nestedCNode}
+			{probe}
+
+			<gf.ErrorBoundary Fallback={func(ctx gf.ErrorBoundaryContext) gf.Node {
+				return failureFallback(ctx, setFailureActive)
+			}}>
+				{failure}
+			</gf.ErrorBoundary>
+		</section>
+	)
+}
+
+func HookTwoSlotProbe(HookTwoSlotProbeProps) gf.Node {
+	useHookDocumentMetadata("hook-probe-one", documentmeta.Metadata{
+		Title:       "Hook probe one · GoFrame",
+		Description: "Hook slot one metadata.",
+	})
+	useHookDocumentMetadata("hook-probe-two", documentmeta.Metadata{
+		Title:       "Hook probe two · GoFrame",
+		Description: "Hook slot two metadata.",
+	})
+	return gf.Empty()
+}
+
+func conditionalCandidateOwner(active bool, props candidateOwnerProps) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	return candidateOwnerNode(props)
+}
+
+func candidateProbeNode(props CandidateScopeProps, active bool) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	switch props.Mode {
+	case "hook":
+		return gf.Key(
+			"hook-two-slot-probe",
+			gf.ComponentT(
+				hookTwoSlotProbeType,
+				HookTwoSlotProbeProps{},
+				HookTwoSlotProbe,
+			),
+		)
+	case "handle":
+		return candidateOwnerNode(candidateOwnerProps{
+			Mode:       props.Mode,
+			Role:       "handle-duplicate-probe",
+			Metadata:   documentmeta.Metadata{
+				Title:       "Handle probe · GoFrame",
+				Description: "One forwarded handle publication.",
+			},
+			OnSnapshot: props.OnSnapshot,
+			Duplicate:  true,
+		})
+	default:
+		return gf.Empty()
+	}
+}
+
+func speculativeOwnerNode(props CandidateScopeProps, active bool) gf.Node {
+	if !active {
+		return gf.Empty()
+	}
+	return candidateOwnerNode(candidateOwnerProps{
+		Mode: props.Mode,
+		Role: "speculative",
+		Metadata: documentmeta.Metadata{
+			Title:       "Speculative failure · GoFrame",
+			Description: "This pair must never commit.",
+		},
+		Control:    props.Control,
+		OnSnapshot: props.OnSnapshot,
+		Failure:    true,
+	})
+}
+
+func candidateScopeNode(
+	active bool,
+	generation int,
+	props AppProps,
+	onSnapshot func(documentmeta.Snapshot),
+) gf.Node {
+	if !active {
+		return (
+			<section data-testid="candidate-scope-inactive">
+				Candidate ownership scope is unmounted.
+			</section>
+		)
+	}
+	return gf.Key(
+		"candidate-scope:"+gf.ToString(generation),
+		gf.ComponentT(
+			candidateScopeType,
+			CandidateScopeProps{
+				Mode:        props.Mode,
+				Control:     props.Control,
+				OnSnapshot:  onSnapshot,
+				StartActive: generation > 0,
+				StartA2:     generation > 0,
+			},
+			CandidateScope,
+		),
+	)
+}
+
+func scopeToggle(
+	active bool,
+	generation int,
+	setActive func(bool),
+	setGeneration func(int),
+) gf.Node {
+	if active {
+		return gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "unmount-scope",
+				"OnClick": func() {
+					setActive(false)
+				},
+			},
+			gf.Text("Unmount candidate scope"),
+		)
+	}
+	return gf.El(
+		"button",
+		gf.Props{
+			"data-testid": "remount-scope",
+			"OnClick": func() {
+				setGeneration(generation + 1)
+				setActive(true)
+			},
+		},
+		gf.Text("Remount candidate scope"),
+	)
+}
+
+func failureFallback(
+	ctx gf.ErrorBoundaryContext,
+	setFailureActive func(bool),
+) gf.Node {
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "failure-fallback"},
+		gf.El("p", nil, gf.Text("Speculative metadata owner failed.")),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "reset-failure",
+				"OnClick": func() {
+					setFailureActive(false)
+					ctx.Reset()
+				},
+			},
+			gf.Text("Remove failed owner"),
+		),
+	)
+}
+
+func routeMetadataA(updated bool) documentmeta.Metadata {
+	if updated {
+		return documentmeta.Metadata{
+			Title:       "Route A2 · GoFrame",
+			Description: "Route metadata A2.",
+		}
+	}
+	return documentmeta.Metadata{
+		Title:       "Route A · GoFrame",
+		Description: "Route metadata A.",
+	}
+}
+
+func metadataB() documentmeta.Metadata {
+	return documentmeta.Metadata{
+		Title:       "Editor B · GoFrame",
+		Description: "Nested editor metadata B.",
+	}
+}
+
+func metadataC() documentmeta.Metadata {
+	return documentmeta.Metadata{
+		Title:       "Dialog C · GoFrame",
+		Description: "Nested dialog metadata C.",
+	}
+}
+
+func activeOwnerID(snapshot documentmeta.Snapshot) string {
+	if !snapshot.HasOwner {
+		return "authored-baseline"
+	}
+	return gf.ToString(snapshot.ActiveOwnerID)
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/app.gox
+++ b/scripts/fixtures/document-state-api-design/cmd/app/app.gox
@@ -29,6 +29,8 @@ type HookTwoSlotProbeProps struct {
 	Children []gf.Node
 }
 
+type HandleConflictProbeProps struct{}
+
 var (
 	candidateScopeType = gf.NewComponentType(
 		"fixture.document-state-api-design.CandidateScope",
@@ -37,6 +39,10 @@ var (
 	hookTwoSlotProbeType = gf.NewComponentType(
 		"fixture.document-state-api-design.HookTwoSlotProbe",
 		"DocumentAPIDesignHookTwoSlotProbe",
+	)
+	handleConflictProbeType = gf.NewComponentType(
+		"fixture.document-state-api-design.HandleConflictProbe",
+		"DocumentAPIDesignHandleConflictProbe",
 	)
 )
 
@@ -67,10 +73,10 @@ func App(props AppProps) gf.Node {
 			</header>
 
 			<nav class="design-modes" aria-label="Candidate modes">
-				<a href="#/control">Control</a>
-				<a href="#/hook">Hook</a>
-				<a href="#/component">Component</a>
-				<a href="#/handle">Handle</a>
+				<a href="./?candidate=control#/control" data-testid="candidate-mode-control">Control</a>
+				<a href="./?candidate=hook#/hook" data-testid="candidate-mode-hook">Hook</a>
+				<a href="./?candidate=component#/component" data-testid="candidate-mode-component">Component</a>
+				<a href="./?candidate=handle#/handle" data-testid="candidate-mode-handle">Handle</a>
 			</nav>
 
 			<DocumentCommitter Adapter={props.Adapter} Snapshot={snapshot} />
@@ -114,6 +120,7 @@ func CandidateScope(props CandidateScopeProps) gf.Node {
 	nestedC, setNestedC := gf.UseState(false)
 	failureActive, setFailureActive := gf.UseState(false)
 	probeActive, setProbeActive := gf.UseState(false)
+	handleConflictActive, setHandleConflictActive := gf.UseState(false)
 	renderNonce, setRenderNonce := gf.UseState(0)
 
 	gf.UseEffect(func() gf.Cleanup {
@@ -185,6 +192,7 @@ func CandidateScope(props CandidateScopeProps) gf.Node {
 		},
 	)
 	probe := candidateProbeNode(props, probeActive)
+	handleConflictProbe := handleConflictProbeNode(props, handleConflictActive)
 	failure := speculativeOwnerNode(props, failureActive)
 
 	return (
@@ -214,6 +222,11 @@ func CandidateScope(props CandidateScopeProps) gf.Node {
 				<button Type="button" data-testid="release-probe" OnClick={func() {
 					setProbeActive(false)
 				}}>Release candidate probe</button>
+				{handleConflictProbeControls(
+					props.Mode,
+					handleConflictActive,
+					setHandleConflictActive,
+				)}
 				<button Type="button" data-testid="activate-failure" OnClick={func() {
 					setFailureActive(true)
 				}}>Activate speculative failure</button>
@@ -223,6 +236,7 @@ func CandidateScope(props CandidateScopeProps) gf.Node {
 			{nestedBNode}
 			{nestedCNode}
 			{probe}
+			{handleConflictProbe}
 
 			<gf.ErrorBoundary Fallback={func(ctx gf.ErrorBoundaryContext) gf.Node {
 				return failureFallback(ctx, setFailureActive)
@@ -243,6 +257,44 @@ func HookTwoSlotProbe(HookTwoSlotProbeProps) gf.Node {
 		Description: "Hook slot two metadata.",
 	})
 	return gf.Empty()
+}
+
+func HandleConflictProbe(props HandleConflictProbeProps) gf.Node {
+	primaryMetadata, setPrimaryMetadata := gf.UseState(handleConflictMetadataA())
+	duplicateActive, setDuplicateActive := gf.UseState(true)
+	handle := useDocumentMetadataOwnerHandle("handle-conflict-probe")
+
+	useOwnedDocumentMetadata(
+		handle,
+		"handle-conflict-primary",
+		primaryMetadata,
+	)
+	useOptionalOwnedDocumentMetadata(
+		handle,
+		"handle-conflict-duplicate",
+		handleConflictMetadataA(),
+		duplicateActive,
+	)
+
+	return (
+		<section data-testid="handle-conflict-probe">
+			<span data-testid="handle-conflict-owner-id">
+				{gf.ToString(documentMetadataHandleOwnerID(handle))}
+			</span>
+			<span data-testid="handle-conflict-publication-count">
+				{gf.ToString(documentMetadataHandlePublicationCount(handle))}
+			</span>
+			<button Type="button" data-testid="handle-conflict-primary-b" OnClick={func() {
+				setPrimaryMetadata(handleConflictMetadataB())
+			}}>Update primary to B</button>
+			<button Type="button" data-testid="handle-conflict-release-duplicate" OnClick={func() {
+				setDuplicateActive(false)
+			}}>Release duplicate</button>
+			<button Type="button" data-testid="handle-conflict-primary-c" OnClick={func() {
+				setPrimaryMetadata(handleConflictMetadataC())
+			}}>Update sole primary to C</button>
+		</section>
+	)
 }
 
 func conditionalCandidateOwner(active bool, props candidateOwnerProps) gf.Node {
@@ -279,6 +331,76 @@ func candidateProbeNode(props CandidateScopeProps, active bool) gf.Node {
 		})
 	default:
 		return gf.Empty()
+	}
+}
+
+func handleConflictProbeNode(
+	props CandidateScopeProps,
+	active bool,
+) gf.Node {
+	if props.Mode != "handle" || !active {
+		return gf.Empty()
+	}
+	return gf.Key(
+		"handle-conflict-probe",
+		gf.ComponentT(
+			handleConflictProbeType,
+			HandleConflictProbeProps{},
+			HandleConflictProbe,
+		),
+	)
+}
+
+func handleConflictProbeControls(
+	mode string,
+	active bool,
+	setActive func(bool),
+) gf.Node {
+	if mode != "handle" {
+		return gf.Empty()
+	}
+	if active {
+		return gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "release-handle-conflict-probe",
+				"OnClick": func() {
+					setActive(false)
+				},
+			},
+			gf.Text("Release handle conflict probe"),
+		)
+	}
+	return gf.El(
+		"button",
+		gf.Props{
+			"data-testid": "activate-handle-conflict-probe",
+			"OnClick": func() {
+				setActive(true)
+			},
+		},
+		gf.Text("Activate handle conflict probe"),
+	)
+}
+
+func handleConflictMetadataA() documentmeta.Metadata {
+	return documentmeta.Metadata{
+		Title:       "Handle conflict A · GoFrame",
+		Description: "Coalesced handle metadata A.",
+	}
+}
+
+func handleConflictMetadataB() documentmeta.Metadata {
+	return documentmeta.Metadata{
+		Title:       "Handle conflict B · GoFrame",
+		Description: "Rejected handle metadata B.",
+	}
+}
+
+func handleConflictMetadataC() documentmeta.Metadata {
+	return documentmeta.Metadata{
+		Title:       "Handle conflict C · GoFrame",
+		Description: "Sole-primary handle metadata C.",
 	}
 }
 

--- a/scripts/fixtures/document-state-api-design/cmd/app/bindings.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/bindings.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+type documentBindings struct {
+	coordinator *documentmeta.Coordinator
+	onSnapshot  func(documentmeta.Snapshot)
+}
+
+var documentBindingsContext = gf.CreateContext[*documentBindings](nil)
+
+func provideDocumentBindings(bindings *documentBindings) {
+	if bindings == nil || bindings.coordinator == nil || bindings.onSnapshot == nil {
+		panic("document-state API design: document bindings are incomplete")
+	}
+	gf.ProvideContext(documentBindingsContext, bindings)
+}
+
+func requireDocumentBindings() *documentBindings {
+	bindings := gf.UseContext(documentBindingsContext)
+	if bindings == nil || bindings.coordinator == nil || bindings.onSnapshot == nil {
+		panic("document-state API design: document bindings are missing")
+	}
+	return bindings
+}
+
+func publishCandidateTransition(
+	candidate string,
+	role string,
+	transition documentmeta.Transition,
+	onSnapshot func(documentmeta.Snapshot),
+) {
+	recordCandidateTransition(candidate, role, transition)
+	if transition.Change != documentmeta.ChangeNone {
+		onSnapshot(transition.Snapshot)
+	}
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/bindings.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/bindings.go
@@ -31,9 +31,11 @@ func publishCandidateTransition(
 	candidate string,
 	role string,
 	transition documentmeta.Transition,
+	statistics documentmeta.Statistics,
 	onSnapshot func(documentmeta.Snapshot),
 ) {
 	recordCandidateTransition(candidate, role, transition)
+	recordCoordinatorStatistics(statistics)
 	if transition.Change != documentmeta.ChangeNone {
 		onSnapshot(transition.Snapshot)
 	}

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+type candidateOwnerProps struct {
+	Mode        string
+	Role        string
+	Metadata    documentmeta.Metadata
+	Control     *documentmeta.StringOwners
+	OnSnapshot  func(documentmeta.Snapshot)
+	Children    []gf.Node
+	Failure     bool
+	Duplicate   bool
+	RenderNonce int
+}
+
+type componentDocumentMetadataProps struct {
+	Role        string
+	Metadata    documentmeta.Metadata
+	Children    []gf.Node
+	Failure     bool
+	RenderNonce int
+}
+
+type documentMetadataOwnerHandle struct {
+	owner              *documentmeta.Owner
+	activePublications int
+	metadata           documentmeta.Metadata
+	primary            *documentMetadataPublication
+}
+
+type documentMetadataPublication struct {
+	active   bool
+	metadata documentmeta.Metadata
+}
+
+var (
+	candidateOwnerType = gf.NewComponentType(
+		"fixture.document-state-api-design.CandidateOwner",
+		"DocumentAPIDesignCandidateOwner",
+	)
+	componentDocumentMetadataType = gf.NewComponentType(
+		"fixture.document-state-api-design.ComponentDocumentMetadata",
+		"DocumentAPIDesignComponentOwner",
+	)
+)
+
+func candidateOwnerNode(props candidateOwnerProps) gf.Node {
+	return gf.Key(
+		"candidate-owner:"+props.Role,
+		gf.ComponentT(candidateOwnerType, props, CandidateOwner),
+	)
+}
+
+func CandidateOwner(props candidateOwnerProps) gf.Node {
+	switch props.Mode {
+	case "control":
+		useControlDocumentMetadata(props)
+	case "hook":
+		useHookDocumentMetadata(props.Role, props.Metadata)
+	case "component":
+		return gf.ComponentT(
+			componentDocumentMetadataType,
+			componentDocumentMetadataProps{
+				Role:        props.Role,
+				Metadata:    props.Metadata,
+				Children:    props.Children,
+				Failure:     props.Failure,
+				RenderNonce: props.RenderNonce,
+			},
+			ComponentDocumentMetadata,
+		)
+	case "handle":
+		handle := useDocumentMetadataOwnerHandle(props.Role)
+		if props.Duplicate {
+			useOwnedDocumentMetadataThroughHelper(handle, props.Role, props.Metadata)
+		}
+		useOwnedDocumentMetadata(handle, props.Role, props.Metadata)
+	default:
+		panic("document-state API design: unsupported candidate mode")
+	}
+	if props.Failure {
+		panic("document-state API design speculative render failure")
+	}
+	recordCandidateRender(props.Mode, props.Role, props.RenderNonce)
+	return gf.Fragment(props.Children...)
+}
+
+func useControlDocumentMetadata(props candidateOwnerProps) {
+	if props.Control == nil || props.OnSnapshot == nil {
+		panic("document-state API design: control bindings are missing")
+	}
+	key := props.Role
+	metadata := props.Metadata
+	gf.UseEffect(func() gf.Cleanup {
+		transition, err := props.Control.Publish(key, metadata)
+		if err != nil {
+			panic("document-state API design control publish: " + err.Error())
+		}
+		publishCandidateTransition("control", key, transition, props.OnSnapshot)
+		return nil
+	}, gf.Deps(key, metadata.Title, metadata.Description))
+	gf.UseUnmount(func() {
+		transition, err := props.Control.Release(key)
+		if err != nil {
+			panic("document-state API design control release: " + err.Error())
+		}
+		publishCandidateTransition("control", key, transition, props.OnSnapshot)
+	})
+}
+
+func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
+	bindings := requireDocumentBindings()
+	owner, _ := gf.UseState(bindings.coordinator.NewOwner())
+	recordCandidateOwnerRender("hook", role, owner.ID())
+
+	gf.UseEffect(func() gf.Cleanup {
+		transition, err := bindings.coordinator.Publish(owner, metadata)
+		if err != nil {
+			panic("document-state API design hook publish: " + err.Error())
+		}
+		publishCandidateTransition("hook", role, transition, bindings.onSnapshot)
+		return nil
+	}, gf.Deps(metadata.Title, metadata.Description))
+	gf.UseUnmount(func() {
+		transition, err := bindings.coordinator.Release(owner)
+		if err != nil {
+			panic("document-state API design hook release: " + err.Error())
+		}
+		publishCandidateTransition("hook", role, transition, bindings.onSnapshot)
+	})
+}
+
+func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
+	bindings := requireDocumentBindings()
+	owner, _ := gf.UseState(bindings.coordinator.NewOwner())
+	recordCandidateOwnerRender("component", props.Role, owner.ID())
+	metadata := props.Metadata
+
+	gf.UseEffect(func() gf.Cleanup {
+		recordComponentOwnerMount(props.Role, owner.ID())
+		transition, err := bindings.coordinator.Publish(owner, metadata)
+		if err != nil {
+			panic("document-state API design component publish: " + err.Error())
+		}
+		publishCandidateTransition("component", props.Role, transition, bindings.onSnapshot)
+		return nil
+	}, gf.Deps(metadata.Title, metadata.Description))
+	gf.UseUnmount(func() {
+		recordComponentOwnerUnmount(props.Role, owner.ID())
+		transition, err := bindings.coordinator.Release(owner)
+		if err != nil {
+			panic("document-state API design component release: " + err.Error())
+		}
+		publishCandidateTransition("component", props.Role, transition, bindings.onSnapshot)
+	})
+	if props.Failure {
+		panic("document-state API design speculative render failure")
+	}
+	recordCandidateRender("component", props.Role, props.RenderNonce)
+	return gf.Fragment(props.Children...)
+}
+
+func useDocumentMetadataOwnerHandle(role string) *documentMetadataOwnerHandle {
+	bindings := requireDocumentBindings()
+	handle, _ := gf.UseState(&documentMetadataOwnerHandle{
+		owner: bindings.coordinator.NewOwner(),
+	})
+	recordCandidateOwnerRender("handle", role, handle.owner.ID())
+	return handle
+}
+
+func useOwnedDocumentMetadataThroughHelper(
+	handle *documentMetadataOwnerHandle,
+	role string,
+	metadata documentmeta.Metadata,
+) {
+	recordHandleForward(handle.owner.ID())
+	useOwnedDocumentMetadata(handle, role, metadata)
+}
+
+func useOwnedDocumentMetadata(
+	handle *documentMetadataOwnerHandle,
+	role string,
+	metadata documentmeta.Metadata,
+) {
+	bindings := requireDocumentBindings()
+	if handle == nil || handle.owner == nil {
+		panic("document-state API design: document owner handle is nil")
+	}
+	publication, _ := gf.UseState(&documentMetadataPublication{})
+
+	gf.UseEffect(func() gf.Cleanup {
+		switch {
+		case !publication.active && handle.activePublications == 0:
+			publication.active = true
+			publication.metadata = metadata
+			handle.activePublications = 1
+			handle.metadata = metadata
+			handle.primary = publication
+			transition, err := bindings.coordinator.Publish(handle.owner, metadata)
+			if err != nil {
+				panic("document-state API design handle publish: " + err.Error())
+			}
+			publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+		case !publication.active && handle.metadata == metadata:
+			publication.active = true
+			publication.metadata = metadata
+			handle.activePublications++
+			recordHandleDuplicateCoalesced(handle.owner.ID())
+		case publication.active && handle.primary == publication:
+			publication.metadata = metadata
+			handle.metadata = metadata
+			transition, err := bindings.coordinator.Publish(handle.owner, metadata)
+			if err != nil {
+				panic("document-state API design handle update: " + err.Error())
+			}
+			publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+		case publication.active && handle.metadata == metadata:
+			publication.metadata = metadata
+		default:
+			panic("document-state API design: one owner handle has conflicting active publications")
+		}
+		return nil
+	}, gf.Deps(metadata.Title, metadata.Description))
+	gf.UseUnmount(func() {
+		if !publication.active || handle.activePublications <= 0 {
+			panic("document-state API design: document owner handle publication underflow")
+		}
+		publication.active = false
+		handle.activePublications--
+		if handle.activePublications != 0 {
+			return
+		}
+		handle.primary = nil
+		transition, err := bindings.coordinator.Release(handle.owner)
+		if err != nil {
+			panic("document-state API design handle release: " + err.Error())
+		}
+		publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+	})
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
@@ -100,7 +100,13 @@ func useControlDocumentMetadata(props candidateOwnerProps) {
 		if err != nil {
 			panic("document-state API design control publish: " + err.Error())
 		}
-		publishCandidateTransition("control", key, transition, props.OnSnapshot)
+		publishCandidateTransition(
+			"control",
+			key,
+			transition,
+			props.Control.Stats(),
+			props.OnSnapshot,
+		)
 		return nil
 	}, gf.Deps(key, metadata.Title, metadata.Description))
 	gf.UseUnmount(func() {
@@ -108,7 +114,13 @@ func useControlDocumentMetadata(props candidateOwnerProps) {
 		if err != nil {
 			panic("document-state API design control release: " + err.Error())
 		}
-		publishCandidateTransition("control", key, transition, props.OnSnapshot)
+		publishCandidateTransition(
+			"control",
+			key,
+			transition,
+			props.Control.Stats(),
+			props.OnSnapshot,
+		)
 	})
 }
 
@@ -119,6 +131,7 @@ func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
 
 	gf.UseEffect(func() gf.Cleanup {
 		setOwner(bindings.coordinator.NewOwner())
+		recordCoordinatorStatistics(bindings.coordinator.Stats())
 		return nil
 	}, gf.Once())
 	gf.UseEffect(func() gf.Cleanup {
@@ -129,7 +142,13 @@ func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
 		if err != nil {
 			panic("document-state API design hook publish: " + err.Error())
 		}
-		publishCandidateTransition("hook", role, transition, bindings.onSnapshot)
+		publishCandidateTransition(
+			"hook",
+			role,
+			transition,
+			bindings.coordinator.Stats(),
+			bindings.onSnapshot,
+		)
 		return nil
 	}, gf.Deps(owner != nil, metadata.Title, metadata.Description))
 	gf.UseUnmount(func() {
@@ -140,7 +159,13 @@ func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
 		if err != nil {
 			panic("document-state API design hook release: " + err.Error())
 		}
-		publishCandidateTransition("hook", role, transition, bindings.onSnapshot)
+		publishCandidateTransition(
+			"hook",
+			role,
+			transition,
+			bindings.coordinator.Stats(),
+			bindings.onSnapshot,
+		)
 	})
 }
 
@@ -152,6 +177,7 @@ func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
 
 	gf.UseEffect(func() gf.Cleanup {
 		setOwner(bindings.coordinator.NewOwner())
+		recordCoordinatorStatistics(bindings.coordinator.Stats())
 		return nil
 	}, gf.Once())
 	gf.UseEffect(func() gf.Cleanup {
@@ -165,7 +191,13 @@ func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
 		if transition.Change == documentmeta.ChangeAdded {
 			recordComponentOwnerMount(props.Role, owner.ID())
 		}
-		publishCandidateTransition("component", props.Role, transition, bindings.onSnapshot)
+		publishCandidateTransition(
+			"component",
+			props.Role,
+			transition,
+			bindings.coordinator.Stats(),
+			bindings.onSnapshot,
+		)
 		return nil
 	}, gf.Deps(owner != nil, metadata.Title, metadata.Description))
 	gf.UseUnmount(func() {
@@ -177,7 +209,13 @@ func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
 		if err != nil {
 			panic("document-state API design component release: " + err.Error())
 		}
-		publishCandidateTransition("component", props.Role, transition, bindings.onSnapshot)
+		publishCandidateTransition(
+			"component",
+			props.Role,
+			transition,
+			bindings.coordinator.Stats(),
+			bindings.onSnapshot,
+		)
 	})
 	if props.Failure {
 		panic("document-state API design speculative render failure")
@@ -190,9 +228,12 @@ func useDocumentMetadataOwnerHandle(role string) *documentMetadataOwnerHandle {
 	bindings := requireDocumentBindings()
 	handle, setHandle := gf.UseState[*documentMetadataOwnerHandle](nil)
 	gf.UseEffect(func() gf.Cleanup {
-		setHandle(&documentMetadataOwnerHandle{
+		next := &documentMetadataOwnerHandle{
 			owner: bindings.coordinator.NewOwner(),
-		})
+		}
+		recordHandleCreation(role)
+		recordCoordinatorStatistics(bindings.coordinator.Stats())
+		setHandle(next)
 		return nil
 	}, gf.Once())
 	recordCandidateOwnerRender("handle", role, documentMetadataHandleOwnerID(handle))
@@ -225,6 +266,7 @@ func useOwnedDocumentMetadataSlot(
 	publication, setPublication := gf.UseState[*documentMetadataPublication](nil)
 
 	gf.UseEffect(func() gf.Cleanup {
+		recordPublicationCreation(role, forwarded)
 		setPublication(&documentMetadataPublication{})
 		return nil
 	}, gf.Once())
@@ -243,7 +285,13 @@ func useOwnedDocumentMetadataSlot(
 			if err != nil {
 				panic("document-state API design handle publish: " + err.Error())
 			}
-			publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+			publishCandidateTransition(
+				"handle",
+				role,
+				transition,
+				bindings.coordinator.Stats(),
+				bindings.onSnapshot,
+			)
 		case !publication.active && handle.metadata == metadata:
 			publication.active = true
 			publication.metadata = metadata
@@ -256,7 +304,13 @@ func useOwnedDocumentMetadataSlot(
 			if err != nil {
 				panic("document-state API design handle update: " + err.Error())
 			}
-			publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+			publishCandidateTransition(
+				"handle",
+				role,
+				transition,
+				bindings.coordinator.Stats(),
+				bindings.onSnapshot,
+			)
 		case publication.active && handle.metadata == metadata:
 			publication.metadata = metadata
 		default:
@@ -290,7 +344,13 @@ func useOwnedDocumentMetadataSlot(
 		if err != nil {
 			panic("document-state API design handle release: " + err.Error())
 		}
-		publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
+		publishCandidateTransition(
+			"handle",
+			role,
+			transition,
+			bindings.coordinator.Stats(),
+			bindings.onSnapshot,
+		)
 	})
 }
 

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
@@ -114,18 +114,28 @@ func useControlDocumentMetadata(props candidateOwnerProps) {
 
 func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
 	bindings := requireDocumentBindings()
-	owner, _ := gf.UseState(bindings.coordinator.NewOwner())
+	owner, setOwner := gf.UseState[*documentmeta.Owner](nil)
 	recordCandidateOwnerRender("hook", role, owner.ID())
 
 	gf.UseEffect(func() gf.Cleanup {
+		setOwner(bindings.coordinator.NewOwner())
+		return nil
+	}, gf.Once())
+	gf.UseEffect(func() gf.Cleanup {
+		if owner == nil {
+			return nil
+		}
 		transition, err := bindings.coordinator.Publish(owner, metadata)
 		if err != nil {
 			panic("document-state API design hook publish: " + err.Error())
 		}
 		publishCandidateTransition("hook", role, transition, bindings.onSnapshot)
 		return nil
-	}, gf.Deps(metadata.Title, metadata.Description))
+	}, gf.Deps(owner != nil, metadata.Title, metadata.Description))
 	gf.UseUnmount(func() {
+		if owner == nil {
+			return
+		}
 		transition, err := bindings.coordinator.Release(owner)
 		if err != nil {
 			panic("document-state API design hook release: " + err.Error())
@@ -136,20 +146,32 @@ func useHookDocumentMetadata(role string, metadata documentmeta.Metadata) {
 
 func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
 	bindings := requireDocumentBindings()
-	owner, _ := gf.UseState(bindings.coordinator.NewOwner())
+	owner, setOwner := gf.UseState[*documentmeta.Owner](nil)
 	recordCandidateOwnerRender("component", props.Role, owner.ID())
 	metadata := props.Metadata
 
 	gf.UseEffect(func() gf.Cleanup {
-		recordComponentOwnerMount(props.Role, owner.ID())
+		setOwner(bindings.coordinator.NewOwner())
+		return nil
+	}, gf.Once())
+	gf.UseEffect(func() gf.Cleanup {
+		if owner == nil {
+			return nil
+		}
 		transition, err := bindings.coordinator.Publish(owner, metadata)
 		if err != nil {
 			panic("document-state API design component publish: " + err.Error())
 		}
+		if transition.Change == documentmeta.ChangeAdded {
+			recordComponentOwnerMount(props.Role, owner.ID())
+		}
 		publishCandidateTransition("component", props.Role, transition, bindings.onSnapshot)
 		return nil
-	}, gf.Deps(metadata.Title, metadata.Description))
+	}, gf.Deps(owner != nil, metadata.Title, metadata.Description))
 	gf.UseUnmount(func() {
+		if owner == nil || owner.ID() == 0 {
+			return
+		}
 		recordComponentOwnerUnmount(props.Role, owner.ID())
 		transition, err := bindings.coordinator.Release(owner)
 		if err != nil {
@@ -166,10 +188,14 @@ func ComponentDocumentMetadata(props componentDocumentMetadataProps) gf.Node {
 
 func useDocumentMetadataOwnerHandle(role string) *documentMetadataOwnerHandle {
 	bindings := requireDocumentBindings()
-	handle, _ := gf.UseState(&documentMetadataOwnerHandle{
-		owner: bindings.coordinator.NewOwner(),
-	})
-	recordCandidateOwnerRender("handle", role, handle.owner.ID())
+	handle, setHandle := gf.UseState[*documentMetadataOwnerHandle](nil)
+	gf.UseEffect(func() gf.Cleanup {
+		setHandle(&documentMetadataOwnerHandle{
+			owner: bindings.coordinator.NewOwner(),
+		})
+		return nil
+	}, gf.Once())
+	recordCandidateOwnerRender("handle", role, documentMetadataHandleOwnerID(handle))
 	return handle
 }
 
@@ -178,8 +204,7 @@ func useOwnedDocumentMetadataThroughHelper(
 	role string,
 	metadata documentmeta.Metadata,
 ) {
-	recordHandleForward(handle.owner.ID())
-	useOwnedDocumentMetadata(handle, role, metadata)
+	useOwnedDocumentMetadataSlot(handle, role, metadata, true)
 }
 
 func useOwnedDocumentMetadata(
@@ -187,13 +212,26 @@ func useOwnedDocumentMetadata(
 	role string,
 	metadata documentmeta.Metadata,
 ) {
+	useOwnedDocumentMetadataSlot(handle, role, metadata, false)
+}
+
+func useOwnedDocumentMetadataSlot(
+	handle *documentMetadataOwnerHandle,
+	role string,
+	metadata documentmeta.Metadata,
+	forwarded bool,
+) {
 	bindings := requireDocumentBindings()
-	if handle == nil || handle.owner == nil {
-		panic("document-state API design: document owner handle is nil")
-	}
-	publication, _ := gf.UseState(&documentMetadataPublication{})
+	publication, setPublication := gf.UseState[*documentMetadataPublication](nil)
 
 	gf.UseEffect(func() gf.Cleanup {
+		setPublication(&documentMetadataPublication{})
+		return nil
+	}, gf.Once())
+	gf.UseEffect(func() gf.Cleanup {
+		if handle == nil || handle.owner == nil || publication == nil {
+			return nil
+		}
 		switch {
 		case !publication.active && handle.activePublications == 0:
 			publication.active = true
@@ -224,10 +262,22 @@ func useOwnedDocumentMetadata(
 		default:
 			panic("document-state API design: one owner handle has conflicting active publications")
 		}
+		if forwarded {
+			recordHandleForward(handle.owner.ID())
+		}
 		return nil
-	}, gf.Deps(metadata.Title, metadata.Description))
+	}, gf.Deps(
+		handle != nil,
+		publication != nil,
+		metadata.Title,
+		metadata.Description,
+	))
 	gf.UseUnmount(func() {
-		if !publication.active || handle.activePublications <= 0 {
+		if handle == nil || handle.owner == nil || publication == nil ||
+			!publication.active {
+			return
+		}
+		if handle.activePublications <= 0 {
 			panic("document-state API design: document owner handle publication underflow")
 		}
 		publication.active = false
@@ -242,4 +292,11 @@ func useOwnedDocumentMetadata(
 		}
 		publishCandidateTransition("handle", role, transition, bindings.onSnapshot)
 	})
+}
+
+func documentMetadataHandleOwnerID(handle *documentMetadataOwnerHandle) uint64 {
+	if handle == nil || handle.owner == nil {
+		return 0
+	}
+	return handle.owner.ID()
 }

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
@@ -256,7 +256,7 @@ func useOwnedDocumentMetadataThroughHelper(
 	role string,
 	metadata documentmeta.Metadata,
 ) {
-	useOwnedDocumentMetadataSlot(handle, role, metadata, true)
+	useOwnedDocumentMetadataSlot(handle, role, metadata, true, true)
 }
 
 func useOwnedDocumentMetadata(
@@ -264,7 +264,16 @@ func useOwnedDocumentMetadata(
 	role string,
 	metadata documentmeta.Metadata,
 ) {
-	useOwnedDocumentMetadataSlot(handle, role, metadata, false)
+	useOwnedDocumentMetadataSlot(handle, role, metadata, false, true)
+}
+
+func useOptionalOwnedDocumentMetadata(
+	handle *documentMetadataOwnerHandle,
+	role string,
+	metadata documentmeta.Metadata,
+	active bool,
+) {
+	useOwnedDocumentMetadataSlot(handle, role, metadata, false, active)
 }
 
 func useOwnedDocumentMetadataSlot(
@@ -272,6 +281,7 @@ func useOwnedDocumentMetadataSlot(
 	role string,
 	metadata documentmeta.Metadata,
 	forwarded bool,
+	active bool,
 ) {
 	bindings := requireDocumentBindings()
 	publication, setPublication := gf.UseState[*documentMetadataPublication](nil)
@@ -285,6 +295,32 @@ func useOwnedDocumentMetadataSlot(
 		if handle == nil || handle.owner == nil || publication == nil {
 			return nil
 		}
+		if !active {
+			transition, err := releaseDocumentMetadataPublication(
+				bindings.coordinator,
+				handle,
+				publication,
+			)
+			if err != nil {
+				panic(err.Error())
+			}
+			recordHandlePublicationState(
+				role,
+				"release",
+				handle.owner.ID(),
+				handle.activePublications,
+			)
+			if transition.Change != documentmeta.ChangeNone {
+				publishCandidateTransition(
+					"handle",
+					role,
+					transition,
+					bindings.coordinator.Stats(),
+					bindings.onSnapshot,
+				)
+			}
+			return nil
+		}
 		transition, coalesced, err := reconcileDocumentMetadataPublication(
 			bindings.coordinator,
 			handle,
@@ -294,9 +330,17 @@ func useOwnedDocumentMetadataSlot(
 		if err != nil {
 			panic(err.Error())
 		}
+		action := transition.Change.String()
 		if coalesced {
+			action = "coalesced"
 			recordHandleDuplicateCoalesced(handle.owner.ID())
 		}
+		recordHandlePublicationState(
+			role,
+			action,
+			handle.owner.ID(),
+			handle.activePublications,
+		)
 		if transition.Change != documentmeta.ChangeNone {
 			publishCandidateTransition(
 				"handle",
@@ -313,6 +357,7 @@ func useOwnedDocumentMetadataSlot(
 	}, gf.Deps(
 		handle != nil,
 		publication != nil,
+		active,
 		metadata.Title,
 		metadata.Description,
 	))
@@ -329,6 +374,12 @@ func useOwnedDocumentMetadataSlot(
 		if err != nil {
 			panic(err.Error())
 		}
+		recordHandlePublicationState(
+			role,
+			"unmount",
+			handle.owner.ID(),
+			handle.activePublications,
+		)
 		if transition.Change != documentmeta.ChangeNone {
 			publishCandidateTransition(
 				"handle",
@@ -434,4 +485,13 @@ func documentMetadataHandleOwnerID(handle *documentMetadataOwnerHandle) uint64 {
 		return 0
 	}
 	return handle.owner.ID()
+}
+
+func documentMetadataHandlePublicationCount(
+	handle *documentMetadataOwnerHandle,
+) int {
+	if handle == nil {
+		return 0
+	}
+	return handle.activePublications
 }

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	gf "github.com/graybuton/goframe/pkg/goframe"
 	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
 )
@@ -36,6 +38,15 @@ type documentMetadataPublication struct {
 	active   bool
 	metadata documentmeta.Metadata
 }
+
+var (
+	errDocumentMetadataPublicationConflict = errors.New(
+		"document-state API design: one owner handle has conflicting active publications",
+	)
+	errDocumentMetadataPublicationUnderflow = errors.New(
+		"document-state API design: document owner handle publication underflow",
+	)
+)
 
 var (
 	candidateOwnerType = gf.NewComponentType(
@@ -274,36 +285,19 @@ func useOwnedDocumentMetadataSlot(
 		if handle == nil || handle.owner == nil || publication == nil {
 			return nil
 		}
-		switch {
-		case !publication.active && handle.activePublications == 0:
-			publication.active = true
-			publication.metadata = metadata
-			handle.activePublications = 1
-			handle.metadata = metadata
-			handle.primary = publication
-			transition, err := bindings.coordinator.Publish(handle.owner, metadata)
-			if err != nil {
-				panic("document-state API design handle publish: " + err.Error())
-			}
-			publishCandidateTransition(
-				"handle",
-				role,
-				transition,
-				bindings.coordinator.Stats(),
-				bindings.onSnapshot,
-			)
-		case !publication.active && handle.metadata == metadata:
-			publication.active = true
-			publication.metadata = metadata
-			handle.activePublications++
+		transition, coalesced, err := reconcileDocumentMetadataPublication(
+			bindings.coordinator,
+			handle,
+			publication,
+			metadata,
+		)
+		if err != nil {
+			panic(err.Error())
+		}
+		if coalesced {
 			recordHandleDuplicateCoalesced(handle.owner.ID())
-		case publication.active && handle.primary == publication:
-			publication.metadata = metadata
-			handle.metadata = metadata
-			transition, err := bindings.coordinator.Publish(handle.owner, metadata)
-			if err != nil {
-				panic("document-state API design handle update: " + err.Error())
-			}
+		}
+		if transition.Change != documentmeta.ChangeNone {
 			publishCandidateTransition(
 				"handle",
 				role,
@@ -311,10 +305,6 @@ func useOwnedDocumentMetadataSlot(
 				bindings.coordinator.Stats(),
 				bindings.onSnapshot,
 			)
-		case publication.active && handle.metadata == metadata:
-			publication.metadata = metadata
-		default:
-			panic("document-state API design: one owner handle has conflicting active publications")
 		}
 		if forwarded {
 			recordHandleForward(handle.owner.ID())
@@ -331,27 +321,112 @@ func useOwnedDocumentMetadataSlot(
 			!publication.active {
 			return
 		}
-		if handle.activePublications <= 0 {
-			panic("document-state API design: document owner handle publication underflow")
+		transition, err := releaseDocumentMetadataPublication(
+			bindings.coordinator,
+			handle,
+			publication,
+		)
+		if err != nil {
+			panic(err.Error())
 		}
+		if transition.Change != documentmeta.ChangeNone {
+			publishCandidateTransition(
+				"handle",
+				role,
+				transition,
+				bindings.coordinator.Stats(),
+				bindings.onSnapshot,
+			)
+		}
+	})
+}
+
+func reconcileDocumentMetadataPublication(
+	coordinator *documentmeta.Coordinator,
+	handle *documentMetadataOwnerHandle,
+	publication *documentMetadataPublication,
+	metadata documentmeta.Metadata,
+) (documentmeta.Transition, bool, error) {
+	if !publication.active {
+		if handle.activePublications < 0 {
+			return documentmeta.Transition{}, false,
+				errDocumentMetadataPublicationUnderflow
+		}
+		if handle.activePublications == 0 {
+			transition, err := coordinator.Publish(handle.owner, metadata)
+			if err != nil {
+				return documentmeta.Transition{}, false, errors.New(
+					"document-state API design handle publish: " + err.Error(),
+				)
+			}
+			publication.active = true
+			publication.metadata = metadata
+			handle.activePublications = 1
+			handle.metadata = metadata
+			handle.primary = publication
+			return transition, false, nil
+		}
+		if handle.metadata != metadata {
+			return documentmeta.Transition{}, false,
+				errDocumentMetadataPublicationConflict
+		}
+		publication.active = true
+		publication.metadata = metadata
+		handle.activePublications++
+		return documentmeta.Transition{}, true, nil
+	}
+
+	if publication.metadata == metadata && handle.metadata == metadata {
+		return documentmeta.Transition{}, false, nil
+	}
+	if handle.primary != publication || handle.activePublications > 1 {
+		return documentmeta.Transition{}, false,
+			errDocumentMetadataPublicationConflict
+	}
+	if handle.activePublications <= 0 {
+		return documentmeta.Transition{}, false,
+			errDocumentMetadataPublicationUnderflow
+	}
+
+	transition, err := coordinator.Publish(handle.owner, metadata)
+	if err != nil {
+		return documentmeta.Transition{}, false, errors.New(
+			"document-state API design handle update: " + err.Error(),
+		)
+	}
+	publication.metadata = metadata
+	handle.metadata = metadata
+	return transition, false, nil
+}
+
+func releaseDocumentMetadataPublication(
+	coordinator *documentmeta.Coordinator,
+	handle *documentMetadataOwnerHandle,
+	publication *documentMetadataPublication,
+) (documentmeta.Transition, error) {
+	if !publication.active {
+		return documentmeta.Transition{}, nil
+	}
+	if handle.activePublications <= 0 {
+		return documentmeta.Transition{},
+			errDocumentMetadataPublicationUnderflow
+	}
+	if handle.activePublications > 1 {
 		publication.active = false
 		handle.activePublications--
-		if handle.activePublications != 0 {
-			return
-		}
-		handle.primary = nil
-		transition, err := bindings.coordinator.Release(handle.owner)
-		if err != nil {
-			panic("document-state API design handle release: " + err.Error())
-		}
-		publishCandidateTransition(
-			"handle",
-			role,
-			transition,
-			bindings.coordinator.Stats(),
-			bindings.onSnapshot,
+		return documentmeta.Transition{}, nil
+	}
+
+	transition, err := coordinator.Release(handle.owner)
+	if err != nil {
+		return documentmeta.Transition{}, errors.New(
+			"document-state API design handle release: " + err.Error(),
 		)
-	})
+	}
+	publication.active = false
+	handle.activePublications = 0
+	handle.primary = nil
+	return transition, nil
 }
 
 func documentMetadataHandleOwnerID(handle *documentMetadataOwnerHandle) uint64 {

--- a/scripts/fixtures/document-state-api-design/cmd/app/candidates_test.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/candidates_test.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+func TestDocumentMetadataHandleRejectsPrimaryUpdateWhileDuplicated(t *testing.T) {
+	baseline := documentmeta.Metadata{
+		Title:       "authored title",
+		Description: "authored description",
+	}
+	metadataA := documentmeta.Metadata{
+		Title:       "title A",
+		Description: "description A",
+	}
+	metadataB := documentmeta.Metadata{
+		Title:       "title B",
+		Description: "description B",
+	}
+	metadataC := documentmeta.Metadata{
+		Title:       "title C",
+		Description: "description C",
+	}
+	coordinator := documentmeta.New(baseline)
+	handle := &documentMetadataOwnerHandle{owner: coordinator.NewOwner()}
+	primary := &documentMetadataPublication{}
+	duplicate := &documentMetadataPublication{}
+
+	added, coalesced, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+		metadataA,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if added.Change != documentmeta.ChangeAdded || coalesced {
+		t.Fatalf(
+			"primary publication = (%s, coalesced %t), want (added, false)",
+			added.Change.String(),
+			coalesced,
+		)
+	}
+	ownerID := handle.owner.ID()
+	ownerOrder := coordinator.OwnerIDs()
+
+	transition, coalesced, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		duplicate,
+		metadataA,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.Change != documentmeta.ChangeNone || !coalesced {
+		t.Fatalf(
+			"duplicate publication = (%s, coalesced %t), want (none, true)",
+			transition.Change.String(),
+			coalesced,
+		)
+	}
+	if duplicate.metadata != primary.metadata ||
+		handle.owner.ID() != added.OwnerID {
+		t.Fatalf(
+			"forwarded identity = (metadata %#v, owner %d), want (%#v, %d)",
+			duplicate.metadata,
+			handle.owner.ID(),
+			primary.metadata,
+			added.OwnerID,
+		)
+	}
+	beforeDuplicateNoOpStats := coordinator.Stats()
+	transition, coalesced, err = reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		duplicate,
+		metadataA,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.Change != documentmeta.ChangeNone || coalesced {
+		t.Fatalf(
+			"active duplicate no-op = (%s, coalesced %t), want (none, false)",
+			transition.Change.String(),
+			coalesced,
+		)
+	}
+	if got := coordinator.Stats(); got != beforeDuplicateNoOpStats {
+		t.Fatalf(
+			"active duplicate no-op statistics = %#v, want %#v",
+			got,
+			beforeDuplicateNoOpStats,
+		)
+	}
+
+	beforeHandle := *handle
+	beforePrimary := *primary
+	beforeDuplicate := *duplicate
+	beforeSnapshot := coordinator.Snapshot()
+	beforeStats := coordinator.Stats()
+	transition, coalesced, err = reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+		metadataB,
+	)
+	if !errors.Is(err, errDocumentMetadataPublicationConflict) {
+		t.Fatalf("primary conflict error = %v", err)
+	}
+	if got, want := err.Error(),
+		"document-state API design: one owner handle has conflicting active publications"; got != want {
+		t.Fatalf("primary conflict diagnostic = %q, want %q", got, want)
+	}
+	if transition.Change != documentmeta.ChangeNone || coalesced {
+		t.Fatalf(
+			"conflicting publication = (%s, coalesced %t), want (none, false)",
+			transition.Change.String(),
+			coalesced,
+		)
+	}
+	assertDocumentMetadataHandleState(
+		t,
+		coordinator,
+		handle,
+		primary,
+		duplicate,
+		beforeHandle,
+		beforePrimary,
+		beforeDuplicate,
+		beforeSnapshot,
+		beforeStats,
+	)
+
+	released, err := releaseDocumentMetadataPublication(
+		coordinator,
+		handle,
+		duplicate,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if released.Change != documentmeta.ChangeNone {
+		t.Fatalf(
+			"duplicate release change = %s, want none",
+			released.Change.String(),
+		)
+	}
+	if handle.activePublications != 1 || duplicate.active {
+		t.Fatalf(
+			"duplicate release state = (count %d, active %t), want (1, false)",
+			handle.activePublications,
+			duplicate.active,
+		)
+	}
+
+	updated, coalesced, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+		metadataC,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Change != documentmeta.ChangeUpdated || coalesced {
+		t.Fatalf(
+			"sole-primary update = (%s, coalesced %t), want (updated, false)",
+			updated.Change.String(),
+			coalesced,
+		)
+	}
+	if handle.owner.ID() != ownerID || updated.OwnerID != ownerID {
+		t.Fatalf(
+			"sole-primary owner IDs = handle %d, transition %d; want %d",
+			handle.owner.ID(),
+			updated.OwnerID,
+			ownerID,
+		)
+	}
+	if got := coordinator.OwnerIDs(); !reflect.DeepEqual(got, ownerOrder) {
+		t.Fatalf("owner order after update = %v, want %v", got, ownerOrder)
+	}
+	if got := coordinator.Snapshot().Metadata; got != metadataC {
+		t.Fatalf("updated coordinator metadata = %#v, want %#v", got, metadataC)
+	}
+	if got := coordinator.Stats().Updates; got != beforeStats.Updates+1 {
+		t.Fatalf("coordinator updates = %d, want %d", got, beforeStats.Updates+1)
+	}
+
+	final, err := releaseDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if final.Change != documentmeta.ChangeRemoved {
+		t.Fatalf("final release change = %s, want removed", final.Change.String())
+	}
+	if final.Snapshot.Metadata != baseline {
+		t.Fatalf(
+			"final metadata = %#v, want baseline %#v",
+			final.Snapshot.Metadata,
+			baseline,
+		)
+	}
+	if handle.activePublications != 0 || handle.primary != nil {
+		t.Fatalf(
+			"final handle state = (count %d, primary %p), want (0, nil)",
+			handle.activePublications,
+			handle.primary,
+		)
+	}
+	repeated, err := releaseDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated.Change != documentmeta.ChangeNone {
+		t.Fatalf(
+			"repeated release change = %s, want none",
+			repeated.Change.String(),
+		)
+	}
+	if got := coordinator.Stats().Releases; got != 1 {
+		t.Fatalf("coordinator releases = %d, want 1", got)
+	}
+}
+
+func TestDocumentMetadataHandleRejectsMismatchedInitialDuplicate(t *testing.T) {
+	metadataA := documentmeta.Metadata{Title: "A", Description: "pair A"}
+	metadataB := documentmeta.Metadata{Title: "B", Description: "pair B"}
+	coordinator := documentmeta.New(documentmeta.Metadata{})
+	handle := &documentMetadataOwnerHandle{owner: coordinator.NewOwner()}
+	primary := &documentMetadataPublication{}
+	duplicate := &documentMetadataPublication{}
+	if _, _, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		primary,
+		metadataA,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	beforeHandle := *handle
+	beforePrimary := *primary
+	beforeDuplicate := *duplicate
+	beforeSnapshot := coordinator.Snapshot()
+	beforeStats := coordinator.Stats()
+	transition, coalesced, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		duplicate,
+		metadataB,
+	)
+	if !errors.Is(err, errDocumentMetadataPublicationConflict) {
+		t.Fatalf("mismatched duplicate error = %v", err)
+	}
+	if transition.Change != documentmeta.ChangeNone || coalesced {
+		t.Fatalf(
+			"mismatched duplicate = (%s, coalesced %t), want (none, false)",
+			transition.Change.String(),
+			coalesced,
+		)
+	}
+	assertDocumentMetadataHandleState(
+		t,
+		coordinator,
+		handle,
+		primary,
+		duplicate,
+		beforeHandle,
+		beforePrimary,
+		beforeDuplicate,
+		beforeSnapshot,
+		beforeStats,
+	)
+}
+
+func TestDocumentMetadataHandlePublicationUnderflowIsAtomic(t *testing.T) {
+	metadata := documentmeta.Metadata{Title: "A", Description: "pair A"}
+	coordinator := documentmeta.New(documentmeta.Metadata{})
+	handle := &documentMetadataOwnerHandle{owner: coordinator.NewOwner()}
+	publication := &documentMetadataPublication{}
+	if _, _, err := reconcileDocumentMetadataPublication(
+		coordinator,
+		handle,
+		publication,
+		metadata,
+	); err != nil {
+		t.Fatal(err)
+	}
+	handle.activePublications = 0
+
+	beforeHandle := *handle
+	beforePublication := *publication
+	beforeSnapshot := coordinator.Snapshot()
+	beforeStats := coordinator.Stats()
+	transition, err := releaseDocumentMetadataPublication(
+		coordinator,
+		handle,
+		publication,
+	)
+	if !errors.Is(err, errDocumentMetadataPublicationUnderflow) {
+		t.Fatalf("underflow error = %v", err)
+	}
+	if transition.Change != documentmeta.ChangeNone {
+		t.Fatalf("underflow change = %s, want none", transition.Change.String())
+	}
+	if *handle != beforeHandle {
+		t.Fatalf("handle changed after underflow: got %#v, want %#v", *handle, beforeHandle)
+	}
+	if *publication != beforePublication {
+		t.Fatalf(
+			"publication changed after underflow: got %#v, want %#v",
+			*publication,
+			beforePublication,
+		)
+	}
+	if got := coordinator.Snapshot(); got != beforeSnapshot {
+		t.Fatalf("snapshot after underflow = %#v, want %#v", got, beforeSnapshot)
+	}
+	if got := coordinator.Stats(); got != beforeStats {
+		t.Fatalf("statistics after underflow = %#v, want %#v", got, beforeStats)
+	}
+}
+
+func assertDocumentMetadataHandleState(
+	t *testing.T,
+	coordinator *documentmeta.Coordinator,
+	handle *documentMetadataOwnerHandle,
+	primary *documentMetadataPublication,
+	duplicate *documentMetadataPublication,
+	wantHandle documentMetadataOwnerHandle,
+	wantPrimary documentMetadataPublication,
+	wantDuplicate documentMetadataPublication,
+	wantSnapshot documentmeta.Snapshot,
+	wantStats documentmeta.Statistics,
+) {
+	t.Helper()
+	if *handle != wantHandle {
+		t.Fatalf("handle = %#v, want %#v", *handle, wantHandle)
+	}
+	if *primary != wantPrimary {
+		t.Fatalf("primary publication = %#v, want %#v", *primary, wantPrimary)
+	}
+	if *duplicate != wantDuplicate {
+		t.Fatalf("duplicate publication = %#v, want %#v", *duplicate, wantDuplicate)
+	}
+	if got := coordinator.Snapshot(); got != wantSnapshot {
+		t.Fatalf("coordinator snapshot = %#v, want %#v", got, wantSnapshot)
+	}
+	if got := coordinator.Stats(); got != wantStats {
+		t.Fatalf("coordinator statistics = %#v, want %#v", got, wantStats)
+	}
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
@@ -1,0 +1,228 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+type browserDocumentAdapter struct {
+	title       js.Value
+	description js.Value
+	unrelated   js.Value
+	baseline    documentmeta.Metadata
+	current     documentmeta.Metadata
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	document := js.Global().Get("document")
+	if document.IsUndefined() || document.IsNull() {
+		return nil, errors.New("document is unavailable")
+	}
+	titles := document.Call("querySelectorAll", "head title")
+	if titles.Get("length").Int() != 1 {
+		return nil, fmt.Errorf("expected one authored title, found %d", titles.Get("length").Int())
+	}
+	descriptions := document.Call("querySelectorAll", `head meta[name="description"]`)
+	if descriptions.Get("length").Int() != 1 {
+		return nil, fmt.Errorf(
+			"expected one authored description, found %d",
+			descriptions.Get("length").Int(),
+		)
+	}
+	unrelated := document.Call("querySelector", `head meta[name="fixture-unrelated"]`)
+	if unrelated.IsUndefined() || unrelated.IsNull() {
+		return nil, errors.New("authored unrelated metadata is missing")
+	}
+
+	title := titles.Index(0)
+	description := descriptions.Index(0)
+	baseline := documentmeta.Metadata{
+		Title:       title.Get("textContent").String(),
+		Description: description.Call("getAttribute", "content").String(),
+	}
+	return &browserDocumentAdapter{
+		title:       title,
+		description: description,
+		unrelated:   unrelated,
+		baseline:    baseline,
+		current:     baseline,
+	}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() documentmeta.Metadata {
+	if adapter == nil {
+		return documentmeta.Metadata{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(metadata documentmeta.Metadata) error {
+	if adapter == nil {
+		return errors.New("document adapter is nil")
+	}
+	if !adapter.title.Get("isConnected").Bool() {
+		return errors.New("authored title element is disconnected")
+	}
+	if !adapter.description.Get("isConnected").Bool() {
+		return errors.New("authored description element is disconnected")
+	}
+	if adapter.unrelated.Call("getAttribute", "content").String() != "preserve-me" {
+		return errors.New("unrelated authored metadata changed")
+	}
+
+	previous := adapter.current
+	if adapter.title.Get("textContent").String() != metadata.Title {
+		adapter.title.Set("textContent", metadata.Title)
+	}
+	if adapter.description.Call("getAttribute", "content").String() != metadata.Description {
+		adapter.description.Call("setAttribute", "content", metadata.Description)
+	}
+	adapter.current = metadata
+	incrementEvidence("documentCommits")
+	if previous != adapter.baseline && metadata == adapter.baseline {
+		incrementEvidence("baselineRestorations")
+	}
+	return nil
+}
+
+func initDocumentAPIDesignEvidence(mode string) {
+	evidence := js.Global().Get("Object").New()
+	evidence.Set("mode", mode)
+	for _, field := range []string{
+		"transitions",
+		"adds",
+		"updates",
+		"removes",
+		"noops",
+		"renders",
+		"documentCommits",
+		"baselineRestorations",
+		"scopeMounts",
+		"scopeUnmounts",
+		"componentMounts",
+		"componentUnmounts",
+		"handleForwards",
+		"handleDuplicateCoalesces",
+		"errorBoundaryCaptures",
+	} {
+		evidence.Set(field, 0)
+	}
+	for _, field := range []string{
+		"events",
+		"ownerRenders",
+		"componentLifetimes",
+		"handleForwardedOwnerIDs",
+		"handleDuplicateOwnerIDs",
+		"runtimeErrors",
+	} {
+		evidence.Set(field, js.Global().Get("Array").New())
+	}
+	js.Global().Set("goframeDocumentAPIDesignEvidence", evidence)
+}
+
+func recordCandidateTransition(
+	candidate string,
+	role string,
+	transition documentmeta.Transition,
+) {
+	incrementEvidence("transitions")
+	switch transition.Change {
+	case documentmeta.ChangeAdded:
+		incrementEvidence("adds")
+	case documentmeta.ChangeUpdated:
+		incrementEvidence("updates")
+	case documentmeta.ChangeRemoved:
+		incrementEvidence("removes")
+	default:
+		incrementEvidence("noops")
+	}
+	event := js.Global().Get("Object").New()
+	event.Set("candidate", candidate)
+	event.Set("role", role)
+	event.Set("change", transition.Change.String())
+	event.Set("ownerID", transition.OwnerID)
+	event.Set("activeOwnerID", transition.Snapshot.ActiveOwnerID)
+	event.Set("ownerCount", transition.Snapshot.OwnerCount)
+	event.Set("title", transition.Snapshot.Metadata.Title)
+	event.Set("description", transition.Snapshot.Metadata.Description)
+	evidence().Get("events").Call("push", event)
+}
+
+func recordCandidateRender(candidate string, role string, nonce int) {
+	incrementEvidence("renders")
+	event := js.Global().Get("Object").New()
+	event.Set("candidate", candidate)
+	event.Set("role", role)
+	event.Set("nonce", nonce)
+	evidence().Get("ownerRenders").Call("push", event)
+}
+
+func recordCandidateOwnerRender(candidate string, role string, ownerID uint64) {
+	incrementEvidence("renders")
+	event := js.Global().Get("Object").New()
+	event.Set("candidate", candidate)
+	event.Set("role", role)
+	event.Set("ownerID", ownerID)
+	evidence().Get("ownerRenders").Call("push", event)
+}
+
+func recordComponentOwnerMount(role string, ownerID uint64) {
+	incrementEvidence("componentMounts")
+	recordComponentLifetime("mount", role, ownerID)
+}
+
+func recordComponentOwnerUnmount(role string, ownerID uint64) {
+	incrementEvidence("componentUnmounts")
+	recordComponentLifetime("unmount", role, ownerID)
+}
+
+func recordComponentLifetime(action string, role string, ownerID uint64) {
+	event := js.Global().Get("Object").New()
+	event.Set("action", action)
+	event.Set("role", role)
+	event.Set("ownerID", ownerID)
+	evidence().Get("componentLifetimes").Call("push", event)
+}
+
+func recordHandleForward(ownerID uint64) {
+	incrementEvidence("handleForwards")
+	evidence().Get("handleForwardedOwnerIDs").Call("push", ownerID)
+}
+
+func recordHandleDuplicateCoalesced(ownerID uint64) {
+	incrementEvidence("handleDuplicateCoalesces")
+	evidence().Get("handleDuplicateOwnerIDs").Call("push", ownerID)
+}
+
+func recordScopeMount() {
+	incrementEvidence("scopeMounts")
+}
+
+func recordScopeUnmount() {
+	incrementEvidence("scopeUnmounts")
+}
+
+func recordDocumentAPIDesignError(info gf.ErrorInfo) {
+	incrementEvidence("errorBoundaryCaptures")
+	report := js.Global().Get("Object").New()
+	report.Set("phase", info.Phase.String())
+	report.Set("component", info.Component)
+	report.Set("operation", info.Operation)
+	report.Set("panic", gf.ToString(info.Panic))
+	evidence().Get("runtimeErrors").Call("push", report)
+}
+
+func incrementEvidence(field string) {
+	current := evidence()
+	current.Set(field, current.Get(field).Int()+1)
+}
+
+func evidence() js.Value {
+	return js.Global().Get("goframeDocumentAPIDesignEvidence")
+}

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
@@ -109,6 +109,9 @@ func initDocumentAPIDesignEvidence(mode string) {
 		"componentUnmounts",
 		"handleForwards",
 		"handleDuplicateCoalesces",
+		"handleCreations",
+		"publicationCreations",
+		"zeroIDOwnerRenders",
 		"errorBoundaryCaptures",
 	} {
 		evidence.Set(field, 0)
@@ -119,6 +122,9 @@ func initDocumentAPIDesignEvidence(mode string) {
 		"componentLifetimes",
 		"handleForwardedOwnerIDs",
 		"handleDuplicateOwnerIDs",
+		"handleCreationEvents",
+		"publicationCreationEvents",
+		"coordinatorStatisticsEvents",
 		"runtimeErrors",
 	} {
 		evidence.Set(field, js.Global().Get("Array").New())
@@ -165,6 +171,9 @@ func recordCandidateRender(candidate string, role string, nonce int) {
 
 func recordCandidateOwnerRender(candidate string, role string, ownerID uint64) {
 	incrementEvidence("renders")
+	if ownerID == 0 {
+		incrementEvidence("zeroIDOwnerRenders")
+	}
 	event := js.Global().Get("Object").New()
 	event.Set("candidate", candidate)
 	event.Set("role", role)
@@ -198,6 +207,52 @@ func recordHandleForward(ownerID uint64) {
 func recordHandleDuplicateCoalesced(ownerID uint64) {
 	incrementEvidence("handleDuplicateCoalesces")
 	evidence().Get("handleDuplicateOwnerIDs").Call("push", ownerID)
+}
+
+func recordHandleCreation(role string) {
+	incrementEvidence("handleCreations")
+	recordLifecycleCreation("handleCreationEvents", role, false)
+}
+
+func recordPublicationCreation(role string, forwarded bool) {
+	incrementEvidence("publicationCreations")
+	recordLifecycleCreation("publicationCreationEvents", role, forwarded)
+}
+
+func recordLifecycleCreation(field string, role string, forwarded bool) {
+	event := js.Global().Get("Object").New()
+	event.Set("role", role)
+	event.Set("forwarded", forwarded)
+	setCurrentEvidencePhase(event)
+	evidence().Get(field).Call("push", event)
+}
+
+func recordCoordinatorStatistics(statistics documentmeta.Statistics) {
+	current := coordinatorStatisticsValue(statistics)
+	evidence().Set("coordinatorStatistics", current)
+	event := coordinatorStatisticsValue(statistics)
+	setCurrentEvidencePhase(event)
+	evidence().Get("coordinatorStatisticsEvents").Call("push", event)
+}
+
+func coordinatorStatisticsValue(statistics documentmeta.Statistics) js.Value {
+	value := js.Global().Get("Object").New()
+	value.Set("tokenCreations", statistics.TokenCreations)
+	value.Set("committedIDAssignments", statistics.CommittedIDAssignments)
+	value.Set("activeAdditions", statistics.ActiveAdditions)
+	value.Set("updates", statistics.Updates)
+	value.Set("releases", statistics.Releases)
+	value.Set("activeOwnerCount", statistics.ActiveOwnerCount)
+	value.Set("lastCommittedOwnerID", statistics.LastCommittedOwnerID)
+	return value
+}
+
+func setCurrentEvidencePhase(value js.Value) {
+	head := js.Global().Get("__documentAPIDesignHeadEvidence")
+	if head.IsUndefined() || head.IsNull() {
+		return
+	}
+	value.Set("phase", head.Get("phase"))
 }
 
 func recordScopeMount() {

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_js.go
@@ -124,6 +124,7 @@ func initDocumentAPIDesignEvidence(mode string) {
 		"handleDuplicateOwnerIDs",
 		"handleCreationEvents",
 		"publicationCreationEvents",
+		"handlePublicationEvents",
 		"coordinatorStatisticsEvents",
 		"runtimeErrors",
 	} {
@@ -217,6 +218,21 @@ func recordHandleCreation(role string) {
 func recordPublicationCreation(role string, forwarded bool) {
 	incrementEvidence("publicationCreations")
 	recordLifecycleCreation("publicationCreationEvents", role, forwarded)
+}
+
+func recordHandlePublicationState(
+	role string,
+	action string,
+	ownerID uint64,
+	activePublications int,
+) {
+	event := js.Global().Get("Object").New()
+	event.Set("role", role)
+	event.Set("action", action)
+	event.Set("ownerID", ownerID)
+	event.Set("activePublications", activePublications)
+	setCurrentEvidencePhase(event)
+	evidence().Get("handlePublicationEvents").Call("push", event)
 }
 
 func recordLifecycleCreation(field string, role string, forwarded bool) {

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
@@ -1,0 +1,49 @@
+//go:build !js || !wasm
+
+package main
+
+import (
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+type browserDocumentAdapter struct {
+	baseline documentmeta.Metadata
+}
+
+func newBrowserDocumentAdapter() (*browserDocumentAdapter, error) {
+	return &browserDocumentAdapter{}, nil
+}
+
+func (adapter *browserDocumentAdapter) Baseline() documentmeta.Metadata {
+	if adapter == nil {
+		return documentmeta.Metadata{}
+	}
+	return adapter.baseline
+}
+
+func (adapter *browserDocumentAdapter) Apply(documentmeta.Metadata) error {
+	return nil
+}
+
+func initDocumentAPIDesignEvidence(string) {}
+
+func recordCandidateTransition(string, string, documentmeta.Transition) {}
+
+func recordCandidateRender(string, string, int) {}
+
+func recordCandidateOwnerRender(string, string, uint64) {}
+
+func recordComponentOwnerMount(string, uint64) {}
+
+func recordComponentOwnerUnmount(string, uint64) {}
+
+func recordHandleForward(uint64) {}
+
+func recordHandleDuplicateCoalesced(uint64) {}
+
+func recordScopeMount() {}
+
+func recordScopeUnmount() {}
+
+func recordDocumentAPIDesignError(gf.ErrorInfo) {}

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
@@ -42,6 +42,12 @@ func recordHandleForward(uint64) {}
 
 func recordHandleDuplicateCoalesced(uint64) {}
 
+func recordHandleCreation(string) {}
+
+func recordPublicationCreation(string, bool) {}
+
+func recordCoordinatorStatistics(documentmeta.Statistics) {}
+
 func recordScopeMount() {}
 
 func recordScopeUnmount() {}

--- a/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/document_nonjs.go
@@ -46,6 +46,8 @@ func recordHandleCreation(string) {}
 
 func recordPublicationCreation(string, bool) {}
 
+func recordHandlePublicationState(string, string, uint64, int) {}
+
 func recordCoordinatorStatistics(documentmeta.Statistics) {}
 
 func recordScopeMount() {}

--- a/scripts/fixtures/document-state-api-design/cmd/app/main.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/main.go
@@ -21,6 +21,7 @@ func main() {
 		panic("document-state API design fixture: " + err.Error())
 	}
 	coordinator := documentmeta.New(adapter.Baseline())
+	recordCoordinatorStatistics(coordinator.Stats())
 	control := documentmeta.NewStringOwners(coordinator)
 	gf.SetErrorHandler(recordDocumentAPIDesignError)
 

--- a/scripts/fixtures/document-state-api-design/cmd/app/main.go
+++ b/scripts/fixtures/document-state-api-design/cmd/app/main.go
@@ -1,0 +1,46 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"strings"
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+	"github.com/graybuton/goframe/scripts/fixtures/document-state-api-design/internal/documentmeta"
+)
+
+func main() {
+	mode := strings.TrimPrefix(js.Global().Get("location").Get("hash").String(), "#/")
+	if !validDesignMode(mode) {
+		mode = "control"
+	}
+	initDocumentAPIDesignEvidence(mode)
+	adapter, err := newBrowserDocumentAdapter()
+	if err != nil {
+		panic("document-state API design fixture: " + err.Error())
+	}
+	coordinator := documentmeta.New(adapter.Baseline())
+	control := documentmeta.NewStringOwners(coordinator)
+	gf.SetErrorHandler(recordDocumentAPIDesignError)
+
+	done := make(chan struct{})
+	gf.Mount("root", func() gf.Node {
+		return App(AppProps{
+			Mode:        mode,
+			Adapter:     adapter,
+			Coordinator: coordinator,
+			Control:     control,
+		})
+	})
+	<-done
+}
+
+func validDesignMode(mode string) bool {
+	switch mode {
+	case "control", "hook", "component", "handle":
+		return true
+	default:
+		return false
+	}
+}

--- a/scripts/fixtures/document-state-api-design/goframe.json
+++ b/scripts/fixtures/document-state-api-design/goframe.json
@@ -1,0 +1,6 @@
+{
+  "name": "document-state-api-design",
+  "entry": "./cmd/app",
+  "compiler": "tinygo",
+  "assets": "./assets"
+}

--- a/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
+++ b/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
@@ -72,6 +72,17 @@ type ownerRecord struct {
 	metadata Metadata
 }
 
+// Statistics records fixture-only ownership lifecycle evidence.
+type Statistics struct {
+	TokenCreations         int
+	CommittedIDAssignments int
+	ActiveAdditions        int
+	Updates                int
+	Releases               int
+	ActiveOwnerCount       int
+	LastCommittedOwnerID   uint64
+}
+
 // Coordinator selects the most recently activated owner while preserving
 // existing-owner priority across updates.
 type Coordinator struct {
@@ -79,6 +90,7 @@ type Coordinator struct {
 	nextID   uint64
 	owners   []ownerRecord
 	index    map[*Owner]int
+	stats    Statistics
 }
 
 // New creates an empty coordinator with an authored baseline.
@@ -94,10 +106,9 @@ func (coordinator *Coordinator) NewOwner() *Owner {
 	if coordinator == nil {
 		panic("document metadata: owner coordinator is nil")
 	}
-	coordinator.nextID++
+	coordinator.stats.TokenCreations++
 	return &Owner{
 		coordinator: coordinator,
-		id:          coordinator.nextID,
 	}
 }
 
@@ -128,13 +139,20 @@ func (coordinator *Coordinator) Publish(owner *Owner, metadata Metadata) (Transi
 			return coordinator.transition(owner, ChangeNone), nil
 		}
 		coordinator.owners[index].metadata = metadata
+		coordinator.stats.Updates++
 		return coordinator.transition(owner, ChangeUpdated), nil
+	}
+	if owner.id == 0 {
+		coordinator.nextID++
+		owner.id = coordinator.nextID
+		coordinator.stats.CommittedIDAssignments++
 	}
 	coordinator.index[owner] = len(coordinator.owners)
 	coordinator.owners = append(coordinator.owners, ownerRecord{
 		owner:    owner,
 		metadata: metadata,
 	})
+	coordinator.stats.ActiveAdditions++
 	return coordinator.transition(owner, ChangeAdded), nil
 }
 
@@ -153,7 +171,19 @@ func (coordinator *Coordinator) Release(owner *Owner) (Transition, error) {
 	for next := index; next < len(coordinator.owners); next++ {
 		coordinator.index[coordinator.owners[next].owner] = next
 	}
+	coordinator.stats.Releases++
 	return coordinator.transition(owner, ChangeRemoved), nil
+}
+
+// Stats returns a read-only snapshot of fixture ownership lifecycle evidence.
+func (coordinator *Coordinator) Stats() Statistics {
+	if coordinator == nil {
+		return Statistics{}
+	}
+	stats := coordinator.stats
+	stats.ActiveOwnerCount = len(coordinator.owners)
+	stats.LastCommittedOwnerID = coordinator.nextID
+	return stats
 }
 
 // OwnerIDs returns active owners in activation-priority order.

--- a/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
+++ b/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
@@ -1,0 +1,240 @@
+package documentmeta
+
+import (
+	"errors"
+	"strings"
+)
+
+// Metadata is one title and description pair.
+type Metadata struct {
+	Title       string
+	Description string
+}
+
+// Change identifies one ownership transition.
+type Change uint8
+
+const (
+	ChangeNone Change = iota
+	ChangeAdded
+	ChangeUpdated
+	ChangeRemoved
+)
+
+// String returns the stable fixture evidence name for a change.
+func (change Change) String() string {
+	switch change {
+	case ChangeAdded:
+		return "added"
+	case ChangeUpdated:
+		return "updated"
+	case ChangeRemoved:
+		return "removed"
+	default:
+		return "none"
+	}
+}
+
+// Owner is an opaque ownership lifetime allocated by one Coordinator.
+type Owner struct {
+	coordinator *Coordinator
+	id          uint64
+}
+
+// ID returns the fixture-local identity used only for deterministic evidence.
+func (owner *Owner) ID() uint64 {
+	if owner == nil {
+		return 0
+	}
+	return owner.id
+}
+
+// Snapshot is the currently selected metadata and owner.
+type Snapshot struct {
+	Metadata      Metadata
+	ActiveOwnerID uint64
+	HasOwner      bool
+	OwnerCount    int
+}
+
+// Transition describes one coordinator operation.
+type Transition struct {
+	Snapshot TransitionSnapshot
+	Change   Change
+	OwnerID  uint64
+}
+
+// TransitionSnapshot is kept distinct so transition values remain comparable.
+type TransitionSnapshot = Snapshot
+
+type ownerRecord struct {
+	owner    *Owner
+	metadata Metadata
+}
+
+// Coordinator selects the most recently activated owner while preserving
+// existing-owner priority across updates.
+type Coordinator struct {
+	baseline Metadata
+	nextID   uint64
+	owners   []ownerRecord
+	index    map[*Owner]int
+}
+
+// New creates an empty coordinator with an authored baseline.
+func New(baseline Metadata) *Coordinator {
+	return &Coordinator{
+		baseline: baseline,
+		index:    make(map[*Owner]int),
+	}
+}
+
+// NewOwner allocates an inactive ownership lifetime.
+func (coordinator *Coordinator) NewOwner() *Owner {
+	if coordinator == nil {
+		panic("document metadata: owner coordinator is nil")
+	}
+	coordinator.nextID++
+	return &Owner{
+		coordinator: coordinator,
+		id:          coordinator.nextID,
+	}
+}
+
+// Snapshot returns the selected owner metadata or the authored baseline.
+func (coordinator *Coordinator) Snapshot() Snapshot {
+	if coordinator == nil {
+		return Snapshot{}
+	}
+	if len(coordinator.owners) == 0 {
+		return Snapshot{Metadata: coordinator.baseline}
+	}
+	active := coordinator.owners[len(coordinator.owners)-1]
+	return Snapshot{
+		Metadata:      active.metadata,
+		ActiveOwnerID: active.owner.id,
+		HasOwner:      true,
+		OwnerCount:    len(coordinator.owners),
+	}
+}
+
+// Publish activates a new owner or updates an active owner's pair in place.
+func (coordinator *Coordinator) Publish(owner *Owner, metadata Metadata) (Transition, error) {
+	if err := coordinator.validateOwner(owner); err != nil {
+		return Transition{}, err
+	}
+	if index, ok := coordinator.index[owner]; ok {
+		if coordinator.owners[index].metadata == metadata {
+			return coordinator.transition(owner, ChangeNone), nil
+		}
+		coordinator.owners[index].metadata = metadata
+		return coordinator.transition(owner, ChangeUpdated), nil
+	}
+	coordinator.index[owner] = len(coordinator.owners)
+	coordinator.owners = append(coordinator.owners, ownerRecord{
+		owner:    owner,
+		metadata: metadata,
+	})
+	return coordinator.transition(owner, ChangeAdded), nil
+}
+
+// Release removes an active owner. Duplicate releases are no-ops.
+func (coordinator *Coordinator) Release(owner *Owner) (Transition, error) {
+	if err := coordinator.validateOwner(owner); err != nil {
+		return Transition{}, err
+	}
+	index, ok := coordinator.index[owner]
+	if !ok {
+		return coordinator.transition(owner, ChangeNone), nil
+	}
+	delete(coordinator.index, owner)
+	copy(coordinator.owners[index:], coordinator.owners[index+1:])
+	coordinator.owners = coordinator.owners[:len(coordinator.owners)-1]
+	for next := index; next < len(coordinator.owners); next++ {
+		coordinator.index[coordinator.owners[next].owner] = next
+	}
+	return coordinator.transition(owner, ChangeRemoved), nil
+}
+
+// OwnerIDs returns active owners in activation-priority order.
+func (coordinator *Coordinator) OwnerIDs() []uint64 {
+	if coordinator == nil {
+		return nil
+	}
+	ids := make([]uint64, len(coordinator.owners))
+	for index, owner := range coordinator.owners {
+		ids[index] = owner.owner.id
+	}
+	return ids
+}
+
+func (coordinator *Coordinator) validateOwner(owner *Owner) error {
+	if coordinator == nil {
+		return errors.New("document metadata: coordinator is nil")
+	}
+	if owner == nil {
+		return errors.New("document metadata: owner is nil")
+	}
+	if owner.coordinator != coordinator {
+		return errors.New("document metadata: owner belongs to another coordinator")
+	}
+	return nil
+}
+
+func (coordinator *Coordinator) transition(owner *Owner, change Change) Transition {
+	return Transition{
+		Snapshot: coordinator.Snapshot(),
+		Change:   change,
+		OwnerID:  owner.id,
+	}
+}
+
+// StringOwners adapts the current application-local string-key pattern to the
+// same opaque-token coordinator used by the three candidate prototypes.
+type StringOwners struct {
+	coordinator *Coordinator
+	owners      map[string]*Owner
+}
+
+// NewStringOwners creates the explicit control adapter.
+func NewStringOwners(coordinator *Coordinator) *StringOwners {
+	return &StringOwners{
+		coordinator: coordinator,
+		owners:      make(map[string]*Owner),
+	}
+}
+
+// Publish activates or updates the owner associated with key.
+func (owners *StringOwners) Publish(key string, metadata Metadata) (Transition, error) {
+	if strings.TrimSpace(key) == "" {
+		return Transition{}, errors.New("document metadata: owner key must not be empty")
+	}
+	if owners == nil || owners.coordinator == nil {
+		return Transition{}, errors.New("document metadata: string-owner bindings are missing")
+	}
+	owner := owners.owners[key]
+	if owner == nil {
+		owner = owners.coordinator.NewOwner()
+		owners.owners[key] = owner
+	}
+	return owners.coordinator.Publish(owner, metadata)
+}
+
+// Release removes the owner associated with key.
+func (owners *StringOwners) Release(key string) (Transition, error) {
+	if strings.TrimSpace(key) == "" {
+		return Transition{}, errors.New("document metadata: owner key must not be empty")
+	}
+	if owners == nil || owners.coordinator == nil {
+		return Transition{}, errors.New("document metadata: string-owner bindings are missing")
+	}
+	owner := owners.owners[key]
+	if owner == nil {
+		return Transition{Snapshot: owners.coordinator.Snapshot()}, nil
+	}
+	transition, err := owners.coordinator.Release(owner)
+	if err == nil {
+		delete(owners.owners, key)
+	}
+	return transition, err
+}

--- a/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
+++ b/scripts/fixtures/document-state-api-design/internal/documentmeta/model.go
@@ -268,3 +268,11 @@ func (owners *StringOwners) Release(key string) (Transition, error) {
 	}
 	return transition, err
 }
+
+// Stats returns fixture ownership evidence for the explicit control adapter.
+func (owners *StringOwners) Stats() Statistics {
+	if owners == nil {
+		return Statistics{}
+	}
+	return owners.coordinator.Stats()
+}

--- a/scripts/fixtures/document-state-api-design/internal/documentmeta/model_test.go
+++ b/scripts/fixtures/document-state-api-design/internal/documentmeta/model_test.go
@@ -78,13 +78,13 @@ func (owner *controlOwner) release() (Transition, error) {
 	return owner.owners.Release(owner.key)
 }
 
-func TestCandidateOwnershipConformance(t *testing.T) {
-	for _, candidate := range []string{"control", "hook", "component", "handle"} {
-		t.Run(candidate, func(t *testing.T) {
+func TestPureCoordinatorConformance(t *testing.T) {
+	for _, model := range []string{"control", "opaque-token"} {
+		t.Run(model, func(t *testing.T) {
 			baseline := Metadata{Title: "authored", Description: "baseline"}
 			coordinator := New(baseline)
 			var driver conformanceDriver
-			if candidate == "control" {
+			if model == "control" {
 				driver = &controlDriver{
 					coordinator: coordinator,
 					owners:      NewStringOwners(coordinator),
@@ -95,6 +95,142 @@ func TestCandidateOwnershipConformance(t *testing.T) {
 			exerciseConformance(t, driver, baseline)
 		})
 	}
+}
+
+func TestCoordinatorInactiveOwnersDoNotReserveIDs(t *testing.T) {
+	coordinator := New(Metadata{})
+	first := coordinator.NewOwner()
+	second := coordinator.NewOwner()
+
+	if first.ID() != 0 || second.ID() != 0 {
+		t.Fatalf("inactive owner IDs = %d, %d; want 0, 0", first.ID(), second.ID())
+	}
+	transition := mustCoordinatorPublish(t, coordinator, second, Metadata{Title: "second"})
+	if transition.OwnerID != 1 || second.ID() != 1 {
+		t.Fatalf("first committed owner ID = %d, want 1", transition.OwnerID)
+	}
+	if first.ID() != 0 {
+		t.Fatalf("unpublished owner ID = %d, want 0", first.ID())
+	}
+	assertStatistics(t, coordinator.Stats(), Statistics{
+		TokenCreations:         2,
+		CommittedIDAssignments: 1,
+		ActiveAdditions:        1,
+		ActiveOwnerCount:       1,
+		LastCommittedOwnerID:   1,
+	})
+}
+
+func TestCoordinatorInactiveOwnerLeavesNoCommittedIDGap(t *testing.T) {
+	coordinator := New(Metadata{})
+	discarded := coordinator.NewOwner()
+	committed := coordinator.NewOwner()
+
+	transition := mustCoordinatorPublish(t, coordinator, committed, Metadata{Title: "committed"})
+	if discarded.ID() != 0 {
+		t.Fatalf("discarded owner ID = %d, want 0", discarded.ID())
+	}
+	if transition.OwnerID != 1 {
+		t.Fatalf("first committed owner ID = %d, want 1", transition.OwnerID)
+	}
+}
+
+func TestCoordinatorUpdatePreservesIdentityPriorityAndStatistics(t *testing.T) {
+	coordinator := New(Metadata{})
+	first := coordinator.NewOwner()
+	second := coordinator.NewOwner()
+	mustCoordinatorPublish(t, coordinator, first, Metadata{Title: "first"})
+	mustCoordinatorPublish(t, coordinator, second, Metadata{Title: "second"})
+	beforeID := first.ID()
+	beforeOrder := coordinator.OwnerIDs()
+
+	transition := mustCoordinatorPublish(t, coordinator, first, Metadata{
+		Title:       "first updated",
+		Description: "pair updated",
+	})
+	if transition.Change != ChangeUpdated {
+		t.Fatalf("update change = %s, want updated", transition.Change.String())
+	}
+	if first.ID() != beforeID {
+		t.Fatalf("owner ID changed from %d to %d", beforeID, first.ID())
+	}
+	if got := coordinator.OwnerIDs(); !reflect.DeepEqual(got, beforeOrder) {
+		t.Fatalf("owner order = %v, want %v", got, beforeOrder)
+	}
+	if transition.Snapshot.ActiveOwnerID != second.ID() {
+		t.Fatalf(
+			"selected owner ID = %d, want %d",
+			transition.Snapshot.ActiveOwnerID,
+			second.ID(),
+		)
+	}
+	assertStatistics(t, coordinator.Stats(), Statistics{
+		TokenCreations:         2,
+		CommittedIDAssignments: 2,
+		ActiveAdditions:        2,
+		Updates:                1,
+		ActiveOwnerCount:       2,
+		LastCommittedOwnerID:   2,
+	})
+}
+
+func TestCoordinatorDuplicatePublicationDoesNotChangeStatistics(t *testing.T) {
+	coordinator := New(Metadata{})
+	owner := coordinator.NewOwner()
+	metadata := Metadata{Title: "same", Description: "pair"}
+	mustCoordinatorPublish(t, coordinator, owner, metadata)
+	before := coordinator.Stats()
+
+	transition := mustCoordinatorPublish(t, coordinator, owner, metadata)
+	if transition.Change != ChangeNone {
+		t.Fatalf("duplicate change = %s, want none", transition.Change.String())
+	}
+	assertStatistics(t, coordinator.Stats(), before)
+}
+
+func TestCoordinatorReleaseUnpublishedOwnerIsNoOp(t *testing.T) {
+	coordinator := New(Metadata{Title: "authored"})
+	owner := coordinator.NewOwner()
+	before := coordinator.Stats()
+
+	transition, err := coordinator.Release(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transition.Change != ChangeNone {
+		t.Fatalf("unpublished release change = %s, want none", transition.Change.String())
+	}
+	if owner.ID() != 0 {
+		t.Fatalf("unpublished owner ID = %d, want 0", owner.ID())
+	}
+	assertStatistics(t, coordinator.Stats(), before)
+}
+
+func TestCoordinatorRemountUsesNextCommittedID(t *testing.T) {
+	coordinator := New(Metadata{})
+	first := coordinator.NewOwner()
+	mustCoordinatorPublish(t, coordinator, first, Metadata{Title: "first"})
+	if _, err := coordinator.Release(first); err != nil {
+		t.Fatal(err)
+	}
+	second := coordinator.NewOwner()
+	transition := mustCoordinatorPublish(t, coordinator, second, Metadata{Title: "second"})
+
+	if transition.OwnerID != first.ID()+1 {
+		t.Fatalf(
+			"remount owner ID = %d, want %d",
+			transition.OwnerID,
+			first.ID()+1,
+		)
+	}
+	assertStatistics(t, coordinator.Stats(), Statistics{
+		TokenCreations:         2,
+		CommittedIDAssignments: 2,
+		ActiveAdditions:        2,
+		Releases:               1,
+		ActiveOwnerCount:       1,
+		LastCommittedOwnerID:   2,
+	})
 }
 
 func exerciseConformance(t *testing.T, driver conformanceDriver, baseline Metadata) {
@@ -169,6 +305,13 @@ func TestCoordinatorRejectsMissingOrForeignOwners(t *testing.T) {
 	if _, err := coordinator.Publish(foreign, Metadata{}); err == nil {
 		t.Fatal("Publish(foreign) succeeded")
 	}
+	mustCoordinatorPublish(t, foreign.coordinator, foreign, Metadata{Title: "foreign"})
+	if _, err := coordinator.Publish(foreign, Metadata{}); err == nil {
+		t.Fatal("Publish(published foreign) succeeded")
+	}
+	if _, err := coordinator.Release(foreign); err == nil {
+		t.Fatal("Release(published foreign) succeeded")
+	}
 	if _, err := (*Coordinator)(nil).Publish(foreign, Metadata{}); err == nil {
 		t.Fatal("nil coordinator Publish succeeded")
 	}
@@ -193,22 +336,42 @@ func TestCoordinatorComparesMetadataAsOnePair(t *testing.T) {
 	if changed.Snapshot.Metadata.Description != "description B" {
 		t.Fatalf("selected pair = %#v", changed.Snapshot.Metadata)
 	}
+	titleChanged := mustCoordinatorPublish(t, coordinator, owner, Metadata{
+		Title:       "new title",
+		Description: "description B",
+	})
+	if titleChanged.Change != ChangeUpdated {
+		t.Fatalf("title-only change = %s, want updated", titleChanged.Change.String())
+	}
+	assertMetadataPair(t, titleChanged.Snapshot.Metadata, Metadata{
+		Title:       "new title",
+		Description: "description B",
+	})
 }
 
-func TestCandidateOwnerIdentityDerivations(t *testing.T) {
+func TestCoordinatorOwnerIdentityDerivations(t *testing.T) {
 	coordinator := New(Metadata{})
 
 	hookSlotOne := coordinator.NewOwner()
 	hookSlotTwo := coordinator.NewOwner()
+	if hookSlotOne.ID() != 0 || hookSlotTwo.ID() != 0 {
+		t.Fatal("inactive hook slots reserved owner identity")
+	}
+	mustCoordinatorPublish(t, coordinator, hookSlotOne, Metadata{Title: "hook one"})
+	mustCoordinatorPublish(t, coordinator, hookSlotTwo, Metadata{Title: "hook two"})
+	hookSlotOneID := hookSlotOne.ID()
 	if hookSlotOne.ID() == hookSlotTwo.ID() {
 		t.Fatalf("two hook slots share owner %d", hookSlotOne.ID())
 	}
-	if hookSlotOne.ID() != hookSlotOne.ID() {
+	mustCoordinatorPublish(t, coordinator, hookSlotOne, Metadata{Title: "hook one updated"})
+	if hookSlotOne.ID() != hookSlotOneID {
 		t.Fatal("hook owner identity is not stable")
 	}
 
 	componentInstanceOne := coordinator.NewOwner()
 	componentInstanceTwo := coordinator.NewOwner()
+	mustCoordinatorPublish(t, coordinator, componentInstanceOne, Metadata{Title: "component one"})
+	mustCoordinatorPublish(t, coordinator, componentInstanceTwo, Metadata{Title: "component two"})
 	if componentInstanceOne.ID() == componentInstanceTwo.ID() {
 		t.Fatalf("two component instances share owner %d", componentInstanceOne.ID())
 	}
@@ -278,5 +441,12 @@ func assertMetadataPair(t *testing.T, got, want Metadata) {
 	t.Helper()
 	if got != want {
 		t.Fatalf("metadata = %#v, want %#v", got, want)
+	}
+}
+
+func assertStatistics(t *testing.T, got, want Statistics) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("statistics = %#v, want %#v", got, want)
 	}
 }

--- a/scripts/fixtures/document-state-api-design/internal/documentmeta/model_test.go
+++ b/scripts/fixtures/document-state-api-design/internal/documentmeta/model_test.go
@@ -1,0 +1,282 @@
+package documentmeta
+
+import (
+	"reflect"
+	"testing"
+)
+
+type conformanceDriver interface {
+	mount(name string) conformanceOwner
+	snapshot() Snapshot
+	ownerIDs() []uint64
+}
+
+type conformanceOwner interface {
+	publish(Metadata) (Transition, error)
+	release() (Transition, error)
+}
+
+type tokenDriver struct {
+	coordinator *Coordinator
+}
+
+type tokenOwner struct {
+	coordinator *Coordinator
+	owner       *Owner
+}
+
+func (driver *tokenDriver) mount(string) conformanceOwner {
+	return &tokenOwner{
+		coordinator: driver.coordinator,
+		owner:       driver.coordinator.NewOwner(),
+	}
+}
+
+func (driver *tokenDriver) snapshot() Snapshot {
+	return driver.coordinator.Snapshot()
+}
+
+func (driver *tokenDriver) ownerIDs() []uint64 {
+	return driver.coordinator.OwnerIDs()
+}
+
+func (owner *tokenOwner) publish(metadata Metadata) (Transition, error) {
+	return owner.coordinator.Publish(owner.owner, metadata)
+}
+
+func (owner *tokenOwner) release() (Transition, error) {
+	return owner.coordinator.Release(owner.owner)
+}
+
+type controlDriver struct {
+	coordinator *Coordinator
+	owners      *StringOwners
+}
+
+type controlOwner struct {
+	owners *StringOwners
+	key    string
+}
+
+func (driver *controlDriver) mount(name string) conformanceOwner {
+	return &controlOwner{owners: driver.owners, key: name}
+}
+
+func (driver *controlDriver) snapshot() Snapshot {
+	return driver.coordinator.Snapshot()
+}
+
+func (driver *controlDriver) ownerIDs() []uint64 {
+	return driver.coordinator.OwnerIDs()
+}
+
+func (owner *controlOwner) publish(metadata Metadata) (Transition, error) {
+	return owner.owners.Publish(owner.key, metadata)
+}
+
+func (owner *controlOwner) release() (Transition, error) {
+	return owner.owners.Release(owner.key)
+}
+
+func TestCandidateOwnershipConformance(t *testing.T) {
+	for _, candidate := range []string{"control", "hook", "component", "handle"} {
+		t.Run(candidate, func(t *testing.T) {
+			baseline := Metadata{Title: "authored", Description: "baseline"}
+			coordinator := New(baseline)
+			var driver conformanceDriver
+			if candidate == "control" {
+				driver = &controlDriver{
+					coordinator: coordinator,
+					owners:      NewStringOwners(coordinator),
+				}
+			} else {
+				driver = &tokenDriver{coordinator: coordinator}
+			}
+			exerciseConformance(t, driver, baseline)
+		})
+	}
+}
+
+func exerciseConformance(t *testing.T, driver conformanceDriver, baseline Metadata) {
+	t.Helper()
+	routeA := Metadata{Title: "route A", Description: "route A pair"}
+	routeA2 := Metadata{Title: "route A2", Description: "route A2 pair"}
+	editorB := Metadata{Title: "editor B", Description: "editor B pair"}
+	dialogC := Metadata{Title: "dialog C", Description: "dialog C pair"}
+
+	route := driver.mount("route")
+	first := mustPublish(t, route, routeA)
+	assertTransition(t, first, ChangeAdded, routeA, 1)
+
+	editor := driver.mount("editor")
+	second := mustPublish(t, editor, editorB)
+	assertTransition(t, second, ChangeAdded, editorB, 2)
+
+	order := append([]uint64(nil), driver.ownerIDs()...)
+	updated := mustPublish(t, route, routeA2)
+	assertTransition(t, updated, ChangeUpdated, editorB, 2)
+	if got := driver.ownerIDs(); !reflect.DeepEqual(got, order) {
+		t.Fatalf("owner update changed priority: got %v, want %v", got, order)
+	}
+
+	removed := mustRelease(t, editor)
+	assertTransition(t, removed, ChangeRemoved, routeA2, 1)
+
+	editor = driver.mount("editor-remount")
+	mustPublish(t, editor, editorB)
+	dialog := driver.mount("dialog")
+	mustPublish(t, dialog, dialogC)
+	nonTop := mustRelease(t, editor)
+	assertTransition(t, nonTop, ChangeRemoved, dialogC, 2)
+
+	identical := mustPublish(t, dialog, dialogC)
+	if identical.Change != ChangeNone {
+		t.Fatalf("identical pair change = %s, want none", identical.Change.String())
+	}
+	assertMetadataPair(t, identical.Snapshot.Metadata, dialogC)
+
+	speculative := driver.mount("speculative")
+	if got := driver.snapshot(); got.Metadata != dialogC || got.OwnerCount != 2 {
+		t.Fatalf("inactive speculative owner changed snapshot: %#v", got)
+	}
+	_ = speculative
+
+	mustRelease(t, dialog)
+	final := mustRelease(t, route)
+	assertTransition(t, final, ChangeRemoved, baseline, 0)
+
+	duplicate := mustRelease(t, route)
+	if duplicate.Change != ChangeNone {
+		t.Fatalf("duplicate release change = %s, want none", duplicate.Change.String())
+	}
+
+	remounted := driver.mount("route-new-lifetime")
+	next := mustPublish(t, remounted, routeA)
+	if next.Snapshot.ActiveOwnerID == first.OwnerID {
+		t.Fatalf("remount reused owner identity %d", first.OwnerID)
+	}
+}
+
+func TestCoordinatorRejectsMissingOrForeignOwners(t *testing.T) {
+	coordinator := New(Metadata{})
+	if _, err := coordinator.Publish(nil, Metadata{}); err == nil {
+		t.Fatal("Publish(nil) succeeded")
+	}
+	if _, err := coordinator.Release(nil); err == nil {
+		t.Fatal("Release(nil) succeeded")
+	}
+	foreign := New(Metadata{}).NewOwner()
+	if _, err := coordinator.Publish(foreign, Metadata{}); err == nil {
+		t.Fatal("Publish(foreign) succeeded")
+	}
+	if _, err := (*Coordinator)(nil).Publish(foreign, Metadata{}); err == nil {
+		t.Fatal("nil coordinator Publish succeeded")
+	}
+	if _, err := (*StringOwners)(nil).Publish("route", Metadata{}); err == nil {
+		t.Fatal("nil string-owner bindings Publish succeeded")
+	}
+}
+
+func TestCoordinatorComparesMetadataAsOnePair(t *testing.T) {
+	coordinator := New(Metadata{})
+	owner := coordinator.NewOwner()
+	initial := Metadata{Title: "same title", Description: "description A"}
+	mustCoordinatorPublish(t, coordinator, owner, initial)
+
+	changed := mustCoordinatorPublish(t, coordinator, owner, Metadata{
+		Title:       "same title",
+		Description: "description B",
+	})
+	if changed.Change != ChangeUpdated {
+		t.Fatalf("description-only change = %s, want updated", changed.Change.String())
+	}
+	if changed.Snapshot.Metadata.Description != "description B" {
+		t.Fatalf("selected pair = %#v", changed.Snapshot.Metadata)
+	}
+}
+
+func TestCandidateOwnerIdentityDerivations(t *testing.T) {
+	coordinator := New(Metadata{})
+
+	hookSlotOne := coordinator.NewOwner()
+	hookSlotTwo := coordinator.NewOwner()
+	if hookSlotOne.ID() == hookSlotTwo.ID() {
+		t.Fatalf("two hook slots share owner %d", hookSlotOne.ID())
+	}
+	if hookSlotOne.ID() != hookSlotOne.ID() {
+		t.Fatal("hook owner identity is not stable")
+	}
+
+	componentInstanceOne := coordinator.NewOwner()
+	componentInstanceTwo := coordinator.NewOwner()
+	if componentInstanceOne.ID() == componentInstanceTwo.ID() {
+		t.Fatalf("two component instances share owner %d", componentInstanceOne.ID())
+	}
+
+	handleSlot := coordinator.NewOwner()
+	forwarded := handleSlot
+	if handleSlot.ID() != forwarded.ID() {
+		t.Fatal("helper forwarding changed handle owner identity")
+	}
+	first := mustCoordinatorPublish(t, coordinator, handleSlot, Metadata{Title: "handle"})
+	second := mustCoordinatorPublish(t, coordinator, forwarded, Metadata{Title: "handle"})
+	if first.Change != ChangeAdded || second.Change != ChangeNone {
+		t.Fatalf("forwarded handle changes = %s, %s", first.Change.String(), second.Change.String())
+	}
+}
+
+func mustPublish(t *testing.T, owner conformanceOwner, metadata Metadata) Transition {
+	t.Helper()
+	transition, err := owner.publish(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return transition
+}
+
+func mustRelease(t *testing.T, owner conformanceOwner) Transition {
+	t.Helper()
+	transition, err := owner.release()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return transition
+}
+
+func mustCoordinatorPublish(
+	t *testing.T,
+	coordinator *Coordinator,
+	owner *Owner,
+	metadata Metadata,
+) Transition {
+	t.Helper()
+	transition, err := coordinator.Publish(owner, metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return transition
+}
+
+func assertTransition(
+	t *testing.T,
+	transition Transition,
+	change Change,
+	metadata Metadata,
+	ownerCount int,
+) {
+	t.Helper()
+	if transition.Change != change {
+		t.Fatalf("change = %s, want %s", transition.Change.String(), change.String())
+	}
+	assertMetadataPair(t, transition.Snapshot.Metadata, metadata)
+	if transition.Snapshot.OwnerCount != ownerCount {
+		t.Fatalf("owner count = %d, want %d", transition.Snapshot.OwnerCount, ownerCount)
+	}
+}
+
+func assertMetadataPair(t *testing.T, got, want Metadata) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("metadata = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds executable design evidence for component-owned document metadata and
compares three private API shapes:

- an implicit hook;
- a non-DOM component;
- an explicit owner handle.

All candidates are evaluated against the same ordered ownership contract for
`<title>` and `meta[name="description"]`.

This PR does not add a public API or change runtime behavior.

## What changed

- Adds a private `document-state-api-design` fixture with control, hook,
  component, and handle modes.
- Adds a shared coordinator model where:
  - inactive owners have no committed identity;
  - IDs are assigned only on the first lifecycle-committed publication;
  - owner updates preserve identity and priority;
  - failed renders create no owner token or ID;
  - final release restores the authored baseline.
- Adds focused model tests for ownership ordering, identity assignment,
  duplicate publication, release, remount, and foreign-owner rejection.
- Adds deterministic browser evidence covering:
  - nested ownership;
  - parent updates beneath an active override;
  - selected and non-selected release;
  - identical rerenders;
  - failed-render isolation;
  - baseline restoration;
  - remount lifetimes;
  - candidate-specific hook, component, and handle behavior.
- Adds candidate-specific TinyGo size measurements.
- Projects every candidate onto the existing server-backed reference and records
  reproducible patch hashes, commands, and lifecycle results.
- Adds a design record documenting the evidence, limitations, and final
  decision.

## Findings

The focused fixture contract is expressible by all three candidates, and the
corrected implementations avoid render-time owner allocation.

However, every server-backed projection introduces an additional committed
initialization phase:

```text
render without an owner
→ committed owner initialization
→ rerender
→ committed metadata publication
```

During ordinary route-owner replacement, the previous owner can release before
the replacement publishes. This temporarily restores the authored baseline and
adds observable document mutations.

The projections consistently produced:

| Counter | Reference | Hook | Component | Handle |
|---|---:|---:|---:|---:|
| baseline restorations | 1 | 9 | 9 | 9 |
| title mutation batches | 43 | 51 | 51 | 51 |
| description mutation batches | 43 | 51 | 51 | 51 |
| document snapshots | 139 | 147 | 147 | 147 |

The result is therefore **Result D: no implementation candidate selected**.

The component form remains the clearest GOX-facing shape, but its ergonomic
advantage does not justify selecting an API with the same lifecycle handoff gap
as the hook and handle forms.

## Validation

- Pure coordinator tests passed with `100` repetitions and `20` race-enabled
  repetitions.
- Two focused Chrome runs produced identical normalized evidence, mutation logs,
  and committed owner-ID sequences.
- Existing document-state and server-backed tests and browser evidence remained
  green.
- All three temporary server-backed projections compiled, passed pure tests,
  built with TinyGo, and packaged with standard Go.
- Full tests, race checks, debug-tag tests, and `go vet` passed on Go `1.22.12`
  and Go `1.25.12`.
- Focused Go `1.26.5` validation passed; only the known source-selection parity
  failures remain.
- Repository checks, aggregate browser smoke, size budgets, documentation,
  artifact, module-path, and Windows compilation checks passed.
- All existing generated GOX and eleven budgeted WASM outputs remain
  byte-identical, including gzip, Brotli, and Zstandard artifacts.

## Scope

This PR adds design evidence only.

It does not:

- add or authorize a public document metadata API;
- modify `pkg/goframe`, `pkg/gox`, or `cmd/goxc`;
- change existing examples or evidence fixtures;
- change dependencies, workflows, or WASM budgets;
- introduce router-specific metadata ownership;
- define arbitrary head management, SSR, hydration, SEO, or multi-document
  semantics.

A future design stage must first establish a lifecycle-safe handoff between
owner lifetimes without render-time identity allocation or an observable
authored-baseline interval.