### PR TITLE
fix(goxc): align browser source selection with selected toolchain

### DIFF
--- a/cmd/goxc/generation_constraints.go
+++ b/cmd/goxc/generation_constraints.go
@@ -6,8 +6,10 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
+	"go/version"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -19,6 +21,15 @@ type generationSourceSelection struct {
 	excludeGoTests bool
 }
 
+type browserToolchainObservation struct {
+	goVersion string
+}
+
+type browserToolchainObserver func(
+	compiler string,
+	environment []string,
+) (browserToolchainObservation, error)
+
 func defaultGenerationSourceSelection() generationSourceSelection {
 	context := cloneBuildContext(build.Default)
 	return generationSourceSelection{
@@ -28,7 +39,40 @@ func defaultGenerationSourceSelection() generationSourceSelection {
 }
 
 func browserGenerationSourceSelection(compiler string) (generationSourceSelection, error) {
-	context, err := browserBuildContext(compiler, build.Default, os.Environ())
+	return browserGenerationSourceSelectionWith(
+		compiler,
+		build.Default,
+		os.Environ(),
+		observeSelectedBrowserToolchain,
+	)
+}
+
+func browserGenerationSourceSelectionWith(
+	compiler string,
+	base build.Context,
+	environment []string,
+	observe browserToolchainObserver,
+) (generationSourceSelection, error) {
+	if err := validateCompiler(compiler); err != nil {
+		return generationSourceSelection{}, err
+	}
+	if _, err := browserWASMFeatures(environment); err != nil {
+		return generationSourceSelection{}, err
+	}
+	observation, err := observe(compiler, environment)
+	if err != nil {
+		return generationSourceSelection{}, fmt.Errorf(
+			"observe selected Go toolchain for %s browser source selection: %w",
+			compiler,
+			err,
+		)
+	}
+	context, err := browserBuildContext(
+		compiler,
+		base,
+		environment,
+		observation.goVersion,
+	)
 	if err != nil {
 		return generationSourceSelection{}, err
 	}
@@ -50,6 +94,7 @@ func browserBuildContext(
 	compiler string,
 	base build.Context,
 	environment []string,
+	selectedGoVersion string,
 ) (build.Context, error) {
 	context := base
 	context.GOOS = "js"
@@ -57,7 +102,11 @@ func browserBuildContext(
 	context.Compiler = "gc"
 	context.BuildTags = nil
 	context.ReleaseTags = append([]string(nil), context.ReleaseTags...)
-	toolTags, err := browserTargetToolTags(base.ToolTags, environment)
+	toolTags, err := browserTargetToolTags(
+		base.ToolTags,
+		environment,
+		selectedGoVersion,
+	)
 	if err != nil {
 		return build.Context{}, err
 	}
@@ -86,7 +135,15 @@ func browserBuildContext(
 	return context, nil
 }
 
-func browserTargetToolTags(base []string, environment []string) ([]string, error) {
+func browserTargetToolTags(
+	base []string,
+	environment []string,
+	selectedGoVersion string,
+) ([]string, error) {
+	languageVersion, err := selectedGoLanguageVersion(selectedGoVersion)
+	if err != nil {
+		return nil, err
+	}
 	tags := make([]string, 0, len(base)+2)
 	for _, tag := range base {
 		if !architectureFeatureToolTag(tag) {
@@ -94,17 +151,99 @@ func browserTargetToolTags(base []string, environment []string) ([]string, error
 		}
 	}
 
+	features, err := browserWASMFeatures(environment)
+	if err != nil {
+		return nil, err
+	}
+	if version.Compare(languageVersion, "go1.26") >= 0 {
+		features = append(features, "satconv", "signext")
+	}
+	for _, feature := range features {
+		tags = append(tags, "wasm."+feature)
+	}
+	return sortedUniqueStrings(tags), nil
+}
+
+func browserWASMFeatures(environment []string) ([]string, error) {
 	goWASM, _ := environmentValue(environment, "GOWASM")
+	var features []string
 	for _, feature := range strings.Split(goWASM, ",") {
 		switch feature {
 		case "":
 		case "satconv", "signext":
-			tags = append(tags, "wasm."+feature)
+			features = append(features, feature)
 		default:
 			return nil, fmt.Errorf("invalid GOWASM feature %q for browser source selection", feature)
 		}
 	}
-	return sortedUniqueStrings(tags), nil
+	return sortedUniqueStrings(features), nil
+}
+
+func selectedGoLanguageVersion(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if !version.IsValid(raw) {
+		return "", fmt.Errorf(
+			"selected Go toolchain reported unsupported version %q",
+			raw,
+		)
+	}
+	language := version.Lang(raw)
+	if language == "" {
+		return "", fmt.Errorf(
+			"selected Go toolchain version %q has no language version",
+			raw,
+		)
+	}
+	return language, nil
+}
+
+func observeSelectedBrowserToolchain(
+	compiler string,
+	environment []string,
+) (browserToolchainObservation, error) {
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		return browserToolchainObservation{}, fmt.Errorf(
+			"locate Go executable for %s browser source selection: %w",
+			compiler,
+			err,
+		)
+	}
+	command := exec.Command(goPath, "env", "GOVERSION")
+	commandEnvironment, directory, err := workspaceCompilerEnvironmentFrom(
+		environment,
+		compilerEnvironmentOptions{
+			Compiler:         "go",
+			Invocation:       compilerInvocationEmbedDiscovery,
+			WorkingDirectory: ".",
+			GoFlags:          workspaceCompilerBaseGoFlags,
+		},
+	)
+	if err != nil {
+		return browserToolchainObservation{}, err
+	}
+	command.Dir = directory
+	command.Env = commandEnvironment
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return browserToolchainObservation{}, fmt.Errorf(
+			"run %s env GOVERSION for %s browser source selection: %s",
+			goPath,
+			compiler,
+			detail,
+		)
+	}
+	goVersion := strings.TrimSpace(string(output))
+	if _, err := selectedGoLanguageVersion(goVersion); err != nil {
+		return browserToolchainObservation{}, err
+	}
+	return browserToolchainObservation{goVersion: goVersion}, nil
 }
 
 func architectureFeatureToolTag(tag string) bool {

--- a/cmd/goxc/generation_constraints.go
+++ b/cmd/goxc/generation_constraints.go
@@ -28,6 +28,7 @@ type browserToolchainObservation struct {
 type browserToolchainObserver func(
 	compiler string,
 	environment []string,
+	workingDirectory string,
 ) (browserToolchainObservation, error)
 
 func defaultGenerationSourceSelection() generationSourceSelection {
@@ -38,11 +39,15 @@ func defaultGenerationSourceSelection() generationSourceSelection {
 	}
 }
 
-func browserGenerationSourceSelection(compiler string) (generationSourceSelection, error) {
+func browserGenerationSourceSelection(
+	compiler,
+	workingDirectory string,
+) (generationSourceSelection, error) {
 	return browserGenerationSourceSelectionWith(
 		compiler,
 		build.Default,
 		os.Environ(),
+		workingDirectory,
 		observeSelectedBrowserToolchain,
 	)
 }
@@ -51,6 +56,7 @@ func browserGenerationSourceSelectionWith(
 	compiler string,
 	base build.Context,
 	environment []string,
+	workingDirectory string,
 	observe browserToolchainObserver,
 ) (generationSourceSelection, error) {
 	if err := validateCompiler(compiler); err != nil {
@@ -59,7 +65,7 @@ func browserGenerationSourceSelectionWith(
 	if _, err := browserWASMFeatures(environment); err != nil {
 		return generationSourceSelection{}, err
 	}
-	observation, err := observe(compiler, environment)
+	observation, err := observe(compiler, environment, workingDirectory)
 	if err != nil {
 		return generationSourceSelection{}, fmt.Errorf(
 			"observe selected Go toolchain for %s browser source selection: %w",
@@ -101,11 +107,19 @@ func browserBuildContext(
 	context.GOARCH = "wasm"
 	context.Compiler = "gc"
 	context.BuildTags = nil
-	context.ReleaseTags = append([]string(nil), context.ReleaseTags...)
-	toolTags, err := browserTargetToolTags(
+	languageVersion, err := selectedGoLanguageVersion(selectedGoVersion)
+	if err != nil {
+		return build.Context{}, err
+	}
+	releaseTags, err := selectedGoReleaseTags(languageVersion)
+	if err != nil {
+		return build.Context{}, err
+	}
+	context.ReleaseTags = releaseTags
+	toolTags, err := browserTargetToolTagsForLanguage(
 		base.ToolTags,
 		environment,
-		selectedGoVersion,
+		languageVersion,
 	)
 	if err != nil {
 		return build.Context{}, err
@@ -144,6 +158,18 @@ func browserTargetToolTags(
 	if err != nil {
 		return nil, err
 	}
+	return browserTargetToolTagsForLanguage(
+		base,
+		environment,
+		languageVersion,
+	)
+}
+
+func browserTargetToolTagsForLanguage(
+	base []string,
+	environment []string,
+	languageVersion string,
+) ([]string, error) {
 	tags := make([]string, 0, len(base)+2)
 	for _, tag := range base {
 		if !architectureFeatureToolTag(tag) {
@@ -197,9 +223,32 @@ func selectedGoLanguageVersion(raw string) (string, error) {
 	return language, nil
 }
 
+func selectedGoReleaseTags(languageVersion string) ([]string, error) {
+	minorText, ok := strings.CutPrefix(languageVersion, "go1.")
+	if !ok {
+		return nil, fmt.Errorf(
+			"selected Go language version %q is not a supported Go 1.x version",
+			languageVersion,
+		)
+	}
+	minor, err := strconv.Atoi(minorText)
+	if err != nil || minor < 1 {
+		return nil, fmt.Errorf(
+			"selected Go language version %q is not a supported Go 1.x version",
+			languageVersion,
+		)
+	}
+	tags := make([]string, 0, minor)
+	for release := 1; release <= minor; release++ {
+		tags = append(tags, "go1."+strconv.Itoa(release))
+	}
+	return tags, nil
+}
+
 func observeSelectedBrowserToolchain(
 	compiler string,
 	environment []string,
+	workingDirectory string,
 ) (browserToolchainObservation, error) {
 	goPath, err := exec.LookPath("go")
 	if err != nil {
@@ -215,7 +264,7 @@ func observeSelectedBrowserToolchain(
 		compilerEnvironmentOptions{
 			Compiler:         "go",
 			Invocation:       compilerInvocationEmbedDiscovery,
-			WorkingDirectory: ".",
+			WorkingDirectory: workingDirectory,
 			GoFlags:          workspaceCompilerBaseGoFlags,
 		},
 	)

--- a/cmd/goxc/generation_constraints_test.go
+++ b/cmd/goxc/generation_constraints_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"go/build"
 	"os"
 	"os/exec"
@@ -76,10 +77,12 @@ func TestAuthoredSourceConstraintsMatchBrowserTargets(t *testing.T) {
 		}},
 	} {
 		t.Run(compiler.name, func(t *testing.T) {
-			selection, err := browserGenerationSourceSelection(compiler.name)
-			if err != nil {
-				t.Fatal(err)
-			}
+			selection := browserGenerationSourceSelectionForVersion(
+				t,
+				compiler.name,
+				"go1.25.12",
+				[]string{"GOWASM="},
+			)
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
 					source := "package app\n"
@@ -161,11 +164,21 @@ func TestBrowserBuildContextNormalizesTargetToolTags(t *testing.T) {
 
 	for _, compiler := range []string{"go", "tinygo"} {
 		t.Run(compiler, func(t *testing.T) {
-			first, err := browserBuildContext(compiler, firstBase, firstEnvironment)
+			first, err := browserBuildContext(
+				compiler,
+				firstBase,
+				firstEnvironment,
+				"go1.25.12",
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
-			second, err := browserBuildContext(compiler, secondBase, secondEnvironment)
+			second, err := browserBuildContext(
+				compiler,
+				secondBase,
+				secondEnvironment,
+				"go1.25.12",
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -229,6 +242,7 @@ func TestBrowserBuildContextRejectsInvalidGOWASM(t *testing.T) {
 		"go",
 		build.Default,
 		[]string{"GOWASM=satconv,unknown"},
+		"go1.25.12",
 	)
 	if err == nil {
 		t.Fatal("browserBuildContext() accepted invalid GOWASM")
@@ -236,6 +250,378 @@ func TestBrowserBuildContextRejectsInvalidGOWASM(t *testing.T) {
 	if !strings.Contains(err.Error(), `invalid GOWASM feature "unknown"`) {
 		t.Fatalf("error %q does not identify invalid GOWASM feature", err)
 	}
+}
+
+func TestBrowserFeatureToolTagsUseSelectedGoVersion(t *testing.T) {
+	base := []string{
+		"amd64.v1",
+		"arm64.v8.0",
+		"custom.tool",
+		"wasm.signext",
+		"custom.tool",
+	}
+	baseBefore := append([]string(nil), base...)
+	tests := []struct {
+		name      string
+		goVersion string
+		goWASM    string
+		want      []string
+		wantError string
+	}{
+		{
+			name:      "Go 1.25 default",
+			goVersion: "go1.25.12",
+			want:      []string{"custom.tool"},
+		},
+		{
+			name:      "Go 1.25 satconv",
+			goVersion: "go1.25.12",
+			goWASM:    "satconv",
+			want:      []string{"custom.tool", "wasm.satconv"},
+		},
+		{
+			name:      "Go 1.25 signext",
+			goVersion: "go1.25.12",
+			goWASM:    "signext",
+			want:      []string{"custom.tool", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.25 both",
+			goVersion: "go1.25.12",
+			goWASM:    "satconv,signext",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.25 reverse order",
+			goVersion: "go1.25.12",
+			goWASM:    "signext,satconv",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.25 duplicates",
+			goVersion: "go1.25.12",
+			goWASM:    "satconv,signext,satconv",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.26 default",
+			goVersion: "go1.26.5",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.26 explicit old feature",
+			goVersion: "go1.26.5",
+			goWASM:    "satconv",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.26 duplicates",
+			goVersion: "go1.26",
+			goWASM:    "signext,signext",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.26 beta",
+			goVersion: "go1.26beta1",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "Go 1.26 release candidate",
+			goVersion: "go1.26rc1",
+			want:      []string{"custom.tool", "wasm.satconv", "wasm.signext"},
+		},
+		{
+			name:      "invalid GOWASM",
+			goVersion: "go1.25.12",
+			goWASM:    "satconv,unknown",
+			wantError: `invalid GOWASM feature "unknown"`,
+		},
+		{
+			name:      "malformed selected version",
+			goVersion: "1.26.5",
+			wantError: `unsupported version "1.26.5"`,
+		},
+		{
+			name:      "development selected version",
+			goVersion: "devel go1.27-deadbeef",
+			wantError: `unsupported version "devel go1.27-deadbeef"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			environment := []string{
+				"SENTINEL=preserved",
+				"GOWASM=" + test.goWASM,
+			}
+			environmentBefore := append([]string(nil), environment...)
+			got, err := browserTargetToolTags(
+				base,
+				environment,
+				test.goVersion,
+			)
+			if test.wantError != "" {
+				if err == nil {
+					t.Fatal("browserTargetToolTags() succeeded")
+				}
+				if !strings.Contains(err.Error(), test.wantError) {
+					t.Fatalf("error %q does not contain %q", err, test.wantError)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(got, test.want) {
+					t.Fatalf("ToolTags = %v, want %v", got, test.want)
+				}
+			}
+			if !reflect.DeepEqual(environment, environmentBefore) {
+				t.Fatalf("environment mutated: %v", environment)
+			}
+		})
+	}
+	if !reflect.DeepEqual(base, baseBefore) {
+		t.Fatalf("base ToolTags mutated: %v", base)
+	}
+}
+
+func TestBrowserSelectedToolchainOverridesBuildToolchainTags(t *testing.T) {
+	tests := []struct {
+		name              string
+		buildReleaseTags  []string
+		buildToolTags     []string
+		selectedGoVersion string
+		wantFeatures      bool
+	}{
+		{
+			name:              "selected Go 1.26 overrides Go 1.25 build context",
+			buildReleaseTags:  []string{"go1.1", "go1.25"},
+			selectedGoVersion: "go1.26.5",
+			wantFeatures:      true,
+		},
+		{
+			name:             "selected Go 1.25 overrides Go 1.26 build context",
+			buildReleaseTags: []string{"go1.1", "go1.26"},
+			buildToolTags: []string{
+				"wasm.satconv",
+				"wasm.signext",
+			},
+			selectedGoVersion: "go1.25.12",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := build.Context{
+				GOOS:        "linux",
+				GOARCH:      "amd64",
+				Compiler:    "gc",
+				ToolTags:    append([]string(nil), test.buildToolTags...),
+				ReleaseTags: append([]string(nil), test.buildReleaseTags...),
+			}
+			environment := []string{"GOWASM=", "SENTINEL=preserved"}
+			environmentBefore := append([]string(nil), environment...)
+			observations := 0
+			selection, err := browserGenerationSourceSelectionWith(
+				"go",
+				base,
+				environment,
+				func(
+					compiler string,
+					observedEnvironment []string,
+				) (browserToolchainObservation, error) {
+					observations++
+					if compiler != "go" {
+						t.Fatalf("compiler = %q, want go", compiler)
+					}
+					if !reflect.DeepEqual(
+						observedEnvironment,
+						environment,
+					) {
+						t.Fatalf(
+							"observer environment = %v, want %v",
+							observedEnvironment,
+							environment,
+						)
+					}
+					return browserToolchainObservation{
+						goVersion: test.selectedGoVersion,
+					}, nil
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, feature := range []string{
+				"wasm.satconv",
+				"wasm.signext",
+			} {
+				if got := containsString(
+					selection.buildContext.ToolTags,
+					feature,
+				); got != test.wantFeatures {
+					t.Fatalf(
+						"ToolTags %v contain %q = %t, want %t",
+						selection.buildContext.ToolTags,
+						feature,
+						got,
+						test.wantFeatures,
+					)
+				}
+			}
+			if observations != 1 {
+				t.Fatalf("toolchain observations = %d, want 1", observations)
+			}
+			if !reflect.DeepEqual(environment, environmentBefore) {
+				t.Fatalf("environment mutated: %v", environment)
+			}
+		})
+	}
+}
+
+func TestBrowserToolchainObservationOccursOncePerGeneration(t *testing.T) {
+	sourceRoot := t.TempDir()
+	writeTestFile(t, sourceRoot, "root.go", "package app\n")
+	writeTestFile(t, sourceRoot, "root.gox", `package app
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Root() gf.Node {
+	return <main>root</main>
+}
+`)
+	writeTestFile(t, sourceRoot, "child/child.go", "package child\n")
+	writeTestFile(t, sourceRoot, "child/child.gox", `package child
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func Child() gf.Node {
+	return <main>child</main>
+}
+`)
+	destination := t.TempDir()
+	observations := 0
+	err := generateIntoDirectoryForCompilerWithObserver(
+		sourceRoot,
+		destination,
+		true,
+		"go",
+		func(
+			string,
+			[]string,
+		) (browserToolchainObservation, error) {
+			observations++
+			return browserToolchainObservation{goVersion: "go1.26.5"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observations != 1 {
+		t.Fatalf("toolchain observations = %d, want 1", observations)
+	}
+	for _, output := range []string{
+		"root.gox.go",
+		"child/child.gox.go",
+	} {
+		if _, err := os.Stat(filepath.Join(destination, output)); err != nil {
+			t.Fatalf("generated output %s missing: %v", output, err)
+		}
+	}
+}
+
+func TestBrowserToolchainObservationIsNotGloballyCached(t *testing.T) {
+	versions := []string{"go1.25.12", "go1.26.5"}
+	observations := 0
+	observe := func(
+		string,
+		[]string,
+	) (browserToolchainObservation, error) {
+		version := versions[observations]
+		observations++
+		return browserToolchainObservation{goVersion: version}, nil
+	}
+	base := build.Context{
+		GOOS:        "linux",
+		GOARCH:      "amd64",
+		Compiler:    "gc",
+		ReleaseTags: []string{"go1.1", "go1.26"},
+	}
+	first, err := browserGenerationSourceSelectionWith(
+		"go",
+		base,
+		[]string{"GOWASM="},
+		observe,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := browserGenerationSourceSelectionWith(
+		"go",
+		base,
+		[]string{"GOWASM="},
+		observe,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if containsString(first.buildContext.ToolTags, "wasm.satconv") {
+		t.Fatalf("Go 1.25 ToolTags = %v", first.buildContext.ToolTags)
+	}
+	for _, feature := range []string{"wasm.satconv", "wasm.signext"} {
+		if !containsString(second.buildContext.ToolTags, feature) {
+			t.Fatalf("Go 1.26 ToolTags %v do not contain %q", second.buildContext.ToolTags, feature)
+		}
+	}
+	if observations != 2 {
+		t.Fatalf("toolchain observations = %d, want 2", observations)
+	}
+}
+
+func TestBrowserToolchainObservationFailurePublishesNothing(t *testing.T) {
+	sourceRoot := t.TempDir()
+	source := "package app\n\nconst Authored = true\n"
+	writeTestFile(t, sourceRoot, "view.gox", source)
+	destination := t.TempDir()
+	writeTestFile(t, destination, "sentinel.txt", "preserved")
+
+	err := generateIntoDirectoryForCompilerWithObserver(
+		sourceRoot,
+		destination,
+		true,
+		"tinygo",
+		func(
+			string,
+			[]string,
+		) (browserToolchainObservation, error) {
+			return browserToolchainObservation{}, errors.New("probe failed")
+		},
+	)
+	if err == nil {
+		t.Fatal("generation succeeded")
+	}
+	for _, want := range []string{
+		"observe selected Go toolchain",
+		"tinygo",
+		"probe failed",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destination, "view.gox.go")); !os.IsNotExist(err) {
+		t.Fatalf("generated output exists after observation failure: %v", err)
+	}
+	assertTestFileUnchanged(
+		t,
+		filepath.Join(sourceRoot, "view.gox"),
+		source,
+	)
+	assertTestFileUnchanged(
+		t,
+		filepath.Join(destination, "sentinel.txt"),
+		"preserved",
+	)
 }
 
 func TestPackageSourceSelectionUsesObservedCompilerTargets(t *testing.T) {
@@ -1274,7 +1660,10 @@ func TestBrowserCompilerSourceSelectionParity(t *testing.T) {
 		gowasm string
 	}{
 		{name: "default"},
+		{name: "satconv", gowasm: "satconv"},
+		{name: "signext", gowasm: "signext"},
 		{name: "wasm features", gowasm: "satconv,signext"},
+		{name: "wasm features reverse order", gowasm: "signext,satconv"},
 	} {
 		t.Run(target.name, func(t *testing.T) {
 			t.Setenv("GOWASM", target.gowasm)
@@ -1335,7 +1724,10 @@ func TestBrowserGOXSourceSelectionParity(t *testing.T) {
 		gowasm string
 	}{
 		{name: "default"},
+		{name: "satconv", gowasm: "satconv"},
+		{name: "signext", gowasm: "signext"},
 		{name: "wasm features", gowasm: "satconv,signext"},
+		{name: "wasm features reverse order", gowasm: "signext,satconv"},
 	} {
 		t.Run(target.name, func(t *testing.T) {
 			t.Setenv("GOWASM", target.gowasm)
@@ -1647,6 +2039,30 @@ func realCurrentGoSourceSelection(t *testing.T, root string) []string {
 	files := append(packageInfo.GoFiles, packageInfo.CgoFiles...)
 	sort.Strings(files)
 	return files
+}
+
+func browserGenerationSourceSelectionForVersion(
+	t *testing.T,
+	compiler,
+	goVersion string,
+	environment []string,
+) generationSourceSelection {
+	t.Helper()
+	selection, err := browserGenerationSourceSelectionWith(
+		compiler,
+		build.Default,
+		environment,
+		func(
+			string,
+			[]string,
+		) (browserToolchainObservation, error) {
+			return browserToolchainObservation{goVersion: goVersion}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return selection
 }
 
 func containsString(values []string, want string) bool {

--- a/cmd/goxc/generation_constraints_test.go
+++ b/cmd/goxc/generation_constraints_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"go/build"
+	"go/version"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1626,6 +1627,199 @@ var _goxComponent_view_Button = 1
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("compile browser package: %v\n%s", err, output)
 	}
+}
+
+func TestFeatureTaggedStandardGoBuild(t *testing.T) {
+	runFeatureTaggedCompilerBuild(t, "go")
+}
+
+func TestFeatureTaggedTinyGoBuild(t *testing.T) {
+	if _, err := exec.LookPath("tinygo"); err != nil {
+		t.Skip("tinygo is not installed")
+	}
+	runFeatureTaggedCompilerBuild(t, "tinygo")
+}
+
+func runFeatureTaggedCompilerBuild(t *testing.T, compiler string) {
+	t.Helper()
+	observation, err := observeSelectedBrowserToolchain(
+		compiler,
+		os.Environ(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	languageVersion, err := selectedGoLanguageVersion(observation.goVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version.Compare(languageVersion, "go1.26") < 0 &&
+		os.Getenv("GOWASM") == "" {
+		t.Setenv("GOWASM", "satconv,signext")
+	}
+
+	selection, err := browserGenerationSourceSelection(compiler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, feature := range []string{"wasm.satconv", "wasm.signext"} {
+		if !containsString(selection.buildContext.ToolTags, feature) {
+			t.Fatalf(
+				"%s selected Go %s ToolTags %v do not contain %q",
+				compiler,
+				observation.goVersion,
+				selection.buildContext.ToolTags,
+				feature,
+			)
+		}
+	}
+
+	appDir := newFeatureTaggedCompilerFixture(t, compiler)
+	selected, err := authoredPackageSources(appDir, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var selectedAuthored []string
+	for _, source := range selected {
+		selectedAuthored = append(
+			selectedAuthored,
+			filepath.Base(source.Filename),
+		)
+	}
+	sort.Strings(selectedAuthored)
+	for _, name := range []string{
+		"feature_satconv.go",
+		"feature_signext.go",
+	} {
+		if !containsString(selectedAuthored, name) {
+			t.Fatalf(
+				"%s private authored selection %v does not contain %s",
+				compiler,
+				selectedAuthored,
+				name,
+			)
+		}
+	}
+
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	output, err := buildApp(buildOptions{
+		appDir:    appDir,
+		compiler:  compiler,
+		workspace: workspace,
+	})
+	if err != nil {
+		t.Fatalf(
+			"%s feature-tagged WASM build with selected Go %s: %v",
+			compiler,
+			observation.goVersion,
+			err,
+		)
+	}
+	assertNonEmptyCompilerOutput(t, output)
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		compiler:  compiler,
+		profile:   defaultProfileName,
+		workspace: workspace,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(
+		layout.WorkDir,
+		filepath.FromSlash(config.AppRel),
+	)
+	metadata := realToolchainSourceMetadata(t, compiler, appWorkDir)
+	active := metadata.activeFiles()
+	for _, name := range []string{
+		"feature_satconv.go",
+		"feature_signext.go",
+		"satconv.gox.go",
+		"signext.gox.go",
+	} {
+		if !containsString(active, name) {
+			t.Fatalf(
+				"%s active workspace files %v do not contain %s",
+				compiler,
+				active,
+				name,
+			)
+		}
+	}
+	t.Logf(
+		"%s selected Go %s active feature files: %v",
+		compiler,
+		observation.goVersion,
+		active,
+	)
+}
+
+func newFeatureTaggedCompilerFixture(t *testing.T, compiler string) string {
+	t.Helper()
+	appDir := t.TempDir()
+	writeTestFile(
+		t,
+		appDir,
+		"go.mod",
+		"module example.com/feature-tags\n\ngo 1.22\n",
+	)
+	writeTestFile(
+		t,
+		appDir,
+		manifestName,
+		`{"name":"feature-tags","compiler":"`+compiler+`"}`,
+	)
+	writeTestFile(t, appDir, "main.go", `//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return gf.Fragment(SignextView(), SatconvView())
+}
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}
+`)
+	writeTestFile(t, appDir, "feature_signext.go", `//go:build wasm.signext
+
+package main
+
+const authoredSignext = "signext"
+`)
+	writeTestFile(t, appDir, "feature_satconv.go", `//go:build wasm.satconv
+
+package main
+
+const authoredSatconv = "satconv"
+`)
+	writeTestFile(t, appDir, "signext.gox", `//go:build wasm.signext
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func SignextView() gf.Node {
+	return <span>{authoredSignext}</span>
+}
+`)
+	writeTestFile(t, appDir, "satconv.gox", `//go:build wasm.satconv
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func SatconvView() gf.Node {
+	return <span>{authoredSatconv}</span>
+}
+`)
+	return appDir
 }
 
 func TestStandaloneGenerationSourceSelectionParity(t *testing.T) {

--- a/cmd/goxc/generation_constraints_test.go
+++ b/cmd/goxc/generation_constraints_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -121,7 +122,10 @@ func TestBrowserAuthoredSourceSelectionExcludesHostArchitectureFeature(t *testin
 	t.Setenv("GOWASM", "")
 	for _, compiler := range []string{"go", "tinygo"} {
 		t.Run(compiler, func(t *testing.T) {
-			selection, err := browserGenerationSourceSelection(compiler)
+			selection, err := browserGenerationSourceSelection(
+				compiler,
+				t.TempDir(),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -218,8 +222,9 @@ func TestBrowserBuildContextNormalizesTargetToolTags(t *testing.T) {
 					}
 				}
 			}
-			if !reflect.DeepEqual(first.ReleaseTags, firstBase.ReleaseTags) {
-				t.Fatalf("ReleaseTags = %v, want %v", first.ReleaseTags, firstBase.ReleaseTags)
+			wantReleaseTags := testReleaseTagsThrough(25)
+			if !reflect.DeepEqual(first.ReleaseTags, wantReleaseTags) {
+				t.Fatalf("ReleaseTags = %v, want %v", first.ReleaseTags, wantReleaseTags)
 			}
 		})
 	}
@@ -427,9 +432,11 @@ func TestBrowserSelectedToolchainOverridesBuildToolchainTags(t *testing.T) {
 				"go",
 				base,
 				environment,
+				t.TempDir(),
 				func(
 					compiler string,
 					observedEnvironment []string,
+					_ string,
 				) (browserToolchainObservation, error) {
 					observations++
 					if compiler != "go" {
@@ -480,6 +487,147 @@ func TestBrowserSelectedToolchainOverridesBuildToolchainTags(t *testing.T) {
 	}
 }
 
+func TestBrowserSelectedReleaseTagsControlAuthoredAndGOXSelection(t *testing.T) {
+	tests := []struct {
+		name              string
+		buildReleaseTags  []string
+		selectedGoVersion string
+		wantReleaseMinor  int
+		constraints       map[string]bool
+	}{
+		{
+			name:              "selected Go 1.26 overrides Go 1.25 build context",
+			buildReleaseTags:  testReleaseTagsThrough(25),
+			selectedGoVersion: "go1.26.5",
+			wantReleaseMinor:  26,
+			constraints: map[string]bool{
+				"go1.25": true,
+				"go1.26": true,
+				"go1.27": false,
+			},
+		},
+		{
+			name:              "selected Go 1.25 overrides Go 1.26 build context",
+			buildReleaseTags:  testReleaseTagsThrough(26),
+			selectedGoVersion: "go1.25.12",
+			wantReleaseMinor:  25,
+			constraints: map[string]bool{
+				"go1.25": true,
+				"go1.26": false,
+			},
+		},
+		{
+			name:              "selected Go 1.26 beta",
+			buildReleaseTags:  testReleaseTagsThrough(25),
+			selectedGoVersion: "go1.26beta1",
+			wantReleaseMinor:  26,
+			constraints: map[string]bool{
+				"go1.26": true,
+				"go1.27": false,
+			},
+		},
+		{
+			name:              "selected Go 1.26 release candidate",
+			buildReleaseTags:  testReleaseTagsThrough(25),
+			selectedGoVersion: "go1.26rc1",
+			wantReleaseMinor:  26,
+			constraints: map[string]bool{
+				"go1.26": true,
+				"go1.27": false,
+			},
+		},
+		{
+			name:              "selected Go 1.22",
+			buildReleaseTags:  testReleaseTagsThrough(26),
+			selectedGoVersion: "go1.22.12",
+			wantReleaseMinor:  22,
+			constraints: map[string]bool{
+				"go1.22": true,
+				"go1.23": false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := build.Context{
+				GOOS:        "linux",
+				GOARCH:      "amd64",
+				Compiler:    "gc",
+				ReleaseTags: append([]string(nil), test.buildReleaseTags...),
+			}
+			selection, err := browserGenerationSourceSelectionWith(
+				"go",
+				base,
+				[]string{"GOWASM="},
+				t.TempDir(),
+				func(
+					string,
+					[]string,
+					string,
+				) (browserToolchainObservation, error) {
+					return browserToolchainObservation{
+						goVersion: test.selectedGoVersion,
+					}, nil
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantReleaseTags := testReleaseTagsThrough(test.wantReleaseMinor)
+			if !reflect.DeepEqual(
+				selection.buildContext.ReleaseTags,
+				wantReleaseTags,
+			) {
+				t.Fatalf(
+					"ReleaseTags = %v, want %v",
+					selection.buildContext.ReleaseTags,
+					wantReleaseTags,
+				)
+			}
+
+			packageDir := t.TempDir()
+			for constraint, want := range test.constraints {
+				source := []byte(
+					"//go:build " + constraint + "\n\npackage app\n",
+				)
+				authored, err := selection.matchAuthoredGo(
+					packageDir,
+					"source.go",
+					source,
+				)
+				if err != nil {
+					t.Fatalf("match authored %s: %v", constraint, err)
+				}
+				if authored != want {
+					t.Fatalf(
+						"authored %s match = %t, want %t",
+						constraint,
+						authored,
+						want,
+					)
+				}
+				goxSource, err := selection.matchGOX(
+					packageDir,
+					"source.gox",
+					source,
+				)
+				if err != nil {
+					t.Fatalf("match GOX %s: %v", constraint, err)
+				}
+				if goxSource != want {
+					t.Fatalf(
+						"GOX %s match = %t, want %t",
+						constraint,
+						goxSource,
+						want,
+					)
+				}
+			}
+		})
+	}
+}
+
 func TestBrowserToolchainObservationOccursOncePerGeneration(t *testing.T) {
 	sourceRoot := t.TempDir()
 	writeTestFile(t, sourceRoot, "root.go", "package app\n")
@@ -505,11 +653,13 @@ func Child() gf.Node {
 	err := generateIntoDirectoryForCompilerWithObserver(
 		sourceRoot,
 		destination,
+		destination,
 		true,
 		"go",
 		func(
 			string,
 			[]string,
+			string,
 		) (browserToolchainObservation, error) {
 			observations++
 			return browserToolchainObservation{goVersion: "go1.26.5"}, nil
@@ -537,6 +687,7 @@ func TestBrowserToolchainObservationIsNotGloballyCached(t *testing.T) {
 	observe := func(
 		string,
 		[]string,
+		string,
 	) (browserToolchainObservation, error) {
 		version := versions[observations]
 		observations++
@@ -552,6 +703,7 @@ func TestBrowserToolchainObservationIsNotGloballyCached(t *testing.T) {
 		"go",
 		base,
 		[]string{"GOWASM="},
+		t.TempDir(),
 		observe,
 	)
 	if err != nil {
@@ -561,6 +713,7 @@ func TestBrowserToolchainObservationIsNotGloballyCached(t *testing.T) {
 		"go",
 		base,
 		[]string{"GOWASM="},
+		t.TempDir(),
 		observe,
 	)
 	if err != nil {
@@ -589,11 +742,13 @@ func TestBrowserToolchainObservationFailurePublishesNothing(t *testing.T) {
 	err := generateIntoDirectoryForCompilerWithObserver(
 		sourceRoot,
 		destination,
+		destination,
 		true,
 		"tinygo",
 		func(
 			string,
 			[]string,
+			string,
 		) (browserToolchainObservation, error) {
 			return browserToolchainObservation{}, errors.New("probe failed")
 		},
@@ -627,11 +782,14 @@ func TestBrowserToolchainObservationFailurePublishesNothing(t *testing.T) {
 
 func TestPackageSourceSelectionUsesObservedCompilerTargets(t *testing.T) {
 	t.Setenv("GOWASM", "")
-	goSelection, err := browserGenerationSourceSelection("go")
+	goSelection, err := browserGenerationSourceSelection("go", t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	tinySelection, err := browserGenerationSourceSelection("tinygo")
+	tinySelection, err := browserGenerationSourceSelection(
+		"tinygo",
+		t.TempDir(),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1011,7 +1169,10 @@ func View() gf.Node {
 		{compiler: "tinygo", want: true},
 	} {
 		t.Run(test.compiler, func(t *testing.T) {
-			selection, err := browserGenerationSourceSelection(test.compiler)
+			selection, err := browserGenerationSourceSelection(
+				test.compiler,
+				t.TempDir(),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1642,9 +1803,11 @@ func TestFeatureTaggedTinyGoBuild(t *testing.T) {
 
 func runFeatureTaggedCompilerBuild(t *testing.T, compiler string) {
 	t.Helper()
+	appDir := newFeatureTaggedCompilerFixture(t, compiler)
 	observation, err := observeSelectedBrowserToolchain(
 		compiler,
 		os.Environ(),
+		appDir,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1658,7 +1821,7 @@ func runFeatureTaggedCompilerBuild(t *testing.T, compiler string) {
 		t.Setenv("GOWASM", "satconv,signext")
 	}
 
-	selection, err := browserGenerationSourceSelection(compiler)
+	selection, err := browserGenerationSourceSelection(compiler, appDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1674,7 +1837,6 @@ func runFeatureTaggedCompilerBuild(t *testing.T, compiler string) {
 		}
 	}
 
-	appDir := newFeatureTaggedCompilerFixture(t, compiler)
 	selected, err := authoredPackageSources(appDir, selection)
 	if err != nil {
 		t.Fatal(err)
@@ -1868,7 +2030,10 @@ func TestBrowserCompilerSourceSelectionParity(t *testing.T) {
 							t.Skip("tinygo is not installed")
 						}
 					}
-					selection, err := browserGenerationSourceSelection(compiler)
+					selection, err := browserGenerationSourceSelection(
+						compiler,
+						root,
+					)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1932,7 +2097,10 @@ func TestBrowserGOXSourceSelectionParity(t *testing.T) {
 							t.Skip("tinygo is not installed")
 						}
 					}
-					selection, err := browserGenerationSourceSelection(compiler)
+					selection, err := browserGenerationSourceSelection(
+						compiler,
+						root,
+					)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -2048,6 +2216,8 @@ func newSourceSelectionFixture(t *testing.T) string {
 		{name: "tag_not_tinygo.go", constraint: "!tinygo"},
 		{name: "tag_cgo.go", constraint: "cgo"},
 		{name: "tag_go122.go", constraint: "go1.22"},
+		{name: "tag_go125.go", constraint: "go1.25"},
+		{name: "tag_go126.go", constraint: "go1.26"},
 		{name: "tag_go1999.go", constraint: "go1.999"},
 		{name: "tag_tinygowasm.go", constraint: "tinygo.wasm"},
 		{name: "tag_purego.go", constraint: "purego"},
@@ -2100,6 +2270,8 @@ func newGOXSourceSelectionFixture(t *testing.T) (string, []string) {
 		{filename: "tag_gc.gox", constraint: "gc"},
 		{filename: "tag_tinygo.gox", constraint: "tinygo"},
 		{filename: "tag_cgo.gox", constraint: "cgo"},
+		{filename: "tag_go125.gox", constraint: "go1.25"},
+		{filename: "tag_go126.gox", constraint: "go1.26"},
 		{filename: "tag_future.gox", constraint: "go1.999"},
 		{filename: "tag_amd64.gox", constraint: "amd64.v1"},
 		{filename: "tag_satconv.gox", constraint: "wasm.satconv"},
@@ -2246,9 +2418,11 @@ func browserGenerationSourceSelectionForVersion(
 		compiler,
 		build.Default,
 		environment,
+		t.TempDir(),
 		func(
 			string,
 			[]string,
+			string,
 		) (browserToolchainObservation, error) {
 			return browserToolchainObservation{goVersion: goVersion}, nil
 		},
@@ -2273,4 +2447,12 @@ func cloneBuildContextTagSlices(context build.Context) build.Context {
 	context.ToolTags = append([]string(nil), context.ToolTags...)
 	context.ReleaseTags = append([]string(nil), context.ReleaseTags...)
 	return context
+}
+
+func testReleaseTagsThrough(minor int) []string {
+	tags := make([]string, 0, minor)
+	for release := 1; release <= minor; release++ {
+		tags = append(tags, "go1."+strconv.Itoa(release))
+	}
+	return tags
 }

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"sort"
@@ -206,7 +207,28 @@ func generateIntoDirectoryForCompiler(
 	requireFiles bool,
 	compiler string,
 ) error {
-	selection, err := browserGenerationSourceSelection(compiler)
+	return generateIntoDirectoryForCompilerWithObserver(
+		sourceRoot,
+		destinationRoot,
+		requireFiles,
+		compiler,
+		observeSelectedBrowserToolchain,
+	)
+}
+
+func generateIntoDirectoryForCompilerWithObserver(
+	sourceRoot,
+	destinationRoot string,
+	requireFiles bool,
+	compiler string,
+	observe browserToolchainObserver,
+) error {
+	selection, err := browserGenerationSourceSelectionWith(
+		compiler,
+		build.Default,
+		os.Environ(),
+		observe,
+	)
 	if err != nil {
 		return err
 	}

--- a/cmd/goxc/workspace.go
+++ b/cmd/goxc/workspace.go
@@ -30,6 +30,18 @@ type buildWorkspaceResult struct {
 }
 
 func prepareBuildWorkspaceResult(layout BuildLayout, manifest projectManifest) (buildWorkspaceResult, error) {
+	return prepareBuildWorkspaceResultWithObserver(
+		layout,
+		manifest,
+		observeSelectedBrowserToolchain,
+	)
+}
+
+func prepareBuildWorkspaceResultWithObserver(
+	layout BuildLayout,
+	manifest projectManifest,
+	observe browserToolchainObserver,
+) (buildWorkspaceResult, error) {
 	var result buildWorkspaceResult
 	if err := validateWorkspaceRoot(layout); err != nil {
 		return result, err
@@ -46,14 +58,31 @@ func prepareBuildWorkspaceResult(layout BuildLayout, manifest projectManifest) (
 	}
 	config := workspaceModuleConfigForApp(layout.AppDir)
 	appWorkDir := filepath.Join(layout.WorkDir, filepath.FromSlash(config.AppRel))
+	entryRelative, err := filepath.Rel(layout.AppDir, entry)
+	if err != nil {
+		return result, fmt.Errorf("resolve entry workspace path: %w", err)
+	}
+	result.EntryPath = filepath.Join(appWorkDir, entryRelative)
 	if err := copyAuthoredGoFiles(layout.AppDir, appWorkDir); err != nil {
 		return result, err
 	}
-	if err := generateIntoDirectoryForCompiler(
+	if err := mkdirAllBelowRoot(
+		layout.WorkDir,
+		result.EntryPath,
+		"workspace compiler context",
+	); err != nil {
+		return result, err
+	}
+	if err := writeWorkspaceGoMod(layout.WorkDir, layout.AppDir); err != nil {
+		return result, err
+	}
+	if err := generateIntoDirectoryForCompilerWithObserver(
 		layout.AppDir,
 		appWorkDir,
+		result.EntryPath,
 		false,
 		layout.Compiler,
+		observe,
 	); err != nil {
 		return result, err
 	}
@@ -62,14 +91,6 @@ func prepareBuildWorkspaceResult(layout BuildLayout, manifest projectManifest) (
 			return result, err
 		}
 	}
-	if err := writeWorkspaceGoMod(layout.WorkDir, layout.AppDir); err != nil {
-		return result, err
-	}
-	entryRelative, err := filepath.Rel(layout.AppDir, entry)
-	if err != nil {
-		return result, fmt.Errorf("resolve entry workspace path: %w", err)
-	}
-	result.EntryPath = filepath.Join(appWorkDir, entryRelative)
 	result.EmbedPlan, err = discoverAndMaterializeEmbedInputs(layout, appWorkDir, result.EntryPath)
 	if err != nil {
 		return result, err
@@ -210,6 +231,7 @@ func generateIntoDirectoryForCompiler(
 	return generateIntoDirectoryForCompilerWithObserver(
 		sourceRoot,
 		destinationRoot,
+		destinationRoot,
 		requireFiles,
 		compiler,
 		observeSelectedBrowserToolchain,
@@ -218,7 +240,8 @@ func generateIntoDirectoryForCompiler(
 
 func generateIntoDirectoryForCompilerWithObserver(
 	sourceRoot,
-	destinationRoot string,
+	destinationRoot,
+	compilerContextDirectory string,
 	requireFiles bool,
 	compiler string,
 	observe browserToolchainObserver,
@@ -227,6 +250,7 @@ func generateIntoDirectoryForCompilerWithObserver(
 		compiler,
 		build.Default,
 		os.Environ(),
+		compilerContextDirectory,
 		observe,
 	)
 	if err != nil {

--- a/cmd/goxc/workspace_test.go
+++ b/cmd/goxc/workspace_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"go/ast"
 	"go/build"
 	"go/parser"
@@ -884,6 +885,272 @@ func Layout() gf.Node {
 	}
 }
 
+func TestPrepareBuildWorkspaceUsesGeneratedCompilerContext(t *testing.T) {
+	root := t.TempDir()
+	callerDir := filepath.Join(root, "caller")
+	writeTestFile(t, callerDir, "go.mod", `module example.com/caller
+
+go 1.25
+
+toolchain go1.25.12
+`)
+	t.Setenv("PWD", callerDir)
+
+	appDir := filepath.Join(root, "app")
+	authoredGoMod := "module example.com/app\n\ngo 1.22\n"
+	writeTestFile(t, appDir, "go.mod", authoredGoMod)
+	writeTestFile(t, appDir, "cmd/app/main.go", "package main\n")
+	writeTestFile(t, appDir, "cmd/app/app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main>generated context</main>
+}
+`)
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(root, "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	appWorkDir := filepath.Join(
+		layout.WorkDir,
+		filepath.FromSlash(config.AppRel),
+	)
+	wantEntry := filepath.Join(appWorkDir, "cmd", "app")
+	wantGoMod := filepath.Join(layout.WorkDir, "go.mod")
+	observations := 0
+	var observedGoMod string
+
+	result, err := prepareBuildWorkspaceResultWithObserver(
+		layout,
+		projectManifest{Entry: "cmd/app"},
+		func(
+			compiler string,
+			environment []string,
+			workingDirectory string,
+		) (browserToolchainObservation, error) {
+			observations++
+			if compiler != "go" {
+				t.Fatalf("compiler = %q, want go", compiler)
+			}
+			if got, ok := environmentValue(environment, "PWD"); !ok ||
+				filepath.Clean(got) != filepath.Clean(callerDir) {
+				t.Fatalf(
+					"caller PWD = %q, present=%t, want %q",
+					got,
+					ok,
+					callerDir,
+				)
+			}
+			if filepath.Clean(workingDirectory) != filepath.Clean(wantEntry) {
+				t.Fatalf(
+					"observer directory = %q, want compiler entry %q",
+					workingDirectory,
+					wantEntry,
+				)
+			}
+			if filepath.Clean(workingDirectory) == filepath.Clean(callerDir) {
+				t.Fatal("observer used the caller module directory")
+			}
+			info, err := os.Stat(workingDirectory)
+			if err != nil {
+				t.Fatalf("stat observer directory: %v", err)
+			}
+			if !info.IsDir() {
+				t.Fatalf("observer path mode = %s, want directory", info.Mode())
+			}
+			nearest, err := nearestGoModForTest(workingDirectory)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if filepath.Clean(nearest) != filepath.Clean(wantGoMod) {
+				t.Fatalf(
+					"nearest observer go.mod = %q, want %q",
+					nearest,
+					wantGoMod,
+				)
+			}
+			content, err := os.ReadFile(nearest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			observedGoMod = string(content)
+			if !strings.Contains(observedGoMod, "\ngo 1.22\n") {
+				t.Fatalf("generated go.mod has unexpected language version:\n%s", content)
+			}
+			if strings.Contains(observedGoMod, "toolchain go1.25.12") {
+				t.Fatalf("generated go.mod inherited caller toolchain:\n%s", content)
+			}
+			return browserToolchainObservation{goVersion: "go1.26.5"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResultWithObserver() error: %v", err)
+	}
+	if observations != 1 {
+		t.Fatalf("toolchain observations = %d, want 1", observations)
+	}
+	if filepath.Clean(result.EntryPath) != filepath.Clean(wantEntry) {
+		t.Fatalf("compiler entry = %q, want %q", result.EntryPath, wantEntry)
+	}
+	finalGoMod, err := os.ReadFile(wantGoMod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(finalGoMod) != observedGoMod {
+		t.Fatalf(
+			"workspace go.mod changed after observation:\nobserved:\n%s\nfinal:\n%s",
+			observedGoMod,
+			finalGoMod,
+		)
+	}
+	assertTestFileUnchanged(t, filepath.Join(appDir, "go.mod"), authoredGoMod)
+}
+
+func TestPrepareBuildWorkspaceObservesGOXOnlyChildEntry(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, appDir, "go.mod", "module example.com/gox-only\n\ngo 1.22\n")
+	writeTestFile(t, appDir, "cmd/app/app.gox", `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main>GOX only</main>
+}
+`)
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(root, "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	wantEntry := filepath.Join(
+		layout.WorkDir,
+		filepath.FromSlash(config.AppRel),
+		"cmd",
+		"app",
+	)
+	observations := 0
+	result, err := prepareBuildWorkspaceResultWithObserver(
+		layout,
+		projectManifest{Entry: "cmd/app"},
+		func(
+			_ string,
+			_ []string,
+			workingDirectory string,
+		) (browserToolchainObservation, error) {
+			observations++
+			if filepath.Clean(workingDirectory) != filepath.Clean(wantEntry) {
+				t.Fatalf(
+					"observer directory = %q, want %q",
+					workingDirectory,
+					wantEntry,
+				)
+			}
+			info, err := os.Stat(workingDirectory)
+			if err != nil {
+				t.Fatalf("stat GOX-only observer directory: %v", err)
+			}
+			if !info.IsDir() {
+				t.Fatalf("GOX-only observer mode = %s, want directory", info.Mode())
+			}
+			if _, err := os.Stat(filepath.Join(layout.WorkDir, "go.mod")); err != nil {
+				t.Fatalf("workspace go.mod missing before observation: %v", err)
+			}
+			return browserToolchainObservation{goVersion: "go1.26.5"}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("prepareBuildWorkspaceResultWithObserver() error: %v", err)
+	}
+	if observations != 1 {
+		t.Fatalf("toolchain observations = %d, want 1", observations)
+	}
+	if filepath.Clean(result.EntryPath) != filepath.Clean(wantEntry) {
+		t.Fatalf("entry = %q, want %q", result.EntryPath, wantEntry)
+	}
+	if _, err := os.Stat(filepath.Join(wantEntry, "app.gox.go")); err != nil {
+		t.Fatalf("GOX-only generated output missing: %v", err)
+	}
+}
+
+func TestPrepareBuildWorkspaceObservationFailureAfterModuleMaterialization(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	authoredGoMod := "module example.com/observation-failure\n\ngo 1.22\n"
+	authoredGOX := `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	return <main>failure</main>
+}
+`
+	writeTestFile(t, appDir, "go.mod", authoredGoMod)
+	writeTestFile(t, appDir, "main.go", "package main\n")
+	writeTestFile(t, appDir, "app.gox", authoredGOX)
+
+	layout, err := newBuildLayout(layoutOptions{
+		appDir:    appDir,
+		workspace: filepath.Join(root, "workspace"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observations := 0
+	_, err = prepareBuildWorkspaceResultWithObserver(
+		layout,
+		projectManifest{Entry: "."},
+		func(
+			_ string,
+			_ []string,
+			workingDirectory string,
+		) (browserToolchainObservation, error) {
+			observations++
+			if _, err := os.Stat(workingDirectory); err != nil {
+				t.Fatalf("observer directory missing: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(layout.WorkDir, "go.mod")); err != nil {
+				t.Fatalf("workspace go.mod missing before observation: %v", err)
+			}
+			return browserToolchainObservation{}, errors.New("probe failed")
+		},
+	)
+	if err == nil {
+		t.Fatal("prepareBuildWorkspaceResultWithObserver() succeeded")
+	}
+	for _, want := range []string{"observe selected Go toolchain", "probe failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+	if observations != 1 {
+		t.Fatalf("toolchain observations = %d, want 1", observations)
+	}
+	config := workspaceModuleConfigForApp(appDir)
+	generated := filepath.Join(
+		layout.WorkDir,
+		filepath.FromSlash(config.AppRel),
+		"app.gox.go",
+	)
+	if _, err := os.Stat(generated); !os.IsNotExist(err) {
+		t.Fatalf("generated output exists after observation failure: %v", err)
+	}
+	assertTestFileUnchanged(t, filepath.Join(appDir, "go.mod"), authoredGoMod)
+	assertTestFileUnchanged(t, filepath.Join(appDir, "app.gox"), authoredGOX)
+}
+
 func TestPrepareBuildWorkspaceAcceptsGenericSrcEntry(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, root, "go.mod", "module github.com/example/root\n\ngo 1.22\n")
@@ -1000,6 +1267,21 @@ func assertGeneratedFileContains(t *testing.T, path string, wants ...string) {
 		if !strings.Contains(string(content), want) {
 			t.Fatalf("generated file %s missing %q:\n%s", path, want, content)
 		}
+	}
+}
+
+func nearestGoModForTest(directory string) (string, error) {
+	current := filepath.Clean(directory)
+	for {
+		path := filepath.Join(current, "go.mod")
+		if info, err := os.Stat(path); err == nil && info.Mode().IsRegular() {
+			return path, nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", errors.New("no go.mod found")
+		}
+		current = parent
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes `goxc` browser source selection follow the Go toolchain that will
actually compile the generated workspace.

The selector now observes `GOVERSION` from the generated compiler entry
context and derives both Go release tags and WebAssembly feature tags from the
selected toolchain. This keeps authored `.go` and generated `.gox.go` source
selection aligned with standard Go and TinyGo `0.41.1` across Go `1.25` and
Go `1.26`.

This PR does not change public APIs, runtime behavior, or GOX language
semantics.

## What changed

- Materializes the generated workspace module and compiler entry before
  observing the selected toolchain.
- Runs toolchain observation from the same entry context used by the compiler,
  rather than the caller's working directory.
- Rebuilds `go1.N` release tags from the selected Go language version instead
  of inheriting `build.Default.ReleaseTags`.
- Enables `wasm.satconv` and `wasm.signext` by default for Go `1.26` and newer
  while preserving Go `1.25` `GOWASM` behavior.
- Reuses one selected browser build context across authored Go and GOX source
  selection for the complete generation operation.
- Adds regressions for differing caller and generated-workspace contexts,
  GOX-only child entries, beta and release-candidate versions, observation
  failure, standard Go and TinyGo parity, and real feature-tagged WASM builds.

## Validation

- Focused, repeated, and race-enabled `cmd/goxc` tests on Go `1.22.12`,
  `1.25.12`, and `1.26.5`.
- Full tests, debug-tag tests, race checks, and `go vet` across the three Go
  toolchains.
- Real standard Go and TinyGo `0.41.1` feature-tagged WASM builds under Go
  `1.25.12` and `1.26.5`.
- Standard Go and TinyGo source-selection parity against their real compiler
  metadata.
- Two complete Chrome browser-smoke runs.
- Artifact, module-path, documentation, formatting, and diff checks.
- Node `24` extension tests and Windows `amd64` cross-compilation.

## WASM size

Frozen-base and branch-head outputs are byte-identical for all eleven budgeted
applications under both:

- Go `1.25.12` with TinyGo `0.41.1`;
- Go `1.26.5` with TinyGo `0.41.1`.

Some existing budgets are exceeded under these newer toolchain combinations,
but the same failures occur on the frozen base. This PR introduces no WASM
output delta and does not change budgets or compression limits.

## Scope

Changes are limited to `goxc` browser source selection, generated-workspace
sequencing, and focused regression evidence.

This PR does not modify `pkg/goframe`, `pkg/gox`, examples, dependencies,
workflows, documentation, or WASM budgets.