### PR TITLE
ci: adopt supported Go and WASM baselines

### DIFF
--- a/.github/workflows/ci-browser-smoke.yml
+++ b/.github/workflows/ci-browser-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.26.5'
           cache: true
 
       - name: Setup Node.js

--- a/.github/workflows/ci-browser-smoke.yml
+++ b/.github/workflows/ci-browser-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24.18.1'
 
       - name: Setup Chrome
         id: setup-chrome

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -11,17 +11,31 @@ permissions:
 
 jobs:
   go:
-    name: Go and GOX checks
+    name: Go and GOX checks (${{ matrix.os }}, Go ${{ matrix.go }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+            go: '1.22.12'
+            tier: minimum
+            full: false
+          - os: ubuntu-latest
+            go: '1.25.12'
+            tier: supported
+            full: true
+          - os: ubuntu-latest
+            go: '1.26.5'
+            tier: supported
             full: true
           - os: macos-15-intel
+            go: '1.26.5'
+            tier: host
             full: false
           - os: windows-latest
+            go: '1.26.5'
+            tier: host
             full: false
 
     steps:
@@ -31,14 +45,14 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: ${{ matrix.go }}
           cache: true
 
       - name: Setup Node.js
         if: matrix.full
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24.18.1'
 
       - name: Artifact gate
         if: matrix.full
@@ -72,3 +86,39 @@ jobs:
 
       - name: GOX golden tests
         run: go test ./pkg/gox -run 'TestGolden|TestErrorGolden'
+
+  tinygo-parity:
+    name: TinyGo source selection (Go ${{ matrix.go }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - '1.25.12'
+          - '1.26.5'
+
+    env:
+      TINYGO_VERSION: 0.41.1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+
+      - name: Install TinyGo
+        run: |
+          curl -fsSL -o /tmp/tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
+          sudo apt-get install -y /tmp/tinygo.deb
+          tinygo version
+
+      - name: TinyGo source-selection parity
+        run: |
+          go test ./cmd/goxc \
+            -run 'TestBrowser(Compiler|GOX)SourceSelectionParity|TestFeatureTaggedTinyGoBuild' \
+            -count=1 \
+            -v

--- a/.github/workflows/ci-vscode.yml
+++ b/.github/workflows/ci-vscode.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24.18.1'
           cache: npm
           cache-dependency-path: extensions/vscode-gox/package-lock.json
 

--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22.x'
+          go-version: '1.26.5'
           cache: true
 
       - name: Install compression tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Supported CI baselines for Go `1.22.12`, `1.25.12`, and `1.26.5`, Node.js
+  `24.18.1`, and the Go `1.26.5`/TinyGo `0.41.1` browser and WASM-size lanes,
+  with three reproducibly measured size-budget cells aligned to that baseline.
 - Watched `goxc dev` workflow with serialized full-package rebuilds, effective
   authored-input polling, quiet-period debounce, verified process-private
   generation serving, last-successful-generation failure preservation,

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -12,11 +12,21 @@ All workflows request read-only repository contents permissions by default.
 
 `.github/workflows/ci-core.yml` runs on pull requests and pushes to `main`.
 
-It uses a small OS matrix:
+It uses an explicit Go and host matrix:
 
-- `ubuntu-latest`: full `artifact/module path/docs` + existing core gates.
-- `macos-15-intel`, `windows-latest`: minimal Go/toolchain evidence (core
-  formatting/tests/vet/debug-tag/selected GOX tests).
+| host | Go | tier | full-only gates |
+| --- | --- | --- | --- |
+| `ubuntu-latest` | `1.22.12` | minimum module compatibility | none |
+| `ubuntu-latest` | `1.25.12` | supported | artifact/module/docs/race |
+| `ubuntu-latest` | `1.26.5` | supported | artifact/module/docs/race |
+| `macos-15-intel` | `1.26.5` | host evidence | none |
+| `windows-latest` | `1.26.5` | host evidence | none |
+
+Every matrix entry runs formatting, ordinary tests, vet, debug-tag tests, and
+selected GOX golden tests. The two supported Linux entries additionally run
+the artifact, module-path, docs, and race gates. Go `1.22.12` verifies the
+module's declared minimum without duplicating the full Linux gate. Every entry
+is required; no matrix lane is advisory.
 
 It checks:
 
@@ -30,6 +40,10 @@ It checks:
 - `go test -tags=goframe_debug ./...`;
 - GOX golden tests, including source-oriented error diagnostics.
 - GOX fuzz seed targets through the normal `go test ./...` seed pass.
+
+A separate focused Linux matrix installs TinyGo `0.41.1` under Go `1.25.12`
+and Go `1.26.5`. It checks browser source-selection parity and feature-tagged
+TinyGo builds without duplicating the full package, browser, or size workflows.
 
 The `cmd/goxc` test suite includes manifest/path/package/export/workspace
 regression tests, including root-aware symlink checks for app roots, entry
@@ -51,8 +65,8 @@ automation pass.
 `.github/workflows/ci-wasm-size.yml` runs on pull requests, pushes to `main`,
 and manually through `workflow_dispatch`.
 
-It installs Go, TinyGo `0.41.1`, brotli, and zstd. Then it packages the
-counter, components, todo, dashboard, context, virtualized, multipackage,
+It installs Go `1.26.5`, TinyGo `0.41.1`, brotli, and zstd. Then it packages
+the counter, components, todo, dashboard, context, virtualized, multipackage,
 cmdapp, router, router-dashboard, and resource examples with TinyGo. It also
 runs a release-style package pass with `--asset-hash --preload
 --compress=gzip,br` before checking:
@@ -72,8 +86,8 @@ older `main.wasm` packages.
 `.github/workflows/ci-browser-smoke.yml` runs on pull requests, pushes to
 `main`, and manually through `workflow_dispatch` on `ubuntu-latest` only.
 
-It installs Go, TinyGo `0.41.1`, Node.js 20, Chrome, and compression tools,
-then runs:
+It installs Go `1.26.5`, TinyGo `0.41.1`, Node.js `24.18.1`, Chrome, and
+compression tools, then runs:
 
 ```bash
 scripts/browser-smoke.sh
@@ -130,8 +144,8 @@ surface remains experimental.
 `.github/workflows/ci-vscode.yml` runs on pull requests and pushes to `main`.
 
 It validates extension JSON files, installs dependencies with `npm ci`,
-compiles the TypeScript extension, and runs pure Node tests for the diagnostics
-transport helpers through:
+compiles the TypeScript extension, and runs pure Node tests under Node.js
+`24.18.1` for the diagnostics transport helpers through:
 
 ```bash
 npm test
@@ -246,14 +260,22 @@ test run is not needed.
 
 Local checks use:
 
-- Go 1.22 or newer;
-- TinyGo 0.41.1 for WASM size and browser smoke gates;
+- Go `1.22` or newer; the module declaration remains `go 1.22`;
+- Go `1.22.12` for minimum-version compatibility evidence;
+- Go `1.25.12` and `1.26.5` for supported full Core evidence;
+- Go `1.26.5` for the browser-smoke and WASM-size baselines;
+- TinyGo `0.41.1` for focused source-selection parity, WASM size, and browser
+  smoke gates;
 - gzip;
 - brotli;
 - zstd, optional locally but installed in CI;
-- Node.js 20 or newer for browser smoke and extension checks;
+- Node.js `24.18.1` for browser smoke and extension checks;
 - Chrome or Chromium for browser smoke;
 - curl for smoke server readiness checks.
+
+Go `1.25.12` currently has correctness and source-selection evidence. The
+single heavy browser and size baseline uses Go `1.26.5`; it does not imply a
+second Go `1.25.12` browser or size matrix.
 
 Set `CHROME=/path/to/chrome` when Chrome is not available as `google-chrome`.
 There is no local non-Chrome smoke command in the current preview contract.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -24,9 +24,9 @@ Labels:
 
 | Host | Status | Evidence |
 |---|---|---|
-| Linux amd64 | CI-tested | GitHub Actions and local validation run Go, TinyGo, Node, Chrome, size, smoke, and DOM pressure gates. |
-| macOS | CI-tested (minimal, Intel runner) | Core Go/toolchain gates run in CI on `macos-15-intel`: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
-| Windows | CI-tested (minimal) | Core Go/toolchain gates run in CI: `go fmt`, `go test ./...`, `go vet`, `go test -tags=goframe_debug`, and selected GOX golden tests. TinyGo/browser smoke remain Linux-first checks. |
+| Linux amd64 | CI-tested | Core runs Go `1.22.12`, `1.25.12`, and `1.26.5`. The supported Go entries run full correctness gates; Go `1.26.5` also owns the TinyGo size and Chrome browser baselines. |
+| macOS | CI-tested (minimal, Intel runner) | Core runs Go `1.26.5` on `macos-15-intel`: formatting, ordinary tests, vet, debug-tag tests, and selected GOX golden tests. TinyGo/browser smoke remain Linux-only checks. |
+| Windows | CI-tested (minimal) | Core runs Go `1.26.5`: formatting, ordinary tests, vet, debug-tag tests, and selected GOX golden tests. TinyGo/browser smoke remain Linux-only checks. |
 
 Symlink safety tests skip when `os.Symlink` is unavailable or restricted.
 
@@ -34,12 +34,15 @@ Symlink safety tests skip when `os.Symlink` is unavailable or restricted.
 
 | Compiler target | Status | Notes |
 |---|---|---|
-| Go/WASM | CI-tested for selected smoke fixtures | Used for recover-capable runtime error and Error Boundary scenarios. Larger bundle size is expected. |
-| TinyGo/WASM | CI-tested for packaging, size, and most browser smoke | Preferred size-oriented path. Current CI uses TinyGo `0.41.1`. Default package path uses `-panic=trap`. |
+| Go/WASM | CI-tested for selected smoke fixtures | Current heavy browser baseline uses Go `1.26.5`. It covers recover-capable runtime error and Error Boundary scenarios. Larger bundle size is expected. |
+| TinyGo/WASM | CI-tested for packaging, size, and most browser smoke | Current heavy baseline uses Go `1.26.5` with TinyGo `0.41.1`. Focused source-selection parity also runs under Go `1.25.12`. Default package path uses `-panic=trap`. |
 | Native Go runtime | CI-tested for pure tests | Pure runtime/compiler/tooling tests run with normal Go. Browser runtime requires `js/wasm`. |
 
-Minimum module declaration is `go 1.22`. Current local/CI baselines use newer Go
-toolchains.
+Minimum module declaration is `go 1.22`, with Go `1.22.12` in Core CI as the
+minimum-version check. Go `1.25.12` and `1.26.5` are the supported full Core
+toolchains. The browser and size workflows use Go `1.26.5`, TinyGo `0.41.1`,
+and Node.js `24.18.1`; Go `1.25.12` does not currently have a separate heavy
+browser or size lane.
 
 ## Browser Targets
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -2,33 +2,22 @@
 
 ## Summary
 
-This audit exists because an attempted keyed-reorder LIS optimization was
-blocked by the local WASM size gate. The local gate failed even after the
-runtime changes were removed, which made the local size result unsuitable for
-deciding whether the LIS implementation itself was too large.
+This document began with a toolchain-sensitive dashboard size investigation.
+The historical Go `1.24.4` and Go `1.22.12` results remain below for context.
 
-Current `main` at `587c06d1345415960cd9100d42fa81df360fc1a0` behaves
-differently across toolchains:
-
-- Local Go `1.24.4` plus TinyGo `0.41.1` fails the dashboard raw budget.
-- A clean containerized Go `1.22.12` plus TinyGo `0.41.1` reproduction passes
-  the full size-budget workflow.
-
-The dashboard result is still tight under the CI-like toolchain:
-
-- Local current toolchain: `169789 B / 168960 B`, over by `829 B`.
-- CI-like Go `1.22.12`: `168907 B / 168960 B`, under by `53 B`.
-
-Top recommendation: keep budgets unchanged, keep CI Go `1.22.x` as the release
-size source of truth for now, and recover at least 1-4 KB of dashboard raw
-headroom before retrying LIS or updating the size workflow to a newer Go
-toolchain.
+The current supported release-size source of truth is Go `1.26.5` plus TinyGo
+`0.41.1` on Linux amd64. The 2026-07-30 migration reproduced the frozen base
+twice with isolated workspaces and caches. Both runs produced identical raw,
+gzip, Brotli, and Zstandard outputs for all eleven applications. Three measured
+cells exceeded their previous limits, so only those cells were aligned to the
+new baseline. No runtime, example, compression-ratio, or package behavior
+changed.
 
 ## Source of Truth
 
 - Workflow: `.github/workflows/ci-wasm-size.yml`
 - Budget script: `scripts/size-budget.sh`
-- CI Go version: `1.22.x`
+- CI Go version: `1.26.5`
 - CI TinyGo version: `0.41.1`
 
 The workflow installs `goxc`, generates and packages every listed example with
@@ -52,14 +41,54 @@ If no match exists, it reports the default missing path
 | counter | 97280 B | 40960 B | 56320 B | 49152 B |
 | components | 107520 B | 43008 B | 56320 B | 49152 B |
 | todo | 122880 B | 40960 B | 56320 B | 49152 B |
-| dashboard | 168960 B | 53248 B | 71680 B | 61440 B |
+| dashboard | 171008 B | 53248 B | 71680 B | 61440 B |
 | context | 116736 B | 36864 B | 46080 B | 40960 B |
 | virtualized | 124928 B | 40960 B | 49152 B | 44032 B |
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
 | router | 116736 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 233472 B | 77824 B | 94208 B | 81920 B |
-| resource | 156672 B | 57344 B | 68608 B | 61440 B |
+| router-dashboard | 233472 B | 77824 B | 94208 B | 82944 B |
+| resource | 156672 B | 58368 B | 68608 B | 61440 B |
+
+## Supported Toolchain Baseline Migration - 2026-07-30
+
+The frozen base is `ed88c68328ca0c969c816c2191732751f9af10dd`.
+Measurements use Go `1.26.5`, TinyGo `0.41.1` with LLVM `20.1.1`, Linux
+amd64, gzip `1.13`, Brotli `1.1.0`, and Zstandard `1.5.7`. Each isolated run
+installed its own `goxc`, generated and packaged all eleven applications, and
+then repeated packaging with `--asset-hash --preload --compress=gzip,br`.
+
+Two frozen-base runs with separate workspaces, Go caches, module caches, TinyGo
+caches, and output directories were byte-identical. Repeating the package
+sequence on the final workflow and budget state produced the same artifacts.
+
+| app | raw | gzip | br | zstd | raw WASM SHA-256 (base and final) |
+| --- | ---: | ---: | ---: | ---: | --- |
+| counter | 84536 B | 34007 B | 28303 B | 30571 B | `c503b7d0d8c11a3a11123626f972bb494b6acad1835c014c892d6427931d1d29` |
+| components | 90176 B | 35788 B | 29714 B | 31968 B | `c6e2a7076a3a638f15d73ec8bd3e7fa5d9b21ffcaea0c20b38e0b06deeffb0b0` |
+| todo | 119423 B | 46237 B | 38222 B | 41269 B | `54419f7df8c972241639453557c481da264ba35b45c96e1e2b8b5b3769379d22` |
+| dashboard | 169794 B | 63522 B | 51527 B | 55534 B | `ccf1115134115770a3d2e18b3eb141394090c5e27e972021ef6fc88eec407cd2` |
+| context | 116313 B | 43907 B | 35932 B | 38714 B | `74343c753dd9dfb36f3743856069c33d67b53990ee1d0ce0ceda29165015023d` |
+| virtualized | 123248 B | 47631 B | 38998 B | 42209 B | `7265158603003d6ef0bb15034e48047cb757066689abac23c8497252d8383930` |
+| multipackage | 95340 B | 37501 B | 31020 B | 33510 B | `a908e6fbe0b0efdffe7d50dcb9a606b46d951866794640f10212d9d15aeecdbd` |
+| cmdapp | 95358 B | 37516 B | 31121 B | 33494 B | `5ec1dcb73d0e4c85abe9d6549cd8305934914ae034c2fa0dc97798429a5865d9` |
+| router | 116602 B | 44598 B | 36780 B | 39614 B | `64008632fe639c1c6851ecfa1517f5294b8feeb715b779b200a8a35e7a7dd5e0` |
+| router-dashboard | 233415 B | 93591 B | 77001 B | 82143 B | `24a53d9c4546d3dbb6354cd414048787edf2143b14d0a9ca97167f4c6b091f14` |
+| resource | 156239 B | 68172 B | 57464 B | 61009 B | `5075f6dd01b1ee7e78a0c96c576827805fd1f7c059c5aec3cd61426b96c4fcde` |
+
+All base-to-final raw, gzip, Brotli, and Zstandard sizes and SHA-256 values are
+unchanged. The three-cell budget decision is:
+
+| app/format | measured | old budget | overage | new budget | headroom |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| dashboard raw | 169794 B | 168960 B | 834 B | 171008 B | 1214 B |
+| router-dashboard zstd | 82143 B | 81920 B | 223 B | 82944 B | 801 B |
+| resource br | 57464 B | 57344 B | 120 B | 58368 B | 904 B |
+
+Every other raw and compressed budget remains unchanged. Compression ratio
+limits remain gzip `52.00%`, Brotli `38.00%`, and Zstandard `46.00%`.
+This evidence-backed migration is the only supersession of the older Go
+`1.22.12` toolchain source-of-truth recommendation.
 
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 
@@ -91,15 +120,18 @@ remain byte-identical at the raw WASM SHA-256 boundary; their compressed sizes
 are also unchanged. The final compression ratios remain within the existing
 limits: gzip `52.00%`, Brotli `38.00%`, and Zstandard `46.00%`.
 
-The earlier recommendation to keep budgets unchanged is superseded only for
-this accepted ErrorBoundary correctness guarantee. Raw budgets increase by
-3 KiB for `router-dashboard` and `resource`. Resource gzip increases by 1 KiB
-under the aligned compressed-budget rule; the other compressed budgets remain
-unchanged because their final artifacts fit. No workflow or ratio limit
-changes, no unrelated application budget changes, and no general runtime
-headroom are authorized by this rebaseline.
+At that historical stage, the earlier recommendation to keep budgets unchanged
+was superseded only for this accepted ErrorBoundary correctness guarantee. Raw
+budgets increased by 3 KiB for `router-dashboard` and `resource`. Resource gzip
+increased by 1 KiB under the aligned compressed-budget rule; the other
+compressed budgets remained unchanged because their final artifacts fit. No
+workflow or ratio limit changes, no unrelated application budget changes, and
+no general runtime headroom were authorized by this rebaseline.
 
-## Toolchain Matrix
+## Historical Toolchain Matrix
+
+This matrix records the original audit environment. The supported baseline
+migration above supersedes it as current CI guidance.
 
 | environment | Go version | TinyGo version | goxc version | reproduction method | status |
 | --- | --- | --- | --- | --- | --- |
@@ -274,7 +306,12 @@ The first follow-up should target dashboard-linked code and should measure size
 after each production change. Test-only and benchmark-only changes do not help
 the dashboard WASM size.
 
-## Recommendation
+## Historical Recommendation (Superseded 2026-07-30)
+
+The following recommendation records the earlier Go `1.22.12` source-of-truth
+decision. The evidence-backed supported toolchain migration above is the only
+supersession of its toolchain source-of-truth guidance; it does not alter the
+historical runtime cleanup observations.
 
 - Do not update the size workflow to Go `1.24` yet. The local Go `1.24.4`
   reproduction fails the dashboard raw budget by `829 B`.
@@ -408,5 +445,7 @@ dashboard    raw     168907 B /   168960 B
 - The CI-like reproduction used Docker and cloned from GitHub inside the
   container because host `/tmp` bind mounts were not visible inside the Docker
   daemon namespace.
-- The audit does not change runtime code, size budgets, workflows, examples, or
-  generated artifacts.
+- The original audit did not change runtime code, size budgets, workflows,
+  examples, or generated artifacts. The later supported-toolchain migration
+  changes only workflow versions and the three measured budget cells documented
+  above.

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -131,13 +131,13 @@ status=0
 check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
-check_app "dashboard" "$(bundle_path dashboard)" 168960 53248 71680 61440 || status=1
+check_app "dashboard" "$(bundle_path dashboard)" 171008 53248 71680 61440 || status=1
 check_app "context" "$(bundle_path context)" 116736 36864 46080 40960 || status=1
 check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 233472 77824 94208 81920 || status=1
-check_app "resource" "$(bundle_path resource)" 156672 57344 68608 61440 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 233472 77824 94208 82944 || status=1
+check_app "resource" "$(bundle_path resource)" 156672 58368 68608 61440 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Expands CI from a single Go `1.22` baseline into explicit minimum,
supported-toolchain, and heavy browser/WASM validation tiers.

This PR adds required Go `1.22.12`, `1.25.12`, and `1.26.5` evidence, moves
Node-based workflows to Node `24.18.1`, and adopts Go `1.26.5` with TinyGo
`0.41.1` as the single Browser Smoke and WASM Size baseline.

No production code or generated application output changes.

## What changed

- Adds a Core matrix with:
  - Go `1.22.12` minimum-version compatibility;
  - full Linux gates on Go `1.25.12` and `1.26.5`;
  - lightweight macOS and Windows evidence on Go `1.26.5`.
- Adds focused TinyGo `0.41.1` source-selection and feature-build checks under
  Go `1.25.12` and `1.26.5`.
- Moves Browser Smoke and WASM Size to Go `1.26.5`.
- Moves Core documentation checks, Browser Smoke, and the VS Code extension to
  Node `24.18.1`.
- Aligns three WASM budget cells with the reproducible Go `1.26.5` baseline.
- Updates CI, platform-support, size-audit, and changelog documentation to
  reflect the new evidence.

## WASM size

Two independent frozen-base reproductions under Go `1.26.5` and TinyGo
`0.41.1` produced byte-identical raw, gzip, Brotli, and Zstandard outputs for
all eleven budgeted applications.

Only three previously failing cells were adjusted:

- `dashboard` raw: `168,960 B` → `171,008 B`;
- `router-dashboard` Zstandard: `81,920 B` → `82,944 B`;
- `resource` Brotli: `57,344 B` → `58,368 B`.

All frozen-base and final-branch artifacts remain byte-identical. Compression
commands, ratio limits, and all other budgets are unchanged.

## Validation

- `actionlint`
- Full tests, debug-tag tests, and `go vet` on Go `1.22.12`, `1.25.12`, and
  `1.26.5`
- Race tests on Go `1.25.12` and `1.26.5`
- TinyGo parity and real feature-tagged builds under Go `1.25.12` and
  `1.26.5`
- `scripts/check.sh`
- Two complete Chrome Browser Smoke runs
- Full WASM Size workflow reproduction
- Node `24.18.1` VS Code extension tests
- Windows `amd64` cross-compilation
- Artifact, module-path, documentation, formatting, and diff checks

## Scope

This PR changes CI workflows, three measured size ceilings, and their factual
documentation.

It does not modify runtime or toolchain production code, public APIs, GOX
behavior, examples, dependencies, lockfiles, action references, TinyGo
`0.41.1`, or compression ratio limits.