### PR TITLE
fix(runtime): restore controlled select value after option reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@
 
 ### Fixed
 
+- Controlled select values are restored after dynamic option reconciliation.
 - `splitProps` allocation behavior was characterized and reduced for common
   runtime prop paths while preserving nil and empty zero-allocation behavior.
 - `VirtualTable` runtime code was reduced to recover dashboard WASM size

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,6 +114,9 @@ identity. It also covers route Error Boundary fallback and safe navigation
 recovery in the reference app. It also covers the resource example for explicit
 loading/ready/failed state, reload, stale completion guards, and
 cleanup-after-unmount behavior.
+The private controlled-select fixture verifies post-option reconciliation,
+uncontrolled selection ownership, stable DOM identity, and event behavior under
+both standard Go and TinyGo on the current Chrome/Linux heavy baseline.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
 connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,9 +114,12 @@ identity. It also covers route Error Boundary fallback and safe navigation
 recovery in the reference app. It also covers the resource example for explicit
 loading/ready/failed state, reload, stale completion guards, and
 cleanup-after-unmount behavior.
-The private controlled-select fixture verifies post-option reconciliation,
-uncontrolled selection ownership, stable DOM identity, and event behavior under
-both standard Go and TinyGo on the current Chrome/Linux heavy baseline.
+The private controlled-select fixture verifies parent-driven option
+reconciliation and independently dirty stateful option descendants. It covers
+an unchanged parent render count during child-only updates, a changed current
+parent value, uncontrolled selection ownership, stable DOM identity, and the
+absence of runtime-synthesized input or change events under both standard Go
+and TinyGo on the current Chrome/Linux heavy baseline.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
 connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -49,6 +49,12 @@ added, removed, restored, or reordered options are resolved before selection
 is synchronized. When no option matches the authored value, no option is
 selected.
 
+The parent select's current committed `value` remains authoritative when an
+independently updating stateful descendant component produces the option
+nodes. Child-only option reconciliation resynchronizes the nearest mounted
+select from that current value; it does not reuse a value captured during an
+earlier render.
+
 A `<select>` without a `value` prop remains browser-owned. This contract does
 not add a form framework or a multi-select value abstraction.
 

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -41,6 +41,17 @@ Go callback during patching. Reducer dispatch is the preferred pattern when
 callbacks may be retained by memoized children, because dispatch reads the
 latest state slot at event time.
 
+### Controlled Selects
+
+A controlled single-value `<select>` is driven by its `value` prop. The runtime
+reapplies that value after reconciling the option children, so dynamically
+added, removed, restored, or reordered options are resolved before selection
+is synchronized. When no option matches the authored value, no option is
+selected.
+
+A `<select>` without a `value` prop remains browser-owned. This contract does
+not add a form framework or a multi-select value abstraction.
+
 ## Submit Handling
 
 Use `OnSubmit` on the `<form>` and prevent the browser's default navigation:

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -10,8 +10,14 @@ The current supported release-size source of truth is Go `1.26.5` plus TinyGo
 twice with isolated workspaces and caches. Both runs produced identical raw,
 gzip, Brotli, and Zstandard outputs for all eleven applications. Three measured
 cells exceeded their previous limits, so only those cells were aligned to the
-new baseline. No runtime, example, compression-ratio, or package behavior
-changed.
+new baseline.
+
+The controlled-select correctness correction later added a measured shared raw
+runtime cost of `514 B` to `526 B`. The 2026-07-31 closeout reproduced the base
+and behavior-correct head twice, evaluated four bounded compactness candidates,
+and aligned only four raw ceilings by one KiB. No compressed ceiling, ratio,
+runtime behavior, application code, or package behavior changed in that
+closeout.
 
 ## Source of Truth
 
@@ -42,13 +48,13 @@ If no match exists, it reports the default missing path
 | components | 107520 B | 43008 B | 56320 B | 49152 B |
 | todo | 122880 B | 40960 B | 56320 B | 49152 B |
 | dashboard | 171008 B | 53248 B | 71680 B | 61440 B |
-| context | 116736 B | 36864 B | 46080 B | 40960 B |
+| context | 117760 B | 36864 B | 46080 B | 40960 B |
 | virtualized | 124928 B | 40960 B | 49152 B | 44032 B |
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
-| router | 116736 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 233472 B | 77824 B | 94208 B | 82944 B |
-| resource | 156672 B | 58368 B | 68608 B | 61440 B |
+| router | 117760 B | 45056 B | 58368 B | 51200 B |
+| router-dashboard | 234496 B | 77824 B | 94208 B | 82944 B |
+| resource | 157696 B | 58368 B | 68608 B | 61440 B |
 
 ## Supported Toolchain Baseline Migration - 2026-07-30
 
@@ -89,6 +95,83 @@ Every other raw and compressed budget remains unchanged. Compression ratio
 limits remain gzip `52.00%`, Brotli `38.00%`, and Zstandard `46.00%`.
 This evidence-backed migration is the only supersession of the older Go
 `1.22.12` toolchain source-of-truth recommendation.
+
+## Controlled Select Correctness Rebaseline — 2026-07-31
+
+The frozen base is `6bcbde2318099f92f940b817a69c2e1f52ad4058`.
+The behavior-correct branch head is
+`9531d48ae64fd0db966dad4e03c7f67575e6ed27`. Measurements use Go `1.26.5`,
+TinyGo `0.41.1`, Linux amd64, gzip `1.14`, Brotli `1.2.0`, and Zstandard
+`1.5.7`.
+
+The accepted runtime guarantee restores a controlled single-value select's
+current value after option reconciliation. It preserves browser ownership for
+uncontrolled selects, stable select DOM identity, and the absence of synthetic
+`input` or `change` events. Dedicated Chrome evidence passes under both
+standard Go and TinyGo.
+
+Two isolated frozen-base builds and two isolated behavior-correct-head builds
+were byte-identical within each ref for raw, gzip, Brotli, and Zstandard
+outputs. The resulting raw matrix is:
+
+| app | frozen base | reviewed head | delta | reviewed raw SHA-256 | old raw budget result |
+| --- | ---: | ---: | ---: | --- | --- |
+| counter | 84536 B | 85052 B | +516 B | `33f72247577f8f2b6f5d6ee889e267d48548236e1cdca0208d9c46efdfbb91b1` | pass |
+| components | 90176 B | 90691 B | +515 B | `8a94c41998279827c415d6f4e3fa16c4c74389f43f62d57a1e85a7278858c66c` | pass |
+| todo | 119423 B | 119938 B | +515 B | `54b7308666ddb090bf5ae3a93120e1158a7fa218b0f8698ab78a5462b06e1664` | pass |
+| dashboard | 169794 B | 170308 B | +514 B | `bc59482b4746f5a9100e8072769289d6e34d99fc57121c7358bce8e44afa2aa9` | pass |
+| context | 116313 B | 116828 B | +515 B | `f4d4c19c691aa91a568fa361dc0fd017812fe1cb81c040443611627346168e8a` | fail by 92 B |
+| virtualized | 123248 B | 123762 B | +514 B | `1c36299671986e8aef8c2203ccd6a5bb2159a2246677a1189483c3dd0efa5378` | pass |
+| multipackage | 95340 B | 95854 B | +514 B | `83f3402aae1b8a0bd358616810e0574e0a6cf02ff3ef197cca47c5f38c78c3f0` | pass |
+| cmdapp | 95358 B | 95872 B | +514 B | `f0ae215386be33e6b9f35b4e62a19a32cabca8d11c7aaa9689a0e5e5b66fcbae` | pass |
+| router | 116602 B | 117117 B | +515 B | `f49b180f0a523a2ec5e3d5e9cf8152f799c3f8ffbcdf312e73516844c2792978` | fail by 381 B |
+| router-dashboard | 233415 B | 233941 B | +526 B | `9dd248b23ebc527037eb53e504e9f90fd5bfa52cbcc94e45ea23943b8ed578d8` | fail by 469 B |
+| resource | 156239 B | 156764 B | +525 B | `03f7f32e9c9e422a78b7aa8bf131d8575c4b0a8471be106adc1062d7703a2aa1` | fail by 92 B |
+
+Deterministic compression used gzip `-n -9`, Brotli quality 11, and
+Zstandard level 19. Every compressed size remained within its existing ceiling
+and every gzip `52.00%`, Brotli `38.00%`, and Zstandard `46.00%` ratio limit
+passed.
+
+| app | gzip | br | zstd | result |
+| --- | ---: | ---: | ---: | --- |
+| counter | 34008 B | 28491 B | 30675 B | pass |
+| components | 35899 B | 29739 B | 32074 B | pass |
+| todo | 46336 B | 38399 B | 41370 B | pass |
+| dashboard | 63874 B | 51504 B | 55609 B | pass |
+| context | 44024 B | 35925 B | 38825 B | pass |
+| virtualized | 47750 B | 39062 B | 42290 B | pass |
+| multipackage | 37642 B | 31123 B | 33610 B | pass |
+| cmdapp | 37651 B | 31289 B | 33610 B | pass |
+| router | 44739 B | 36877 B | 39773 B | pass |
+| router-dashboard | 93747 B | 77105 B | 82271 B | pass |
+| resource | 68351 B | 57508 B | 61140 B | pass |
+
+Four bounded private renderer shapes preserved the browser contract but failed
+at least one mandatory raw sentinel ceiling:
+
+| candidate | shape | counter | context | router | router-dashboard | resource | rejection |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| A | return and reuse normalized DOM props | 85013 B | 116789 B | 117087 B | 233877 B | 156700 B | four blockers remained |
+| B | mount-only helper plus local patch synchronization | 84813 B | 116590 B | 116892 B | 233689 B | 156513 B | router cells remained over |
+| C1 | compact value/presence handoff with local synchronization | 84715 B | 116492 B | 116788 B | 233584 B | 156408 B | router by 52 B; router-dashboard by 112 B |
+| C2 | compact handoff plus shared synchronization | 84920 B | 116690 B | 116994 B | 233797 B | 156626 B | router cells remained over |
+
+The decision is to preserve the simpler shared post-children runtime
+implementation instead of adopting compiler-shaped Candidate C1 solely for a
+smaller binary. The measured correctness cost is accepted through four aligned
+one-KiB raw ceiling increases:
+
+| app | measured | old ceiling | new ceiling | headroom |
+| --- | ---: | ---: | ---: | ---: |
+| context | 116828 B | 116736 B | 117760 B | 932 B |
+| router | 117117 B | 116736 B | 117760 B | 643 B |
+| router-dashboard | 233941 B | 233472 B | 234496 B | 555 B |
+| resource | 156764 B | 156672 B | 157696 B | 932 B |
+
+This rebaseline does not authorize general renderer optimization, compressed
+budget changes, ratio changes, workflow changes, or unrelated application
+headroom. No compressed ceiling or compression command changed.
 
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -19,6 +19,11 @@ and aligned only four raw ceilings by one KiB. No compressed ceiling, ratio,
 runtime behavior, application code, or package behavior changed in that
 closeout.
 
+The descendant-component review follow-up adds `387 B` to `416 B` of raw WASM
+over that closeout. Every raw, Brotli, and Zstandard cell remains within its
+existing ceiling. The only old-ceiling failure is `resource` gzip at `68636 B`,
+so that one ceiling is aligned from `68608 B` to `69632 B`.
+
 ## Source of Truth
 
 - Workflow: `.github/workflows/ci-wasm-size.yml`
@@ -54,7 +59,7 @@ If no match exists, it reports the default missing path
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
 | router | 117760 B | 45056 B | 58368 B | 51200 B |
 | router-dashboard | 234496 B | 77824 B | 94208 B | 82944 B |
-| resource | 157696 B | 58368 B | 68608 B | 61440 B |
+| resource | 157696 B | 58368 B | 69632 B | 61440 B |
 
 ## Supported Toolchain Baseline Migration - 2026-07-30
 
@@ -172,6 +177,115 @@ one-KiB raw ceiling increases:
 This rebaseline does not authorize general renderer optimization, compressed
 budget changes, ratio changes, workflow changes, or unrelated application
 headroom. No compressed ceiling or compression command changed.
+
+## Controlled Select Descendant-Component Follow-up - 2026-07-31
+
+The parent-driven correction is
+`9531d48ae64fd0db966dad4e03c7f67575e6ed27`, and the initial size closeout is
+`77802ebd219c89805cfc8e5f3c953854a5654055`. The descendant-component
+follow-up is the commit containing this audit, `fix(runtime): sync selects
+after child component updates`. It closes review finding `3690405967` without
+changing the public API or the single-value select contract.
+
+The pre-fix fixture rendered a controlled select with authored value `"b"` and
+only option `"a"`. A stateful child then added option `"b"` independently. The
+parent render count remained `9`, the child render count advanced from `9` to
+`10`, and the same select DOM node contained options `["a", "b"]`, but the
+browser value remained `"a"` at index `0`. No `input` or `change` event fired.
+The same failure reproduced under standard Go and TinyGo.
+
+The correction retains the nearest mounted select on mounted component nodes,
+propagates that owner through elements, fragments, and nested components, and
+reapplies the select's current mounted VNode props after a successful
+independent child patch. A nested select shadows an outer owner, and release
+clears retained ownership before component teardown. The fixture also changes
+the parent value from `"b"` to `"c"` before a child-only option insertion; the
+result selects current value `"c"`, proving that no authored value was captured
+at mount time. Ten fresh package/server/Chrome runs passed under standard Go,
+and ten passed under TinyGo, with stable DOM identity and no synthetic events.
+
+Two bounded compact variants were already exhausted alongside the clearer
+ownership implementation:
+
+| candidate | resource gzip | old-ceiling result | decision |
+| --- | ---: | ---: | --- |
+| compact variant 1 | 68629 B | 21 B over | rejected; the smaller compiler shape did not clear the gate |
+| clear nearest-select ownership | 68636 B | 28 B over | accepted for explicit ownership and lifecycle behavior |
+| compact variant 2 | 68637 B | 29 B over | rejected; no correctness or budget advantage |
+
+Measurements compare the initial closeout head with the accepted follow-up in
+the same extraction path using Go `1.26.5`, TinyGo `0.41.1`, Linux amd64, gzip
+`1.14`, Brotli `1.2.0`, and Zstandard `1.5.7`. Compression uses the unchanged
+budget commands: gzip level 9, Brotli quality 11, and Zstandard level 19.
+
+| app | format | current head | follow-up | delta | ceiling | headroom |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| counter | raw | 85052 B | 85439 B | +387 B | 97280 B | 11841 B |
+| counter | gzip | 34008 B | 34339 B | +331 B | 56320 B | 21981 B |
+| counter | br | 28491 B | 28633 B | +142 B | 40960 B | 12327 B |
+| counter | zstd | 30675 B | 30823 B | +148 B | 49152 B | 18329 B |
+| components | raw | 90691 B | 91078 B | +387 B | 107520 B | 16442 B |
+| components | gzip | 35899 B | 36104 B | +205 B | 56320 B | 20216 B |
+| components | br | 29739 B | 29845 B | +106 B | 43008 B | 13163 B |
+| components | zstd | 32074 B | 32261 B | +187 B | 49152 B | 16891 B |
+| todo | raw | 119938 B | 120344 B | +406 B | 122880 B | 2536 B |
+| todo | gzip | 46336 B | 46571 B | +235 B | 56320 B | 9749 B |
+| todo | br | 38399 B | 38506 B | +107 B | 40960 B | 2454 B |
+| todo | zstd | 41370 B | 41514 B | +144 B | 49152 B | 7638 B |
+| dashboard | raw | 170308 B | 170706 B | +398 B | 171008 B | 302 B |
+| dashboard | gzip | 63874 B | 64126 B | +252 B | 71680 B | 7554 B |
+| dashboard | br | 51504 B | 51645 B | +141 B | 53248 B | 1603 B |
+| dashboard | zstd | 55609 B | 55772 B | +163 B | 61440 B | 5668 B |
+| context | raw | 116828 B | 117215 B | +387 B | 117760 B | 545 B |
+| context | gzip | 44024 B | 44232 B | +208 B | 46080 B | 1848 B |
+| context | br | 35925 B | 36098 B | +173 B | 36864 B | 766 B |
+| context | zstd | 38825 B | 38961 B | +136 B | 40960 B | 1999 B |
+| virtualized | raw | 123762 B | 124160 B | +398 B | 124928 B | 768 B |
+| virtualized | gzip | 47750 B | 47986 B | +236 B | 49152 B | 1166 B |
+| virtualized | br | 39062 B | 39122 B | +60 B | 40960 B | 1838 B |
+| virtualized | zstd | 42290 B | 42422 B | +132 B | 44032 B | 1610 B |
+| multipackage | raw | 95854 B | 96260 B | +406 B | 110592 B | 14332 B |
+| multipackage | gzip | 37642 B | 37856 B | +214 B | 56320 B | 18464 B |
+| multipackage | br | 31123 B | 31354 B | +231 B | 43008 B | 11654 B |
+| multipackage | zstd | 33610 B | 33783 B | +173 B | 49152 B | 15369 B |
+| cmdapp | raw | 95872 B | 96278 B | +406 B | 110592 B | 14314 B |
+| cmdapp | gzip | 37651 B | 37861 B | +210 B | 56320 B | 18459 B |
+| cmdapp | br | 31289 B | 31394 B | +105 B | 43008 B | 11614 B |
+| cmdapp | zstd | 33610 B | 33797 B | +187 B | 49152 B | 15355 B |
+| router | raw | 117117 B | 117523 B | +406 B | 117760 B | 237 B |
+| router | gzip | 44739 B | 44971 B | +232 B | 58368 B | 13397 B |
+| router | br | 36877 B | 37005 B | +128 B | 45056 B | 8051 B |
+| router | zstd | 39773 B | 39933 B | +160 B | 51200 B | 11267 B |
+| router-dashboard | raw | 233941 B | 234357 B | +416 B | 234496 B | 139 B |
+| router-dashboard | gzip | 93747 B | 93995 B | +248 B | 94208 B | 213 B |
+| router-dashboard | br | 77105 B | 77381 B | +276 B | 77824 B | 443 B |
+| router-dashboard | zstd | 82271 B | 82523 B | +252 B | 82944 B | 421 B |
+| resource | raw | 156764 B | 157180 B | +416 B | 157696 B | 516 B |
+| resource | gzip | 68351 B | 68636 B | +285 B | 69632 B | 996 B |
+| resource | br | 57508 B | 57823 B | +315 B | 58368 B | 545 B |
+| resource | zstd | 61140 B | 61371 B | +231 B | 61440 B | 69 B |
+
+SHA-256 values identify the exact measured current-head and follow-up streams:
+
+| app | current raw / gzip / br / zstd | follow-up raw / gzip / br / zstd |
+| --- | --- | --- |
+| counter | `33f72247577f8f2b6f5d6ee889e267d48548236e1cdca0208d9c46efdfbb91b1` / `59044087171271c521850c409618f608285d49814125f08920571d63b5a51880` / `0005f228978e0157b5827b850a88214374c1dcac621754fd9d78fe98a5a425b9` / `b2ad4989f07a3f565789946d819a7c0641d78c2c556e54c3686be2cc7f035cbc` | `773b4effb417d4497f051387e0c2221206014f6cdc79f37cc719f47b0ce8d10f` / `6709d97e54f31ca0e803815cf79e21e80ac3845113426111fc6c6fd43cebe3dc` / `e228bb0e1a8c9e0fd72e0fc316e0f84675332010b7d6d17f82b6c23ad859bb9a` / `bf67579f1d22115f936c32299c57a963ac7a52f9f62b77e77da246535753ea0a` |
+| components | `8a94c41998279827c415d6f4e3fa16c4c74389f43f62d57a1e85a7278858c66c` / `f74455980d64d9cc36705d517af8e08a054c6601fcad211efa6342c2e08598ac` / `96a0c417639f7462ee53cb26afb42e6d1e625854a6961ecca870fade80f4fd40` / `e1cfd1f7e2f47c56b8f7a6aeafff066dfd0979e353b9c960891b039c20a14386` | `e29e56e0ff8a863f35faf5423a5ea0e888e97c244ef4cd87d420fbf9818117b7` / `2821267b0fb2ec2857fff5a95625a9a8d92f939172416a8846bd26b410123a14` / `bb5dceee395bfe0828b1d44e64ca66dcd8ba7cc92ecd04f66e6df78682de4ee4` / `4a38d62198fd72b7516f00ea0ad5adc7939014de9768d22bf071ed91039b728d` |
+| todo | `54b7308666ddb090bf5ae3a93120e1158a7fa218b0f8698ab78a5462b06e1664` / `f3ac9b9b13177ab7916f0f426ea93f21d74587341c09b6dc1708f4a197b766ac` / `044130a727035557237045b19e1fa8f5637361eb68805a1e4bbfefcf8d795042` / `2ce6d7540b09311ae9a01d0c5770612ffefd500fdaaffb13437a778843e966c3` | `96c27f77d529548334fc683e4a8a847830f742a2a44a9c53cd143cd3328fcde4` / `187305a1e3b12e3fe994704ecf023f8d4da884abcc98dbb743d78eaec4ddbe70` / `ec67c7bcb0aeffd4cf3bc0353dadb9062ab0d7889430f2bac9ae44d73d6071aa` / `c67daf7da9c9a0e0780e25460038c217523c31c85d84946835ef54039d5c8842` |
+| dashboard | `bc59482b4746f5a9100e8072769289d6e34d99fc57121c7358bce8e44afa2aa9` / `f651da4454df46f897b508da4721dc10d90f0c6f375ed3e17be3882c169c9553` / `bc4a86bd158acfd4759dd95f37b754fafc0823b8e856448ded97c15f2bd63546` / `95466f901011a6eec1cbb52cb19f1d249ec9256344cd0520dd0589ff3158dec8` | `bbbef9fbd418fe85746d3544286b2457b1ece002cf776ceb20afbffebaca2864` / `837fc55e52a99acc698fa977300d93b95f9b673d8b84d1a7e576a3112592d15` / `a9ab0f3b7641082ccac7f22460e75d5cf791c439d125c6d05af0bb2c2bfd747d` / `5d2310ade93819eba619ad64fe0d8a11dd141b565e0c694ebfe0549910901d02` |
+| context | `f4d4c19c691aa91a568fa361dc0fd017812fe1cb81c040443611627346168e8a` / `f17e3cf16f1e0926a8948ec4983d362a4d48b83043510842b399a8a025908209` / `48b37204950035db1db84074931603a8682e95ba1e5b65cdd2b37737cfee0e5b` / `edeefab63505a649e51ea9b8e96100f384dbd1a6d92ed131a9e8a63eaa7ebe1a` | `a7a0691659447a67cbbdf183f198107b86a09be25e99d4b589a0c4ef811f2067` / `f1deba745e4b669df669a0961fb110b65376738169fb1579489208a74c5b1026` / `e04340ff513e8e1a9d4088e7e9dbb8ae8472085b3b58811f3f83356f921a3493` / `b94940a80d59510b3f3677becfbc15de4bd5a57586cb50c87845a776ed639b5b` |
+| virtualized | `1c36299671986e8aef8c2203ccd6a5bb2159a2246677a1189483c3dd0efa5378` / `eaecb7cb68d70d7e90a6ba1f3f38c0a838d65e5bf7053d90158b8be3cf1f21d5` / `000bcfcabcb6ab7b4a50850232f960c7522ff6b111b5cf8420d37cb88df1697d` / `9ea8454dfe3fd8541e2db854b04923830e3d30ba0971117552775d76cd62d952` | `4e120d473883ba074285a918b73e1b37a66f81e7850aa7d7b985f2c8cc8d263b` / `cc19b8c53c707468ae35dd700224aa02a57054fc2fc222bab6aef979fa6a8868` / `e875b23552a8b4542298e8e9bbf9d1150dcedeab76e743aa3cb16077a513b42a` / `1d421a384b4477ca373449dfe4deb233ed8299b5f78eb5c9e19172b0f2db203f` |
+| multipackage | `83f3402aae1b8a0bd358616810e0574e0a6cf02ff3ef197cca47c5f38c78c3f0` / `5168bc907547ff19bf1fb4b2da17ef74ce7fb80e4a4adc43d531a9a593e0a0be` / `ab69df4744ec8fa2686b87f3e731237cca8c86d7b15f3b06cc12b958aa7bd5ea` / `9e0dea0bdb28e893e2374e0eed8ab107f4cd350dc0b2a256b56de0a41f222f69` | `601d36f8d6e5b90bffcb80e164c1c8f73502df42a8a20dd017ea16dec5e37677` / `404e672b5581c747265a97ff8c0eb443979438a5f1cbd061d990273f28385b16` / `cc3631ccbd7e474d9aaa0fd09efdbec755935af6f19c33d76128a2f68708344d` / `697693ce66d0af59d5ade0531d17b32c228a2baa57641aadbb7f4ca1572f9d85` |
+| cmdapp | `f0ae215386be33e6b9f35b4e62a19a32cabca8d11c7aaa9689a0e5e5b66fcbae` / `6cacb0f27327532d7960fb32d0a1d974de16e0f98f43ccb5032b63081f584933` / `0fcc6c7990aaeefe0aaa98583d0bca0e6935b7a1008789c1979151cedd863158` / `f2c14a052573f66c609257e59faf5fdb841e510ab86b9fc37cda8de77e91dd0c` | `32a47fc52c53c53de985602a4624cfe67f76fd6aa444a8f61823389fe9648640` / `8704fa998501e2ae9b13867a284e7ecf0fd9fad41018df80a4fa942caafa1216` / `eae473813325102d777a136074ba82b5da04c54587017a46627708546b73b9f2` / `e7428a7d96e222a9566ce048065000712b5790e9f7601dddc2c46756002bd598` |
+| router | `f49b180f0a523a2ec5e3d5e9cf8152f799c3f8ffbcdf312e73516844c2792978` / `3320ef65841ccbf4af2001b08449560cce3f05f16459e6df070fb9b02bd9675d` / `f1ff16268f064313e9fffdf8be7acfaa0e4ba829c5250e2a3724eac4e89729c4` / `18d7a50a16fed4f47d16c06ed27376483db5b3429bdd531ee9546dc0f27c67b6` | `242c0f6c65028f3f21a00932265d5c24148df2c1b84cd8d76bad267fcdcc6638` / `cbfd9e5a9f5bff9c29bdf3a14e97e42cc308aecd3e9b79196ce94ee43db2efdf` / `db0e79ce2ef23b5c7f81baa0cec76756b9894a72487da468efef5b3c86e08702` / `17ef65a118cba5daa930be86cb3a806c5a8f9a0da1c609b830659502c8b6539b` |
+| router-dashboard | `9dd248b23ebc527037eb53e504e9f90fd5bfa52cbcc94e45ea23943b8ed578d8` / `4520eae8500d12a21f0f0aca562bf88d26e817d45a3ecb683e95a7dab40458ac` / `f83cf0932ae31a132e475e9b7c4c07c445699e3a8bf33ceb0a716cc50d11d504` / `18dc21f40c6e21e1808e2bd2f22c558d16249a3a0ba511c1a276381bf9c9a782` | `4ca08e0be2db602601306e1b7c7f2ad48454f39c57b7cd798f2268df4cc0ae97` / `6214017b749fa20c2ac72d17230ee7e7322af29110d66dc1b59a62fa6b1f94fc` / `9734a0d25a87000a92161f230fa85b5f612f0dbf41f1f0448b5d9e859a9baa35` / `327781d1ca426e1d0d36a60ddde288894823f83b8ca3289463e99afc0a8ad3a5` |
+| resource | `03f7f32e9c9e422a78b7aa8bf131d8575c4b0a8471be106adc1062d7703a2aa1` / `bca9aad94cc3a2bcaf283d930de0c8d66ac84db66b78518cae27f8fd06a7f9e1` / `161223db5a6cfd3cc027207540e38c483a86fe949cd6955244bf45915b1259ca` / `ce9ce0fd7033c93514cbaa65edf06af4a3e568b9de6cd1e33d007f94a23a3401` | `17b29f7b316e77d5b5872f613f3699db43bb0de4122c49c71632af6107a0a171` / `5f5c0187a2ff7b488d8d60a14744348c9b1aa7bcce13da959ac96ebe7616435e` / `97d2966701e8c746d73f6ae72b252a88ce4d5c100a83db72bae935e519d2a560` / `49c3731eccf30634e1cc1affa9a32cdf39d787e2924712de95289234fb43b376` |
+
+Every final raw artifact reproduced byte-for-byte in a second package tree, and
+all compressed sizes reproduced. All 44 cells pass. The only ceiling change is
+`resource` gzip, from `68608 B` to `69632 B`, leaving `996 B` of headroom.
+Raw, Brotli, and Zstandard ceilings are unchanged, as are gzip `52.00%`,
+Brotli `38.00%`, and Zstandard `46.00%` ratio limits and the WASM workflow.
 
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -24,9 +24,14 @@ type mountedNode struct {
 	events         map[string]*mountedEvent
 	component      *componentInstance
 	componentChild *mountedNode
+	selectOwner    *mountedNode
 }
 
 func mountNode(document js.Value, node Node, owner *componentInstance) *mountedNode {
+	return mountNodeBelow(document, node, owner, nil)
+}
+
+func mountNodeBelow(document js.Value, node Node, owner *componentInstance, selectOwner *mountedNode) *mountedNode {
 	key, node := unwrapNode(node)
 	mounted := &mountedNode{
 		node:    node,
@@ -41,7 +46,10 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		mounted.last = element
 		mounted.pending = element
 		patchProps(element, mounted, nil, node.Props, owner)
-		mounted.children = mountChildren(document, element, node.Children, js.Null(), owner)
+		if node.Tag == "select" {
+			selectOwner = mounted
+		}
+		mounted.children = mountChildren(document, element, node.Children, js.Null(), owner, selectOwner)
 		applyPostChildrenProps(element, node)
 	case TextNode:
 		text := document.Call("createTextNode", node.Value)
@@ -53,7 +61,7 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		end := document.Call("createComment", "/goframe-fragment")
 		fragment := document.Call("createDocumentFragment")
 		fragment.Call("appendChild", start)
-		mounted.children = mountChildren(document, fragment, node.Children, js.Null(), owner)
+		mounted.children = mountChildren(document, fragment, node.Children, js.Null(), owner, selectOwner)
 		fragment.Call("appendChild", end)
 		mounted.first = start
 		mounted.last = end
@@ -64,7 +72,7 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		mounted.last = comment
 		mounted.pending = comment
 	case ComponentNode:
-		mountComponent(document, mounted, node, owner)
+		mountComponent(document, mounted, node, owner, selectOwner)
 	default:
 		panic("goframe: unsupported node type")
 	}
@@ -81,21 +89,31 @@ func applyPostChildrenProps(element js.Value, node VNode) {
 	}
 }
 
-func mountChildren(document, parent js.Value, nodes []Node, boundary js.Value, owner *componentInstance) []*mountedNode {
+func applyMountedSelectProps(mounted *mountedNode) {
+	if mounted == nil {
+		return
+	}
+	node, ok := mounted.node.(VNode)
+	if ok {
+		applyPostChildrenProps(mounted.first, node)
+	}
+}
+
+func mountChildren(document, parent js.Value, nodes []Node, boundary js.Value, owner *componentInstance, selectOwner *mountedNode) []*mountedNode {
 	reportDuplicateSiblingNodeKeys(nodes, ownerDebugName(owner))
 	children := make([]*mountedNode, 0, len(nodes))
 	for _, node := range nodes {
-		child := mountNode(document, node, owner)
+		child := mountNodeBelow(document, node, owner, selectOwner)
 		placeMountedBefore(parent, child, boundary)
 		children = append(children, child)
 	}
 	return children
 }
 
-func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node, owner *componentInstance) *mountedNode {
+func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node, owner *componentInstance, selectOwner *mountedNode) *mountedNode {
 	newKey, newNode := unwrapNode(newNode)
 	if mounted.key != newKey || !sameNodeIdentity(mounted.node, newNode) {
-		replacement := mountNode(document, Key(newKey, newNode), owner)
+		replacement := mountNodeBelow(document, Key(newKey, newNode), owner, selectOwner)
 		placeMountedBefore(parent, replacement, mounted.first)
 		removeMounted(parent, mounted)
 		return replacement
@@ -105,7 +123,10 @@ func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node,
 	case VNode:
 		newNode := newNode.(VNode)
 		patchProps(mounted.first, mounted, oldNode.Props, newNode.Props, owner)
-		mounted.children = patchChildren(document, mounted.first, mounted.children, newNode.Children, js.Null(), owner)
+		if newNode.Tag == "select" {
+			selectOwner = mounted
+		}
+		mounted.children = patchChildren(document, mounted.first, mounted.children, newNode.Children, js.Null(), owner, selectOwner)
 		applyPostChildrenProps(mounted.first, newNode)
 	case TextNode:
 		newNode := newNode.(TextNode)
@@ -114,9 +135,10 @@ func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node,
 		}
 	case FragmentNode:
 		newNode := newNode.(FragmentNode)
-		mounted.children = patchChildren(document, parent, mounted.children, newNode.Children, mounted.last, owner)
+		mounted.children = patchChildren(document, parent, mounted.children, newNode.Children, mounted.last, owner, selectOwner)
 	case EmptyNode:
 	case ComponentNode:
+		mounted.selectOwner = selectOwner
 		patchComponent(document, parent, mounted, newNode.(ComponentNode), owner)
 	}
 	mounted.node = newNode
@@ -124,9 +146,10 @@ func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node,
 	return mounted
 }
 
-func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode, owner *componentInstance) {
+func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode, owner *componentInstance, selectOwner *mountedNode) {
 	instance := newComponentInstance(node, mounted.key, owner, queueDirtyComponent)
 	mounted.component = instance
+	mounted.selectOwner = selectOwner
 
 	start := document.Call("createComment", "goframe-component")
 	end := document.Call("createComment", "/goframe-component")
@@ -136,7 +159,7 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 	if state := instance.errorBoundary; state != nil {
 		defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
 	}
-	child := mountNode(document, rendered, instance)
+	child := mountNodeBelow(document, rendered, instance, selectOwner)
 	placeMountedBefore(fragment, child, js.Null())
 	fragment.Call("appendChild", end)
 	mounted.componentChild = child
@@ -167,6 +190,7 @@ func mountComponent(document js.Value, mounted *mountedNode, node ComponentNode,
 			}
 		}
 		patchComponent(document, parent, mounted, instance.node, instance.parent)
+		applyMountedSelectProps(mounted.selectOwner)
 	}
 }
 
@@ -186,10 +210,10 @@ func patchComponent(document, parent js.Value, mounted *mountedNode, newNode Com
 		state.phase == errorBoundaryProtected {
 		defer finishProtectedLifecycle(state, beginProtectedLifecycle(state))
 	}
-	mounted.componentChild = patchMounted(document, parent, mounted.componentChild, rendered, instance)
+	mounted.componentChild = patchMounted(document, parent, mounted.componentChild, rendered, instance, mounted.selectOwner)
 }
 
-func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNodes []Node, boundary js.Value, owner *componentInstance) []*mountedNode {
+func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNodes []Node, boundary js.Value, owner *componentInstance, selectOwner *mountedNode) []*mountedNode {
 	oldKeys := make([]string, len(oldChildren))
 	for index, child := range oldChildren {
 		oldKeys[index] = child.key
@@ -206,11 +230,11 @@ func patchChildren(document, parent js.Value, oldChildren []*mountedNode, newNod
 	for index, node := range newNodes {
 		oldIndex := matches[index]
 		if oldIndex == noChildMatch {
-			children[index] = mountNode(document, node, owner)
+			children[index] = mountNodeBelow(document, node, owner, selectOwner)
 			continue
 		}
 		used[oldIndex] = true
-		children[index] = patchMounted(document, parent, oldChildren[oldIndex], node, owner)
+		children[index] = patchMounted(document, parent, oldChildren[oldIndex], node, owner, selectOwner)
 	}
 	for index, child := range oldChildren {
 		if !used[index] {
@@ -271,6 +295,7 @@ func releaseMounted(mounted *mountedNode) {
 		return
 	}
 	if mounted.component != nil {
+		mounted.selectOwner = nil
 		releaseMounted(mounted.componentChild)
 		deactivateComponent(mounted.component)
 		mounted.component = nil

--- a/pkg/goframe/render_js.go
+++ b/pkg/goframe/render_js.go
@@ -42,7 +42,7 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 		mounted.pending = element
 		patchProps(element, mounted, nil, node.Props, owner)
 		mounted.children = mountChildren(document, element, node.Children, js.Null(), owner)
-		applyPostMountProps(element, node)
+		applyPostChildrenProps(element, node)
 	case TextNode:
 		text := document.Call("createTextNode", node.Value)
 		mounted.first = text
@@ -71,7 +71,7 @@ func mountNode(document js.Value, node Node, owner *componentInstance) *mountedN
 	return mounted
 }
 
-func applyPostMountProps(element js.Value, node VNode) {
+func applyPostChildrenProps(element js.Value, node VNode) {
 	if node.Tag != "select" || len(node.Props) == 0 {
 		return
 	}
@@ -106,6 +106,7 @@ func patchMounted(document, parent js.Value, mounted *mountedNode, newNode Node,
 		newNode := newNode.(VNode)
 		patchProps(mounted.first, mounted, oldNode.Props, newNode.Props, owner)
 		mounted.children = patchChildren(document, mounted.first, mounted.children, newNode.Children, js.Null(), owner)
+		applyPostChildrenProps(mounted.first, newNode)
 	case TextNode:
 		newNode := newNode.(TextNode)
 		if oldNode.Value != newNode.Value {

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -10,6 +10,7 @@ TODO_SMOKE_URL_BASE="${GOFRAME_TODO_SMOKE_URL:-http://127.0.0.1}"
 DUPLICATE_SMOKE_URL_BASE="${GOFRAME_DUPLICATE_KEY_SMOKE_URL:-http://127.0.0.1}"
 RUNTIME_ERRORS_SMOKE_URL_BASE="${GOFRAME_RUNTIME_ERRORS_SMOKE_URL:-http://127.0.0.1}"
 ERROR_BOUNDARY_SMOKE_URL_BASE="${GOFRAME_ERROR_BOUNDARY_SMOKE_URL:-http://127.0.0.1}"
+CONTROLLED_SELECT_SMOKE_URL_BASE="${GOFRAME_CONTROLLED_SELECT_SMOKE_URL:-http://127.0.0.1}"
 DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
 VIRTUALIZED_SMOKE_URL_BASE="${GOFRAME_VIRTUALIZED_SMOKE_URL:-http://127.0.0.1}"
@@ -102,6 +103,11 @@ build_runtime_errors_smoke_url() {
 build_error_boundary_smoke_url() {
 	local port="$1"
 	echo "${ERROR_BOUNDARY_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_controlled_select_smoke_url() {
+	local port="$1"
+	echo "${CONTROLLED_SELECT_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 build_dashboard_smoke_url() {
@@ -202,6 +208,12 @@ run_with_server() {
 	return "$status"
 }
 
+run_controlled_select_browser() {
+	local compiler="$1"
+	local url="$2"
+	node --experimental-websocket scripts/controlled-select-browser-smoke.mjs "$url" "$compiler"
+}
+
 if [[ -z "$GOXC" ]]; then
 	GOBIN="$BIN_DIR" go install ./cmd/goxc
 	GOXC="$BIN_DIR/goxc"
@@ -261,6 +273,26 @@ export GOFRAME_ERROR_BOUNDARY_CHROME_DEBUG_PORT="${GOFRAME_ERROR_BOUNDARY_CHROME
 ERROR_BOUNDARY_URL="$(build_error_boundary_smoke_url "$ERROR_BOUNDARY_PORT")"
 run_with_server ./scripts/fixtures/error-boundary "$ERROR_BOUNDARY_PORT" "$ERROR_BOUNDARY_URL" \
 	node --experimental-websocket scripts/error-boundary-browser-smoke.mjs
+
+echo
+echo "== Controlled select browser smoke (TinyGo) =="
+"$GOXC" package ./scripts/fixtures/controlled-select --compiler=tinygo
+
+CONTROLLED_SELECT_TINYGO_PORT="$(resolve_port "${GOFRAME_CONTROLLED_SELECT_TINYGO_SMOKE_PORT:-}")"
+export GOFRAME_CONTROLLED_SELECT_CHROME_DEBUG_PORT="$(pick_free_port)"
+CONTROLLED_SELECT_TINYGO_URL="$(build_controlled_select_smoke_url "$CONTROLLED_SELECT_TINYGO_PORT")"
+run_with_server ./scripts/fixtures/controlled-select "$CONTROLLED_SELECT_TINYGO_PORT" "$CONTROLLED_SELECT_TINYGO_URL" \
+	run_controlled_select_browser tinygo
+
+echo
+echo "== Controlled select browser smoke (standard Go) =="
+"$GOXC" package ./scripts/fixtures/controlled-select --compiler=go
+
+CONTROLLED_SELECT_GO_PORT="$(resolve_port "${GOFRAME_CONTROLLED_SELECT_GO_SMOKE_PORT:-}")"
+export GOFRAME_CONTROLLED_SELECT_CHROME_DEBUG_PORT="$(pick_free_port)"
+CONTROLLED_SELECT_GO_URL="$(build_controlled_select_smoke_url "$CONTROLLED_SELECT_GO_PORT")"
+run_with_server ./scripts/fixtures/controlled-select "$CONTROLLED_SELECT_GO_PORT" "$CONTROLLED_SELECT_GO_URL" \
+	run_controlled_select_browser go
 
 echo
 echo "== Dashboard debug browser smoke =="

--- a/scripts/controlled-select-browser-smoke.mjs
+++ b/scripts/controlled-select-browser-smoke.mjs
@@ -46,6 +46,8 @@ try {
             document.querySelector("[data-testid='controlled-select']");
         window.__uncontrolledSelectNode =
             document.querySelector("[data-testid='uncontrolled-select']");
+        window.__descendantControlledSelectNode =
+            document.querySelector("[data-testid='descendant-controlled-select']");
         return true;
     })()`);
 
@@ -206,6 +208,153 @@ try {
         changeCount: 1,
     }));
 
+    evidence.push(await assertSnapshot(client, "descendant initial no-match", {
+        descendantPhase: "only-a",
+        descendantAuthoredValue: "b",
+        descendantOptionValues: ["a"],
+        descendantActualValue: "",
+        descendantSelectedIndex: -1,
+        descendantSame: true,
+        descendantParentRenderCount: 9,
+        descendantChildRenderCount: 9,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-add-match']",
+        (state) => state.descendantPhase === "a-and-b",
+        "descendant matching option insertion",
+    );
+    evidence.push(await assertSnapshot(client, "descendant add matching option", {
+        descendantPhase: "a-and-b",
+        descendantAuthoredValue: "b",
+        descendantOptionValues: ["a", "b"],
+        descendantActualValue: "b",
+        descendantSelectedIndex: 1,
+        descendantSame: true,
+        descendantParentRenderCount: 9,
+        descendantChildRenderCount: 10,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-remove-match']",
+        (state) => state.descendantPhase === "only-a",
+        "descendant matching option removal",
+    );
+    evidence.push(await assertSnapshot(client, "descendant remove matching option", {
+        descendantPhase: "only-a",
+        descendantAuthoredValue: "b",
+        descendantOptionValues: ["a"],
+        descendantActualValue: "",
+        descendantSelectedIndex: -1,
+        descendantSame: true,
+        descendantParentRenderCount: 9,
+        descendantChildRenderCount: 11,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-restore-match']",
+        (state) => state.descendantPhase === "a-and-b",
+        "descendant matching option restoration",
+    );
+    evidence.push(await assertSnapshot(client, "descendant restore matching option", {
+        descendantPhase: "a-and-b",
+        descendantAuthoredValue: "b",
+        descendantOptionValues: ["a", "b"],
+        descendantActualValue: "b",
+        descendantSelectedIndex: 1,
+        descendantSame: true,
+        descendantParentRenderCount: 9,
+        descendantChildRenderCount: 12,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-change-value']",
+        (state) => state.descendantAuthoredValue === "c",
+        "descendant parent value change",
+    );
+    evidence.push(await assertSnapshot(client, "descendant change current value", {
+        descendantPhase: "a-and-b",
+        descendantAuthoredValue: "c",
+        descendantOptionValues: ["a", "b"],
+        descendantActualValue: "",
+        descendantSelectedIndex: -1,
+        descendantSame: true,
+        descendantParentRenderCount: 10,
+        descendantChildRenderCount: 13,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-add-current']",
+        (state) => state.descendantPhase === "a-b-and-c",
+        "descendant current option insertion",
+    );
+    evidence.push(await assertSnapshot(client, "descendant add current option", {
+        descendantPhase: "a-b-and-c",
+        descendantAuthoredValue: "c",
+        descendantOptionValues: ["a", "b", "c"],
+        descendantActualValue: "c",
+        descendantSelectedIndex: 2,
+        descendantSame: true,
+        descendantParentRenderCount: 10,
+        descendantChildRenderCount: 14,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='descendant-reorder']",
+        (state) => state.descendantPhase === "c-a-and-b",
+        "descendant option reorder",
+    );
+    evidence.push(await assertSnapshot(client, "descendant reorder options", {
+        descendantPhase: "c-a-and-b",
+        descendantAuthoredValue: "c",
+        descendantOptionValues: ["c", "a", "b"],
+        descendantActualValue: "c",
+        descendantSelectedIndex: 0,
+        descendantSame: true,
+        descendantParentRenderCount: 10,
+        descendantChildRenderCount: 15,
+        descendantInputCount: 0,
+        descendantChangeCount: 0,
+    }));
+
+    await client.evaluate(`(() => {
+        document.querySelector("[data-testid='descendant-controlled-select']")
+            .dispatchEvent(new Event("change", { bubbles: true }));
+        return true;
+    })()`);
+    await waitForState(
+        client,
+        (state) => state.descendantChangeCount === 1,
+        "explicit descendant change callback",
+    );
+    evidence.push(await assertSnapshot(client, "descendant explicit event liveness", {
+        descendantActualValue: "c",
+        descendantSelectedIndex: 0,
+        descendantSame: true,
+        descendantParentRenderCount: 11,
+        descendantChildRenderCount: 16,
+        descendantInputCount: 0,
+        descendantChangeCount: 1,
+    }));
+
     console.log(`controlled select evidence (${compiler}): ${JSON.stringify(evidence)}`);
     client.close();
     console.log(`Controlled select browser smoke (${compiler}): ok`);
@@ -263,6 +412,10 @@ async function selectState(client) {
             document.querySelector("[data-testid='controlled-select']");
         const uncontrolled =
             document.querySelector("[data-testid='uncontrolled-select']");
+        const descendant =
+            document.querySelector("[data-testid='descendant-controlled-select']");
+        const statefulOptions =
+            document.querySelector("[data-testid='stateful-options']");
         const number = (selector) =>
             Number(document.querySelector(selector)?.textContent.trim() ?? "0");
         return {
@@ -286,6 +439,23 @@ async function selectState(client) {
             uncontrolledSame: uncontrolled === window.__uncontrolledSelectNode,
             uncontrolledRenderCount:
                 number("[data-testid='uncontrolled-rerender-count']"),
+            descendantPhase: statefulOptions?.dataset.phase ?? "",
+            descendantAuthoredValue: descendant?.dataset.authoredValue ?? "",
+            descendantOptionValues: descendant
+                ? Array.from(descendant.options, (option) => option.value)
+                : [],
+            descendantActualValue: descendant?.value ?? "",
+            descendantSelectedIndex: descendant?.selectedIndex ?? -2,
+            descendantSame:
+                descendant === window.__descendantControlledSelectNode,
+            descendantParentRenderCount:
+                number("[data-testid='descendant-parent-render-count']"),
+            descendantChildRenderCount:
+                Number(statefulOptions?.dataset.renderCount ?? "0"),
+            descendantInputCount:
+                number("[data-testid='descendant-input-count']"),
+            descendantChangeCount:
+                number("[data-testid='descendant-change-count']"),
         };
     })()`);
 }

--- a/scripts/controlled-select-browser-smoke.mjs
+++ b/scripts/controlled-select-browser-smoke.mjs
@@ -1,0 +1,419 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_CONTROLLED_SELECT_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const compiler = process.argv[3] ?? "unknown";
+const debugPort = Number(process.env.GOFRAME_CONTROLLED_SELECT_CHROME_DEBUG_PORT ?? "19261");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-controlled-select-smoke-"));
+const expectedApp = new URL(appURL);
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+let browserExit = null;
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+browser.on("exit", (code, signal) => {
+    browserExit = { code, signal };
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Page.navigate", { url: withSmokeParam(appURL, compiler) });
+    await waitForAppPage(client, expectedApp);
+
+    await client.evaluate(`(() => {
+        window.__controlledSelectNode =
+            document.querySelector("[data-testid='controlled-select']");
+        window.__uncontrolledSelectNode =
+            document.querySelector("[data-testid='uncontrolled-select']");
+        return true;
+    })()`);
+
+    const evidence = [];
+    evidence.push(await assertSnapshot(client, "initial no-match mount", {
+        phase: "initial-no-match",
+        authoredValue: "b",
+        optionValues: ["a"],
+        actualValue: "",
+        selectedIndex: -1,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-add-match']",
+        (state) => state.phase === "matching-option-added",
+        "matching option insertion",
+    );
+    evidence.push(await assertSnapshot(client, "add matching option", {
+        phase: "matching-option-added",
+        authoredValue: "b",
+        optionValues: ["a", "b"],
+        actualValue: "b",
+        selectedIndex: 1,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-change-value']",
+        (state) => state.phase === "value-and-options-changed",
+        "value and option change",
+    );
+    evidence.push(await assertSnapshot(client, "change value and options", {
+        phase: "value-and-options-changed",
+        authoredValue: "c",
+        optionValues: ["a", "c"],
+        actualValue: "c",
+        selectedIndex: 1,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-remove-match']",
+        (state) => state.phase === "matching-option-removed",
+        "matching option removal",
+    );
+    evidence.push(await assertSnapshot(client, "remove matching option", {
+        phase: "matching-option-removed",
+        authoredValue: "c",
+        optionValues: ["a", "b"],
+        actualValue: "",
+        selectedIndex: -1,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-restore-match']",
+        (state) => state.phase === "matching-option-restored",
+        "matching option restoration",
+    );
+    evidence.push(await assertSnapshot(client, "restore matching option", {
+        phase: "matching-option-restored",
+        authoredValue: "c",
+        optionValues: ["a", "b", "c"],
+        actualValue: "c",
+        selectedIndex: 2,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-reorder']",
+        (state) => state.phase === "options-reordered",
+        "option reorder",
+    );
+    evidence.push(await assertSnapshot(client, "reorder options", {
+        phase: "options-reordered",
+        authoredValue: "c",
+        optionValues: ["c", "a", "b"],
+        actualValue: "c",
+        selectedIndex: 0,
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 0,
+    }));
+
+    await client.evaluate(`(() => {
+        const select = document.querySelector("[data-testid='uncontrolled-select']");
+        select.value = "b";
+        return select.value;
+    })()`);
+    evidence.push(await assertSnapshot(client, "set uncontrolled selection", {
+        uncontrolledValue: "b",
+        uncontrolledIndex: 1,
+        uncontrolledOptions: ["a", "b"],
+        uncontrolledSame: true,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-rerender-uncontrolled']",
+        (state) => state.uncontrolledRenderCount === 1,
+        "uncontrolled unrelated rerender",
+    );
+    evidence.push(await assertSnapshot(client, "uncontrolled rerender", {
+        uncontrolledValue: "b",
+        uncontrolledIndex: 1,
+        uncontrolledOptions: ["a", "b"],
+        uncontrolledSame: true,
+    }));
+
+    await clickAndWait(
+        client,
+        "[data-testid='select-extend-uncontrolled']",
+        (state) => state.uncontrolledOptions.length === 3,
+        "uncontrolled option insertion",
+    );
+    evidence.push(await assertSnapshot(client, "uncontrolled option insertion", {
+        uncontrolledValue: "b",
+        uncontrolledIndex: 1,
+        uncontrolledOptions: ["a", "b", "c"],
+        uncontrolledSame: true,
+    }));
+
+    evidence.push(await assertSnapshot(client, "programmatic event counts", {
+        actualValue: "c",
+        inputCount: 0,
+        changeCount: 0,
+    }));
+    await client.evaluate(`(() => {
+        document.querySelector("[data-testid='controlled-select']")
+            .dispatchEvent(new Event("change", { bubbles: true }));
+        return true;
+    })()`);
+    await waitForState(
+        client,
+        (state) => state.changeCount === 1,
+        "explicit controlled change callback",
+    );
+    evidence.push(await assertSnapshot(client, "explicit event liveness", {
+        actualValue: "c",
+        controlledSame: true,
+        inputCount: 0,
+        changeCount: 1,
+    }));
+
+    console.log(`controlled select evidence (${compiler}): ${JSON.stringify(evidence)}`);
+    client.close();
+    console.log(`Controlled select browser smoke (${compiler}): ok`);
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function assertSnapshot(client, label, expected) {
+    const actual = await selectState(client);
+    console.log(`controlled select ${label} (${compiler}): ${JSON.stringify(actual)}`);
+    for (const [key, value] of Object.entries(expected)) {
+        if (JSON.stringify(actual[key]) !== JSON.stringify(value)) {
+            throw new Error(
+                `APP FAILURE: ${label} (${compiler}): ${key} got ` +
+                `${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; ` +
+                `state=${JSON.stringify(actual)}`,
+            );
+        }
+    }
+    return { label, ...actual };
+}
+
+async function clickAndWait(client, selector, predicate, label) {
+    await client.evaluate(`(() => {
+        const button = document.querySelector(${JSON.stringify(selector)});
+        if (!button) throw new Error("missing button " + ${JSON.stringify(selector)});
+        button.click();
+        return true;
+    })()`);
+    await waitForState(client, predicate, label);
+}
+
+async function waitForState(client, predicate, label) {
+    const started = Date.now();
+    let lastState;
+    while (Date.now() - started < 10_000) {
+        lastState = await selectState(client);
+        if (predicate(lastState)) {
+            return lastState;
+        }
+        await wait(50);
+    }
+    throw new Error(
+        `APP FAILURE: timed out waiting for ${label} (${compiler}); ` +
+        `state=${JSON.stringify(lastState)}`,
+    );
+}
+
+async function selectState(client) {
+    return await client.evaluate(`(() => {
+        const controlled =
+            document.querySelector("[data-testid='controlled-select']");
+        const uncontrolled =
+            document.querySelector("[data-testid='uncontrolled-select']");
+        const number = (selector) =>
+            Number(document.querySelector(selector)?.textContent.trim() ?? "0");
+        return {
+            phase:
+                document.querySelector("[data-testid='controlled-phase']")
+                    ?.textContent.trim() ?? "",
+            authoredValue: controlled?.dataset.authoredValue ?? "",
+            optionValues: controlled
+                ? Array.from(controlled.options, (option) => option.value)
+                : [],
+            actualValue: controlled?.value ?? "",
+            selectedIndex: controlled?.selectedIndex ?? -2,
+            controlledSame: controlled === window.__controlledSelectNode,
+            inputCount: number("[data-testid='controlled-input-count']"),
+            changeCount: number("[data-testid='controlled-change-count']"),
+            uncontrolledValue: uncontrolled?.value ?? "",
+            uncontrolledIndex: uncontrolled?.selectedIndex ?? -2,
+            uncontrolledOptions: uncontrolled
+                ? Array.from(uncontrolled.options, (option) => option.value)
+                : [],
+            uncontrolledSame: uncontrolled === window.__uncontrolledSelectNode,
+            uncontrolledRenderCount:
+                number("[data-testid='uncontrolled-rerender-count']"),
+        };
+    })()`);
+}
+
+async function waitForPage(port) {
+    let lastError;
+    for (let attempt = 0; attempt < 100; attempt++) {
+        if (browserExit) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome exited before CDP was ready ` +
+                `(${compiler}): ${JSON.stringify(browserExit)}\n${browserError}`,
+            );
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            if (response.ok) {
+                const targets = await response.json();
+                const page = targets.find(
+                    (target) => target.type === "page" && target.webSocketDebuggerUrl,
+                );
+                if (page) {
+                    return page;
+                }
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(50);
+    }
+    throw new Error(
+        `HARNESS FAILURE: Chrome DevTools did not become ready (${compiler}): ` +
+        `${lastError?.message ?? browserError}`,
+    );
+}
+
+async function waitForAppPage(client, expected) {
+    const started = Date.now();
+    let lastState;
+    while (Date.now() - started < 10_000) {
+        lastState = await client.evaluate(`(() => ({
+            href: location.href,
+            origin: location.origin,
+            protocol: location.protocol,
+            readyState: document.readyState,
+            root: Boolean(document.querySelector("#root")),
+            appReady: Boolean(
+                document.querySelector("[data-testid='controlled-select-fixture']"),
+            ),
+        }))()`);
+        if (lastState.href.startsWith("chrome-error://")) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome loaded an error document (${compiler}): ` +
+                `${JSON.stringify(lastState)}`,
+            );
+        }
+        if (
+            (lastState.protocol === "http:" || lastState.protocol === "https:") &&
+            lastState.origin === expected.origin &&
+            lastState.root &&
+            lastState.appReady
+        ) {
+            return;
+        }
+        await wait(50);
+    }
+    throw new Error(
+        `HARNESS FAILURE: app did not become ready at expected origin ` +
+        `(${compiler}): ${JSON.stringify(lastState)}`,
+    );
+}
+
+function withSmokeParam(url, label) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", `${Date.now()}-${label}`);
+    return next.toString();
+}
+
+async function connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+        socket.addEventListener("open", resolve, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+    });
+
+    let nextID = 1;
+    const pending = new Map();
+    socket.addEventListener("message", (event) => {
+        const message = JSON.parse(event.data);
+        if (!message.id || !pending.has(message.id)) {
+            return;
+        }
+        const request = pending.get(message.id);
+        pending.delete(message.id);
+        if (message.error) {
+            request.reject(new Error(message.error.message));
+        } else {
+            request.resolve(message.result ?? {});
+        }
+    });
+
+    return {
+        call(method, params = {}) {
+            const id = nextID++;
+            socket.send(JSON.stringify({ id, method, params }));
+            return new Promise((resolve, reject) => {
+                pending.set(id, { resolve, reject });
+            });
+        },
+        async evaluate(expression) {
+            const result = await this.call("Runtime.evaluate", {
+                expression,
+                awaitPromise: true,
+                returnByValue: true,
+            });
+            if (result.exceptionDetails) {
+                throw new Error(
+                    `APP FAILURE: browser evaluation failed (${compiler}): ` +
+                    `${JSON.stringify(result.exceptionDetails)}`,
+                );
+            }
+            return result.result.value;
+        },
+        close() {
+            socket.close();
+        },
+    };
+}
+
+function wait(duration) {
+    return new Promise((resolve) => setTimeout(resolve, duration));
+}

--- a/scripts/fixtures/controlled-select/app.gox
+++ b/scripts/fixtures/controlled-select/app.gox
@@ -2,14 +2,24 @@ package main
 
 import gf "github.com/graybuton/goframe/pkg/goframe"
 
+var (
+	setStatefulOptionsPhase   func(int)
+	descendantParentRenders  int
+	descendantOptionsRenders int
+)
+
 func App() gf.Node {
 	phase, setPhase := gf.UseState(0)
 	inputCount, setInputCount := gf.UseState(0)
 	changeCount, setChangeCount := gf.UseState(0)
 	uncontrolledRenders, setUncontrolledRenders := gf.UseState(0)
 	uncontrolledExtended, setUncontrolledExtended := gf.UseState(false)
+	descendantValue, setDescendantValue := gf.UseState("b")
+	descendantInputCount, setDescendantInputCount := gf.UseState(0)
+	descendantChangeCount, setDescendantChangeCount := gf.UseState(0)
 
 	value := controlledValue(phase)
+	descendantParentRenders++
 
 	return (
 		<main data-testid="controlled-select-fixture">
@@ -18,6 +28,9 @@ func App() gf.Node {
 			<p data-testid="controlled-input-count">{inputCount}</p>
 			<p data-testid="controlled-change-count">{changeCount}</p>
 			<p data-testid="uncontrolled-rerender-count">{uncontrolledRenders}</p>
+			<p data-testid="descendant-parent-render-count">{descendantParentRenders}</p>
+			<p data-testid="descendant-input-count">{descendantInputCount}</p>
+			<p data-testid="descendant-change-count">{descendantChangeCount}</p>
 
 			<label>
 				Controlled
@@ -33,6 +46,23 @@ func App() gf.Node {
 					}}
 				>
 					{controlledOptions(phase)}
+				</select>
+			</label>
+
+			<label>
+				Stateful descendant controlled
+				<select
+					data-testid="descendant-controlled-select"
+					data-authored-value={descendantValue}
+					Value={descendantValue}
+					OnInput={func() {
+						setDescendantInputCount(descendantInputCount + 1)
+					}}
+					OnChange={func() {
+						setDescendantChangeCount(descendantChangeCount + 1)
+					}}
+				>
+					<StatefulOptions />
 				</select>
 			</label>
 
@@ -68,8 +98,73 @@ func App() gf.Node {
 			<button data-testid="select-extend-uncontrolled" OnClick={func() {
 				setUncontrolledExtended(true)
 			}}>Extend uncontrolled options</button>
+			<button data-testid="descendant-add-match" OnClick={func() {
+				setStatefulOptionsPhase(1)
+			}}>Add descendant matching option</button>
+			<button data-testid="descendant-remove-match" OnClick={func() {
+				setStatefulOptionsPhase(0)
+			}}>Remove descendant matching option</button>
+			<button data-testid="descendant-restore-match" OnClick={func() {
+				setStatefulOptionsPhase(1)
+			}}>Restore descendant matching option</button>
+			<button data-testid="descendant-change-value" OnClick={func() {
+				setDescendantValue("c")
+			}}>Change descendant select value</button>
+			<button data-testid="descendant-add-current" OnClick={func() {
+				setStatefulOptionsPhase(2)
+			}}>Add current descendant option</button>
+			<button data-testid="descendant-reorder" OnClick={func() {
+				setStatefulOptionsPhase(3)
+			}}>Reorder descendant options</button>
 		</main>
 	)
+}
+
+type StatefulOptionsProps struct{}
+
+func StatefulOptions(StatefulOptionsProps) gf.Node {
+	phase, setPhase := gf.UseState(0)
+	setStatefulOptionsPhase = setPhase
+	descendantOptionsRenders++
+
+	return (
+		<optgroup
+			data-testid="stateful-options"
+			data-phase={statefulOptionsPhase(phase)}
+			data-render-count={descendantOptionsRenders}
+			label="Stateful options"
+		>
+			{gf.Map(statefulOptionValues(phase), func(value string) gf.Node {
+				return <option Key={value} Value={value}>{value}</option>
+			})}
+		</optgroup>
+	)
+}
+
+func statefulOptionsPhase(phase int) string {
+	switch phase {
+	case 0:
+		return "only-a"
+	case 1:
+		return "a-and-b"
+	case 2:
+		return "a-b-and-c"
+	default:
+		return "c-a-and-b"
+	}
+}
+
+func statefulOptionValues(phase int) []string {
+	switch phase {
+	case 0:
+		return []string{"a"}
+	case 1:
+		return []string{"a", "b"}
+	case 2:
+		return []string{"a", "b", "c"}
+	default:
+		return []string{"c", "a", "b"}
+	}
 }
 
 func controlledValue(phase int) string {

--- a/scripts/fixtures/controlled-select/app.gox
+++ b/scripts/fixtures/controlled-select/app.gox
@@ -1,0 +1,120 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+	phase, setPhase := gf.UseState(0)
+	inputCount, setInputCount := gf.UseState(0)
+	changeCount, setChangeCount := gf.UseState(0)
+	uncontrolledRenders, setUncontrolledRenders := gf.UseState(0)
+	uncontrolledExtended, setUncontrolledExtended := gf.UseState(false)
+
+	value := controlledValue(phase)
+
+	return (
+		<main data-testid="controlled-select-fixture">
+			<h1>Controlled select reconciliation</h1>
+			<p data-testid="controlled-phase">{controlledPhase(phase)}</p>
+			<p data-testid="controlled-input-count">{inputCount}</p>
+			<p data-testid="controlled-change-count">{changeCount}</p>
+			<p data-testid="uncontrolled-rerender-count">{uncontrolledRenders}</p>
+
+			<label>
+				Controlled
+				<select
+					data-testid="controlled-select"
+					data-authored-value={value}
+					Value={value}
+					OnInput={func() {
+						setInputCount(inputCount + 1)
+					}}
+					OnChange={func() {
+						setChangeCount(changeCount + 1)
+					}}
+				>
+					{controlledOptions(phase)}
+				</select>
+			</label>
+
+			<label>
+				Uncontrolled
+				<select data-testid="uncontrolled-select">
+					<option Key="a" Value="a">a</option>
+					<option Key="b" Value="b">b</option>
+					{uncontrolledExtended && (
+						<option Key="c" Value="c">c</option>
+					)}
+				</select>
+			</label>
+
+			<button data-testid="select-add-match" OnClick={func() {
+				setPhase(1)
+			}}>Add matching option</button>
+			<button data-testid="select-change-value" OnClick={func() {
+				setPhase(2)
+			}}>Change value and options</button>
+			<button data-testid="select-remove-match" OnClick={func() {
+				setPhase(3)
+			}}>Remove matching option</button>
+			<button data-testid="select-restore-match" OnClick={func() {
+				setPhase(4)
+			}}>Restore matching option</button>
+			<button data-testid="select-reorder" OnClick={func() {
+				setPhase(5)
+			}}>Reorder options</button>
+			<button data-testid="select-rerender-uncontrolled" OnClick={func() {
+				setUncontrolledRenders(uncontrolledRenders + 1)
+			}}>Rerender uncontrolled select</button>
+			<button data-testid="select-extend-uncontrolled" OnClick={func() {
+				setUncontrolledExtended(true)
+			}}>Extend uncontrolled options</button>
+		</main>
+	)
+}
+
+func controlledValue(phase int) string {
+	if phase < 2 {
+		return "b"
+	}
+	return "c"
+}
+
+func controlledPhase(phase int) string {
+	switch phase {
+	case 0:
+		return "initial-no-match"
+	case 1:
+		return "matching-option-added"
+	case 2:
+		return "value-and-options-changed"
+	case 3:
+		return "matching-option-removed"
+	case 4:
+		return "matching-option-restored"
+	case 5:
+		return "options-reordered"
+	default:
+		return "unknown"
+	}
+}
+
+func controlledOptions(phase int) []gf.Node {
+	var values []string
+	switch phase {
+	case 0:
+		values = []string{"a"}
+	case 1:
+		values = []string{"a", "b"}
+	case 2:
+		values = []string{"a", "c"}
+	case 3:
+		values = []string{"a", "b"}
+	case 4:
+		values = []string{"a", "b", "c"}
+	default:
+		values = []string{"c", "a", "b"}
+	}
+	return gf.Map(values, func(value string) gf.Node {
+		return <option Key={value} Value={value}>{value}</option>
+	})
+}

--- a/scripts/fixtures/controlled-select/goframe.json
+++ b/scripts/fixtures/controlled-select/goframe.json
@@ -1,0 +1,10 @@
+{
+  "name": "controlled-select",
+  "entry": ".",
+  "output": "dist",
+  "compiler": "tinygo",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html"
+  ]
+}

--- a/scripts/fixtures/controlled-select/index.html
+++ b/scripts/fixtures/controlled-select/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>goframe controlled select fixture</title>
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root"></div>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/controlled-select/main.go
+++ b/scripts/fixtures/controlled-select/main.go
@@ -1,0 +1,11 @@
+//go:build js && wasm
+
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func main() {
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -138,6 +138,6 @@ check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
 check_app "router" "$(bundle_path router)" 117760 45056 58368 51200 || status=1
 check_app "routerdash" "$(bundle_path router-dashboard)" 234496 77824 94208 82944 || status=1
-check_app "resource" "$(bundle_path resource)" 157696 58368 68608 61440 || status=1
+check_app "resource" "$(bundle_path resource)" 157696 58368 69632 61440 || status=1
 
 exit "$status"

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -132,12 +132,12 @@ check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
 check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
 check_app "dashboard" "$(bundle_path dashboard)" 171008 53248 71680 61440 || status=1
-check_app "context" "$(bundle_path context)" 116736 36864 46080 40960 || status=1
+check_app "context" "$(bundle_path context)" 117760 36864 46080 40960 || status=1
 check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
-check_app "router" "$(bundle_path router)" 116736 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 233472 77824 94208 82944 || status=1
-check_app "resource" "$(bundle_path resource)" 156672 58368 68608 61440 || status=1
+check_app "router" "$(bundle_path router)" 117760 45056 58368 51200 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 234496 77824 94208 82944 || status=1
+check_app "resource" "$(bundle_path resource)" 157696 58368 68608 61440 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Restores controlled single-value `<select>` state after option reconciliation,
including independently updating stateful descendant components.

The runtime now reapplies the select's current authored `value` after:

- initial option mounting;
- parent-driven option patching;
- successful child-only component reconciliation beneath the select.

This prevents the browser from retaining an unrelated selection when matching
options are added, removed, restored, or reordered without rerendering the
parent select.

No public API or GOX behavior changes.

## What changed

- Keeps the existing post-children controlled-value synchronization for select
  mount and parent-driven patch paths.
- Propagates nearest-mounted-select ownership through elements, fragments, and
  component boundaries.
- Lets independently dirty descendant components resynchronize their nearest
  controlled select after a successful subtree patch.
- Reads the select's current committed VNode props instead of retaining a value
  captured during an earlier render.
- Lets inner selects shadow outer select ownership.
- Clears retained ownership during component subtree teardown.
- Preserves the existing select DOM node instead of forcing a remount or parent
  rerender.
- Leaves selects without a `value` prop browser-owned.

## Review follow-up

The original correction covered option changes that also patched the select
VNode.

Codex review identified a separate path where a stateful descendant component
could update its option subtree independently. In that path, the parent select
was not revisited and its controlled value was not restored.

The gap was reproduced under both standard Go and TinyGo:

```text
parent value:        "b"
child options:       ["a"] → ["a", "b"]
parent renders:      9 → 9
child renders:       9 → 10
actual selection:    "a", index 0
expected selection:  "b", index 1
```

Nearest-select ownership now closes that path without changing parent render
ownership, DOM identity, or event semantics.

## Browser evidence

The private Chrome fixture covers both parent-driven and independently dirty
descendant reconciliation under standard Go/WASM and TinyGo/WASM.

Covered behavior includes:

- initial controlled values without a matching option;
- matching option insertion;
- simultaneous value and option changes;
- matching option removal and restoration;
- option reordering;
- child-only option insertion, removal, restoration, and reordering;
- changing the parent-authored value before a later child-only update;
- stable select DOM identity;
- unchanged parent render counts during child-only updates;
- browser-owned uncontrolled selection;
- absence of runtime-synthesized `input` and `change` events;
- explicit event-listener liveness.

The focused fixture passed ten fresh runs per compiler, followed by two complete
Browser Smoke runs.

## WASM size

The initial parent-driven runtime correction introduced a reproducible shared
raw WASM cost of `514–526 B` across the eleven budgeted applications.

Four bounded compactness variants preserved behavior but could not keep all
previous raw ceilings green. Exactly four raw ceilings were therefore aligned
by `1 KiB`:

- `context`: `116,736 B` → `117,760 B`;
- `router`: `116,736 B` → `117,760 B`;
- `router-dashboard`: `233,472 B` → `234,496 B`;
- `resource`: `156,672 B` → `157,696 B`.

The descendant-component follow-up adds another reproducible raw delta of
`387–416 B`. All raw, Brotli, and Zstandard cells remained within their
existing ceilings.

The only additional failing cell was:

```text
resource gzip:
68,636 B measured
68,608 B previous ceiling
28 B over
```

Two bounded compact representations remained `21 B` and `29 B` over the same
ceiling. The clearer nearest-select ownership implementation was retained, and
only this gzip ceiling was aligned:

- `resource` gzip: `68,608 B` → `69,632 B`.

No other compressed ceiling, ratio limit, compression command, application
budget, or workflow changed.

## Validation

- Full tests, debug-tag tests, and `go vet` on Go `1.22.12`, `1.25.12`, and
  `1.26.5`
- Race tests on Go `1.25.12` and `1.26.5`
- Focused controlled-select Chrome evidence:
  - 10 fresh standard-Go runs;
  - 10 fresh TinyGo `0.41.1` runs
- Two complete Browser Smoke runs
- Full eleven-application WASM size and hash comparison
- `scripts/check.sh`
- Artifact, module-path, documentation, formatting, and `actionlint` checks
- Node `24.18.1` / npm `11.16.0` VS Code extension compile and tests
- Windows `amd64` `cmd/goxc` cross-compilation

## Scope

This PR changes:

- private controlled-select reconciliation;
- nearest-select ownership for stateful descendant updates;
- focused browser evidence;
- controlled-select and CI documentation;
- four measured raw WASM ceilings;
- one measured gzip ceiling.

It does not add:

- a form framework;
- multi-select or array-valued selection semantics;
- a generic DOM commit phase;
- parent-rerender forcing;
- a global select registry;
- a public API;
- a GOX change;
- an example or workflow change;
- a dependency or lockfile update;
- a compression-ratio change;
- a broader browser-support claim.