### PR TITLE
fix(runtime): rebind context subscriptions after selector failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,9 @@
 
 ### Fixed
 
+- Context selector subscriptions now rebind to the new nearest provider during
+  topology refresh even when selector evaluation fails, preserving the previous
+  selected value while allowing safe updates from the new provider to recover.
 - Controlled select values are restored after dynamic option reconciliation.
 - `splitProps` allocation behavior was characterized and reduced for common
   runtime prop paths while preserving nil and empty zero-allocation behavior.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -120,6 +120,12 @@ an unchanged parent render count during child-only updates, a changed current
 parent value, uncontrolled selection ownership, stable DOM identity, and the
 absence of runtime-synthesized input or change events under both standard Go
 and TinyGo on the current Chrome/Linux heavy baseline.
+The private context-selector-topology fixture runs with standard Go/WASM. It
+verifies an outer-to-inner selector failure rebind, an ignored update from the
+old outer provider, recovery from a later safe inner update, removal of the
+inner provider while a failing outer provider is revealed, safe outer recovery,
+and live `ErrorPhaseContext` / `UseContextSelector` reporting without remounting
+the application.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
 connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure
@@ -134,11 +140,11 @@ a small form-driven request. The same smoke covers a controlled backend failure
 state, delayed stale request no-overwrite behavior, and recovery after a later
 valid form submission. This does not add a GoFrame server API.
 
-The runtime error containment fixture, Error Boundary fixture, and
-router-dashboard reference-app smoke are compiled with the Go WASM compiler
-where recover-based render containment is being asserted. The size-oriented
-TinyGo package path uses trap-style panic behavior, which is documented as a
-runtime error containment limitation.
+The runtime error containment fixture, Error Boundary fixture, context selector
+topology fixture, and router-dashboard reference-app smoke are compiled with
+the Go WASM compiler where recover-based render containment is being asserted.
+The size-oriented TinyGo package path uses trap-style panic behavior, which is
+documented as a runtime error containment limitation.
 
 GOX diagnostic golden tests intentionally assert filenames, line/column
 prefixes, specific unsupported-syntax messages, and source snippets. They are

--- a/docs/context.md
+++ b/docs/context.md
@@ -72,6 +72,14 @@ component render error handling. A nearest scoped `gf.ErrorBoundary` can catch
 that initial render-path failure, but it does not catch later provider
 notification failures.
 
+During a provider topology refresh, structural subscription ownership advances
+to the new nearest provider even when its selector evaluation fails. The old or
+shadowed provider no longer notifies that subscription, while a later safe
+update from the new provider retries the selector and can recover the consumer.
+When the context default becomes nearest, the subscription detaches from its
+previous provider. The previous selected value remains committed and the
+consumer remains clean until a selector evaluation succeeds.
+
 ## Broad Consumers
 
 `UseContext(ctx)` returns the full nearest value. Because the runtime cannot
@@ -98,9 +106,11 @@ subscribers.
 
 Provider topology changes are observable. If a provider appears above an
 existing consumer, disappears, or a nearer nested provider appears between an
-outer provider and a consumer, affected consumers are marked dirty and resubscribe
-to the new nearest provider on their next render. This happens even when a
-selector's comparable result is equal, because the provider scope itself changed.
+outer provider and a consumer, affected subscriptions rebind to the new nearest
+provider. A successful selector evaluation marks the consumer dirty even when
+the comparable result is equal, because the provider scope itself changed. A
+failed selector evaluation leaves the previous selection committed and does not
+dirty the consumer, while keeping the new structural provider binding.
 
 ## Memoization Interaction
 
@@ -110,10 +120,10 @@ If a parent/provider rerenders, clean memoized descendants may skip. A context
 consumer whose selected value changed is marked dirty, so memoized ancestors
 above it cannot skip over the update.
 
-Memoized ancestors also cannot hide context topology changes. When a provider
-appears, is removed, or a nearer nested provider takes over, the runtime marks
-affected consumers dirty and updates dirty descendant accounting through any
-memoized wrappers above them.
+Memoized ancestors also cannot hide successful context topology changes. When a
+provider appears, is removed, or a nearer nested provider takes over and its
+selector succeeds, the runtime marks affected consumers dirty and updates dirty
+descendant accounting through any memoized wrappers above them.
 
 This means selector consumers should usually be component boundaries, and clean
 structural wrappers can use explicit `MemoEqual` where useful.

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -145,6 +145,16 @@ subscription already has a previous selected value. The runtime reports
 `ErrorPhaseContext`, keeps the previous selected value, and does not mark the
 consumer dirty from that failed selector evaluation.
 
+Provider topology refresh separates structural ownership from selected-value
+commit. The subscription first binds to the new nearest provider, or detaches
+when the context default becomes nearest. If selector evaluation then fails, the
+new structural binding remains, the previous selection remains committed, and
+the consumer remains clean. The old or shadowed provider can no longer notify
+the subscription; a later safe update from the new provider retries the
+selector. Ordinary same-provider notification failures keep the existing
+provider binding and the same selected-value containment behavior. These
+failures report operation `UseContextSelector`.
+
 ### Virtualized Item/Row Render
 
 `VirtualList.RenderItem`, `VirtualTable.Header`, `VirtualTable.RenderRow`, and
@@ -221,11 +231,14 @@ lifecycle warnings remain separate.
 Browser smoke verifies that recoverable event and cleanup failures do not
 unmount the app or leak listeners. A separate Error Boundary fixture verifies
 render fallback, retry, `ResetKey`, nested boundaries, and cleanup behavior.
+The context selector topology fixture verifies failed outer/inner provider
+transitions, old-provider isolation, and later new-provider recovery.
 
-Both fixtures use Go-compiled WASM because the current TinyGo package path uses
-trap-style panic lowering, where panics do not return to Go `recover`.
+These panic-containment fixtures use Go-compiled WASM because the current
+TinyGo package path uses trap-style panic lowering, where panics do not return
+to Go `recover`.
 
-It should not use timing gates for runtime error behavior.
+Browser smoke should not use timing gates for runtime error behavior.
 
 ## TinyGo Panic Mode Note
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -287,6 +287,66 @@ all compressed sizes reproduced. All 44 cells pass. The only ceiling change is
 Raw, Brotli, and Zstandard ceilings are unchanged, as are gzip `52.00%`,
 Brotli `38.00%`, and Zstandard `46.00%` ratio limits and the WASM workflow.
 
+## Context Topology Recovery — 2026-08-01
+
+This measurement compares frozen base
+`195ccf8b9bf3300b7bd86bbcea07ae9dbd727c2a` with measured implementation head
+`9cc93493b619bd570041fe5512f9ef81e2eeb063`. The documentation closeout is the
+commit containing this section; it does not change runtime or package inputs.
+The runtime correction rebinds a context subscription before evaluating a
+selector against a newly nearest provider.
+
+Measurements use Go `1.26.5`, TinyGo `0.41.1`, Linux amd64, gzip `1.14`,
+Brotli `1.2.0`, and Zstandard `1.5.7`. Both refs were built sequentially in the
+same extraction path with the CI package order and shared task-owned caches.
+Compression uses the unchanged budget commands: gzip level 9, Brotli quality
+11, and Zstandard level 19. SHA comparison fixes the source mtime for comparable
+gzip container metadata; the compression command and measured byte count are
+unchanged.
+
+| app | raw base → final | gzip base → final | br base → final | zstd base → final |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85439 → 85439 B (0 B) | 34348 → 34348 B (0 B) | 28633 → 28633 B (0 B) | 30823 → 30823 B (0 B) |
+| components | 91078 → 91078 B (0 B) | 36113 → 36113 B (0 B) | 29845 → 29845 B (0 B) | 32261 → 32261 B (0 B) |
+| todo | 120344 → 120344 B (0 B) | 46580 → 46580 B (0 B) | 38506 → 38506 B (0 B) | 41514 → 41514 B (0 B) |
+| dashboard | 170706 → 170706 B (0 B) | 64135 → 64135 B (0 B) | 51645 → 51645 B (0 B) | 55772 → 55772 B (0 B) |
+| context | 117215 → 117209 B (-6 B) | 44241 → 44252 B (+11 B) | 36098 → 36066 B (-32 B) | 38961 → 38957 B (-4 B) |
+| virtualized | 124160 → 124160 B (0 B) | 47995 → 47995 B (0 B) | 39122 → 39122 B (0 B) | 42422 → 42422 B (0 B) |
+| multipackage | 96260 → 96260 B (0 B) | 37865 → 37865 B (0 B) | 31354 → 31354 B (0 B) | 33783 → 33783 B (0 B) |
+| cmdapp | 96278 → 96278 B (0 B) | 37870 → 37870 B (0 B) | 31394 → 31394 B (0 B) | 33797 → 33797 B (0 B) |
+| router | 117523 → 117523 B (0 B) | 44980 → 44980 B (0 B) | 37005 → 37005 B (0 B) | 39933 → 39933 B (0 B) |
+| router-dashboard | 234357 → 234351 B (-6 B) | 94004 → 94011 B (+7 B) | 77381 → 77333 B (-48 B) | 82523 → 82516 B (-7 B) |
+| resource | 157180 → 157180 B (0 B) | 68645 → 68645 B (0 B) | 57823 → 57823 B (0 B) | 61371 → 61371 B (0 B) |
+
+Final ceilings and byte headroom remain:
+
+| app | raw final / ceiling (headroom) | gzip final / ceiling (headroom) | br final / ceiling (headroom) | zstd final / ceiling (headroom) |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85439 / 97280 B (11841 B) | 34348 / 56320 B (21972 B) | 28633 / 40960 B (12327 B) | 30823 / 49152 B (18329 B) |
+| components | 91078 / 107520 B (16442 B) | 36113 / 56320 B (20207 B) | 29845 / 43008 B (13163 B) | 32261 / 49152 B (16891 B) |
+| todo | 120344 / 122880 B (2536 B) | 46580 / 56320 B (9740 B) | 38506 / 40960 B (2454 B) | 41514 / 49152 B (7638 B) |
+| dashboard | 170706 / 171008 B (302 B) | 64135 / 71680 B (7545 B) | 51645 / 53248 B (1603 B) | 55772 / 61440 B (5668 B) |
+| context | 117209 / 117760 B (551 B) | 44252 / 46080 B (1828 B) | 36066 / 36864 B (798 B) | 38957 / 40960 B (2003 B) |
+| virtualized | 124160 / 124928 B (768 B) | 47995 / 49152 B (1157 B) | 39122 / 40960 B (1838 B) | 42422 / 44032 B (1610 B) |
+| multipackage | 96260 / 110592 B (14332 B) | 37865 / 56320 B (18455 B) | 31354 / 43008 B (11654 B) | 33783 / 49152 B (15369 B) |
+| cmdapp | 96278 / 110592 B (14314 B) | 37870 / 56320 B (18450 B) | 31394 / 43008 B (11614 B) | 33797 / 49152 B (15355 B) |
+| router | 117523 / 117760 B (237 B) | 44980 / 58368 B (13388 B) | 37005 / 45056 B (8051 B) | 39933 / 51200 B (11267 B) |
+| router-dashboard | 234351 / 234496 B (145 B) | 94011 / 94208 B (197 B) | 77333 / 77824 B (491 B) | 82516 / 82944 B (428 B) |
+| resource | 157180 / 157696 B (516 B) | 68645 / 69632 B (987 B) | 57823 / 58368 B (545 B) | 61371 / 61440 B (69 B) |
+
+Nine applications have identical raw, gzip, Brotli, and Zstandard SHA-256
+values across the comparison. The two changed streams are:
+
+| app | base raw / gzip / br / zstd SHA-256 | final raw / gzip / br / zstd SHA-256 |
+| --- | --- | --- |
+| context | `a7a0691659447a67cbbdf183f198107b86a09be25e99d4b589a0c4ef811f2067` / `fb11ea8f199d8636557e9ab80ed38f11d5e7fc5b3561363095442e7981ad9a0e` / `e04340ff513e8e1a9d4088e7e9dbb8ae8472085b3b58811f3f83356f921a3493` / `b94940a80d59510b3f3677becfbc15de4bd5a57586cb50c87845a776ed639b5b` | `547722e8a94f126cf5f21944b9b120e31aae023e2cb40fbbced1fccf9796c626` / `b885e8372bd6373b07c5862f797eb801bb6192496a6804b0cb6f1d9cbe358b72` / `504a2b1ec41b988dbad31915260ff5c6d6e09dd539dfa77b78e8b47b26b98822` / `1213d9c6fa431403291a36babd86b7e70d9bd8e7edae60775c43bf46ae29461e` |
+| router-dashboard | `4ca08e0be2db602601306e1b7c7f2ad48454f39c57b7cd798f2268df4cc0ae97` / `c69dad8280b65b1bccd1111c5fd7586d03922f240a9b722504c8ff9df9fd9a1b` / `9734a0d25a87000a92161f230fa85b5f612f0dbf41f1f0448b5d9e859a9baa35` / `327781d1ca426e1d0d36a60ddde288894823f83b8ca3289463e99afc0a8ad3a5` | `b00e2dcf4cdf997f7240c6b7efe475f6a8920715cfdbecbabe7105ba830c03d0` / `aa144e4726f4052fcac6e112bd5bb154f6ff0b102ea43ffff4ae274c16f52220` / `1f17b59c8157df476ce6214acf365001ed741f533f1840dfeb8cc0e4ef4e5b4d` / `305feb072e7b2a72d6b856b52d9de59fa008f29f011f223c9dcfcdc393ac6881` |
+
+All 44 cells and all ratio limits pass. Gzip remains capped at `52.00%`,
+Brotli at `38.00%`, and Zstandard at `46.00%`. No ceiling, ratio, compression
+command, size workflow, or budget-matrix membership changed; the private
+standard-Go browser fixture is not part of the size matrix.
+
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 
 This targeted rebaseline covers complete mounted-subtree teardown ownership

--- a/pkg/goframe/context.go
+++ b/pkg/goframe/context.go
@@ -331,10 +331,10 @@ func refreshContextSubscription(slot *contextSubscription) {
 	if provider != nil {
 		value = provider.value
 	}
+	setContextSubscriptionProvider(slot, provider)
 	if _, ok := updateContextSubscription(slot, value); !ok {
 		return
 	}
-	setContextSubscriptionProvider(slot, provider)
 	markComponentDirty(slot.owner)
 }
 

--- a/pkg/goframe/context_test.go
+++ b/pkg/goframe/context_test.go
@@ -7,6 +7,15 @@ type contextValueFixture struct {
 	Accent string
 }
 
+type contextTopologyValueFixture struct {
+	Count       int
+	PanicSelect bool
+}
+
+type contextSelectorPanicFixture struct {
+	name string
+}
+
 type contextMemoPropsFixture struct {
 	ID int
 }
@@ -392,6 +401,369 @@ func TestContextInnerProviderRemovalRebindsConsumerToOuterProvider(t *testing.T)
 	}
 }
 
+func TestContextSelectorTopologyPanicRebindsDefaultToProvider(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "default-to-provider"}
+	ctx := CreateContext(contextTopologyValueFixture{Count: 1})
+	providing := false
+	provided := contextTopologyValueFixture{}
+	provider := contextTestInstance("Provider", nil, func() {
+		if providing {
+			ProvideContext(ctx, provided)
+		}
+	})
+	renderComponentInstance(provider)
+
+	selectorCalls := 0
+	selected := -1
+	consumer := contextTestInstance("Consumer", provider, func() {
+		selected = UseContextSelector(ctx, contextTopologySelector(
+			&selectorCalls,
+			panicValue,
+		))
+	})
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+	if slot.provider != nil {
+		t.Fatalf("initial provider = %#v, want default", slot.provider)
+	}
+
+	providing = true
+	provided = contextTopologyValueFixture{Count: 2, PanicSelect: true}
+	renderComponentInstance(provider)
+	newProvider := provider.contextProviders[ctx.id]
+
+	assertFailedContextTopologyRefresh(t, contextTopologyFailureExpectation{
+		errors:           errors(),
+		panicValue:       panicValue,
+		slot:             slot,
+		provider:         newProvider,
+		previous:         nil,
+		selected:         1,
+		consumer:         consumer,
+		ancestors:        []*componentInstance{provider},
+		selectorCalls:    selectorCalls,
+		wantSelectorCall: 2,
+	})
+
+	provided = contextTopologyValueFixture{Count: 2}
+	renderComponentInstance(provider)
+	assertRecoveredContextSelection(t, slot, consumer, 2, selectorCalls, 3)
+	if provider.dirtyDescendants != 1 {
+		t.Fatalf("provider dirty descendants after recovery = %d, want 1", provider.dirtyDescendants)
+	}
+	renderComponentInstance(consumer)
+	if selected != 2 {
+		t.Fatalf("rendered selection after recovery = %d, want 2", selected)
+	}
+
+	deactivateComponent(consumer)
+	deactivateComponent(provider)
+}
+
+func TestContextSelectorTopologyPanicRebindsOuterToInnerProvider(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "outer-to-inner"}
+	ctx := CreateContext(contextTopologyValueFixture{})
+	outer := contextProviderInstance("Outer", nil, ctx, contextTopologyValueFixture{Count: 1})
+	renderComponentInstance(outer)
+	outerProvider := outer.contextProviders[ctx.id]
+
+	innerProviding := false
+	innerValue := contextTopologyValueFixture{}
+	inner := contextTestInstance("Inner", outer, func() {
+		if innerProviding {
+			ProvideContext(ctx, innerValue)
+		}
+	})
+	renderComponentInstance(inner)
+
+	selectorCalls := 0
+	selected := -1
+	consumer := contextTestInstance("Consumer", inner, func() {
+		selected = UseContextSelector(ctx, contextTopologySelector(
+			&selectorCalls,
+			panicValue,
+		))
+	})
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+
+	innerProviding = true
+	innerValue = contextTopologyValueFixture{Count: 2, PanicSelect: true}
+	renderComponentInstance(inner)
+	innerProvider := inner.contextProviders[ctx.id]
+
+	assertFailedContextTopologyRefresh(t, contextTopologyFailureExpectation{
+		errors:           errors(),
+		panicValue:       panicValue,
+		slot:             slot,
+		provider:         innerProvider,
+		previous:         outerProvider,
+		selected:         1,
+		consumer:         consumer,
+		ancestors:        []*componentInstance{inner, outer},
+		selectorCalls:    selectorCalls,
+		wantSelectorCall: 2,
+	})
+
+	updateContextProvider(outer, ctx, contextTopologyValueFixture{Count: 9})
+	if selectorCalls != 2 {
+		t.Fatalf("selector calls after shadowed outer update = %d, want 2", selectorCalls)
+	}
+	if slot.selected != 1 || consumer.dirty {
+		t.Fatalf("state after shadowed outer update = selected %#v dirty %t, want 1 false", slot.selected, consumer.dirty)
+	}
+
+	innerValue = contextTopologyValueFixture{Count: 2}
+	renderComponentInstance(inner)
+	assertRecoveredContextSelection(t, slot, consumer, 2, selectorCalls, 3)
+	if inner.dirtyDescendants != 1 || outer.dirtyDescendants != 1 {
+		t.Fatalf("dirty descendants after inner recovery = inner %d outer %d, want 1 each",
+			inner.dirtyDescendants, outer.dirtyDescendants)
+	}
+	renderComponentInstance(consumer)
+	if selected != 2 {
+		t.Fatalf("rendered selection after inner recovery = %d, want 2", selected)
+	}
+
+	deactivateComponent(consumer)
+	deactivateComponent(inner)
+	deactivateComponent(outer)
+}
+
+func TestContextSelectorTopologyPanicRebindsInnerToOuterProvider(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "inner-to-outer"}
+	ctx := CreateContext(contextTopologyValueFixture{})
+	outer := contextProviderInstance("Outer", nil, ctx, contextTopologyValueFixture{
+		Count:       3,
+		PanicSelect: true,
+	})
+	renderComponentInstance(outer)
+	outerProvider := outer.contextProviders[ctx.id]
+
+	innerProviding := true
+	innerValue := contextTopologyValueFixture{Count: 2}
+	inner := contextTestInstance("Inner", outer, func() {
+		if innerProviding {
+			ProvideContext(ctx, innerValue)
+		}
+	})
+	renderComponentInstance(inner)
+	innerProvider := inner.contextProviders[ctx.id]
+
+	selectorCalls := 0
+	selected := -1
+	consumer := contextTestInstance("Consumer", inner, func() {
+		selected = UseContextSelector(ctx, contextTopologySelector(
+			&selectorCalls,
+			panicValue,
+		))
+	})
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+
+	innerProviding = false
+	renderComponentInstance(inner)
+
+	assertFailedContextTopologyRefresh(t, contextTopologyFailureExpectation{
+		errors:           errors(),
+		panicValue:       panicValue,
+		slot:             slot,
+		provider:         outerProvider,
+		previous:         innerProvider,
+		selected:         2,
+		consumer:         consumer,
+		ancestors:        []*componentInstance{inner, outer},
+		selectorCalls:    selectorCalls,
+		wantSelectorCall: 2,
+	})
+
+	notifyContextSubscribers(innerProvider, contextTopologyValueFixture{Count: 8})
+	if selectorCalls != 2 {
+		t.Fatalf("selector calls after removed inner update = %d, want 2", selectorCalls)
+	}
+
+	updateContextProvider(outer, ctx, contextTopologyValueFixture{Count: 3})
+	assertRecoveredContextSelection(t, slot, consumer, 3, selectorCalls, 3)
+	renderComponentInstance(consumer)
+	if selected != 3 {
+		t.Fatalf("rendered selection after outer recovery = %d, want 3", selected)
+	}
+
+	deactivateComponent(consumer)
+	deactivateComponent(inner)
+	deactivateComponent(outer)
+}
+
+func TestContextSelectorTopologyPanicRebindsProviderToDefault(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "provider-to-default"}
+	ctx := CreateContext(contextTopologyValueFixture{
+		Count:       0,
+		PanicSelect: true,
+	})
+	providing := true
+	providerValue := contextTopologyValueFixture{Count: 2}
+	provider := contextTestInstance("Provider", nil, func() {
+		if providing {
+			ProvideContext(ctx, providerValue)
+		}
+	})
+	renderComponentInstance(provider)
+	removedProvider := provider.contextProviders[ctx.id]
+
+	selectorCalls := 0
+	selected := -1
+	consumer := contextTestInstance("Consumer", provider, func() {
+		selected = UseContextSelector(ctx, contextTopologySelector(
+			&selectorCalls,
+			panicValue,
+		))
+	})
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+
+	providing = false
+	renderComponentInstance(provider)
+
+	assertFailedContextTopologyRefresh(t, contextTopologyFailureExpectation{
+		errors:           errors(),
+		panicValue:       panicValue,
+		slot:             slot,
+		provider:         nil,
+		previous:         removedProvider,
+		selected:         2,
+		consumer:         consumer,
+		ancestors:        []*componentInstance{provider},
+		selectorCalls:    selectorCalls,
+		wantSelectorCall: 2,
+	})
+
+	notifyContextSubscribers(removedProvider, contextTopologyValueFixture{Count: 8})
+	if selectorCalls != 2 {
+		t.Fatalf("selector calls after detached provider update = %d, want 2", selectorCalls)
+	}
+
+	providerValue = contextTopologyValueFixture{Count: 4}
+	providing = true
+	renderComponentInstance(provider)
+	newProvider := provider.contextProviders[ctx.id]
+	if slot.provider != newProvider {
+		t.Fatalf("provider after safe appearance = %#v, want %#v", slot.provider, newProvider)
+	}
+	assertRecoveredContextSelection(t, slot, consumer, 4, selectorCalls, 3)
+	renderComponentInstance(consumer)
+	if selected != 4 {
+		t.Fatalf("rendered selection after new provider recovery = %d, want 4", selected)
+	}
+
+	deactivateComponent(consumer)
+	deactivateComponent(provider)
+}
+
+func TestContextSelectorSameProviderPanicKeepsBindingAndRecovers(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "same-provider"}
+	ctx := CreateContext(contextTopologyValueFixture{})
+	provider := contextProviderInstance("Provider", nil, ctx, contextTopologyValueFixture{Count: 1})
+	renderComponentInstance(provider)
+	providerSlot := provider.contextProviders[ctx.id]
+
+	selectorCalls := 0
+	consumer := contextSelectorConsumer(provider, ctx, contextTopologySelector(
+		&selectorCalls,
+		panicValue,
+	))
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+
+	updateContextProvider(provider, ctx, contextTopologyValueFixture{
+		Count:       2,
+		PanicSelect: true,
+	})
+
+	if slot.provider != providerSlot {
+		t.Fatalf("provider after same-provider panic = %#v, want %#v", slot.provider, providerSlot)
+	}
+	if !providerSlot.subscribers[slot] {
+		t.Fatal("same provider lost subscription after selector panic")
+	}
+	if slot.selected != 1 || consumer.dirty || provider.dirtyDescendants != 0 {
+		t.Fatalf("state after same-provider panic = selected %#v dirty %t descendants %d, want 1 false 0",
+			slot.selected, consumer.dirty, provider.dirtyDescendants)
+	}
+	if selectorCalls != 2 {
+		t.Fatalf("selector calls after same-provider panic = %d, want 2", selectorCalls)
+	}
+	assertSingleContextSelectorError(t, errors(), panicValue)
+
+	updateContextProvider(provider, ctx, contextTopologyValueFixture{Count: 2})
+	assertRecoveredContextSelection(t, slot, consumer, 2, selectorCalls, 3)
+
+	deactivateComponent(consumer)
+	deactivateComponent(provider)
+}
+
+func TestContextSelectorTopologyPanicRebindUnmountReleasesSubscription(t *testing.T) {
+	isolateContextSubscriptions(t)
+	errors := captureRuntimeErrors(t)
+	panicValue := &contextSelectorPanicFixture{name: "unmount-after-rebind"}
+	ctx := CreateContext(contextTopologyValueFixture{})
+	outer := contextProviderInstance("Outer", nil, ctx, contextTopologyValueFixture{Count: 1})
+	renderComponentInstance(outer)
+
+	innerProviding := false
+	inner := contextTestInstance("Inner", outer, func() {
+		if innerProviding {
+			ProvideContext(ctx, contextTopologyValueFixture{Count: 2, PanicSelect: true})
+		}
+	})
+	renderComponentInstance(inner)
+
+	selectorCalls := 0
+	consumer := contextSelectorConsumer(inner, ctx, contextTopologySelector(
+		&selectorCalls,
+		panicValue,
+	))
+	renderComponentInstance(consumer)
+	slot := consumer.contextSlots[0]
+
+	innerProviding = true
+	renderComponentInstance(inner)
+	innerProvider := inner.contextProviders[ctx.id]
+	if slot.provider != innerProvider {
+		t.Fatalf("provider after failed topology refresh = %#v, want inner %#v", slot.provider, innerProvider)
+	}
+	assertSingleContextSelectorError(t, errors(), panicValue)
+
+	deactivateComponent(consumer)
+	if slot.provider != nil {
+		t.Fatalf("provider after unmount = %#v, want nil", slot.provider)
+	}
+	if innerProvider.subscribers[slot] {
+		t.Fatal("inner provider retained inactive subscription")
+	}
+	if slots := contextSubscriptionsByID[ctx.id]; slots[slot] || len(slots) != 0 {
+		t.Fatalf("global subscriptions after unmount = %#v, want none", slots)
+	}
+	selectorCallsBeforeUpdate := selectorCalls
+	notifyContextSubscribers(innerProvider, contextTopologyValueFixture{Count: 3})
+	if selectorCalls != selectorCallsBeforeUpdate || consumer.dirty {
+		t.Fatalf("inactive consumer after provider update = calls %d dirty %t, want %d false",
+			selectorCalls, consumer.dirty, selectorCallsBeforeUpdate)
+	}
+
+	deactivateComponent(inner)
+	deactivateComponent(outer)
+}
+
 func TestContextDirtyConsumerPreventsMemoAncestorSkip(t *testing.T) {
 	ctx := CreateContext(contextValueFixture{})
 	provider := contextProviderInstance("Provider", nil, ctx, contextValueFixture{Count: 1})
@@ -486,4 +858,104 @@ func updateContextProvider[T any](instance *componentInstance, ctx *Context[T], 
 		return Empty()
 	}).(ComponentNode)
 	renderComponentInstance(instance)
+}
+
+type contextTopologyFailureExpectation struct {
+	errors           []ErrorInfo
+	panicValue       any
+	slot             *contextSubscription
+	provider         *contextProvider
+	previous         *contextProvider
+	selected         int
+	consumer         *componentInstance
+	ancestors        []*componentInstance
+	selectorCalls    int
+	wantSelectorCall int
+}
+
+func isolateContextSubscriptions(t *testing.T) {
+	t.Helper()
+	previous := contextSubscriptionsByID
+	contextSubscriptionsByID = nil
+	t.Cleanup(func() {
+		contextSubscriptionsByID = previous
+	})
+}
+
+func contextTopologySelector(
+	calls *int,
+	panicValue any,
+) func(contextTopologyValueFixture) int {
+	return func(value contextTopologyValueFixture) int {
+		(*calls)++
+		if value.PanicSelect {
+			panic(panicValue)
+		}
+		return value.Count
+	}
+}
+
+func assertFailedContextTopologyRefresh(t *testing.T, want contextTopologyFailureExpectation) {
+	t.Helper()
+	if want.slot.selected != want.selected {
+		t.Fatalf("selected after failed topology refresh = %#v, want previous %d", want.slot.selected, want.selected)
+	}
+	if want.consumer.dirty {
+		t.Fatal("consumer should remain clean after failed topology selector evaluation")
+	}
+	for _, ancestor := range want.ancestors {
+		if ancestor.dirtyDescendants != 0 {
+			t.Fatalf("%s dirty descendants after failed topology refresh = %d, want 0",
+				ancestor.name, ancestor.dirtyDescendants)
+		}
+	}
+	if want.selectorCalls != want.wantSelectorCall {
+		t.Fatalf("selector calls after failed topology refresh = %d, want %d",
+			want.selectorCalls, want.wantSelectorCall)
+	}
+	assertSingleContextSelectorError(t, want.errors, want.panicValue)
+	if want.slot.provider != want.provider {
+		t.Fatalf("provider after failed topology refresh = %#v, want %#v", want.slot.provider, want.provider)
+	}
+	if want.previous != nil && want.previous.subscribers[want.slot] {
+		t.Fatal("previous provider retained subscription after failed topology refresh")
+	}
+	if want.provider != nil && !want.provider.subscribers[want.slot] {
+		t.Fatal("new provider is missing subscription after failed topology refresh")
+	}
+}
+
+func assertSingleContextSelectorError(t *testing.T, errors []ErrorInfo, panicValue any) {
+	t.Helper()
+	if len(errors) != 1 {
+		t.Fatalf("context errors = %#v, want exactly one", errors)
+	}
+	info := errors[0]
+	if info.Phase != ErrorPhaseContext ||
+		info.Component != "Consumer" ||
+		info.Operation != "UseContextSelector" ||
+		info.Panic != panicValue {
+		t.Fatalf("context error = %#v, want phase context component Consumer operation UseContextSelector panic %#v",
+			info, panicValue)
+	}
+}
+
+func assertRecoveredContextSelection(
+	t *testing.T,
+	slot *contextSubscription,
+	consumer *componentInstance,
+	wantSelected int,
+	selectorCalls int,
+	wantSelectorCalls int,
+) {
+	t.Helper()
+	if slot.selected != wantSelected {
+		t.Fatalf("selected after safe provider update = %#v, want %d", slot.selected, wantSelected)
+	}
+	if !consumer.dirty {
+		t.Fatal("consumer should be dirty after safe provider update")
+	}
+	if selectorCalls != wantSelectorCalls {
+		t.Fatalf("selector calls after safe provider update = %d, want %d", selectorCalls, wantSelectorCalls)
+	}
 }

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -10,6 +10,7 @@ TODO_SMOKE_URL_BASE="${GOFRAME_TODO_SMOKE_URL:-http://127.0.0.1}"
 DUPLICATE_SMOKE_URL_BASE="${GOFRAME_DUPLICATE_KEY_SMOKE_URL:-http://127.0.0.1}"
 RUNTIME_ERRORS_SMOKE_URL_BASE="${GOFRAME_RUNTIME_ERRORS_SMOKE_URL:-http://127.0.0.1}"
 ERROR_BOUNDARY_SMOKE_URL_BASE="${GOFRAME_ERROR_BOUNDARY_SMOKE_URL:-http://127.0.0.1}"
+CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL:-http://127.0.0.1}"
 CONTROLLED_SELECT_SMOKE_URL_BASE="${GOFRAME_CONTROLLED_SELECT_SMOKE_URL:-http://127.0.0.1}"
 DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
@@ -103,6 +104,11 @@ build_runtime_errors_smoke_url() {
 build_error_boundary_smoke_url() {
 	local port="$1"
 	echo "${ERROR_BOUNDARY_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_context_selector_topology_smoke_url() {
+	local port="$1"
+	echo "${CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 build_controlled_select_smoke_url() {
@@ -273,6 +279,16 @@ export GOFRAME_ERROR_BOUNDARY_CHROME_DEBUG_PORT="${GOFRAME_ERROR_BOUNDARY_CHROME
 ERROR_BOUNDARY_URL="$(build_error_boundary_smoke_url "$ERROR_BOUNDARY_PORT")"
 run_with_server ./scripts/fixtures/error-boundary "$ERROR_BOUNDARY_PORT" "$ERROR_BOUNDARY_URL" \
 	node --experimental-websocket scripts/error-boundary-browser-smoke.mjs
+
+echo
+echo "== Context selector topology browser smoke (standard Go) =="
+"$GOXC" package ./scripts/fixtures/context-selector-topology --compiler=go
+
+CONTEXT_SELECTOR_TOPOLOGY_PORT="$(resolve_port "${GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_SMOKE_PORT:-}")"
+export GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_CHROME_DEBUG_PORT="${GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_CHROME_DEBUG_PORT:-$(pick_free_port)}"
+CONTEXT_SELECTOR_TOPOLOGY_URL="$(build_context_selector_topology_smoke_url "$CONTEXT_SELECTOR_TOPOLOGY_PORT")"
+run_with_server ./scripts/fixtures/context-selector-topology "$CONTEXT_SELECTOR_TOPOLOGY_PORT" "$CONTEXT_SELECTOR_TOPOLOGY_URL" \
+	node --experimental-websocket scripts/context-selector-topology-browser-smoke.mjs
 
 echo
 echo "== Controlled select browser smoke (TinyGo) =="

--- a/scripts/context-selector-topology-browser-smoke.mjs
+++ b/scripts/context-selector-topology-browser-smoke.mjs
@@ -1,0 +1,369 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const debugPort = Number(process.env.GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_CHROME_DEBUG_PORT ?? "19248");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-context-selector-topology-smoke-"));
+const expectedApp = new URL(appURL);
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+let browserError = "";
+let browserExit = null;
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+browser.on("exit", (code, signal) => {
+    browserExit = { code, signal };
+});
+
+try {
+    const page = await waitForPage(debugPort);
+    const client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Page.navigate", { url: withSmokeParam(appURL, "topology") });
+    await waitForAppPage(client, expectedApp);
+
+    await client.evaluate(`(() => {
+        window.__contextTopologyFixtureRoot = document.querySelector("#context-selector-topology-fixture");
+        return Boolean(window.__contextTopologyFixtureRoot);
+    })()`);
+
+    let state = await topologyState(client);
+    assertState(state, {
+        activeProvider: "outer",
+        outerPayload: "outer-safe",
+        innerPayload: "inactive",
+        selectedSource: "outer",
+        selectedPayload: "outer-safe",
+        appRenders: 1,
+        consumerRenders: 1,
+        selectorCalls: 1,
+        errorCount: 0,
+        sameRoot: true,
+    }, "initial outer provider");
+
+    await click(client, "#show-failing-inner");
+    state = await waitForTopologyState(client, "failing inner provider", (next) =>
+        next.activeProvider === "inner" && next.errorCount === 1);
+    assertState(state, {
+        activeProvider: "inner",
+        innerPayload: "inner-failing",
+        selectedSource: "outer",
+        selectedPayload: "outer-safe",
+        appRenders: 1,
+        consumerRenders: 1,
+        selectorCalls: 2,
+        errorCount: 1,
+        sameRoot: true,
+    }, "failed outer-to-inner topology refresh");
+    assertContextError(state.errors[0], "inner selector boom", "inner topology failure");
+
+    await click(client, "#update-shadowed-outer");
+    state = await waitForTopologyState(client, "shadowed outer update", (next) =>
+        next.outerPayload === "outer-shadowed");
+    assertState(state, {
+        activeProvider: "inner",
+        outerPayload: "outer-shadowed",
+        selectedSource: "outer",
+        selectedPayload: "outer-safe",
+        appRenders: 1,
+        consumerRenders: 1,
+        selectorCalls: 2,
+        errorCount: 1,
+        sameRoot: true,
+    }, "shadowed outer provider ignored after failed rebind");
+
+    await click(client, "#make-inner-safe");
+    state = await waitForTopologyState(client, "safe inner recovery", (next) =>
+        next.selectedPayload === "inner-safe");
+    assertState(state, {
+        activeProvider: "inner",
+        selectedSource: "inner",
+        selectedPayload: "inner-safe",
+        appRenders: 1,
+        consumerRenders: 2,
+        selectorCalls: 4,
+        errorCount: 1,
+        sameRoot: true,
+    }, "safe inner provider recovery");
+
+    await click(client, "#make-outer-failing");
+    state = await waitForTopologyState(client, "shadowed outer failure prepared", (next) =>
+        next.outerPayload === "outer-failing");
+    assertState(state, {
+        activeProvider: "inner",
+        selectedSource: "inner",
+        selectedPayload: "inner-safe",
+        appRenders: 1,
+        consumerRenders: 2,
+        selectorCalls: 4,
+        errorCount: 1,
+        sameRoot: true,
+    }, "failing outer remains shadowed");
+
+    await click(client, "#remove-inner");
+    state = await waitForTopologyState(client, "failing outer revealed", (next) =>
+        next.activeProvider === "outer" && next.errorCount === 2);
+    assertState(state, {
+        activeProvider: "outer",
+        innerPayload: "inactive",
+        selectedSource: "inner",
+        selectedPayload: "inner-safe",
+        appRenders: 1,
+        consumerRenders: 2,
+        selectorCalls: 5,
+        errorCount: 2,
+        sameRoot: true,
+    }, "failed inner-to-outer topology refresh");
+    assertContextError(state.errors[1], "outer selector boom", "outer topology failure");
+
+    await click(client, "#make-outer-safe");
+    state = await waitForTopologyState(client, "safe outer recovery", (next) =>
+        next.selectedPayload === "outer-safe-recovered");
+    assertState(state, {
+        activeProvider: "outer",
+        selectedSource: "outer",
+        selectedPayload: "outer-safe-recovered",
+        appRenders: 1,
+        consumerRenders: 3,
+        selectorCalls: 7,
+        errorCount: 2,
+        sameRoot: true,
+    }, "safe outer provider recovery");
+
+    await click(client, "#make-inner-safe");
+    state = await waitForTopologyState(client, "post-recovery interaction", (next) =>
+        next.activeProvider === "inner" && next.selectedPayload === "inner-safe");
+    assertState(state, {
+        activeProvider: "inner",
+        selectedSource: "inner",
+        selectedPayload: "inner-safe",
+        appRenders: 1,
+        consumerRenders: 4,
+        selectorCalls: 9,
+        errorCount: 2,
+        sameRoot: true,
+    }, "fixture remains interactive after contained failures");
+
+    client.close();
+    console.log(`context selector topology evidence: ${JSON.stringify(state)}`);
+    console.log("Context selector topology browser smoke: ok");
+} finally {
+    const exited = new Promise((resolve) => browser.once("exit", resolve));
+    browser.kill("SIGTERM");
+    await Promise.race([exited, wait(2000)]);
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function click(client, selector) {
+    const clicked = await client.callFunction(`function(selector) {
+        const element = document.querySelector(selector);
+        if (!element) return false;
+        element.click();
+        return true;
+    }`, selector);
+    if (!clicked) {
+        throw new Error(`APP FAILURE: missing element for click ${selector}`);
+    }
+}
+
+async function topologyState(client) {
+    return await client.evaluate(`(() => {
+        const text = (selector) => document.querySelector(selector)?.textContent ?? "";
+        const count = (selector) => Number(document.querySelector(selector)?.dataset.renderCount ?? "0");
+        const errors = Array.from(globalThis.goframeContextTopologyErrors || []).map((error) => ({
+            phase: error.phase,
+            component: error.component,
+            operation: error.operation,
+            panic: error.panic,
+        }));
+        const root = document.querySelector("#context-selector-topology-fixture");
+        return {
+            activeProvider: text("#active-provider"),
+            outerPayload: text("#outer-provider-payload"),
+            innerPayload: text("#inner-provider-payload"),
+            selectedSource: text("#selected-source"),
+            selectedPayload: text("#selected-payload"),
+            appRenders: Number(root?.dataset.appRenderCount ?? "0"),
+            outerRenders: count("#outer-provider"),
+            innerRenders: count("#inner-scope"),
+            consumerRenders: count("#selector-consumer"),
+            selectorCalls: Number(globalThis.goframeContextTopologySelectorCalls ?? 0),
+            errorCount: errors.length,
+            errors,
+            sameRoot: Boolean(root && window.__contextTopologyFixtureRoot === root),
+        };
+    })()`);
+}
+
+async function waitForTopologyState(client, label, predicate) {
+    const started = Date.now();
+    let state = null;
+    while (Date.now() - started < 5000) {
+        state = await topologyState(client);
+        if (predicate(state)) {
+            return state;
+        }
+        await wait(50);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label}: ${JSON.stringify(state)}`);
+}
+
+function assertState(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (actual[key] !== value) {
+            throw new Error(`APP FAILURE: ${label} ${key} got ${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; state=${JSON.stringify(actual)}`);
+        }
+    }
+    console.log(`${label}: ok`);
+}
+
+function assertContextError(actual, panicText, label) {
+    const expected = {
+        phase: "context",
+        component: "SelectorConsumer",
+        operation: "UseContextSelector",
+        panic: panicText,
+    };
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+        throw new Error(`APP FAILURE: ${label} got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)}`);
+    }
+}
+
+async function waitForPage(port) {
+    const started = Date.now();
+    let lastError;
+    while (Date.now() - started < 5000) {
+        if (browserExit) {
+            throw new Error(`HARNESS FAILURE: Chrome exited before CDP was ready: ${JSON.stringify(browserExit)}\n${browserError}`);
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            if (response.ok) {
+                const targets = await response.json();
+                const page = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+                if (page) return page;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: Chrome DevTools page unavailable: ${lastError?.message ?? browserError}`);
+}
+
+async function waitForAppPage(client, expected) {
+    const started = Date.now();
+    let state = null;
+    while (Date.now() - started < 8000) {
+        state = await client.evaluate(`(() => ({
+            href: window.location.href,
+            ready: Boolean(document.querySelector("#context-selector-topology-fixture")),
+        }))()`);
+        if (state.href.startsWith("chrome-error://")) {
+            throw new Error(`HARNESS FAILURE: Chrome loaded an error document: ${JSON.stringify(state)}`);
+        }
+        const actual = new URL(state.href);
+        if (actual.origin === expected.origin && actual.pathname === expected.pathname && state.ready) {
+            return;
+        }
+        await wait(100);
+    }
+    throw new Error(`HARNESS FAILURE: context selector topology app did not become ready: ${JSON.stringify(state)}`);
+}
+
+function withSmokeParam(url, label) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", `${Date.now()}-${label}`);
+    return next.toString();
+}
+
+function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    return new Promise((resolve, reject) => {
+        socket.addEventListener("open", () => {
+            resolve({
+                call(method, params = {}) {
+                    const id = nextID++;
+                    socket.send(JSON.stringify({ id, method, params }));
+                    return new Promise((callResolve, callReject) => {
+                        pending.set(id, { resolve: callResolve, reject: callReject });
+                    });
+                },
+                async evaluate(expression) {
+                    const response = await this.call("Runtime.evaluate", {
+                        expression,
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.exceptionDetails) {
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
+                    }
+                    return response.result.value;
+                },
+                async callFunction(functionDeclaration, ...args) {
+                    if (!this.globalObjectID) {
+                        const globalResponse = await this.call("Runtime.evaluate", {
+                            expression: "globalThis",
+                            returnByValue: false,
+                        });
+                        if (globalResponse.exceptionDetails) {
+                            throw new Error(`browser evaluation failed: ${JSON.stringify(globalResponse.exceptionDetails)}`);
+                        }
+                        this.globalObjectID = globalResponse.result.objectId;
+                    }
+                    const response = await this.call("Runtime.callFunctionOn", {
+                        objectId: this.globalObjectID,
+                        functionDeclaration,
+                        arguments: args.map((value) => ({ value })),
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.exceptionDetails) {
+                        throw new Error(`browser evaluation failed: ${JSON.stringify(response.exceptionDetails)}`);
+                    }
+                    return response.result.value;
+                },
+                close() {
+                    socket.close();
+                },
+            });
+        }, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+        socket.addEventListener("message", (event) => {
+            const message = JSON.parse(event.data);
+            if (!message.id || !pending.has(message.id)) return;
+            const request = pending.get(message.id);
+            pending.delete(message.id);
+            if (message.error) {
+                request.reject(new Error(message.error.message));
+                return;
+            }
+            request.resolve(message.result);
+        });
+    });
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/fixtures/context-selector-topology/app.gox
+++ b/scripts/fixtures/context-selector-topology/app.gox
@@ -1,0 +1,168 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type topologyContextValue struct {
+	Source      string
+	Payload     string
+	PanicSelect bool
+}
+
+type topologySelection struct {
+	Source  string
+	Payload string
+}
+
+type innerTopologyState struct {
+	Active bool
+	Value  topologyContextValue
+}
+
+type OuterProviderProps struct{}
+
+type InnerScopeProps struct{}
+
+func (InnerScopeProps) MemoEqual(InnerScopeProps) bool {
+	return true
+}
+
+type SelectorConsumerProps struct{}
+
+func (SelectorConsumerProps) MemoEqual(SelectorConsumerProps) bool {
+	return true
+}
+
+var topologyContext = gf.CreateContext(topologyContextValue{
+	Source:  "default",
+	Payload: "default-safe",
+})
+
+var (
+	setOuterTopologyValue func(topologyContextValue)
+	setInnerTopologyState func(innerTopologyState)
+	appRenderCount         int
+	outerRenderCount       int
+	innerRenderCount       int
+	consumerRenderCount    int
+)
+
+func App() gf.Node {
+	appRenderCount++
+
+	return (
+		<main id="context-selector-topology-fixture" data-app-render-count={appRenderCount}>
+			<h1>Context selector topology recovery</h1>
+			<button id="show-failing-inner" OnClick={func() {
+				setInnerTopologyState(innerTopologyState{
+					Active: true,
+					Value: topologyContextValue{
+						Source:      "inner",
+						Payload:     "inner-failing",
+						PanicSelect: true,
+					},
+				})
+			}}>Show failing inner provider</button>
+			<button id="update-shadowed-outer" OnClick={func() {
+				setOuterTopologyValue(topologyContextValue{
+					Source:  "outer",
+					Payload: "outer-shadowed",
+				})
+			}}>Update shadowed outer provider</button>
+			<button id="make-inner-safe" OnClick={func() {
+				setInnerTopologyState(innerTopologyState{
+					Active: true,
+					Value: topologyContextValue{
+						Source:  "inner",
+						Payload: "inner-safe",
+					},
+				})
+			}}>Make inner provider safe</button>
+			<button id="make-outer-failing" OnClick={func() {
+				setOuterTopologyValue(topologyContextValue{
+					Source:      "outer",
+					Payload:     "outer-failing",
+					PanicSelect: true,
+				})
+			}}>Make shadowed outer provider fail</button>
+			<button id="remove-inner" OnClick={func() {
+				setInnerTopologyState(innerTopologyState{})
+			}}>Remove inner provider</button>
+			<button id="make-outer-safe" OnClick={func() {
+				setOuterTopologyValue(topologyContextValue{
+					Source:  "outer",
+					Payload: "outer-safe-recovered",
+				})
+			}}>Make outer provider safe</button>
+			<OuterProvider />
+		</main>
+	)
+}
+
+func OuterProvider(OuterProviderProps) gf.Node {
+	value, setValue := gf.UseState(topologyContextValue{
+		Source:  "outer",
+		Payload: "outer-safe",
+	})
+	setOuterTopologyValue = setValue
+	outerRenderCount++
+	gf.ProvideContext(topologyContext, value)
+
+	return (
+		<section id="outer-provider" data-render-count={outerRenderCount}>
+			<p id="outer-provider-payload">{value.Payload}</p>
+			<InnerScope />
+		</section>
+	)
+}
+
+func InnerScope(InnerScopeProps) gf.Node {
+	state, setState := gf.UseState(innerTopologyState{})
+	setInnerTopologyState = setState
+	innerRenderCount++
+	if state.Active {
+		gf.ProvideContext(topologyContext, state.Value)
+	}
+
+	return (
+		<section id="inner-scope" data-render-count={innerRenderCount}>
+			<p id="active-provider">{activeTopologyProvider(state.Active)}</p>
+			<p id="inner-provider-payload">{innerTopologyPayload(state)}</p>
+			<SelectorConsumer />
+		</section>
+	)
+}
+
+func SelectorConsumer(SelectorConsumerProps) gf.Node {
+	selected := gf.UseContextSelector(topologyContext, func(value topologyContextValue) topologySelection {
+		recordContextTopologySelectorCall()
+		if value.PanicSelect {
+			panic(value.Source + " selector boom")
+		}
+		return topologySelection{
+			Source:  value.Source,
+			Payload: value.Payload,
+		}
+	})
+	consumerRenderCount++
+
+	return (
+		<article id="selector-consumer" data-render-count={consumerRenderCount}>
+			<p id="selected-source">{selected.Source}</p>
+			<p id="selected-payload">{selected.Payload}</p>
+		</article>
+	)
+}
+
+func activeTopologyProvider(innerActive bool) string {
+	if innerActive {
+		return "inner"
+	}
+	return "outer"
+}
+
+func innerTopologyPayload(state innerTopologyState) string {
+	if !state.Active {
+		return "inactive"
+	}
+	return state.Value.Payload
+}

--- a/scripts/fixtures/context-selector-topology/goframe.json
+++ b/scripts/fixtures/context-selector-topology/goframe.json
@@ -1,0 +1,10 @@
+{
+  "name": "context-selector-topology",
+  "entry": ".",
+  "output": "dist",
+  "compiler": "go",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html"
+  ]
+}

--- a/scripts/fixtures/context-selector-topology/index.html
+++ b/scripts/fixtures/context-selector-topology/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>goframe context selector topology fixture</title>
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root"></div>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/context-selector-topology/main.go
+++ b/scripts/fixtures/context-selector-topology/main.go
@@ -1,0 +1,35 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+func main() {
+	global := js.Global()
+	global.Set("goframeContextTopologyErrors", global.Get("Array").New())
+	global.Set("goframeContextTopologySelectorCalls", 0)
+	gf.SetErrorHandler(func(info gf.ErrorInfo) {
+		report := global.Get("Object").New()
+		report.Set("phase", info.Phase.String())
+		report.Set("component", info.Component)
+		report.Set("operation", info.Operation)
+		report.Set("panic", gf.ToString(info.Panic))
+		global.Get("goframeContextTopologyErrors").Call("push", report)
+	})
+
+	done := make(chan struct{})
+	gf.Mount("root", App)
+	<-done
+}
+
+func recordContextTopologySelectorCall() {
+	global := js.Global()
+	global.Set(
+		"goframeContextTopologySelectorCalls",
+		global.Get("goframeContextTopologySelectorCalls").Int()+1,
+	)
+}


### PR DESCRIPTION
## Summary

Keeps context subscriptions bound to the new nearest provider when
`UseContextSelector` fails during provider topology refresh.

Previously, the selector panic was contained, but the refresh returned before
updating structural provider ownership. This could leave a consumer subscribed
to an old, shadowed, or removed provider.

The runtime now advances the provider binding while preserving the previous
selected value and leaving the consumer clean. A later safe update from the
current provider can retry the selector and recover normally.

No public API or GOX behavior changes.

## What changed

- Rebinds the subscription before evaluating the selector against a newly
  nearest provider.
- Keeps selected-value updates transactional: a failed selector retains the
  previous committed selection and does not dirty the consumer.
- Preserves existing same-provider failure behavior and successful
  equal-selection topology invalidation.
- Adds regressions for provider appearance, removal, outer/inner handoff,
  old-provider isolation, recovery, and unmount cleanup.
- Adds private Chrome evidence for contained failures and later recovery.
- Documents structural provider ownership separately from selected-value
  commit.

## WASM size

All eleven budgeted applications remain within their existing raw and
compressed ceilings and ratio limits.

Nine application outputs are byte-identical. Only `context` and
`router-dashboard` change, with both raw bundles decreasing by `6 B`.

No budget, ratio, workflow, or toolchain baseline changes.

## Validation

- Full tests, debug-tag tests, and `go vet` on Go `1.22.12`, `1.25.12`, and
  `1.26.5`
- Race tests on Go `1.25.12` and `1.26.5`
- Focused topology regressions with repeated and race-enabled runs
- Ten fresh standard-Go browser-fixture runs
- Two complete Browser Smoke runs
- `scripts/check.sh` and the full WASM size matrix
- Artifact, module-path, documentation, formatting, and `actionlint` checks
- Node `24.18.1` VS Code extension tests
- Windows `amd64` `cmd/goxc` cross-compilation

## Scope

This PR is limited to private context subscription ownership, regression
evidence, and factual documentation.

It does not change public context APIs, GOX, public examples, router or resource
behavior, workflows, dependencies, lockfiles, or size budgets.

Browser evidence for selector-panic containment uses standard Go/WASM. The
existing TinyGo trap-mode limitation remains unchanged.