### PR TITLE
fix(runtime): preserve root ownership across repeated mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,9 +192,11 @@
 
 ### Fixed
 
-- Repeated `gf.Mount` calls now release the previous application and remove its
-  exact mounted DOM range before mounting into the same or a different root,
-  without removing unrelated host siblings from an inactive root.
+- Valid repeated `gf.Mount` calls now release the previous application and
+  remove its exact mounted DOM range before mounting into the same or an
+  independent root, without removing unrelated host siblings from an inactive
+  root. A different target inside the current root is rejected before the
+  current application is destroyed.
 - Context selector subscriptions now rebind to the new nearest provider during
   topology refresh even when selector evaluation fails, preserving the previous
   selected value while allowing safe updates from the new provider to recover.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,9 @@
 
 ### Fixed
 
+- Repeated `gf.Mount` calls now release the previous application and remove its
+  exact mounted DOM range before mounting into the same or a different root,
+  without removing unrelated host siblings from an inactive root.
 - Context selector subscriptions now rebind to the new nearest provider during
   topology refresh even when selector evaluation fails, preserving the previous
   selected value while allowing safe updates from the new provider to recover.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -132,9 +132,12 @@ roots, exact removal of the old mounted range while preserving unrelated host
 siblings, one-time effect and unmount cleanup, released event listeners and
 stale setters, ignored queued work from the previous application, working
 updates in the replacement, and repeated root transfers. The recover-capable
-standard Go mode also verifies that an unknown target fails before the active
-application is destroyed; TinyGo's trap-style panic path does not make that
-nonfatal assertion.
+standard Go mode also verifies that missing, application-owned descendant, and
+host-owned descendant targets fail before the active application is destroyed.
+Those checks retain the active DOM identity and cleanup counts and prove a
+post-rejection interaction. TinyGo exercises every non-panic replacement and
+isolation scenario; its trap-style panic path makes the three recover-based
+validation cases not applicable.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
 connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -126,6 +126,15 @@ old outer provider, recovery from a later safe inner update, removal of the
 inner provider while a failing outer provider is revealed, safe outer recovery,
 and live `ErrorPhaseContext` / `UseContextSelector` reporting without remounting
 the application.
+The private repeated-mount fixture runs under both standard Go/WASM and TinyGo
+on Chrome/Linux. It verifies same-root replacement, transfer between distinct
+roots, exact removal of the old mounted range while preserving unrelated host
+siblings, one-time effect and unmount cleanup, released event listeners and
+stale setters, ignored queued work from the previous application, working
+updates in the replacement, and repeated root transfers. The recover-capable
+standard Go mode also verifies that an unknown target fails before the active
+application is destroyed; TinyGo's trap-style panic path does not make that
+nonfatal assertion.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
 connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -110,6 +110,14 @@ Unmount cleanups run while the DOM range still exists, but applications should
 not depend on this detail. Treat cleanup as the place to release timers,
 external event listeners, subscriptions, and retained browser resources.
 
+Replacing the active application through `gf.Mount` follows the same cleanup
+contract for same-root and different-root replacement. Each previous cleanup
+runs once while that application's mounted range still exists; the runtime then
+removes the range before mounting the replacement. Effects queued by the
+released application do not run afterward. The DOM visibility during cleanup
+is an implementation detail, not an API for reading or transferring old DOM
+state.
+
 If an effect body panics, the runtime reports `gf.ErrorPhaseEffect` through the
 installed runtime error handler and does not register a cleanup for that failed
 effect run. If an effect cleanup panics, the runtime reports

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -118,6 +118,13 @@ released application do not run afterward. The DOM visibility during cleanup
 is an implementation detail, not an API for reading or transferring old DOM
 state.
 
+`Mount` validates a missing target and a different target nested inside the
+current root before effect cleanup, `UseUnmount` cleanup, application release,
+mounted-range removal, or pending-work reset. A validation panic therefore
+leaves the current application's effects and cleanup ownership intact. This is
+an ordering guarantee for target validation; it does not make panic recovery a
+portable TinyGo behavior.
+
 If an effect body panics, the runtime reports `gf.ErrorPhaseEffect` through the
 installed runtime error handler and does not register a cleanup for that failed
 effect run. If an effect cleanup panics, the runtime reports

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -230,6 +230,34 @@ cursor position. Stable-ID focus restoration remains a replacement fallback.
 its required reference. It calls `insertBefore` only when an actual move is
 needed.
 
+## Replacing the mounted application
+
+`gf.Mount` owns one active application. A later successful `Mount` call
+replaces that application whether the new target is the same DOM root or a
+different root. The runtime resolves the requested target first, so a missing
+target panics before disturbing the currently mounted application.
+
+After the next target is resolved, replacement follows this order:
+
+```text
+release the previous component tree
+  -> run lifecycle and resource cleanup
+  -> remove the exact previous GoFrame-owned DOM range
+  -> clear the next target root
+  -> mount the next application
+```
+
+Cleanup therefore runs while the previous mounted range still exists. The
+range removal preserves host-owned siblings outside that range when ownership
+moves to a different root. If the same root is reused, the subsequent target
+clearing keeps the existing `Mount` contract that the target root is wholly
+replaced. Setters and queued updates retained from the released application are
+inert and cannot mutate the replacement.
+
+This is replacement ownership, not simultaneous multi-root mounting. There is
+no public unmount handle, root registry, or rollback guarantee after the
+previous application has been released and rendering the replacement begins.
+
 ## Virtualized collections
 
 `gf.VirtualList` and `gf.VirtualTable` are framework-level fixed-height

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -232,12 +232,15 @@ needed.
 
 ## Replacing the mounted application
 
-`gf.Mount` owns one active application. A later successful `Mount` call
-replaces that application whether the new target is the same DOM root or a
-different root. The runtime resolves the requested target first, so a missing
-target panics before disturbing the currently mounted application.
+`gf.Mount` owns one active application. A later successful `Mount` call may
+reuse the current DOM root or target a root outside the current root subtree.
+The runtime resolves the requested target first, so a missing target panics
+before disturbing the currently mounted application. When an application is
+active, a different target contained by its current root is also rejected
+before teardown. This includes both GoFrame-rendered descendants and
+host-owned descendants of the current root.
 
-After the next target is resolved, replacement follows this order:
+After the next target is resolved and accepted, replacement follows this order:
 
 ```text
 release the previous component tree
@@ -255,8 +258,11 @@ replaced. Setters and queued updates retained from the released application are
 inert and cannot mutate the replacement.
 
 This is replacement ownership, not simultaneous multi-root mounting. There is
-no public unmount handle, root registry, or rollback guarantee after the
-previous application has been released and rendering the replacement begins.
+no nested-root adoption or transfer, public unmount handle, root registry, or
+rollback guarantee after the previous application has been released and
+rendering the replacement begins. A rejected target-validation attempt leaves
+the current application and its DOM ownership intact; a failure while rendering
+an already accepted replacement does not restore the previous application.
 
 ## Virtualized collections
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -347,6 +347,75 @@ Brotli at `38.00%`, and Zstandard at `46.00%`. No ceiling, ratio, compression
 command, size workflow, or budget-matrix membership changed; the private
 standard-Go browser fixture is not part of the size matrix.
 
+## Repeated Mount Root Ownership — 2026-08-01
+
+This measurement compares frozen base
+`01ac132c10fc82decebe330e359027a92aeea68e` with package-input head
+`5154edf5ec780f0e354209871f6baaad301af56a`. The documentation closeout is the
+commit containing this section; it does not change runtime or package inputs.
+The runtime correction removes the previous GoFrame-owned DOM range when a
+later `Mount` transfers the single active application to the same or a
+different root.
+
+Measurements use Go `1.26.5`, TinyGo `0.41.1`, Linux amd64, gzip `1.14`,
+Brotli `1.2.0`, and Zstandard `1.5.7`. Both refs were built sequentially in the
+same extraction path with the CI package order and shared task-owned caches.
+Compression uses the unchanged budget commands: gzip level 9, Brotli quality
+11, and Zstandard level 19. SHA comparison fixes the source mtime for comparable
+gzip container metadata; the compression command and measured byte count are
+unchanged.
+
+| app | raw base → final | gzip base → final | br base → final | zstd base → final |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85439 → 85481 B (+42 B) | 34348 → 34300 B (-48 B) | 28633 → 28650 B (+17 B) | 30823 → 30793 B (-30 B) |
+| components | 91078 → 91120 B (+42 B) | 36113 → 36045 B (-68 B) | 29845 → 29966 B (+121 B) | 32261 → 32253 B (-8 B) |
+| todo | 120344 → 120386 B (+42 B) | 46580 → 46537 B (-43 B) | 38506 → 38568 B (+62 B) | 41514 → 41485 B (-29 B) |
+| dashboard | 170706 → 170748 B (+42 B) | 64135 → 64068 B (-67 B) | 51645 → 51669 B (+24 B) | 55772 → 55755 B (-17 B) |
+| context | 117209 → 117251 B (+42 B) | 44252 → 44187 B (-65 B) | 36066 → 36107 B (+41 B) | 38957 → 38934 B (-23 B) |
+| virtualized | 124160 → 124202 B (+42 B) | 47995 → 47963 B (-32 B) | 39122 → 39277 B (+155 B) | 42422 → 42412 B (-10 B) |
+| multipackage | 96260 → 96302 B (+42 B) | 37865 → 37792 B (-73 B) | 31354 → 31414 B (+60 B) | 33783 → 33798 B (+15 B) |
+| cmdapp | 96278 → 96320 B (+42 B) | 37870 → 37798 B (-72 B) | 31394 → 31383 B (-11 B) | 33797 → 33749 B (-48 B) |
+| router | 117523 → 117565 B (+42 B) | 44980 → 44935 B (-45 B) | 37005 → 36992 B (-13 B) | 39933 → 39915 B (-18 B) |
+| router-dashboard | 234351 → 234395 B (+44 B) | 94011 → 93964 B (-47 B) | 77333 → 77318 B (-15 B) | 82516 → 82494 B (-22 B) |
+| resource | 157180 → 157224 B (+44 B) | 68645 → 68565 B (-80 B) | 57823 → 57768 B (-55 B) | 61371 → 61404 B (+33 B) |
+
+Final ceilings and byte headroom remain:
+
+| app | raw final / ceiling (headroom) | gzip final / ceiling (headroom) | br final / ceiling (headroom) | zstd final / ceiling (headroom) |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85481 / 97280 B (11799 B) | 34300 / 56320 B (22020 B) | 28650 / 40960 B (12310 B) | 30793 / 49152 B (18359 B) |
+| components | 91120 / 107520 B (16400 B) | 36045 / 56320 B (20275 B) | 29966 / 43008 B (13042 B) | 32253 / 49152 B (16899 B) |
+| todo | 120386 / 122880 B (2494 B) | 46537 / 56320 B (9783 B) | 38568 / 40960 B (2392 B) | 41485 / 49152 B (7667 B) |
+| dashboard | 170748 / 171008 B (260 B) | 64068 / 71680 B (7612 B) | 51669 / 53248 B (1579 B) | 55755 / 61440 B (5685 B) |
+| context | 117251 / 117760 B (509 B) | 44187 / 46080 B (1893 B) | 36107 / 36864 B (757 B) | 38934 / 40960 B (2026 B) |
+| virtualized | 124202 / 124928 B (726 B) | 47963 / 49152 B (1189 B) | 39277 / 40960 B (1683 B) | 42412 / 44032 B (1620 B) |
+| multipackage | 96302 / 110592 B (14290 B) | 37792 / 56320 B (18528 B) | 31414 / 43008 B (11594 B) | 33798 / 49152 B (15354 B) |
+| cmdapp | 96320 / 110592 B (14272 B) | 37798 / 56320 B (18522 B) | 31383 / 43008 B (11625 B) | 33749 / 49152 B (15403 B) |
+| router | 117565 / 117760 B (195 B) | 44935 / 58368 B (13433 B) | 36992 / 45056 B (8064 B) | 39915 / 51200 B (11285 B) |
+| router-dashboard | 234395 / 234496 B (101 B) | 93964 / 94208 B (244 B) | 77318 / 77824 B (506 B) | 82494 / 82944 B (450 B) |
+| resource | 157224 / 157696 B (472 B) | 68565 / 69632 B (1067 B) | 57768 / 58368 B (600 B) | 61404 / 61440 B (36 B) |
+
+SHA-256 values identify every measured base and final stream:
+
+| app | base raw / gzip / br / zstd SHA-256 | final raw / gzip / br / zstd SHA-256 |
+| --- | --- | --- |
+| counter | `773b4effb417d4497f051387e0c2221206014f6cdc79f37cc719f47b0ce8d10f` / `575f652628e05223ccf585abdc2b1c9680529870a0e5be0c159e344d5937a01d` / `e228bb0e1a8c9e0fd72e0fc316e0f84675332010b7d6d17f82b6c23ad859bb9a` / `bf67579f1d22115f936c32299c57a963ac7a52f9f62b77e77da246535753ea0a` | `1b4496b361964f115673be69193569e00c8f0783e4ffb0246192c956b5896457` / `44fc8c4c4ef1ca4dad2d0fc1683c3ce56e12f543e8181b80d509c0b02a44949f` / `63d3868c49fca10129296cd0c948eec7100d9bc09355676a6326e93ce4ab6d58` / `0c7ebba2ac9804b1098d8bc3b2d54d252cb449f19e1a43ecc66f24aca55b1177` |
+| components | `e29e56e0ff8a863f35faf5423a5ea0e888e97c244ef4cd87d420fbf9818117b7` / `26bbe0c559d25878b045c776d479e1dbe2b1012859c44189e830046039ec6b10` / `bb5dceee395bfe0828b1d44e64ca66dcd8ba7cc92ecd04f66e6df78682de4ee4` / `4a38d62198fd72b7516f00ea0ad5adc7939014de9768d22bf071ed91039b728d` | `287c9c495fbefbeb9bc7b11712d9baedef80b6d92c43ed5669be8602d8392c99` / `17798d14bb75c645d06f9cf2054be7dd0b63a63288288d2ae82d65be78eed43b` / `a7c0ecacbd442fee675d520e4523b2aab11582cb10053ec635530845cad5bac5` / `190a851c4c070dac803b73498f82f25c8090584673473440217822ad9c76eed2` |
+| todo | `96c27f77d529548334fc683e4a8a847830f742a2a44a9c53cd143cd3328fcde4` / `ece4aa57b8ef90f7c3f4e094466449e142f3ec0f581155b8e86613be043391fa` / `ec67c7bcb0aeffd4cf3bc0353dadb9062ab0d7889430f2bac9ae44d73d6071aa` / `c67daf7da9c9a0e0780e25460038c217523c31c85d84946835ef54039d5c8842` | `132c288a9b0b418a378df200918e06500a8b8a3a29f84d68bf0311c624006d14` / `13488f66500cddb8364373237f2b7c28ab55f98248a07c8c8080f1459b545369` / `b64e8508907a3a620e4bd19831162a20b8c06f5f3243b0cc73821e0bde796398` / `a4a1dad9e3da988c71825919692941ef50d283c11ddcbd7a87155d79859c0eb2` |
+| dashboard | `bbbef9fbd418fe85746d3544286b2457b1ece002cf776ceb20afbffebaca2864` / `75cacd7308ce086f2e0d57b1ce7726fc900ce174d52670ea19ff8b2b40f1b540` / `a9ab0f3b7641082ccac7f22460e75d5cf791c439d125c6d05af0bb2c2bfd747d` / `5d2310ade93819eba619ad64fe0d8a11dd141b565e0c694ebfe0549910901d02` | `03637d8cf568577acecc09012a13a37c74e948ef9238dec08221f209f7d2440d` / `7e0d77e74cb9bc00388499594f9c595359bedc62b950938ae2a969b76811404c` / `b3eaf0e24d5332de95d76c3d6f0bd88222cc47f097dcff59862d95f5a09a3d22` / `f5b0913a58e714432ef54b58b89494fdbadb22a4ef33621792e4cf25c56db320` |
+| context | `547722e8a94f126cf5f21944b9b120e31aae023e2cb40fbbced1fccf9796c626` / `b885e8372bd6373b07c5862f797eb801bb6192496a6804b0cb6f1d9cbe358b72` / `504a2b1ec41b988dbad31915260ff5c6d6e09dd539dfa77b78e8b47b26b98822` / `1213d9c6fa431403291a36babd86b7e70d9bd8e7edae60775c43bf46ae29461e` | `cf35b1eea5b6e4269326eea4948e21f6415643aa7265777bc84526b322e31fcd` / `737fde984ac35e45a4acfb07a4cd4906ddc46933a00d483cac468450c183c956` / `397eb36a67c47dc1b93376d821551c880c22ee76e92e8bc464793177e9efabdb` / `b532e9fc3b4e6d078c8b476ec95ef8e2fd4fba89ce0e5cda247746f6097bee23` |
+| virtualized | `4e120d473883ba074285a918b73e1b37a66f81e7850aa7d7b985f2c8cc8d263b` / `6b9cefa8bc0f2e72f913fdd0daa698c02c436ff1d4c5442da79c1cd8c89d729f` / `e875b23552a8b4542298e8e9bbf9d1150dcedeab76e743aa3cb16077a513b42a` / `1d421a384b4477ca373449dfe4deb233ed8299b5f78eb5c9e19172b0f2db203f` | `01899b2c6ac85fe4421299921b3f960de8aa581698a9d5b9c6d8e7d5c105c92b` / `197384ab681d1947b31abea26503c1d71781f2c688728096a83700cecc58d2e6` / `b7cfd6a391e4d273ba726af3c76c41c19ed0fd78c2ab22522335c3829e090592` / `304690e8391b4e63e68654283296cc554f886380344e1e470412496c0e9f0754` |
+| multipackage | `601d36f8d6e5b90bffcb80e164c1c8f73502df42a8a20dd017ea16dec5e37677` / `7570bc260b95e4682c83d1ac5dea41a7a3b1b35efe8ad998a2b7d6ec3bfd3159` / `cc3631ccbd7e474d9aaa0fd09efdbec755935af6f19c33d76128a2f68708344d` / `697693ce66d0af59d5ade0531d17b32c228a2baa57641aadbb7f4ca1572f9d85` | `40616cedda7a2f644cf80c5b17b883bee56632be8e4842699c56d7651f2199ba` / `2d894763d983abd041a88e5c6aea73bb6b0d6e2672a733002efb84baf5579c5e` / `e40bc2c465e3f64db1a0e99f2138d5e3221aa7001ce927d8b1dd3e5aea71a946` / `51453d580001c593059068056207d9c4fbdb14f36867861f1f3f3a0f7f036b22` |
+| cmdapp | `32a47fc52c53c53de985602a4624cfe67f76fd6aa444a8f61823389fe9648640` / `4f91cc87eb05e8578069ef383bf05bb2b8038d9427370ca14717e661e9c6b3a5` / `eae473813325102d777a136074ba82b5da04c54587017a46627708546b73b9f2` / `e7428a7d96e222a9566ce048065000712b5790e9f7601dddc2c46756002bd598` | `4ee342784b97bb2e50cf1830959bfa45ba8304155c2c384ececce22f11181eb7` / `b89bd931c2a308a28943ed066636252cf2fa21652a7a1396c0c44d8b5a63b652` / `61fff06eeaa56f852a9e082e85b7acf5ac49fa51839b1a92c0d88332de9e13e2` / `981549f73bfcfa587a3a050e653f85e69922f73d3b6826fad3fa62324d1dba7d` |
+| router | `242c0f6c65028f3f21a00932265d5c24148df2c1b84cd8d76bad267fcdcc6638` / `2f5ef3168e7c0b991a7e49cc276eb35e89fc809950e63cfebe28469686174768` / `db0e79ce2ef23b5c7f81baa0cec76756b9894a72487da468efef5b3c86e08702` / `17ef65a118cba5daa930be86cb3a806c5a8f9a0da1c609b830659502c8b6539b` | `df159357d037b5242b0bd297aa3b8819080d3b14e6ec3926fed97c7d51c3ce99` / `f315f934a8d8c9c36f80deab6dc211ef3653dcbd7582b7688ffd94e00eca0aa5` / `2a2742d8b30a38d9db438e26ec64569ed995f3badd72c9a02271a12fc3cf7315` / `43e7f3e522df944f16254e913260dbc8699c1c310303930dd0e917d20ca82758` |
+| router-dashboard | `b00e2dcf4cdf997f7240c6b7efe475f6a8920715cfdbecbabe7105ba830c03d0` / `aa144e4726f4052fcac6e112bd5bb154f6ff0b102ea43ffff4ae274c16f52220` / `1f17b59c8157df476ce6214acf365001ed741f533f1840dfeb8cc0e4ef4e5b4d` / `305feb072e7b2a72d6b856b52d9de59fa008f29f011f223c9dcfcdc393ac6881` | `8cf8e96b377c9108404f36b8fe2bfa9216df428fb2ac34037262656902496892` / `894747320d642134bb0cfac46ffe6463316941a9af5d56d8350bc098c3a5856a` / `25cb0da315951534908265225993d1346ffefa09355f2785c4cd4d1390144be1` / `3c3529f718bcc2992438a335d3bdbef49c2437ce1d72093d6c15c4963239848c` |
+| resource | `17b29f7b316e77d5b5872f613f3699db43bb0de4122c49c71632af6107a0a171` / `fe18f40401dacf06b37b1f15d59cd4ea32831998148d5d5df1172eb7878f9454` / `97d2966701e8c746d73f6ae72b252a88ce4d5c100a83db72bae935e519d2a560` / `49c3731eccf30634e1cc1affa9a32cdf39d787e2924712de95289234fb43b376` | `5827b43710546eb152e8430b22579053064ab4f9c2395b1122212f740e0e405a` / `f942eb412a62ee54a7612d14706fec9449bf07d0f513bcd7021abbb952de1601` / `2e9de7a76a7d403d99e2df9f24152e42f13467a7bccb2bb67535961b06788db5` / `e7758fb4623f32d04facd20148c4cdb2e07e02af1323c8384f66ad94a6b73720` |
+
+All 44 cells and all ratio limits pass. Gzip remains capped at `52.00%`,
+Brotli at `38.00%`, and Zstandard at `46.00%`. No ceiling, ratio, compression
+command, size workflow, or budget-matrix membership changed; the private
+repeated-mount browser fixture is not part of the size matrix.
+
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 
 This targeted rebaseline covers complete mounted-subtree teardown ownership

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -427,10 +427,13 @@ repeated-mount browser fixture is not part of the size matrix.
 This closeout compares reviewed repeated-Mount head
 `d9c59a7b2e065cd9265108460579f028a8c7c02f` with package-input commit
 `5ab337cc35bcdf5d4bd1ec9fc11e22581b9bb4f2`. At the reviewed head, mounting
-into a descendant rendered by the active application destroyed App A, ran its
-cleanups, mounted App B into a target that had become disconnected, and left no
-document-visible active application. A host-owned descendant appended inside
-the current root had the same ownership defect.
+into an application-owned descendant destroyed App A, ran its cleanups, removed
+the target from the document, and mounted App B into the retained but
+disconnected element. A host-owned descendant appended inside the current root
+but outside the GoFrame-mounted range remained connected and could host the
+replacement. The final contract intentionally rejects every different
+descendant of the current root to keep the ownership rule simple, reviewable,
+size-bounded, and independent of mounted-range traversal.
 
 Four bounded implementations were measured. Candidate A traversed the mounted
 range and added about `472 B` to `490 B` raw; Candidate B reduced ancestry to

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -24,6 +24,12 @@ over that closeout. Every raw, Brotli, and Zstandard cell remains within its
 existing ceiling. The only old-ceiling failure is `resource` gzip at `68636 B`,
 so that one ceiling is aligned from `68608 B` to `69632 B`.
 
+The repeated-Mount nested-target guard adds `216 B` to `235 B` of raw WASM over
+the reviewed repeated-Mount head. Exactly three old-ceiling cells fail:
+`router` raw by `40 B`, `router-dashboard` raw by `134 B`, and `resource`
+Zstandard by `74 B`. Those three ceilings increase by `1024 B`; every other
+absolute ceiling and all ratio limits remain unchanged.
+
 ## Source of Truth
 
 - Workflow: `.github/workflows/ci-wasm-size.yml`
@@ -57,9 +63,9 @@ If no match exists, it reports the default missing path
 | virtualized | 124928 B | 40960 B | 49152 B | 44032 B |
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
-| router | 117760 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 234496 B | 77824 B | 94208 B | 82944 B |
-| resource | 157696 B | 58368 B | 69632 B | 61440 B |
+| router | 118784 B | 45056 B | 58368 B | 51200 B |
+| router-dashboard | 235520 B | 77824 B | 94208 B | 82944 B |
+| resource | 157696 B | 58368 B | 69632 B | 62464 B |
 
 ## Supported Toolchain Baseline Migration - 2026-07-30
 
@@ -415,6 +421,107 @@ All 44 cells and all ratio limits pass. Gzip remains capped at `52.00%`,
 Brotli at `38.00%`, and Zstandard at `46.00%`. No ceiling, ratio, compression
 command, size workflow, or budget-matrix membership changed; the private
 repeated-mount browser fixture is not part of the size matrix.
+
+## Repeated Mount Nested-Target Guard — 2026-08-02
+
+This closeout compares reviewed repeated-Mount head
+`d9c59a7b2e065cd9265108460579f028a8c7c02f` with package-input commit
+`5ab337cc35bcdf5d4bd1ec9fc11e22581b9bb4f2`. At the reviewed head, mounting
+into a descendant rendered by the active application destroyed App A, ran its
+cleanups, mounted App B into a target that had become disconnected, and left no
+document-visible active application. A host-owned descendant appended inside
+the current root had the same ownership defect.
+
+Four bounded implementations were measured. Candidate A traversed the mounted
+range and added about `472 B` to `490 B` raw; Candidate B reduced ancestry to
+direct children but added about `620 B` to `637 B` raw. Candidate C1 used the
+whole current root inline and added about `251 B` to `256 B` raw. Candidate C2
+moved the same whole-root condition into a private helper and added `216 B` to
+`235 B` raw. C2 was selected because it is behaviorally complete, smaller than
+C1, and does not change renderer, scheduler, teardown, or mounted-node
+representation.
+
+The selected condition is:
+
+```go
+mountedApp.tree != nil &&
+	!root.Equal(mountedApp.root) &&
+	mountedApp.root.Call("contains", root).Bool()
+```
+
+It runs after successful target lookup and before application teardown. The
+current root and roots outside its subtree remain valid. A different
+application-owned or host-owned descendant is rejected with
+`goframe: cannot mount inside current root` while the current application is
+still active. Standard-Go Chrome evidence covers both rejections, preserved DOM
+identity and cleanup counts, and post-rejection interaction. TinyGo `0.41.1`
+uses trap-style panic lowering, so the missing-root and descendant-panic cases
+are not invoked there; all non-panic replacement and isolation scenarios pass
+under TinyGo.
+
+Measurements use Go `1.26.5`, TinyGo `0.41.1` with LLVM `20.1.1`, Linux amd64,
+gzip `1.14`, Brotli `1.2.0`, and Zstandard `1.5.7`. Both refs were built
+sequentially from the same absolute extraction path with the CI application
+order and shared task-owned caches. Compression uses gzip level 9, Brotli
+quality 11, and Zstandard level 19. Hash comparison uses the same
+`bundle.00000000.wasm` source basename and a fixed 2000-01-01 source mtime;
+these preserve the normative budget byte counts while removing path and mtime
+differences from compressed-stream identity.
+
+| app | raw reviewed → final | gzip reviewed → final | br reviewed → final | zstd reviewed → final |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85481 → 85716 B (+235 B) | 34300 → 34400 B (+100 B) | 28650 → 28747 B (+97 B) | 30793 → 30901 B (+108 B) |
+| components | 91120 → 91355 B (+235 B) | 36045 → 36147 B (+102 B) | 29966 → 29989 B (+23 B) | 32253 → 32343 B (+90 B) |
+| todo | 120386 → 120621 B (+235 B) | 46537 → 46725 B (+188 B) | 38568 → 38617 B (+49 B) | 41485 → 41587 B (+102 B) |
+| dashboard | 170748 → 170964 B (+216 B) | 64068 → 64174 B (+106 B) | 51669 → 51777 B (+108 B) | 55755 → 55881 B (+126 B) |
+| context | 117251 → 117486 B (+235 B) | 44187 → 44295 B (+108 B) | 36107 → 36184 B (+77 B) | 38934 → 39047 B (+113 B) |
+| virtualized | 124202 → 124418 B (+216 B) | 47963 → 48053 B (+90 B) | 39277 → 39226 B (-51 B) | 42412 → 42489 B (+77 B) |
+| multipackage | 96302 → 96537 B (+235 B) | 37792 → 37893 B (+101 B) | 31414 → 31412 B (-2 B) | 33798 → 33881 B (+83 B) |
+| cmdapp | 96320 → 96555 B (+235 B) | 37798 → 37900 B (+102 B) | 31383 → 31428 B (+45 B) | 33749 → 33877 B (+128 B) |
+| router | 117565 → 117800 B (+235 B) | 44935 → 45038 B (+103 B) | 36992 → 37057 B (+65 B) | 39915 → 40010 B (+95 B) |
+| router-dashboard | 234395 → 234630 B (+235 B) | 93964 → 94041 B (+77 B) | 77318 → 77404 B (+86 B) | 82494 → 82605 B (+111 B) |
+| resource | 157224 → 157459 B (+235 B) | 68565 → 68688 B (+123 B) | 57768 → 57813 B (+45 B) | 61404 → 61514 B (+110 B) |
+
+Final ceilings and headroom are:
+
+| app | raw final / ceiling (headroom) | gzip final / ceiling (headroom) | br final / ceiling (headroom) | zstd final / ceiling (headroom) |
+| --- | ---: | ---: | ---: | ---: |
+| counter | 85716 / 97280 B (11564 B) | 34400 / 56320 B (21920 B) | 28747 / 40960 B (12213 B) | 30901 / 49152 B (18251 B) |
+| components | 91355 / 107520 B (16165 B) | 36147 / 56320 B (20173 B) | 29989 / 43008 B (13019 B) | 32343 / 49152 B (16809 B) |
+| todo | 120621 / 122880 B (2259 B) | 46725 / 56320 B (9595 B) | 38617 / 40960 B (2343 B) | 41587 / 49152 B (7565 B) |
+| dashboard | 170964 / 171008 B (44 B) | 64174 / 71680 B (7506 B) | 51777 / 53248 B (1471 B) | 55881 / 61440 B (5559 B) |
+| context | 117486 / 117760 B (274 B) | 44295 / 46080 B (1785 B) | 36184 / 36864 B (680 B) | 39047 / 40960 B (1913 B) |
+| virtualized | 124418 / 124928 B (510 B) | 48053 / 49152 B (1099 B) | 39226 / 40960 B (1734 B) | 42489 / 44032 B (1543 B) |
+| multipackage | 96537 / 110592 B (14055 B) | 37893 / 56320 B (18427 B) | 31412 / 43008 B (11596 B) | 33881 / 49152 B (15271 B) |
+| cmdapp | 96555 / 110592 B (14037 B) | 37900 / 56320 B (18420 B) | 31428 / 43008 B (11580 B) | 33877 / 49152 B (15275 B) |
+| router | 117800 / 118784 B (984 B) | 45038 / 58368 B (13330 B) | 37057 / 45056 B (7999 B) | 40010 / 51200 B (11190 B) |
+| router-dashboard | 234630 / 235520 B (890 B) | 94041 / 94208 B (167 B) | 77404 / 77824 B (420 B) | 82605 / 82944 B (339 B) |
+| resource | 157459 / 157696 B (237 B) | 68688 / 69632 B (944 B) | 57813 / 58368 B (555 B) | 61514 / 62464 B (950 B) |
+
+SHA-256 values identify every reviewed and final stream:
+
+| app | reviewed raw / gzip / br / zstd SHA-256 | final raw / gzip / br / zstd SHA-256 |
+| --- | --- | --- |
+| counter | `1b4496b361964f115673be69193569e00c8f0783e4ffb0246192c956b5896457` / `ffa59e987bb5c96ad98f7dcaf3d3a593cdb239a2129c2c3cc8786ae49a48cf15` / `63d3868c49fca10129296cd0c948eec7100d9bc09355676a6326e93ce4ab6d58` / `0c7ebba2ac9804b1098d8bc3b2d54d252cb449f19e1a43ecc66f24aca55b1177` | `b2e0c0c44ba1a92a1aea4a5b24546e0babb01dca7819c839aece9a7c638fb03d` / `473585bde053c9c4902798dea12ce84e5552ed3fd4703d2cbbf7bb1d77483b43` / `ae5a5058606273bf2c93e591441f4588943521718f49520d0d996b4788922f90` / `9684c3b6b9c98a5386c2755d65356aab8103b468ad171d08fc154820c1249cba` |
+| components | `287c9c495fbefbeb9bc7b11712d9baedef80b6d92c43ed5669be8602d8392c99` / `612a10723f323c7d496d0ce194ed1062cc9869dc3a5947f9cbc6840ac5a86944` / `a7c0ecacbd442fee675d520e4523b2aab11582cb10053ec635530845cad5bac5` / `190a851c4c070dac803b73498f82f25c8090584673473440217822ad9c76eed2` | `1784f025971927bc697f9d231185b00e5e94ebf7622207f03d42ea9ce947e3fe` / `8b0beb560773f20a7a0f2311ab564e2f93e620c00f95a1feac47223a3b78db01` / `cd59fc6b2f6108caf1aa0ab0826fded8271dab97e925b16cd57dc69a760d054f` / `87908961c33bae16290d5bef79fc7c928f4559570e290a725b4e1dd564dda42c` |
+| todo | `132c288a9b0b418a378df200918e06500a8b8a3a29f84d68bf0311c624006d14` / `77dae4f05240c61db033ca6a239bdac956074cd6ac485351aa855215bf711108` / `b64e8508907a3a620e4bd19831162a20b8c06f5f3243b0cc73821e0bde796398` / `a4a1dad9e3da988c71825919692941ef50d283c11ddcbd7a87155d79859c0eb2` | `1a50a9b5ea1070aa2402d0ff2bccea5eaded4fef4a982f5fb7b76c139b002c1c` / `9aef5b284fe326d793f94628068d9d6ae9659641a7d4f02d2411d6c746ebf125` / `e3a620fd684cbf54c51696fac4003c360c3a41a5ec43607cdf23664ee1485b28` / `28ee84a5685ce253656ad78ceda6547a14bc03f70c404409197fdf970246479e` |
+| dashboard | `03637d8cf568577acecc09012a13a37c74e948ef9238dec08221f209f7d2440d` / `ec2de8966b56c957fd4c689e49c0d1383ebe325cb68e6b22429021c7434fdef9` / `b3eaf0e24d5332de95d76c3d6f0bd88222cc47f097dcff59862d95f5a09a3d22` / `f5b0913a58e714432ef54b58b89494fdbadb22a4ef33621792e4cf25c56db320` | `1f8bae2c8b3a702626c5e021feff3ff58082e475331d385cf9fba652c9384779` / `21a4fde75886508b3fa151818a08325b6743e90aea47aee373ce00d4ea4bfaf8` / `f3bf6dbb038cc833269b31c097abd7c17189f66e7fc73aa2ecc4ebd1b9d7d837` / `7fd8208d1c336ebbdf2c5dd053e3b59ed4659a6d88110801e1337e4cab73d5ad` |
+| context | `cf35b1eea5b6e4269326eea4948e21f6415643aa7265777bc84526b322e31fcd` / `7437eef051d0f521842c40cde485169e3dc820c9b6e9469135a2e9dd750f0861` / `397eb36a67c47dc1b93376d821551c880c22ee76e92e8bc464793177e9efabdb` / `b532e9fc3b4e6d078c8b476ec95ef8e2fd4fba89ce0e5cda247746f6097bee23` | `49d859d5e725438b1501f2356b609c77a950b06a0b12ec097d7185f6d75b9091` / `be5c89f0e06f778da15eb7305e4031be03b1f9331c87bb082375428e1ae45568` / `4c7e6ee5e3db933305e0dcd1ed5c578b165887752f444b24bcf14982b97dabfa` / `0ad2a4d85d30e7026870d58420ffc8157e64bafc32e54163c2b77261eec249b7` |
+| virtualized | `01899b2c6ac85fe4421299921b3f960de8aa581698a9d5b9c6d8e7d5c105c92b` / `3cbb62348c76385ab69f6a823e6085ff29e849795a26802f3d77025d67bddb50` / `b7cfd6a391e4d273ba726af3c76c41c19ed0fd78c2ab22522335c3829e090592` / `304690e8391b4e63e68654283296cc554f886380344e1e470412496c0e9f0754` | `c581dfeda10e3f231b225dddbaf50d4d51bcde74ba9e9db8f0ffb579d1b0331d` / `eed6369e61fd88b8147e1a9bf918fed251d347e6532b5476bf1fae5efa27aa5d` / `02280681aea54fdc3fd69e15082a49989f543796b19dc27ab8a43fc731f8aa6c` / `89c245ea519728b1c4d88568638c80b1932225eff73fc2249505c79ce78ef2f7` |
+| multipackage | `40616cedda7a2f644cf80c5b17b883bee56632be8e4842699c56d7651f2199ba` / `5e852872876ce689e2f243e2efd26d191dba45342f73a8b88005aa8c6c78a2c9` / `e40bc2c465e3f64db1a0e99f2138d5e3221aa7001ce927d8b1dd3e5aea71a946` / `51453d580001c593059068056207d9c4fbdb14f36867861f1f3f3a0f7f036b22` | `ce1131d527e2af8ad557696f5ac0c29c0fc4108a95158848d5e5fb3123a9001f` / `ddf75ad44bd78b1c422868f0d0780fc6b125cbf1961a546727aa8c07ccef7b25` / `ae59ce973fd63fda26ef0464500cb424586b9ff31b08c53ca0eb253cd1af3ff3` / `c9fd085f0537ac86015a77b527f8c368794a0b2377dc0e8915eac09d3fcd24d7` |
+| cmdapp | `4ee342784b97bb2e50cf1830959bfa45ba8304155c2c384ececce22f11181eb7` / `756a548ef19365ecf27605d1041a327a8be26d77324f4463e96d44259154df35` / `61fff06eeaa56f852a9e082e85b7acf5ac49fa51839b1a92c0d88332de9e13e2` / `981549f73bfcfa587a3a050e653f85e69922f73d3b6826fad3fa62324d1dba7d` | `8b389fe2a06d0a2ae4aa2543c0c5b874ad40f3026a33d98a97469f7ef9e0385c` / `7adbf071d48e61375cb0e29766b31016d86b9425f2a678708119ef048698c239` / `6c52bb7f63563f0f98b696c0c31db8cb7eb68591b92aae07c42cf9289c4a3589` / `e87f96f306fe32581d3531db004aa2afb6a6dccc87afe5b93ca8861e41556d89` |
+| router | `df159357d037b5242b0bd297aa3b8819080d3b14e6ec3926fed97c7d51c3ce99` / `6014712186e295844c1b3bba44be15a7a6b9e1ba385fbec6f26383cd31d09183` / `2a2742d8b30a38d9db438e26ec64569ed995f3badd72c9a02271a12fc3cf7315` / `43e7f3e522df944f16254e913260dbc8699c1c310303930dd0e917d20ca82758` | `95c88f56b1fa40054a1008d4813ad5455710076742a06fb26be801765076b293` / `df4cb1e4323fed7ce168c4860a7623addfcd66178df42603a19d2603d9d2b25a` / `466c10552774f166a67a409e43381cca5c2a2661b3534a4ec9774b028eb7dd1d` / `a29fa10c1cb630d1e29a988a570e07ef6957aa6fd1d941659c909720152a14c4` |
+| router-dashboard | `8cf8e96b377c9108404f36b8fe2bfa9216df428fb2ac34037262656902496892` / `090c912909f9ad6ce90c4b619c69b30c72b24b8bd2cea5ae26e9d1d57a26179a` / `25cb0da315951534908265225993d1346ffefa09355f2785c4cd4d1390144be1` / `3c3529f718bcc2992438a335d3bdbef49c2437ce1d72093d6c15c4963239848c` | `ca32baf21d6575699d0de00d2e3af46587794393509c04a053d650a3b56dbcef` / `da7796caf4c12a364c28440e86070aaaeea4f0c979aff6ec5fda587d87502506` / `10ff8380d1863414099cce7ca4922a621318d80eaa0323321f5f5fd405dbd8de` / `aa47210fd11563e2378b024ced6f7ed692a5db070816ee7b17c5599be819de9d` |
+| resource | `5827b43710546eb152e8430b22579053064ab4f9c2395b1122212f740e0e405a` / `13d18c2c42094170328c6dabe61db9379deee8b44695d45c938acbead12912a8` / `2e9de7a76a7d403d99e2df9f24152e42f13467a7bccb2bb67535961b06788db5` / `e7758fb4623f32d04facd20148c4cdb2e07e02af1323c8384f66ad94a6b73720` | `422d330c2d804f65c16ca67dff6d0d3feba81d1d5d55e0b48d0b766a7d04d301` / `66c705aa25e02c39a6e5f50f2b0c73f0e06082e4594109a0b9c79ecbd2e476e7` / `5599eb5bc7ab488444e99257d62050c32d89ad8d26d87ca9ae2b5df79544060f` / `b1d9c57aead2dbaf0eb2e440b6c059c14a3a9d406ad0cf94bf40f8c0294b023c` |
+
+The old ceilings failed only at `router` raw (`117800 / 117760 B`),
+`router-dashboard` raw (`234630 / 234496 B`), and `resource` Zstandard
+(`61514 / 61440 B`). Their new ceilings are `118784 B`, `235520 B`, and
+`62464 B`, respectively, each exactly `1024 B` higher and leaving `984 B`,
+`890 B`, and `950 B` headroom. All 44 final cells and all ratio limits pass.
+No other ceiling, ratio, compression command, workflow, or matrix membership
+changed. This is an accepted root-ownership correctness cost; the private
+repeated-Mount fixture remains outside the size matrix.
 
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 

--- a/pkg/goframe/mount_js.go
+++ b/pkg/goframe/mount_js.go
@@ -33,7 +33,7 @@ func Mount(rootID string, app func() Node) {
 		panic("goframe: root element not found: " + rootID)
 	}
 	if mountedApp.tree != nil {
-		releaseMounted(mountedApp.tree)
+		removeMounted(mountedApp.root, mountedApp.tree)
 	}
 
 	mountedApp.root = root

--- a/pkg/goframe/mount_js.go
+++ b/pkg/goframe/mount_js.go
@@ -32,6 +32,9 @@ func Mount(rootID string, app func() Node) {
 	if root.IsUndefined() || root.IsNull() {
 		panic("goframe: root element not found: " + rootID)
 	}
+	if mountTargetInsideCurrentRoot(root) {
+		panic("goframe: cannot mount inside current root")
+	}
 	if mountedApp.tree != nil {
 		removeMounted(mountedApp.root, mountedApp.tree)
 	}
@@ -48,6 +51,12 @@ func Mount(rootID string, app func() Node) {
 	pendingEffects = nil
 
 	mountApplication(document)
+}
+
+func mountTargetInsideCurrentRoot(root js.Value) bool {
+	return mountedApp.tree != nil &&
+		!root.Equal(mountedApp.root) &&
+		mountedApp.root.Call("contains", root).Bool()
 }
 
 func mountApplication(document js.Value) {

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -11,6 +11,7 @@ DUPLICATE_SMOKE_URL_BASE="${GOFRAME_DUPLICATE_KEY_SMOKE_URL:-http://127.0.0.1}"
 RUNTIME_ERRORS_SMOKE_URL_BASE="${GOFRAME_RUNTIME_ERRORS_SMOKE_URL:-http://127.0.0.1}"
 ERROR_BOUNDARY_SMOKE_URL_BASE="${GOFRAME_ERROR_BOUNDARY_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL:-http://127.0.0.1}"
+REPEATED_MOUNT_SMOKE_URL_BASE="${GOFRAME_REPEATED_MOUNT_SMOKE_URL:-http://127.0.0.1}"
 CONTROLLED_SELECT_SMOKE_URL_BASE="${GOFRAME_CONTROLLED_SELECT_SMOKE_URL:-http://127.0.0.1}"
 DASHBOARD_SMOKE_URL_BASE="${GOFRAME_DASHBOARD_SMOKE_URL:-http://127.0.0.1}"
 CONTEXT_SMOKE_URL_BASE="${GOFRAME_CONTEXT_SMOKE_URL:-http://127.0.0.1}"
@@ -109,6 +110,11 @@ build_error_boundary_smoke_url() {
 build_context_selector_topology_smoke_url() {
 	local port="$1"
 	echo "${CONTEXT_SELECTOR_TOPOLOGY_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
+}
+
+build_repeated_mount_smoke_url() {
+	local port="$1"
+	echo "${REPEATED_MOUNT_SMOKE_URL_BASE}:${port}/?smoke=$(date +%s%N)"
 }
 
 build_controlled_select_smoke_url() {
@@ -220,6 +226,12 @@ run_controlled_select_browser() {
 	node --experimental-websocket scripts/controlled-select-browser-smoke.mjs "$url" "$compiler"
 }
 
+run_repeated_mount_browser() {
+	local compiler="$1"
+	local url="$2"
+	CHROME="$CHROME_BIN" node --experimental-websocket scripts/repeated-mount-browser-smoke.mjs "$url" "$compiler"
+}
+
 if [[ -z "$GOXC" ]]; then
 	GOBIN="$BIN_DIR" go install ./cmd/goxc
 	GOXC="$BIN_DIR/goxc"
@@ -289,6 +301,26 @@ export GOFRAME_CONTEXT_SELECTOR_TOPOLOGY_CHROME_DEBUG_PORT="${GOFRAME_CONTEXT_SE
 CONTEXT_SELECTOR_TOPOLOGY_URL="$(build_context_selector_topology_smoke_url "$CONTEXT_SELECTOR_TOPOLOGY_PORT")"
 run_with_server ./scripts/fixtures/context-selector-topology "$CONTEXT_SELECTOR_TOPOLOGY_PORT" "$CONTEXT_SELECTOR_TOPOLOGY_URL" \
 	node --experimental-websocket scripts/context-selector-topology-browser-smoke.mjs
+
+echo
+echo "== Repeated mount browser smoke (standard Go) =="
+"$GOXC" package ./scripts/fixtures/repeated-mount --compiler=go
+
+REPEATED_MOUNT_GO_PORT="$(resolve_port "${GOFRAME_REPEATED_MOUNT_GO_SMOKE_PORT:-}")"
+export GOFRAME_REPEATED_MOUNT_CHROME_DEBUG_PORT="$(pick_free_port)"
+REPEATED_MOUNT_GO_URL="$(build_repeated_mount_smoke_url "$REPEATED_MOUNT_GO_PORT")"
+run_with_server ./scripts/fixtures/repeated-mount "$REPEATED_MOUNT_GO_PORT" "$REPEATED_MOUNT_GO_URL" \
+	run_repeated_mount_browser go
+
+echo
+echo "== Repeated mount browser smoke (TinyGo) =="
+"$GOXC" package ./scripts/fixtures/repeated-mount --compiler=tinygo
+
+REPEATED_MOUNT_TINYGO_PORT="$(resolve_port "${GOFRAME_REPEATED_MOUNT_TINYGO_SMOKE_PORT:-}")"
+export GOFRAME_REPEATED_MOUNT_CHROME_DEBUG_PORT="$(pick_free_port)"
+REPEATED_MOUNT_TINYGO_URL="$(build_repeated_mount_smoke_url "$REPEATED_MOUNT_TINYGO_PORT")"
+run_with_server ./scripts/fixtures/repeated-mount "$REPEATED_MOUNT_TINYGO_PORT" "$REPEATED_MOUNT_TINYGO_URL" \
+	run_repeated_mount_browser tinygo
 
 echo
 echo "== Controlled select browser smoke (TinyGo) =="

--- a/scripts/fixtures/repeated-mount/app.gox
+++ b/scripts/fixtures/repeated-mount/app.gox
@@ -1,0 +1,123 @@
+package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+type AppAProps struct {
+	Instance int
+}
+
+type AppBProps struct {
+	Instance int
+}
+
+type AppCProps struct {
+	Instance int
+}
+
+func AppA(props AppAProps) gf.Node {
+	value, setValue := gf.UseState(0)
+	appASetter = setValue
+	appAValue = value
+	appARenderCount++
+
+	gf.UseEffect(func() gf.Cleanup {
+		appAEffectSetups[props.Instance]++
+		return func() {
+			recordAppAEffectCleanup(props.Instance)
+		}
+	})
+	gf.UseEffect(func() gf.Cleanup {
+		appAEffectVersions = append(
+			appAEffectVersions,
+			gf.ToString(props.Instance)+":"+gf.ToString(value),
+		)
+		return nil
+	}, gf.Deps(value))
+	gf.UseUnmount(func() {
+		recordAppAUnmount(props.Instance)
+	})
+
+	return (
+		<section
+			id={appElementID("app-a", props.Instance)}
+			data-testid="app-a"
+			data-instance={props.Instance}
+			data-state={value}
+		>
+			<h1>Application A</h1>
+			<p data-testid="app-a-state">{value}</p>
+			<button
+				id={appElementID("app-a-event", props.Instance)}
+				data-testid="app-a-event"
+				OnClick={func() {
+					appAHandlerCount++
+					setValue(value + 1)
+				}}
+			>Update A</button>
+		</section>
+	)
+}
+
+func AppB(props AppBProps) gf.Node {
+	value, setValue := gf.UseState(0)
+	appBValue = value
+	appBRenderCount++
+
+	gf.UseEffect(func() gf.Cleanup {
+		appBScheduledUpdateCount++
+		setValue(1)
+		return nil
+	})
+	gf.UseUnmount(func() {
+		appBCleanups[props.Instance]++
+	})
+
+	return (
+		<section
+			id={appElementID("app-b", props.Instance)}
+			data-testid="app-b"
+			data-instance={props.Instance}
+			data-state={value}
+		>
+			<h1>Application B</h1>
+			<p data-testid="app-b-state">{value}</p>
+			<button
+				id={appElementID("app-b-event", props.Instance)}
+				data-testid="app-b-event"
+				OnClick={func() {
+					appBHandlerCount++
+					setValue(value + 1)
+				}}
+			>Update B</button>
+		</section>
+	)
+}
+
+func AppC(props AppCProps) gf.Node {
+	value, setValue := gf.UseState(0)
+	appCRenderCount++
+
+	gf.UseUnmount(func() {
+		appCCleanups[props.Instance]++
+	})
+
+	return (
+		<section
+			id={appElementID("app-c", props.Instance)}
+			data-testid="app-c"
+			data-instance={props.Instance}
+			data-state={value}
+		>
+			<h1>Application C</h1>
+			<p data-testid="app-c-state">{value}</p>
+			<button
+				id={appElementID("app-c-event", props.Instance)}
+				data-testid="app-c-event"
+				OnClick={func() {
+					appCHandlerCount++
+					setValue(value + 1)
+				}}
+			>Update C</button>
+		</section>
+	)
+}

--- a/scripts/fixtures/repeated-mount/app.gox
+++ b/scripts/fixtures/repeated-mount/app.gox
@@ -54,6 +54,10 @@ func AppA(props AppAProps) gf.Node {
 					setValue(value + 1)
 				}}
 			>Update A</button>
+			<div
+				id="owned-nested-root"
+				data-testid="owned-nested-root"
+			></div>
 		</section>
 	)
 }

--- a/scripts/fixtures/repeated-mount/goframe.json
+++ b/scripts/fixtures/repeated-mount/goframe.json
@@ -1,0 +1,10 @@
+{
+  "name": "repeated-mount",
+  "entry": ".",
+  "output": "dist",
+  "compiler": "go",
+  "wasm": "bundle.wasm",
+  "assets": [
+    "index.html"
+  ]
+}

--- a/scripts/fixtures/repeated-mount/index.html
+++ b/scripts/fixtures/repeated-mount/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>goframe repeated mount fixture</title>
+    <!-- goframe:preload -->
+    <!-- /goframe:preload -->
+</head>
+<body>
+    <div id="root-a"><p id="root-a-host">initial root A host content</p></div>
+    <div id="root-b"><p id="root-b-host">initial root B host content</p></div>
+    <aside id="fixture-diagnostics" aria-live="polite"></aside>
+
+    <!-- goframe:runtime -->
+    <script src="wasm_exec.js"></script>
+    <!-- /goframe:runtime -->
+    <!-- goframe:bootstrap -->
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject)
+            .then((result) => go.run(result.instance));
+    </script>
+    <!-- /goframe:bootstrap -->
+</body>
+</html>

--- a/scripts/fixtures/repeated-mount/main.go
+++ b/scripts/fixtures/repeated-mount/main.go
@@ -37,9 +37,11 @@ var (
 	appCHandlerCount int
 	appCCleanups     = make(map[int]int)
 
-	missingRootPanicCount int
-	missingRootPanicText  string
-	runtimeErrorCount     int
+	missingRootPanicCount  int
+	missingRootPanicText   string
+	nestedTargetPanicCount int
+	nestedTargetPanicText  string
+	runtimeErrorCount      int
 )
 
 func main() {
@@ -107,6 +109,12 @@ func exportFixtureControls() {
 		appASetter(appAValue + 1)
 	})
 	exportFixtureControl("goframeRepeatedMountAttemptMissingRoot", attemptMissingRoot)
+	exportFixtureControl("goframeRepeatedMountAttemptOwnedNestedRoot", func() {
+		attemptMount("owned-nested-root", &nestedTargetPanicCount, &nestedTargetPanicText)
+	})
+	exportFixtureControl("goframeRepeatedMountAttemptHostNestedRoot", func() {
+		attemptMount("host-owned-subroot", &nestedTargetPanicCount, &nestedTargetPanicText)
+	})
 
 	read := js.FuncOf(func(js.Value, []js.Value) any {
 		return repeatedMountEvidence()
@@ -125,13 +133,17 @@ func exportFixtureControl(name string, control func()) {
 }
 
 func attemptMissingRoot() {
+	attemptMount("missing-root", &missingRootPanicCount, &missingRootPanicText)
+}
+
+func attemptMount(rootID string, panicCount *int, panicText *string) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			missingRootPanicCount++
-			missingRootPanicText = gf.ToString(recovered)
+			*panicCount++
+			*panicText = gf.ToString(recovered)
 		}
 	}()
-	mountAppB("missing-root")
+	mountAppB(rootID)
 }
 
 func repeatedMountEvidence() js.Value {
@@ -156,6 +168,8 @@ func repeatedMountEvidence() js.Value {
 	result.Set("appCCleanups", integerEvidence(appCCleanups, nextAppCInstance))
 	result.Set("missingRootPanicCount", missingRootPanicCount)
 	result.Set("missingRootPanicText", missingRootPanicText)
+	result.Set("nestedTargetPanicCount", nestedTargetPanicCount)
+	result.Set("nestedTargetPanicText", nestedTargetPanicText)
 	result.Set("runtimeErrorCount", runtimeErrorCount)
 	return result
 }

--- a/scripts/fixtures/repeated-mount/main.go
+++ b/scripts/fixtures/repeated-mount/main.go
@@ -1,0 +1,200 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"syscall/js"
+
+	gf "github.com/graybuton/goframe/pkg/goframe"
+)
+
+var (
+	fixtureControls []js.Func
+
+	nextAppAInstance  int
+	nextAppBInstance  int
+	nextAppCInstance  int
+	activeApplication string
+
+	appASetter              func(int)
+	appAValue               int
+	appARenderCount         int
+	appAHandlerCount        int
+	appAEffectSetups        = make(map[int]int)
+	appAEffectCleanups      = make(map[int]int)
+	appAUnmounts            = make(map[int]int)
+	appAEffectCleanupSawDOM = make(map[int]int)
+	appAUnmountSawDOM       = make(map[int]int)
+	appAEffectVersions      []string
+
+	appBValue                int
+	appBRenderCount          int
+	appBHandlerCount         int
+	appBScheduledUpdateCount int
+	appBCleanups             = make(map[int]int)
+
+	appCRenderCount  int
+	appCHandlerCount int
+	appCCleanups     = make(map[int]int)
+
+	missingRootPanicCount int
+	missingRootPanicText  string
+	runtimeErrorCount     int
+)
+
+func main() {
+	global := js.Global()
+	global.Set("goframeRepeatedMountErrors", global.Get("Array").New())
+	gf.SetErrorHandler(func(info gf.ErrorInfo) {
+		runtimeErrorCount++
+		report := global.Get("Object").New()
+		report.Set("phase", info.Phase.String())
+		report.Set("component", info.Component)
+		report.Set("operation", info.Operation)
+		report.Set("panic", gf.ToString(info.Panic))
+		global.Get("goframeRepeatedMountErrors").Call("push", report)
+	})
+
+	exportFixtureControls()
+	mountAppA("root-a")
+
+	done := make(chan struct{})
+	<-done
+}
+
+func mountAppA(rootID string) {
+	instance := nextAppAInstance + 1
+	gf.Mount(rootID, func() gf.Node {
+		return AppA(AppAProps{Instance: instance})
+	})
+	nextAppAInstance = instance
+	activeApplication = "A:" + gf.ToString(instance)
+}
+
+func mountAppB(rootID string) {
+	instance := nextAppBInstance + 1
+	gf.Mount(rootID, func() gf.Node {
+		return AppB(AppBProps{Instance: instance})
+	})
+	nextAppBInstance = instance
+	activeApplication = "B:" + gf.ToString(instance)
+}
+
+func mountAppC(rootID string) {
+	instance := nextAppCInstance + 1
+	gf.Mount(rootID, func() gf.Node {
+		return AppC(AppCProps{Instance: instance})
+	})
+	nextAppCInstance = instance
+	activeApplication = "C:" + gf.ToString(instance)
+}
+
+func exportFixtureControls() {
+	exportFixtureControl("goframeRepeatedMountMountB", func() {
+		mountAppB("root-b")
+	})
+	exportFixtureControl("goframeRepeatedMountReplaceBWithC", func() {
+		mountAppC("root-b")
+	})
+	exportFixtureControl("goframeRepeatedMountMountFreshA", func() {
+		mountAppA("root-a")
+	})
+	exportFixtureControl("goframeRepeatedMountQueueAThenMountB", func() {
+		appASetter(appAValue + 1)
+		mountAppB("root-b")
+	})
+	exportFixtureControl("goframeRepeatedMountInvokeStaleASetter", func() {
+		appASetter(appAValue + 1)
+	})
+	exportFixtureControl("goframeRepeatedMountAttemptMissingRoot", attemptMissingRoot)
+
+	read := js.FuncOf(func(js.Value, []js.Value) any {
+		return repeatedMountEvidence()
+	})
+	fixtureControls = append(fixtureControls, read)
+	js.Global().Set("goframeRepeatedMountRead", read)
+}
+
+func exportFixtureControl(name string, control func()) {
+	callback := js.FuncOf(func(js.Value, []js.Value) any {
+		control()
+		return nil
+	})
+	fixtureControls = append(fixtureControls, callback)
+	js.Global().Set(name, callback)
+}
+
+func attemptMissingRoot() {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			missingRootPanicCount++
+			missingRootPanicText = gf.ToString(recovered)
+		}
+	}()
+	mountAppB("missing-root")
+}
+
+func repeatedMountEvidence() js.Value {
+	result := js.Global().Get("Object").New()
+	result.Set("activeApplication", activeApplication)
+	result.Set("appARenders", appARenderCount)
+	result.Set("appBRenders", appBRenderCount)
+	result.Set("appCRenders", appCRenderCount)
+	result.Set("appAHandlers", appAHandlerCount)
+	result.Set("appBHandlers", appBHandlerCount)
+	result.Set("appCHandlers", appCHandlerCount)
+	result.Set("appAValue", appAValue)
+	result.Set("appBValue", appBValue)
+	result.Set("appBScheduledUpdates", appBScheduledUpdateCount)
+	result.Set("appAEffectSetups", integerEvidence(appAEffectSetups, nextAppAInstance))
+	result.Set("appAEffectCleanups", integerEvidence(appAEffectCleanups, nextAppAInstance))
+	result.Set("appAUnmounts", integerEvidence(appAUnmounts, nextAppAInstance))
+	result.Set("appAEffectCleanupSawDOM", integerEvidence(appAEffectCleanupSawDOM, nextAppAInstance))
+	result.Set("appAUnmountSawDOM", integerEvidence(appAUnmountSawDOM, nextAppAInstance))
+	result.Set("appAEffectVersions", stringEvidence(appAEffectVersions))
+	result.Set("appBCleanups", integerEvidence(appBCleanups, nextAppBInstance))
+	result.Set("appCCleanups", integerEvidence(appCCleanups, nextAppCInstance))
+	result.Set("missingRootPanicCount", missingRootPanicCount)
+	result.Set("missingRootPanicText", missingRootPanicText)
+	result.Set("runtimeErrorCount", runtimeErrorCount)
+	return result
+}
+
+func integerEvidence(values map[int]int, count int) js.Value {
+	result := js.Global().Get("Array").New()
+	for index := 1; index <= count; index++ {
+		result.Call("push", values[index])
+	}
+	return result
+}
+
+func stringEvidence(values []string) js.Value {
+	result := js.Global().Get("Array").New()
+	for _, value := range values {
+		result.Call("push", value)
+	}
+	return result
+}
+
+func recordAppAEffectCleanup(instance int) {
+	appAEffectCleanups[instance]++
+	if fixtureElementExists(appElementID("app-a", instance)) {
+		appAEffectCleanupSawDOM[instance]++
+	}
+}
+
+func recordAppAUnmount(instance int) {
+	appAUnmounts[instance]++
+	if fixtureElementExists(appElementID("app-a", instance)) {
+		appAUnmountSawDOM[instance]++
+	}
+}
+
+func fixtureElementExists(id string) bool {
+	element := js.Global().Get("document").Call("getElementById", id)
+	return !element.IsUndefined() && !element.IsNull()
+}
+
+func appElementID(name string, instance int) string {
+	return name + "-" + gf.ToString(instance)
+}

--- a/scripts/repeated-mount-browser-smoke.mjs
+++ b/scripts/repeated-mount-browser-smoke.mjs
@@ -1,0 +1,553 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (typeof WebSocket === "undefined") {
+    throw new Error("WebSocket is unavailable; run Node with --experimental-websocket");
+}
+
+const appURL = process.argv[2] ?? process.env.GOFRAME_REPEATED_MOUNT_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const compiler = process.argv[3] ?? "unknown";
+const debugPort = Number(process.env.GOFRAME_REPEATED_MOUNT_CHROME_DEBUG_PORT ?? "19273");
+const chrome = process.env.CHROME ?? "google-chrome";
+const profile = await mkdtemp(join(tmpdir(), "goframe-repeated-mount-smoke-"));
+const expectedApp = new URL(appURL);
+const browser = spawn(chrome, [
+    "--headless",
+    "--no-sandbox",
+    "--disable-gpu",
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${profile}`,
+    "about:blank",
+], {
+    stdio: ["ignore", "ignore", "pipe"],
+});
+
+const browserSpawn = new Promise((resolve, reject) => {
+    browser.once("spawn", resolve);
+    browser.once("error", reject);
+});
+let browserError = "";
+let browserExit = null;
+browser.stderr.on("data", (chunk) => {
+    browserError += chunk;
+});
+browser.on("exit", (code, signal) => {
+    browserExit = { code, signal };
+});
+
+let client;
+try {
+    try {
+        await browserSpawn;
+    } catch (error) {
+        throw new Error(`HARNESS FAILURE: Chrome failed to spawn (${compiler}): ${error.message}`);
+    }
+    const page = await waitForPage(debugPort);
+    client = await connect(page.webSocketDebuggerUrl);
+    await client.call("Runtime.enable");
+    await client.call("Page.enable");
+    await client.call("Page.navigate", { url: withSmokeParam(appURL, compiler) });
+    await waitForAppPage(client, expectedApp);
+
+    let state = await repeatedMountState(client);
+    assertSubset(state, {
+        activeApplication: "A:1",
+        appARenders: 1,
+        appAHandlers: 0,
+        appAEffectSetups: [1],
+        appAEffectCleanups: [0],
+        appAUnmounts: [0],
+        appAEffectVersions: ["1:0"],
+        runtimeErrorCount: 0,
+    }, "initial App A evidence");
+    assertRoot(state.rootA, { appA: 1, appB: 0, appC: 0, goframeComments: 2 }, "initial root A");
+    assertRoot(state.rootB, { appA: 0, appB: 0, appC: 0, goframeComments: 0 }, "initial root B");
+
+    await client.evaluate(`(() => {
+        window.__repeatedMountRootA = document.querySelector("#root-a");
+        window.__repeatedMountRootB = document.querySelector("#root-b");
+        window.__repeatedMountFirstAMarker = document.querySelector("[data-testid='app-a']");
+        window.__repeatedMountOldAButton = document.querySelector("[data-testid='app-a-event']");
+        const sentinel = document.createElement("span");
+        sentinel.id = "host-owned-sentinel";
+        sentinel.textContent = "host-owned";
+        window.__repeatedMountRootA.appendChild(sentinel);
+        return true;
+    })()`);
+
+    await click(client, "[data-testid='app-a-event']");
+    state = await waitForState(client, "initial App A interaction", (next) =>
+        next.appAHandlers === 1 && next.appAValue === 1);
+    assertSubset(state, {
+        appARenders: 2,
+        appAHandlers: 1,
+        appAEffectVersions: ["1:0", "1:1"],
+        hostSentinelInRootA: true,
+    }, "initial App A interaction");
+
+    await runControl(client, "goframeRepeatedMountMountB");
+    state = await waitForState(client, "different-root App B mount", (next) =>
+        next.activeApplication === "B:1" && next.appBValue === 1);
+    console.log(`different-root replacement before old-range assertion (${compiler}): ${JSON.stringify(state)}`);
+    assertSubset(state, {
+        activeApplication: "B:1",
+        appAEffectCleanups: [1],
+        appAUnmounts: [1],
+        appAEffectCleanupSawDOM: [1],
+        appAUnmountSawDOM: [1],
+        appBRenders: 2,
+        appBScheduledUpdates: 1,
+        appBCleanups: [0],
+        hostSentinelInRootA: true,
+        runtimeErrorCount: 0,
+    }, "different-root lifecycle release");
+    assertRoot(state.rootB, { appA: 0, appB: 1, appC: 0, goframeComments: 2 }, "different-root active root B");
+
+    const oldAHandlers = state.appAHandlers;
+    await client.evaluate(`(() => {
+        window.__repeatedMountOldAButton.click();
+        return true;
+    })()`);
+    await waitForAnimationFrames(client, 2);
+    state = await repeatedMountState(client);
+    assertSubset(state, {
+        appAHandlers: oldAHandlers,
+        appBValue: 1,
+        runtimeErrorCount: 0,
+    }, "released App A listener");
+
+    const appBRendersBeforeStaleSetter = state.appBRenders;
+    await runControl(client, "goframeRepeatedMountInvokeStaleASetter");
+    await waitForAnimationFrames(client, 2);
+    state = await repeatedMountState(client);
+    assertSubset(state, {
+        appARenders: 2,
+        appBRenders: appBRendersBeforeStaleSetter,
+        appBValue: 1,
+        runtimeErrorCount: 0,
+    }, "stale App A setter isolation");
+
+    if (state.rootA.appA !== 0) {
+        throw new Error(
+            `APP FAILURE: root A still contains the App A mounted range after ` +
+            `Mount transfers ownership to root B (${compiler}); state=${JSON.stringify(state)}`,
+        );
+    }
+    assertRoot(state.rootA, { appA: 0, appB: 0, appC: 0, goframeComments: 0 }, "different-root old root A");
+    assertSubset(state, {
+        oldAButtonConnected: false,
+        hostSentinelInRootA: true,
+    }, "different-root physical removal");
+
+    await click(client, "[data-testid='app-b-event']");
+    state = await waitForState(client, "first App B interaction", (next) =>
+        next.appBHandlers === 1 && next.appBValue === 2);
+
+    await runControl(client, "goframeRepeatedMountMountFreshA");
+    state = await waitForState(client, "fresh App A mount", (next) =>
+        next.activeApplication === "A:2" && next.rootA.appA === 1);
+    assertSubset(state, {
+        appARenders: 3,
+        appAEffectSetups: [1, 1],
+        appAEffectVersions: ["1:0", "1:1", "2:0"],
+        appBCleanups: [1],
+        hostSentinelInRootA: false,
+        firstAMarkerIsCurrent: false,
+    }, "fresh App A ownership");
+    assertRoot(state.rootB, { appA: 0, appB: 0, appC: 0, goframeComments: 0 }, "root B after transfer to fresh App A");
+
+    await runControl(client, "goframeRepeatedMountQueueAThenMountB");
+    state = await waitForState(client, "queued App A transfer", (next) =>
+        next.activeApplication === "B:2" && next.appBValue === 1);
+    await waitForAnimationFrames(client, 2);
+    state = await repeatedMountState(client);
+    assertSubset(state, {
+        activeApplication: "B:2",
+        appARenders: 3,
+        appAEffectSetups: [1, 1],
+        appAEffectCleanups: [1, 1],
+        appAUnmounts: [1, 1],
+        appAEffectCleanupSawDOM: [1, 1],
+        appAUnmountSawDOM: [1, 1],
+        appAEffectVersions: ["1:0", "1:1", "2:0"],
+        appBRenders: 5,
+        appBScheduledUpdates: 2,
+        appBCleanups: [1, 0],
+        runtimeErrorCount: 0,
+    }, "queued old update isolation");
+    assertRoot(state.rootA, { appA: 0, appB: 0, appC: 0, goframeComments: 0 }, "root A after queued transfer");
+    assertRoot(state.rootB, { appA: 0, appB: 1, appC: 0, goframeComments: 2 }, "second App B active root");
+
+    await click(client, "[data-testid='app-b-event']");
+    state = await waitForState(client, "second App B interaction", (next) =>
+        next.appBHandlers === 2 && next.appBValue === 2);
+    await client.evaluate(`(() => {
+        window.__repeatedMountOldBButton = document.querySelector("[data-testid='app-b-event']");
+        return true;
+    })()`);
+
+    await runControl(client, "goframeRepeatedMountReplaceBWithC");
+    state = await waitForState(client, "same-root App C replacement", (next) =>
+        next.activeApplication === "C:1" && next.rootB.appC === 1);
+    assertSubset(state, {
+        appBCleanups: [1, 1],
+        appCCleanups: [0],
+        oldBButtonConnected: false,
+        duplicateIDs: [],
+        runtimeErrorCount: 0,
+    }, "same-root replacement");
+    assertRoot(state.rootB, { appA: 0, appB: 0, appC: 1, goframeComments: 2 }, "same-root active App C");
+
+    const oldBHandlers = state.appBHandlers;
+    await client.evaluate(`(() => {
+        window.__repeatedMountOldBButton.click();
+        return true;
+    })()`);
+    await waitForAnimationFrames(client, 2);
+    state = await repeatedMountState(client);
+    assertSubset(state, { appBHandlers: oldBHandlers, runtimeErrorCount: 0 }, "released App B listener");
+
+    await click(client, "[data-testid='app-c-event']");
+    state = await waitForState(client, "App C interaction", (next) =>
+        next.appCHandlers === 1 && next.currentAppState === 1);
+
+    await runControl(client, "goframeRepeatedMountMountFreshA");
+    state = await waitForState(client, "transfer back to root A", (next) =>
+        next.activeApplication === "A:3" && next.rootA.appA === 1);
+    assertSubset(state, {
+        appARenders: 4,
+        appAEffectSetups: [1, 1, 1],
+        appAEffectVersions: ["1:0", "1:1", "2:0", "3:0"],
+        appCCleanups: [1],
+        hostSentinelInRootA: false,
+        firstAMarkerIsCurrent: false,
+        duplicateIDs: [],
+        runtimeErrorCount: 0,
+    }, "A to B to C to A transfer");
+    assertRoot(state.rootA, { appA: 1, appB: 0, appC: 0, goframeComments: 2 }, "fresh App A active root");
+    assertRoot(state.rootB, { appA: 0, appB: 0, appC: 0, goframeComments: 0 }, "root B after transfer back");
+
+    await click(client, "[data-testid='app-a-event']");
+    state = await waitForState(client, "fresh App A interaction", (next) =>
+        next.appAHandlers === 2 && next.appAValue === 1);
+
+    if (compiler === "go") {
+        await client.evaluate(`(() => {
+            window.__repeatedMountBeforeMissing = document.querySelector("[data-testid='app-a']");
+            return true;
+        })()`);
+        const cleanupBeforeMissing = JSON.stringify({
+            effects: state.appAEffectCleanups,
+            unmounts: state.appAUnmounts,
+        });
+        await runControl(client, "goframeRepeatedMountAttemptMissingRoot");
+        state = await repeatedMountState(client);
+        assertSubset(state, {
+            activeApplication: "A:3",
+            missingRootPanicCount: 1,
+            missingRootPanicText: "goframe: root element not found: missing-root",
+            currentAMarkerSameAfterMissing: true,
+            runtimeErrorCount: 0,
+        }, "missing-root preservation");
+        const cleanupAfterMissing = JSON.stringify({
+            effects: state.appAEffectCleanups,
+            unmounts: state.appAUnmounts,
+        });
+        if (cleanupAfterMissing !== cleanupBeforeMissing) {
+            throw new Error(`APP FAILURE: missing-root mount changed cleanup counts: before=${cleanupBeforeMissing}, after=${cleanupAfterMissing}`);
+        }
+        await click(client, "[data-testid='app-a-event']");
+        state = await waitForState(client, "post-panic App A interaction", (next) =>
+            next.appAHandlers === 3 && next.appAValue === 2);
+        console.log("missing-root preservation (go): ok");
+    } else if (compiler === "tinygo") {
+        console.log(
+            "missing-root preservation (tinygo): NOT APPLICABLE - normal TinyGo " +
+            "trap-mode build does not provide recover-based panic containment",
+        );
+    } else {
+        throw new Error(`HARNESS FAILURE: unsupported compiler label ${JSON.stringify(compiler)}`);
+    }
+
+    assertSubset(state, { runtimeErrorCount: 0, duplicateIDs: [] }, "final runtime evidence");
+    console.log(`repeated mount evidence (${compiler}): ${JSON.stringify(state)}`);
+    console.log(`Repeated mount browser smoke (${compiler}): ok`);
+} finally {
+    client?.close();
+    if (browser.exitCode === null && !browser.killed) {
+        const exited = new Promise((resolve) => browser.once("exit", resolve));
+        browser.kill("SIGTERM");
+        await Promise.race([exited, wait(2000)]);
+    }
+    await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function click(client, selector) {
+    const clicked = await client.callFunction(`function(selector) {
+        const element = document.querySelector(selector);
+        if (!element) return false;
+        element.click();
+        return true;
+    }`, selector);
+    if (!clicked) {
+        throw new Error(`APP FAILURE: missing element for click ${selector} (${compiler})`);
+    }
+}
+
+async function runControl(client, name) {
+    const result = await client.callFunction(`function(name) {
+        const control = globalThis[name];
+        if (typeof control !== "function") return { ok: false };
+        control();
+        return { ok: true };
+    }`, name);
+    if (!result?.ok) {
+        throw new Error(`HARNESS FAILURE: missing fixture control ${name} (${compiler})`);
+    }
+}
+
+async function repeatedMountState(client) {
+    return await client.evaluate(`(() => {
+        const rootState = (root) => {
+            const comments = [];
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT);
+            while (walker.nextNode()) comments.push(walker.currentNode.nodeValue ?? "");
+            return {
+                appA: root.querySelectorAll("[data-testid='app-a']").length,
+                appB: root.querySelectorAll("[data-testid='app-b']").length,
+                appC: root.querySelectorAll("[data-testid='app-c']").length,
+                goframeComments: comments.filter((value) => value.includes("goframe-")).length,
+                text: root.textContent,
+            };
+        };
+        const ids = Array.from(document.querySelectorAll("[id]"), (element) => element.id);
+        const duplicateIDs = ids.filter((id, index) => ids.indexOf(id) !== index);
+        const currentMarker = document.querySelector(
+            "[data-testid='app-a'], [data-testid='app-b'], [data-testid='app-c']",
+        );
+        return {
+            ...globalThis.goframeRepeatedMountRead(),
+            rootA: rootState(document.querySelector("#root-a")),
+            rootB: rootState(document.querySelector("#root-b")),
+            hostSentinelInRootA:
+                document.querySelector("#host-owned-sentinel")?.parentElement?.id === "root-a",
+            oldAButtonConnected: Boolean(window.__repeatedMountOldAButton?.isConnected),
+            oldBButtonConnected: Boolean(window.__repeatedMountOldBButton?.isConnected),
+            firstAMarkerIsCurrent:
+                window.__repeatedMountFirstAMarker ===
+                document.querySelector("[data-testid='app-a']"),
+            currentAMarkerSameAfterMissing:
+                window.__repeatedMountBeforeMissing ===
+                document.querySelector("[data-testid='app-a']"),
+            currentAppState: Number(currentMarker?.dataset.state ?? "-1"),
+            duplicateIDs,
+        };
+    })()`);
+}
+
+async function waitForState(client, label, predicate) {
+    const started = Date.now();
+    let state;
+    while (Date.now() - started < 10_000) {
+        state = await repeatedMountState(client);
+        if (predicate(state)) {
+            return state;
+        }
+        await wait(50);
+    }
+    throw new Error(`APP FAILURE: timed out waiting for ${label} (${compiler}): ${JSON.stringify(state)}`);
+}
+
+function assertSubset(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (JSON.stringify(actual[key]) !== JSON.stringify(value)) {
+            throw new Error(
+                `APP FAILURE: ${label} (${compiler}) ${key} got ` +
+                `${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; ` +
+                `state=${JSON.stringify(actual)}`,
+            );
+        }
+    }
+    console.log(`${label} (${compiler}): ok`);
+}
+
+function assertRoot(actual, expected, label) {
+    for (const [key, value] of Object.entries(expected)) {
+        if (actual[key] !== value) {
+            throw new Error(
+                `APP FAILURE: ${label} (${compiler}) ${key} got ` +
+                `${JSON.stringify(actual[key])}, want ${JSON.stringify(value)}; ` +
+                `root=${JSON.stringify(actual)}`,
+            );
+        }
+    }
+    console.log(`${label} (${compiler}): ok`);
+}
+
+async function waitForAnimationFrames(client, count) {
+    await client.callFunction(`async function(count) {
+        for (let index = 0; index < count; index++) {
+            await new Promise((resolve) => requestAnimationFrame(resolve));
+        }
+        return true;
+    }`, count);
+}
+
+async function waitForPage(port) {
+    const started = Date.now();
+    let lastError;
+    while (Date.now() - started < 5000) {
+        if (browserExit) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome exited before CDP was ready (${compiler}): ` +
+                `${JSON.stringify(browserExit)}\n${browserError}`,
+            );
+        }
+        try {
+            const response = await fetch(`http://127.0.0.1:${port}/json`);
+            if (response.ok) {
+                const targets = await response.json();
+                const page = targets.find(
+                    (entry) => entry.type === "page" && entry.webSocketDebuggerUrl,
+                );
+                if (page) return page;
+            }
+        } catch (error) {
+            lastError = error;
+        }
+        await wait(50);
+    }
+    throw new Error(
+        `HARNESS FAILURE: Chrome DevTools page unavailable (${compiler}): ` +
+        `${lastError?.message ?? browserError}`,
+    );
+}
+
+async function waitForAppPage(client, expected) {
+    const started = Date.now();
+    let state;
+    while (Date.now() - started < 10_000) {
+        state = await client.evaluate(`(() => ({
+            href: location.href,
+            origin: location.origin,
+            protocol: location.protocol,
+            readyState: document.readyState,
+            rootA: Boolean(document.querySelector("#root-a")),
+            rootB: Boolean(document.querySelector("#root-b")),
+            appReady: Boolean(document.querySelector("[data-testid='app-a']")),
+            controlsReady: typeof globalThis.goframeRepeatedMountRead === "function",
+        }))()`);
+        if (state.href.startsWith("chrome-error://")) {
+            throw new Error(
+                `HARNESS FAILURE: Chrome loaded an error document (${compiler}): ` +
+                `${JSON.stringify(state)}`,
+            );
+        }
+        if (
+            (state.protocol === "http:" || state.protocol === "https:") &&
+            state.origin === expected.origin &&
+            new URL(state.href).pathname === expected.pathname &&
+            state.rootA &&
+            state.rootB &&
+            state.appReady &&
+            state.controlsReady
+        ) {
+            return;
+        }
+        await wait(50);
+    }
+    throw new Error(
+        `HARNESS FAILURE: repeated mount app did not become ready at expected origin ` +
+        `(${compiler}): ${JSON.stringify(state)}`,
+    );
+}
+
+function withSmokeParam(url, label) {
+    const next = new URL(url);
+    next.searchParams.set("smoke", `${Date.now()}-${label}`);
+    return next.toString();
+}
+
+function connect(url) {
+    const socket = new WebSocket(url);
+    let nextID = 1;
+    const pending = new Map();
+
+    return new Promise((resolve, reject) => {
+        socket.addEventListener("open", () => {
+            resolve({
+                call(method, params = {}) {
+                    const id = nextID++;
+                    socket.send(JSON.stringify({ id, method, params }));
+                    return new Promise((callResolve, callReject) => {
+                        pending.set(id, { resolve: callResolve, reject: callReject });
+                    });
+                },
+                async evaluate(expression) {
+                    const response = await this.call("Runtime.evaluate", {
+                        expression,
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.exceptionDetails) {
+                        throw new Error(
+                            `APP FAILURE: browser evaluation failed (${compiler}): ` +
+                            `${JSON.stringify(response.exceptionDetails)}`,
+                        );
+                    }
+                    return response.result.value;
+                },
+                async callFunction(functionDeclaration, ...args) {
+                    if (!this.globalObjectID) {
+                        const globalResponse = await this.call("Runtime.evaluate", {
+                            expression: "globalThis",
+                            returnByValue: false,
+                        });
+                        if (globalResponse.exceptionDetails) {
+                            throw new Error(
+                                `HARNESS FAILURE: global object unavailable (${compiler}): ` +
+                                `${JSON.stringify(globalResponse.exceptionDetails)}`,
+                            );
+                        }
+                        this.globalObjectID = globalResponse.result.objectId;
+                    }
+                    const response = await this.call("Runtime.callFunctionOn", {
+                        objectId: this.globalObjectID,
+                        functionDeclaration,
+                        arguments: args.map((value) => ({ value })),
+                        awaitPromise: true,
+                        returnByValue: true,
+                    });
+                    if (response.exceptionDetails) {
+                        throw new Error(
+                            `APP FAILURE: browser function failed (${compiler}): ` +
+                            `${JSON.stringify(response.exceptionDetails)}`,
+                        );
+                    }
+                    return response.result.value;
+                },
+                close() {
+                    socket.close();
+                },
+            });
+        }, { once: true });
+        socket.addEventListener("error", reject, { once: true });
+        socket.addEventListener("message", (event) => {
+            const message = JSON.parse(event.data);
+            if (!message.id || !pending.has(message.id)) return;
+            const request = pending.get(message.id);
+            pending.delete(message.id);
+            if (message.error) {
+                request.reject(new Error(message.error.message));
+                return;
+            }
+            request.resolve(message.result);
+        });
+    });
+}
+
+function wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/scripts/repeated-mount-browser-smoke.mjs
+++ b/scripts/repeated-mount-browser-smoke.mjs
@@ -60,6 +60,7 @@ try {
         appAEffectCleanups: [0],
         appAUnmounts: [0],
         appAEffectVersions: ["1:0"],
+        nestedTargetPanicCount: 0,
         runtimeErrorCount: 0,
     }, "initial App A evidence");
     assertRoot(state.rootA, { appA: 1, appB: 0, appC: 0, goframeComments: 2 }, "initial root A");
@@ -235,9 +236,123 @@ try {
 
     if (compiler === "go") {
         await client.evaluate(`(() => {
+            window.__repeatedMountNestedRootA = document.querySelector("#root-a");
+            window.__repeatedMountBeforeNested = document.querySelector("[data-testid='app-a']");
+            window.__repeatedMountOwnedNested = document.querySelector("#owned-nested-root");
+            return true;
+        })()`);
+        const ownedBefore = {
+            activeApplication: state.activeApplication,
+            appARenders: state.appARenders,
+            appBRenders: state.appBRenders,
+            appAHandlers: state.appAHandlers,
+            appAValue: state.appAValue,
+            nestedTargetPanicCount: state.nestedTargetPanicCount,
+            runtimeErrorCount: state.runtimeErrorCount,
+            cleanups: JSON.stringify({
+                effects: state.appAEffectCleanups,
+                unmounts: state.appAUnmounts,
+            }),
+        };
+        await runControl(client, "goframeRepeatedMountAttemptOwnedNestedRoot");
+        state = await repeatedMountState(client);
+        assertSubset(state, {
+            activeApplication: ownedBefore.activeApplication,
+            appARenders: ownedBefore.appARenders,
+            appBRenders: ownedBefore.appBRenders,
+            appAHandlers: ownedBefore.appAHandlers,
+            appAValue: ownedBefore.appAValue,
+            nestedTargetPanicCount: ownedBefore.nestedTargetPanicCount + 1,
+            nestedTargetPanicText: "goframe: cannot mount inside current root",
+            runtimeErrorCount: ownedBefore.runtimeErrorCount,
+            nestedRootASameAfterAttempt: true,
+            currentAMarkerSameAfterNested: true,
+            ownedNestedSameAfterAttempt: true,
+            ownedNestedConnected: true,
+            ownedNestedChildren: 0,
+            documentAppB: 0,
+        }, "owned-descendant rejection");
+        assertRoot(state.rootA, { appA: 1, appB: 0, appC: 0, goframeComments: 2 }, "owned-descendant root A");
+        const ownedCleanupsAfter = JSON.stringify({
+            effects: state.appAEffectCleanups,
+            unmounts: state.appAUnmounts,
+        });
+        if (ownedCleanupsAfter !== ownedBefore.cleanups) {
+            throw new Error(
+                `APP FAILURE: owned-descendant mount changed cleanup counts: ` +
+                `before=${ownedBefore.cleanups}, after=${ownedCleanupsAfter}`,
+            );
+        }
+        await click(client, "[data-testid='app-a-event']");
+        state = await waitForState(client, "post-owned-rejection App A interaction", (next) =>
+            next.appAHandlers === ownedBefore.appAHandlers + 1 &&
+            next.appAValue === ownedBefore.appAValue + 1);
+        console.log("owned-descendant rejection (go): ok");
+
+        await client.evaluate(`(() => {
+            const target = document.createElement("div");
+            target.id = "host-owned-subroot";
+            window.__repeatedMountNestedRootA.appendChild(target);
+            window.__repeatedMountHostNested = target;
+            window.__repeatedMountBeforeHostNested = document.querySelector("[data-testid='app-a']");
+            return true;
+        })()`);
+        state = await repeatedMountState(client);
+        const hostBefore = {
+            activeApplication: state.activeApplication,
+            appARenders: state.appARenders,
+            appBRenders: state.appBRenders,
+            appAHandlers: state.appAHandlers,
+            appAValue: state.appAValue,
+            nestedTargetPanicCount: state.nestedTargetPanicCount,
+            runtimeErrorCount: state.runtimeErrorCount,
+            cleanups: JSON.stringify({
+                effects: state.appAEffectCleanups,
+                unmounts: state.appAUnmounts,
+            }),
+        };
+        await runControl(client, "goframeRepeatedMountAttemptHostNestedRoot");
+        state = await repeatedMountState(client);
+        assertSubset(state, {
+            activeApplication: hostBefore.activeApplication,
+            appARenders: hostBefore.appARenders,
+            appBRenders: hostBefore.appBRenders,
+            appAHandlers: hostBefore.appAHandlers,
+            appAValue: hostBefore.appAValue,
+            nestedTargetPanicCount: hostBefore.nestedTargetPanicCount + 1,
+            nestedTargetPanicText: "goframe: cannot mount inside current root",
+            runtimeErrorCount: hostBefore.runtimeErrorCount,
+            nestedRootASameAfterAttempt: true,
+            currentAMarkerSameAfterHostNested: true,
+            hostNestedSameAfterAttempt: true,
+            hostNestedConnected: true,
+            hostNestedChildren: 0,
+            hostNestedText: "",
+            documentAppB: 0,
+        }, "host-descendant rejection");
+        assertRoot(state.rootA, { appA: 1, appB: 0, appC: 0, goframeComments: 2 }, "host-descendant root A");
+        const hostCleanupsAfter = JSON.stringify({
+            effects: state.appAEffectCleanups,
+            unmounts: state.appAUnmounts,
+        });
+        if (hostCleanupsAfter !== hostBefore.cleanups) {
+            throw new Error(
+                `APP FAILURE: host-descendant mount changed cleanup counts: ` +
+                `before=${hostBefore.cleanups}, after=${hostCleanupsAfter}`,
+            );
+        }
+        await click(client, "[data-testid='app-a-event']");
+        state = await waitForState(client, "post-host-rejection App A interaction", (next) =>
+            next.appAHandlers === hostBefore.appAHandlers + 1 &&
+            next.appAValue === hostBefore.appAValue + 1);
+        console.log("host-descendant rejection (go): ok");
+
+        await client.evaluate(`(() => {
             window.__repeatedMountBeforeMissing = document.querySelector("[data-testid='app-a']");
             return true;
         })()`);
+        const handlersBeforeMissing = state.appAHandlers;
+        const valueBeforeMissing = state.appAValue;
         const cleanupBeforeMissing = JSON.stringify({
             effects: state.appAEffectCleanups,
             unmounts: state.appAUnmounts,
@@ -260,9 +375,18 @@ try {
         }
         await click(client, "[data-testid='app-a-event']");
         state = await waitForState(client, "post-panic App A interaction", (next) =>
-            next.appAHandlers === 3 && next.appAValue === 2);
+            next.appAHandlers === handlersBeforeMissing + 1 &&
+            next.appAValue === valueBeforeMissing + 1);
         console.log("missing-root preservation (go): ok");
     } else if (compiler === "tinygo") {
+        console.log(
+            "owned-descendant rejection (tinygo): NOT APPLICABLE - normal TinyGo " +
+            "trap-mode build does not provide recover-based panic containment",
+        );
+        console.log(
+            "host-descendant rejection (tinygo): NOT APPLICABLE - normal TinyGo " +
+            "trap-mode build does not provide recover-based panic containment",
+        );
         console.log(
             "missing-root preservation (tinygo): NOT APPLICABLE - normal TinyGo " +
             "trap-mode build does not provide recover-based panic containment",
@@ -341,6 +465,24 @@ async function repeatedMountState(client) {
             currentAMarkerSameAfterMissing:
                 window.__repeatedMountBeforeMissing ===
                 document.querySelector("[data-testid='app-a']"),
+            nestedRootASameAfterAttempt:
+                window.__repeatedMountNestedRootA === document.querySelector("#root-a"),
+            currentAMarkerSameAfterNested:
+                window.__repeatedMountBeforeNested ===
+                document.querySelector("[data-testid='app-a']"),
+            ownedNestedSameAfterAttempt:
+                window.__repeatedMountOwnedNested === document.querySelector("#owned-nested-root"),
+            ownedNestedConnected: Boolean(window.__repeatedMountOwnedNested?.isConnected),
+            ownedNestedChildren: window.__repeatedMountOwnedNested?.childNodes.length ?? -1,
+            currentAMarkerSameAfterHostNested:
+                window.__repeatedMountBeforeHostNested ===
+                document.querySelector("[data-testid='app-a']"),
+            hostNestedSameAfterAttempt:
+                window.__repeatedMountHostNested === document.querySelector("#host-owned-subroot"),
+            hostNestedConnected: Boolean(window.__repeatedMountHostNested?.isConnected),
+            hostNestedChildren: window.__repeatedMountHostNested?.childNodes.length ?? -1,
+            hostNestedText: window.__repeatedMountHostNested?.textContent ?? null,
+            documentAppB: document.querySelectorAll("[data-testid='app-b']").length,
             currentAppState: Number(currentMarker?.dataset.state ?? "-1"),
             duplicateIDs,
         };

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -136,8 +136,8 @@ check_app "context" "$(bundle_path context)" 117760 36864 46080 40960 || status=
 check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
-check_app "router" "$(bundle_path router)" 117760 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 234496 77824 94208 82944 || status=1
-check_app "resource" "$(bundle_path resource)" 157696 58368 69632 61440 || status=1
+check_app "router" "$(bundle_path router)" 118784 45056 58368 51200 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 235520 77824 94208 82944 || status=1
+check_app "resource" "$(bundle_path resource)" 157696 58368 69632 62464 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Makes repeated `gf.Mount` calls preserve the single-active-application root
ownership contract.

Previously, replacing an application in another root released the old runtime
tree but could leave its DOM behind. A later correction removed that range, but
a target nested inside the current root could then be resolved before teardown,
removed with the old application, and reused as a disconnected replacement
root.

The runtime now:

- removes the previous exact mounted range for valid replacements;
- allows the current root and independent external roots;
- rejects a different target inside the current root before teardown.

Rejected target validation leaves the current application mounted, unchanged,
and interactive.

No public API or GOX behavior changes.

## What changed

- Uses the existing mounted-range teardown path when replacing the active
  application, removing stale DOM without clearing unrelated host siblings.
- Validates replacement targets before lifecycle cleanup, state reset, or DOM
  removal.
- Rejects both application-owned and host-owned descendants of the current root
  with a focused panic.
- Preserves same-root replacement, independent-root transfer, and missing-root
  fail-before-destruction behavior.
- Keeps stale setters, released event handlers, and queued work from a replaced
  application isolated from its successor.
- Documents the one-active-application ownership boundary and unsupported
  nested-root transfer.

## Browser evidence

The private Chrome fixture covers:

- same-root and independent-root replacement;
- exact old-range removal and host-sibling preservation;
- one-time effect and unmount cleanup;
- released listener and stale-setter isolation;
- queued old-update suppression;
- normal scheduled updates in the replacement;
- repeated root transfers;
- missing-root preservation;
- application-owned and host-owned descendant rejection;
- retained DOM identity, cleanup counts, and interactivity after rejection.

All non-panic scenarios run under standard Go/WASM and TinyGo/WASM. Recoverable
target-validation assertions use standard Go because the normal TinyGo package
path retains trap-style panic behavior.

## WASM size

The selected nested-target guard adds `216–235 B` of raw WASM across the
budgeted applications.

Exactly three measured ceilings are aligned by `1 KiB`:

- `router` raw: `117,760 B` → `118,784 B`;
- `router-dashboard` raw: `234,496 B` → `235,520 B`;
- `resource` Zstandard: `61,440 B` → `62,464 B`.

All eleven applications, all 44 absolute size cells, and all compression-ratio
limits pass.

No other ceiling, ratio, compression command, workflow, or budget-matrix entry
changes.

## Validation

- Full tests, debug-tag tests, and `go vet` on Go `1.22.12`, `1.25.12`, and
  `1.26.5`
- Race tests on Go `1.25.12` and `1.26.5`
- Ten fresh repeated-Mount browser runs per compiler
- Two complete Browser Smoke runs
- `scripts/check.sh` and the full eleven-application WASM size matrix
- Artifact, module-path, documentation, formatting, and `actionlint` checks
- Node `24.18.1` VS Code extension tests
- Windows `amd64` `cmd/goxc` cross-compilation

## Scope

This PR changes:

- private repeated-`Mount` ownership and teardown behavior;
- focused standard-Go and TinyGo browser evidence;
- runtime, lifecycle, CI, and size-audit documentation;
- three measured WASM ceilings.

It does not add:

- multiple active applications;
- nested-root adoption or transfer;
- a public `Unmount` or application handle;
- root registries, portals, hydration, or SSR;
- replacement rollback;
- renderer, scheduler, or lifecycle redesign;
- a public API or GOX change;
- workflow, dependency, or lockfile changes.