### PR TITLE
fix(runtime): defer state slots and reducer replacements until render commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,12 @@
 
 ### Fixed
 
+- Failed recover-capable renders no longer commit newly observed state slots or
+  reducer replacements. State transactions are allocated lazily, commit before
+  generic resource participants, preserve the latest committed reducer for old
+  dispatch closures, and discard new-slot closures on rollback. Standard-Go
+  browser evidence covers failure and retry; standard Go and TinyGo both cover
+  the successful state/reducer/resource path.
 - Coordinated `goxc generate` publication now stages all active outputs and
   recovers the prior generated-source set when a detected write, replacement,
   or managed inactive-removal failure occurs. Rollback failures retain the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,6 +260,7 @@ The MVP runtime currently has:
   plus key and sibling position;
 - component-scoped positional state slots, including the root `App`;
 - reducer dispatch that applies actions to the latest component state slot;
+- lazy render transactions for new state slots and reducer replacements;
 - scoped context providers with selector-based consumer dirtying;
 - component-scoped lifecycle/effect slots;
 - component-scoped explicit-state resources;
@@ -282,6 +283,15 @@ The MVP runtime currently has:
 - debug-only duplicate key warnings compiled only with `goframe_debug`.
 - debug-only lifecycle warnings for Set-after-unmount, Set-during-render, and
   effect update-loop guard trips.
+
+State transactions share the lifecycle render boundary without entering its
+generic participant interface. State commits or rolls back through a dedicated
+path before generic resource participants and lifecycle hooks. This keeps
+hook-free components free of state-transaction allocation and preserves the
+generic participant mechanism for resources. Protected ErrorBoundary subtrees
+defer the same final state decision to the boundary transaction. The model is
+not concurrent rendering, scheduler transactionality, or general rollback of
+updates to already committed state values.
 
 Direct function calls remain possible but do not create a component boundary.
 The single-thread assumption must be revisited before worker-driven updates.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -152,6 +152,14 @@ a small form-driven request. The same smoke covers a controlled backend failure
 state, delayed stale request no-overwrite behavior, and recovery after a later
 valid form submission. This does not add a GoFrame server API.
 
+The private Error Boundary fixture also covers state render transactions. Its
+standard-Go/WASM lane verifies failed initial state rollback, retry without a
+ghost slot, inert discarded setters and dispatchers, preservation and later
+replacement of a committed reducer, resource ordering, stable scenario DOM
+identity, and balanced listener cleanup. A TinyGo `0.41.1` lane verifies the
+successful state, reducer, resource, and cleanup path. It does not intentionally
+panic or claim recover-based rollback under TinyGo's trap-style panic mode.
+
 The runtime error containment fixture, Error Boundary fixture, context selector
 topology fixture, and router-dashboard reference-app smoke are compiled with
 the Go WASM compiler where recover-based render containment is being asserted.

--- a/docs/deep-repository-research.md
+++ b/docs/deep-repository-research.md
@@ -392,7 +392,7 @@ red commit was created.
   runs. Ten fresh standard-Go/WASM runs proved failed-render rollback, retry,
   inert discarded closures, and committed-reducer ownership. Ten fresh
   TinyGo/WASM runs proved the successful state/reducer/resource path without
-  intentionally panicking. Two aggregate Chrome runs passed.
+  intentionally panicking.
 - Two aggregate Chrome runs passed. Their dev publication probes observed
   respectively 18/14 batches, 54/42 complete responses, and zero 404 or partial
   responses. Server-backed, history routing, document ownership, runtime error,

--- a/docs/deep-repository-research.md
+++ b/docs/deep-repository-research.md
@@ -41,7 +41,7 @@ the nearest ordinary test succeeds:
 | Development generations | `cmd/goxc` dev server | A canonical package is verified, activated as an immutable generation, leased by requests, and reloaded or drained. |
 | GOX parser | `pkg/gox` lexer and parser | Markup boundaries, attributes, props, expressions, source positions, and AST shape are accepted or rejected before lowering. |
 | GOX code generation | `pkg/gox` generation plans and codegen | Generated source is parser-safe; a successful package result must also survive Go type checking and compilation. |
-| Runtime render ownership | `pkg/goframe` component and render transaction | Lifecycle and resource work is speculative until commit; component state currently is not part of that transaction. |
+| Runtime render ownership | `pkg/goframe` component and render transaction | Lifecycle, resource, new state-slot, and reducer-replacement work is speculative until commit. |
 | DOM ownership | `pkg/goframe` reconciliation and mount layers | Keyed placement, form state, mounted ranges, and root replacement retain one explicit owner. |
 
 The module floor is Go 1.22. Standard Go 1.22.12, 1.25.12, and 1.26.5,
@@ -77,7 +77,7 @@ scratch sources and generated package trees remain outside version control.
 | DR-01 | `INDEPENDENT_DISCOVERY` | Medium | `pkg/gox`, `cmd/goxc check` | Accepted GOX should not emit duplicate Go fields or ambiguous runtime destinations. | Raw duplicates passed the original baseline; review follow-ups still accepted collisions through synthetic `Children`, DOM aliases, event case, and HTML attribute case. | Raw spelling is not the effective destination: component children add a synthetic field, events normalize separately, and HTML attribute destinations are ASCII case-insensitive before alias mapping. | Fixed in `54a22a65b5e4d2fc1bd0322a2c74cd950d7569bd`, extended in `9777620b0faa4798559f7af71ed256c176c6c302`, and completed in `ed6c96bab1e63c99009a70cf50695a8008440802`. |
 | DR-02 | `INDEPENDENT_DISCOVERY` | High | `cmd/goxc clean` | Cleanup may unlink only the adjacent file whose goxc ownership was validated. | The original baseline deleted an unmarked output; after the first correction, replacing or modifying a planned file before deletion still caused the replacement to be removed. | The first plan retained only paths, so deletion could not compare the current file's identity or content with the validated object. | Fixed in `cdeb83c871ea76d36fda887889f2164a40434da0` and completed in `1bbb319ccfd8c3839862bf75ff9790957c7f1c64`. |
 | DR-03 | `INDEPENDENT_DISCOVERY` | High | `cmd/goxc` generation publication | A coordinated package generation should not expose a partial new source set after a write failure. | With valid `a.gox` and `z.gox` and a directory at `z.gox.go`, generation returned an error after publishing `a.gox.go`. | Generation computed all bytes first but performed independent atomic file replacements and removals without a recoverable publication boundary. | Fixed in `fe293dcbf64b798fbd61fb12d09793f7e89435bf` with the complete fault matrix in `b60d249a6fa2846e9c9a6951068d61afd4047cd5`. |
-| DR-04 | `INDEPENDENT_DISCOVERY` | High | `pkg/goframe` render transaction | A failed render must not commit newly observed state slots or reducer closures. | A failed initial render retained its initial state on retry; a failed reducer rerender changed what an old dispatch closure executed. | `useStateSlot` appends directly to committed `stateSlots`, and `setReducer` replaces the committed reducer during render. | Separate bounded stage. |
+| DR-04 | `INDEPENDENT_DISCOVERY` | High | `pkg/goframe` render transaction | A failed render must not commit newly observed state slots or reducer closures. | A failed initial render retained its initial state on retry; a failed reducer rerender changed what an old dispatch closure executed. | `useStateSlot` appended directly to committed `stateSlots`, and `setReducer` replaced the committed reducer during render. | Fixed in `7d0e27b23fd80199cdfe1d260aeb21bede456266`, with browser evidence in `88ff6031360eeb2edd1fdbc2f27855a59342edc6` and the specialized state path in `ea82bf7d1c0e0e46cf9e9cedce813ff57a6597b5`. |
 
 ### DR-01: duplicate attributes and props
 
@@ -186,17 +186,27 @@ unpublished sibling outputs as read-only verification inputs.
 
 ### DR-04: speculative state escapes rollback
 
-Two temporary tests were run and removed. In the first, a render created state
-with initial value `1`, then panicked. A successful retry requesting initial
-value `99` observed `1`, proving that the failed attempt left a ghost slot. In
-the second, a committed reducer added `1`; a failed rerender staged a reducer
-that added `100`. Dispatching through the old committed closure after recovery
-produced `101` rather than `2`.
+The baseline reproduction created state with initial value `1`, then panicked.
+A successful retry requesting initial value `99` observed `1`, proving that the
+failed attempt left a ghost slot. In a second reproduction, a committed reducer
+added `1`; a failed rerender staged a reducer that added `100`. Dispatching
+through the old committed closure after recovery produced `101` rather than
+`2`.
 
-Lifecycle and resource attempts already have explicit commit and rollback.
-State-slot creation and reducer replacement bypass that boundary. This finding
-is behaviorally separate from the protected-subtree lifecycle transaction
-closed before this stage.
+New state slots and reducer replacements now participate in the shared render
+lifecycle boundary. State participation is allocated lazily and finalized
+through a specialized state path before generic resource participants and
+lifecycle hooks. Failed recover-capable renders discard new slots, make their
+new setters and dispatchers inert, and preserve the latest successfully
+committed reducer for existing dispatch closures. Protected ErrorBoundary
+subtrees retain deferred commit/rollback ownership, including nested boundary
+delegation.
+
+Host and standard-Go/WASM failure evidence prove rollback and retry. Standard
+Go and TinyGo/WASM both prove successful-path state semantics. TinyGo's current
+trap-style panic mode still cannot provide recover-based rollback evidence.
+Existing committed state-value updates are not generally rolled back, and this
+stage does not add concurrent rendering or scheduler transactionality.
 
 ## Historical Hypothesis Disposition
 
@@ -275,28 +285,21 @@ commit, reverse-order rollback, and an explicitly passed fault-injection hook.
 mutation-position, multi-package, retry, no-active-source, single-file, and
 rollback-failure matrix.
 
+`7d0e27b23fd80199cdfe1d260aeb21bede456266` makes new state slots and reducer
+replacements speculative, `5b9f26cc1dc507689bf0011ccfa69128f2815a8d` supplies the host transaction
+matrix, and `c9d3f7b978b6087d46282a0c275533b2d2dec82b` keeps state participation lazy.
+`ea82bf7d1c0e0e46cf9e9cedce813ff57a6597b5` finalizes state directly before
+generic resource participants rather than converting state to the generic
+lifecycle interface. `88ff6031360eeb2edd1fdbc2f27855a59342edc6` adds standard-Go failure/retry
+browser evidence, TinyGo successful-path parity, and the measured absolute
+size-ceiling alignment.
+
 These fixes do not change a public Go API, GOX output for accepted non-collision
-sources, CLI schema, dependencies, workflows, package format, or budgets.
+sources, CLI schema, dependencies, workflows, or package format. The completed
+DR-04 stage aligns only its measured absolute WASM ceilings; compression ratios
+remain unchanged.
 
 ## Separate Bounded Stages
-
-### `fix/runtime-state-render-transactions`
-
-- **Goal:** keep new state slots and reducer replacements speculative until a
-  render commits.
-- **Root cause:** state creation and reducer assignment mutate committed slots
-  while lifecycle/resource work uses a separate render attempt.
-- **Acceptance:** failed initial render leaves no ghost slot; failed rerender
-  preserves the committed reducer and state; retry commits in hook order; old
-  setters/dispatchers retain their documented behavior; host/race/debug,
-  standard-Go browser, TinyGo browser, and size evidence pass.
-- **Allowed paths:** `pkg/goframe` component/state/render transaction files,
-  nearest tests, and a focused browser fixture only if host evidence is
-  insufficient.
-- **Non-goals:** scheduler redesign, state API changes, or general concurrent
-  rendering.
-- **Stop:** public API change, unexplained standard-Go/TinyGo divergence, or an
-  unbounded transaction model.
 
 ### Historical follow-up stages
 
@@ -320,7 +323,8 @@ budget change, or an unreviewed public/language contract expansion.
 
 ## Output And Size Evidence
 
-Unaffected generation modes were compared with fixed paths. Directory,
+For the original deep-research layer through DR-03, unaffected generation modes
+were compared with fixed paths. Directory,
 single-file, and in-place output remained byte-identical at 554 bytes with
 SHA-256
 `fec3121e841a23ba10202b3e38ad9b6a78ebf8f79091e8aa55d71c1aa352ec75`.
@@ -350,7 +354,11 @@ was identical at
 | router-dashboard | 234,630 | 94,032 | 77,404 | 82,605 |
 | resource | 157,459 | 68,679 | 57,813 | 61,514 |
 
-Every current absolute and ratio budget passed. No budget changed.
+Every absolute and ratio budget at that checkpoint passed without a budget
+change. The later DR-04 closeout is recorded in
+`docs/wasm-size-headroom-audit.md`: all ratios still pass unchanged, while only
+the fifteen measured absolute cells that remained over their ceilings after
+state-path specialization move to the next one-KiB boundary.
 
 The DR-03 continuation compared the frozen merge
 `f61f0bc97467165a21bb15d069f34762321283bb` with the final code head
@@ -380,6 +388,11 @@ red commit was created.
   1.25.12 and 1.26.5.
 - `scripts/check.sh` passed, including generation, package, doctor, benchmark,
   race, vet, and size checks.
+- State transaction host tests passed high-count, race, and `goframe_debug`
+  runs. Ten fresh standard-Go/WASM runs proved failed-render rollback, retry,
+  inert discarded closures, and committed-reducer ownership. Ten fresh
+  TinyGo/WASM runs proved the successful state/reducer/resource path without
+  intentionally panicking. Two aggregate Chrome runs passed.
 - Two aggregate Chrome runs passed. Their dev publication probes observed
   respectively 18/14 batches, 54/42 complete responses, and zero 404 or partial
   responses. Server-backed, history routing, document ownership, runtime error,
@@ -408,11 +421,11 @@ partial responses during either accepted run.
 ## Limitations
 
 Research ran on Linux/amd64. Windows received compile evidence, not execution.
-The temporary runtime tests for DR-04 establish the host transaction defect;
-the separate stage still requires browser and TinyGo evidence before changing
-runtime code. Confirmed historical grammar and API questions were reproduced
-but were not expanded into public or language decisions here. No remote CI was
-rerun for the unpublished top layer.
+TinyGo successful-path state semantics have browser evidence, but its trap-style
+panic mode does not supply recover-based failed-render rollback evidence.
+Confirmed historical grammar and API questions were reproduced but were not
+expanded into public or language decisions here. No remote CI was rerun for the
+unpublished top layer.
 
 ## Non-Goals
 

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -88,6 +88,14 @@ deterministically.
 If no boundary exists, the fallback remains the MVP 23 behavior: `gf.Empty()`
 for that render. Future state or parent updates may retry the component.
 
+New state slots and reducer replacements are speculative during render. A
+successful render commits them before generic resource participants and
+lifecycle hooks. A failed recover-capable render discards them, so retry does
+not observe ghost slots and an existing reducer dispatch closure continues to
+use the latest successfully committed reducer. Setters and dispatchers created
+only for discarded slots become inert. This transaction does not generally
+roll back value updates to state slots that were already committed.
+
 ### Event Handlers
 
 An event handler panic is reported as `ErrorPhaseEvent` and contained. The app
@@ -196,6 +204,8 @@ Boundary rules:
 - first error wins until manual reset or `ResetKey` reset;
 - `ctx.Reset()` remounts the protected subtree fresh;
 - changing `ResetKey` while failed clears the incident and remounts children;
+- protected child state remains speculative until the boundary transaction
+  commits or rolls back;
 - runtime invariant panics whose value starts with `goframe:` bypass boundary
   containment.
 
@@ -231,12 +241,17 @@ lifecycle warnings remain separate.
 Browser smoke verifies that recoverable event and cleanup failures do not
 unmount the app or leak listeners. A separate Error Boundary fixture verifies
 render fallback, retry, `ResetKey`, nested boundaries, and cleanup behavior.
+That fixture also verifies failed state-slot and reducer rollback, retry, inert
+discarded closures, successful reducer replacement, resource ordering, stable
+DOM identity, and balanced listener ownership.
 The context selector topology fixture verifies failed outer/inner provider
 transitions, old-provider isolation, and later new-provider recovery.
 
-These panic-containment fixtures use Go-compiled WASM because the current
-TinyGo package path uses trap-style panic lowering, where panics do not return
-to Go `recover`.
+Failed-render state transaction and other panic-containment scenarios use
+Go-compiled WASM because the current TinyGo package path uses trap-style panic
+lowering, where panics do not return to Go `recover`. A separate TinyGo lane
+verifies the successful state, reducer, resource, and cleanup path without
+claiming panic rollback.
 
 Browser smoke should not use timing gates for runtime error behavior.
 
@@ -260,3 +275,5 @@ the size and behavior tradeoff is acceptable.
 - No production crash reporting integration.
 - Context selector containment during initial render is report + re-panic.
 - TinyGo trap-style panic builds cannot provide recover-based containment.
+- Existing committed state-value updates are not a general render rollback
+  surface.

--- a/docs/runtime-errors.md
+++ b/docs/runtime-errors.md
@@ -204,8 +204,8 @@ Boundary rules:
 - first error wins until manual reset or `ResetKey` reset;
 - `ctx.Reset()` remounts the protected subtree fresh;
 - changing `ResetKey` while failed clears the incident and remounts children;
-- protected child state remains speculative until the boundary transaction
-  commits or rolls back;
+- new state slots and reducer replacements observed in protected children
+  remain speculative until the boundary transaction commits or rolls back;
 - runtime invariant panics whose value starts with `goframe:` bypass boundary
   containment.
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -30,6 +30,13 @@ the reviewed repeated-Mount head. Exactly three old-ceiling cells fail:
 Zstandard by `74 B`. Those three ceilings increase by `1024 B`; every other
 absolute ceiling and all ratio limits remain unchanged.
 
+The state render transaction adds speculative new-slot and reducer-replacement
+ownership. Specializing its commit/rollback path removes state-only reachability
+of the generic lifecycle participant interface and reverses about `18 KiB` of
+the eager/lazy state-only growth. All ratio limits pass unchanged. Fifteen
+remaining absolute cells are aligned to the next one-KiB boundary; no other
+ceiling, compression command, workflow, or application changes.
+
 ## Source of Truth
 
 - Workflow: `.github/workflows/ci-wasm-size.yml`
@@ -57,15 +64,15 @@ If no match exists, it reports the default missing path
 | --- | ---: | ---: | ---: | ---: |
 | counter | 97280 B | 40960 B | 56320 B | 49152 B |
 | components | 107520 B | 43008 B | 56320 B | 49152 B |
-| todo | 122880 B | 40960 B | 56320 B | 49152 B |
-| dashboard | 171008 B | 53248 B | 71680 B | 61440 B |
-| context | 117760 B | 36864 B | 46080 B | 40960 B |
-| virtualized | 124928 B | 40960 B | 49152 B | 44032 B |
+| todo | 123904 B | 40960 B | 56320 B | 49152 B |
+| dashboard | 175104 B | 53248 B | 71680 B | 61440 B |
+| context | 120832 B | 37888 B | 46080 B | 40960 B |
+| virtualized | 128000 B | 40960 B | 50176 B | 44032 B |
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
-| router | 118784 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 235520 B | 77824 B | 94208 B | 82944 B |
-| resource | 157696 B | 58368 B | 69632 B | 62464 B |
+| router | 119808 B | 45056 B | 58368 B | 51200 B |
+| router-dashboard | 240640 B | 79872 B | 96256 B | 84992 B |
+| resource | 162816 B | 59392 B | 70656 B | 63488 B |
 
 ## Supported Toolchain Baseline Migration - 2026-07-30
 
@@ -525,6 +532,146 @@ The old ceilings failed only at `router` raw (`117800 / 117760 B`),
 No other ceiling, ratio, compression command, workflow, or matrix membership
 changed. This is an accepted root-ownership correctness cost; the private
 repeated-Mount fixture remains outside the size matrix.
+
+## State Render Transactions — 2026-08-03
+
+This closeout compares frozen parent
+`20fbcf5d9fc6fb67ba43a9aa0e3fd6e5496cec35`, eager state transaction head
+`5b9f26cc1dc507689bf0011ccfa69128f2815a8d`, lazy state transaction head
+`c9d3f7b978b6087d46282a0c275533b2d2dec82b`, specialized production head
+`ea82bf7d1c0e0e46cf9e9cedce813ff57a6597b5`, and browser evidence head
+`88ff6031360eeb2edd1fdbc2f27855a59342edc6`.
+
+New state slots and reducer replacements remain speculative until render
+commit. State is allocated lazily and commits or rolls back directly before
+generic lifecycle participants and hooks. Resources retain the generic
+participant path. Protected ErrorBoundary subtrees retain deferred final
+ownership. Existing committed state-value updates are not generally rolled
+back, and this change does not add concurrent rendering or scheduler
+transactionality.
+
+Measurements use Go `1.26.5`, TinyGo `0.41.1` with LLVM `20.1.1`, Linux amd64,
+gzip `-n -9`, Brotli quality 11, and Zstandard level 19. Checkpoints were built
+sequentially from the same absolute checkout path with isolated writable Go and
+TinyGo caches.
+
+| checkpoint / app | raw | gzip | br | zstd | raw SHA-256 |
+| --- | ---: | ---: | ---: | ---: | --- |
+| parent / counter | 85595 B | 34207 B | 28683 B | 30938 B | `1a45fd38b13eee14aca55bc0fda4260aae1d542d6419786569a46d3fa5951ed1` |
+| eager / counter | 105990 B | 49920 B | 43407 B | 45543 B | `0018c86f9b6eba5508266a9e552ac602f1d0e43623a5d90efdb494777109eace` |
+| lazy / counter | 106050 B | 49911 B | 43430 B | 45584 B | `ee0a9fd711e3f310a8cb99b234b4a2a405822a8ad21fbdc0b034553c0aa44cf7` |
+| specialized / counter | 87732 B | 35063 B | 29338 B | 31568 B | `b7354e7e9a086202aafd4757a3ef5a4ea41e7a58d8400681951d69e8ace10db2` |
+| parent / resource | 157320 B | 68670 B | 57926 B | 61534 B | `5f513a6bd7f30c0d8c0989f3a46e0bb0f1806118f8888dddd09e07c8ec56170a` |
+| eager / resource | 161871 B | 70096 B | 59046 B | 62853 B | `a00b60a2ad3fb20631fc8a2ed29daa092243e2d37145a9d1b40b2440e9aa8b81` |
+| lazy / resource | 161966 B | 70129 B | 59017 B | 62890 B | `c6e19ab213a346e6f3e967bc0fd0e0a903a57ef20035bdfca088e99770081a47` |
+| specialized / resource | 161949 B | 70190 B | 59189 B | 62940 B | `d7d51dfa99aaa3b1ba5b4d2ebe4fa4befcc61fdc30a263c20796212d8cd6ceb8` |
+| parent / router-dashboard | 234569 B | 94057 B | 77481 B | 82654 B | `dc65e8f4fd9b16eca1703ce7b5219d3a5aea337a11dd9c5464d65557c9100c3f` |
+| eager / router-dashboard | 239664 B | 95732 B | 78703 B | 84073 B | `2a543be7d56dd90bd91406894e109ce41c61ccbf5459194df746ffd791fcfcb3` |
+| lazy / router-dashboard | 239759 B | 95814 B | 78758 B | 84099 B | `91fef6fee07b0528d0dcc762c4a1ff2ee0891671f6cd6d38bc68ac4f1178d9e8` |
+| specialized / router-dashboard | 239735 B | 95816 B | 79001 B | 84130 B | `9b93b6755c38522047534f890b1654a92746031ceeec1546f973e17d0bbd22a7` |
+
+The eager and lazy `counter` artifacts contain
+`lifecycleRenderParticipant` and its interface `finishRender` invoke. The
+specialized `counter` contains `finishStateRender` instead and no generic
+participant interface symbol. Resource and router-dashboard continue to retain
+the interface because they use resources.
+
+| checkpoint / app | code section | data section | name section | data segments |
+| --- | ---: | ---: | ---: | ---: |
+| parent / counter | 69368 B | 9959 B | 4830 B | 7 |
+| eager / counter | 74110 B | 24823 B | 5572 B | 31 |
+| lazy / counter | 74170 B | 24823 B | 5572 B | 31 |
+| specialized / counter | 71350 B | 9959 B | 4979 B | 7 |
+| parent / resource | 116447 B | 29175 B | 10032 B | 34 |
+| eager / resource | 120461 B | 29479 B | 10262 B | 34 |
+| lazy / resource | 120556 B | 29479 B | 10262 B | 34 |
+| specialized / resource | 120410 B | 29519 B | 10349 B | 34 |
+| parent / router-dashboard | 180443 B | 35333 B | 16893 B | 40 |
+| eager / router-dashboard | 184993 B | 35645 B | 17123 B | 40 |
+| lazy / router-dashboard | 185088 B | 35645 B | 17123 B | 40 |
+| specialized / router-dashboard | 184944 B | 35677 B | 17210 B | 40 |
+
+The specialized state-only counter reverses `18318 B` of the lazy raw growth,
+including the extra 24 data segments. This confirms interface reachability as
+the large state-only cost. No second bounded representation is meaningful after
+removing the interface conversion: the remaining dedicated state path is the
+smallest direct expression of the required commit/rollback semantics.
+
+Commit 4 and Commit 5 produced byte-identical raw and reproducibly compressed
+streams for all eleven applications. The full parent-to-final matrix is:
+
+| app | parent raw | Commit 4 raw | Commit 5 raw | raw delta | gzip delta | br delta | zstd delta | final budget result |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| counter | 85595 B | 87732 B | 87732 B | +2137 B | +856 B | +655 B | +630 B | pass |
+| components | 91243 B | 93383 B | 93383 B | +2140 B | +703 B | +621 B | +650 B | pass |
+| todo | 120480 B | 123390 B | 123390 B | +2910 B | +1218 B | +855 B | +938 B | pass |
+| dashboard | 170903 B | 174570 B | 174570 B | +3667 B | +1575 B | +1307 B | +1427 B | pass |
+| context | 117366 B | 120131 B | 120131 B | +2765 B | +1059 B | +962 B | +996 B | pass |
+| virtualized | 124297 B | 127601 B | 127601 B | +3304 B | +1275 B | +1160 B | +1166 B | pass |
+| multipackage | 96416 B | 98549 B | 98549 B | +2133 B | +663 B | +508 B | +636 B | pass |
+| cmdapp | 96434 B | 98567 B | 98567 B | +2133 B | +663 B | +630 B | +591 B | pass |
+| router | 117686 B | 119806 B | 119806 B | +2120 B | +700 B | +586 B | +607 B | pass |
+| router-dashboard | 234569 B | 239735 B | 239735 B | +5166 B | +1759 B | +1520 B | +1476 B | pass |
+| resource | 157320 B | 161949 B | 161949 B | +4629 B | +1520 B | +1263 B | +1406 B | pass |
+
+All ratio limits pass unchanged:
+
+| app | gzip ratio | br ratio | zstd ratio |
+| --- | ---: | ---: | ---: |
+| counter | 39.98% | 33.44% | 35.98% |
+| components | 39.50% | 32.88% | 35.38% |
+| todo | 38.78% | 32.00% | 34.49% |
+| dashboard | 37.67% | 30.42% | 32.79% |
+| context | 37.80% | 31.02% | 33.37% |
+| virtualized | 38.65% | 31.72% | 34.24% |
+| multipackage | 39.18% | 32.49% | 35.03% |
+| cmdapp | 39.17% | 32.56% | 35.03% |
+| router | 38.22% | 31.54% | 33.93% |
+| router-dashboard | 39.97% | 32.95% | 35.09% |
+| resource | 43.35% | 36.55% | 38.86% |
+
+Only absolute cells that still failed after specialization move to the next
+one-KiB boundary:
+
+| app / format | measured | old ceiling | overage | new ceiling | headroom |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| todo raw | 123390 B | 122880 B | 510 B | 123904 B | 514 B |
+| dashboard raw | 174570 B | 171008 B | 3562 B | 175104 B | 534 B |
+| context raw | 120131 B | 117760 B | 2371 B | 120832 B | 701 B |
+| context br | 37268 B | 36864 B | 404 B | 37888 B | 620 B |
+| virtualized raw | 127601 B | 124928 B | 2673 B | 128000 B | 399 B |
+| virtualized gzip | 49311 B | 49152 B | 159 B | 50176 B | 865 B |
+| router raw | 119806 B | 118784 B | 1022 B | 119808 B | 2 B |
+| router-dashboard raw | 239735 B | 235520 B | 4215 B | 240640 B | 905 B |
+| router-dashboard br | 79001 B | 77824 B | 1177 B | 79872 B | 871 B |
+| router-dashboard gzip | 95816 B | 94208 B | 1608 B | 96256 B | 440 B |
+| router-dashboard zstd | 84130 B | 82944 B | 1186 B | 84992 B | 862 B |
+| resource raw | 161949 B | 157696 B | 4253 B | 162816 B | 867 B |
+| resource br | 59189 B | 58368 B | 821 B | 59392 B | 203 B |
+| resource gzip | 70190 B | 69632 B | 558 B | 70656 B | 466 B |
+| resource zstd | 62940 B | 62464 B | 476 B | 63488 B | 548 B |
+
+Every other absolute ceiling remains unchanged. Ratio limits remain gzip
+`52.00%`, Brotli `38.00%`, and Zstandard `46.00%`.
+
+Final Commit 4 and Commit 5 stream SHA-256 values are identical:
+
+| app | raw / gzip / br / zstd SHA-256 |
+| --- | --- |
+| counter | `b7354e7e9a086202aafd4757a3ef5a4ea41e7a58d8400681951d69e8ace10db2` / `096b8152071e809e6a9a752b02b036f5327d38908dd3db1ee2d9a90d768b8e24` / `3b4c0a8a8d08cc5519d4c7bc08afd71821a43e6703b5c74f9f096a5957014d5d` / `54c159d36cf946c4ddd84c62479a75bc15846ec0c070b569f1ed12762a0e2d66` |
+| components | `33e6023ec97e2551e9a1c7a49ae2e6d4c903a6de58c46037a36346b5e5284f57` / `989855728221a99ee84017c8adbd8ce3d82d6c326aeea540fa0c1db64f60f16e` / `56f89411c4c7f6d5283f56ab8e3e6354954bcf052d52ea7ebaf93e31d6d70379` / `57cf7e1e2ce583e5b60b8b000c58397c6e4e64648b53059e7b8f870d3e181961` |
+| todo | `32e61235ce954a1f1547d8e9bf6edaa95078b0db65a532eea19f28beefad02f7` / `cc4f6824d8eec0eb632c74940a9925eedbacb60738f6015dffe837b2f509038a` / `6e3e0307ad4fd94bb2e6b52d0228e87f1d8f0366da1ce883a5708be2b575be7a` / `5d2806f20be2f230d5c614ef50b74b9785f47f183c530066769be9ebee50bd86` |
+| dashboard | `8afa3972c38d866329b1119d419b9e7ec043368e7a4e6f66ce810dfb17d783f5` / `ce8ca0237293de1e749165241d8d2715071f28c441e7820197319310d030a0fd` / `618fe8e29220d9e8c321d019791aab0a56c78fab058ceffeb3f57a03ffcb7707` / `40885e2a7e27d41b650521dd63fae81a3a52f8561ddb7356276e131d268ca03e` |
+| context | `245ab1663610641738ebc0ce365b9573e730bac47861e3701055a9963d8b1510` / `1b76ad0a59dff899c5b8369a4488b55d9712caa246afdc1ddd3234f7774cfa9b` / `455c9b1256ecc2ca53e7028f3ffbb5a796e399b6463a81ad7791d2992b9624b0` / `8082f27437b041d26120694789c1db9a068d46c080fa1b410eb6e9c7ee6d0d52` |
+| virtualized | `42cb4a70318c3a6d2eb0dcaa71ea33e188a5e247511278135561b07a1ab3c98d` / `53890d2b090e13f3926fc836d94374059da87f610a993f9a6704c4cb576cd390` / `2b397bc473f0b96f9d5cf98f5467cebc57bf2f71d8afdec6626008e57832f9b0` / `4a1ff9623e4e0c71b0c983a2b30a97bc65ad89a9a62860802e68a271bd9b60c7` |
+| multipackage | `ef78166eb77bf535cae5a80c5f418cb13b1464312118eb89254d04767b58a512` / `e51d1765157ca127e62458afd016f60c8a4b460f7f2ae3ad5167c95bb9cd8250` / `ed71c05d2e996ef4e11ef37b883cdaf1ad554f7fbd2578aa3114f56b14341a47` / `6ed630e644086f72a43be7d7403738087b89d90d92f84b026873e85e0617f6b7` |
+| cmdapp | `94831796b91355bffdd07fee8fb9a9e10e15877c665f7f21a755806ed9494c94` / `92b19780658bb0c2d74d4a38558d9f76651e35fe15c541c0c8abf60a7532d3ab` / `2e29988c64d853b2d45070a14642721ffe6c7c6e634b78e965c91c65332c03cf` / `1dcd8b1c34772927a545cd6bfa0a4f45c5cf83aacc29914e702e9c26f1306f5c` |
+| router | `68229c2236646131b284f83f5ac061a036cc01322e80c15130dde27c05d237ce` / `668fc41104f9773380940dba11d0132f7bf03c37912707d4abbeee32041c76da` / `ef74d5148f356fa4eb11331d5b55e67a254128251b1ddd399e6b2a267157da05` / `64c4db672cb9ce6f7b690aac592c26573733a9d984db422c0871dc3b95eb5cfb` |
+| router-dashboard | `9b93b6755c38522047534f890b1654a92746031ceeec1546f973e17d0bbd22a7` / `17b12139769f8f67b90256d254b7faaa429bb0f71fb01b46ec793faf9e319702` / `08cf939265aa6c6b474051ad969d7f00dd67de35a17db08c3b6cec626c927772` / `b173b695a4153faaeae7cf55454afebb26faf5fe90abff122d255efb32e9bf69` |
+| resource | `d7d51dfa99aaa3b1ba5b4d2ebe4fa4befcc61fdc30a263c20796212d8cd6ceb8` / `6525c7916fec02fa3713d2e2a5d7241eb86617c5061941c9a5c6f85ffc543c67` / `9a4b4c7314ef6622bc2e3fbf7354b1a265dbdb27a31e02d97e32e2ae66101aa3` / `724217c325b0d6539868b39c3bce6849a2643a3104ffb74268c623e54493eedd` |
+
+The sorted 44-stream SHA-256 manifest hashes to
+`9bbce18fe7c2514d15fab3bd1070fc398209d5e52033439bb812c4d8b5eee20f`.
 
 ## Targeted ErrorBoundary Correctness Rebaseline — 2026-07-28
 

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -323,6 +323,9 @@ func commitLifecycleRenderAttempt(instance *componentInstance) {
 		return
 	}
 	attempt := requireLifecycleRenderAttempt(instance)
+	if state := attempt.state; state != nil && state.attempt == attempt {
+		state.finishStateRender(attempt, true)
+	}
 	for _, participant := range attempt.participants {
 		participant.finishRender(attempt, true)
 	}
@@ -367,6 +370,9 @@ func rollbackLifecycleRenderAttempt(instance *componentInstance) {
 		return
 	}
 	attempt := &instance.lifecycleAttempt
+	if state := attempt.state; state != nil && state.attempt == attempt {
+		state.finishStateRender(attempt, false)
+	}
 	for _, participant := range attempt.participants {
 		participant.finishRender(attempt, false)
 	}

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -207,6 +207,7 @@ type renderLifecycleAttempt struct {
 	effects      []effectRenderUpdate
 	unmounts     []Cleanup
 	participants []lifecycleRenderParticipant
+	state        stateRenderParticipant
 }
 
 var (

--- a/pkg/goframe/effects.go
+++ b/pkg/goframe/effects.go
@@ -207,7 +207,7 @@ type renderLifecycleAttempt struct {
 	effects      []effectRenderUpdate
 	unmounts     []Cleanup
 	participants []lifecycleRenderParticipant
-	state        stateRenderParticipant
+	state        *stateRenderParticipant
 }
 
 var (

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -967,6 +967,129 @@ func TestProtectedSubtreeSuccessfulLifecycleOrderRemainsParentFirst(t *testing.T
 	assertEffectEvents(t, events, []string{"parent", "child"})
 }
 
+func TestProtectedSubtreeStateSlotsRollBackAfterDescendantFailure(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	initial := 1
+	observed := 0
+	owner := testComponentInstanceWithParent("StateOwner", boundary, func() Node {
+		observed, _ = UseState(initial)
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		if len(owner.stateSlots) != 0 || !owner.lifecycleAttempt.active {
+			t.Fatalf("state committed before protected subtree result: slots=%d active=%v",
+				len(owner.stateSlots), owner.lifecycleAttempt.active)
+		}
+		renderComponentInstance(transactionTestRisky(boundary, "state descendant boom"))
+	})
+	if len(owner.stateSlots) != 0 || owner.lifecycleAttempt.active || owner.lifecycleAttempt.state.attempt != nil {
+		t.Fatalf("failed protected state retained slots=%d active=%v transaction=%p",
+			len(owner.stateSlots), owner.lifecycleAttempt.active, owner.lifecycleAttempt.state.attempt)
+	}
+
+	clearErrorBoundary(boundary.errorBoundary)
+	initial = 99
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	if observed != 99 || len(owner.stateSlots) != 1 || owner.stateSlots[0].value != 99 {
+		t.Fatalf("protected state retry observed=%d slots=%#v, want fresh 99", observed, owner.stateSlots)
+	}
+}
+
+func TestProtectedSubtreeReducerReplacementCommitsOnlyAfterSuccess(t *testing.T) {
+	isolateLifecycleTestState(t)
+	boundary := transactionTestBoundary()
+	useCandidate := false
+	var firstDispatch func(int)
+	owner := testComponentInstanceWithParent("ReducerOwner", boundary, func() Node {
+		reducer := Reducer[int, int](func(state, action int) int {
+			return state + action
+		})
+		if useCandidate {
+			reducer = func(state, action int) int {
+				return state + action*100
+			}
+		}
+		_, dispatch := UseReducer(1, reducer)
+		if firstDispatch == nil {
+			firstDispatch = dispatch
+		}
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	slot := owner.stateSlots[0]
+	useCandidate = true
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+		renderComponentInstance(transactionTestRisky(boundary, "reducer descendant boom"))
+	})
+	if owner.stateSlots[0] != slot || slot.value != 1 {
+		t.Fatalf("failed protected reducer changed slot=%p value=%v, want %p/1", owner.stateSlots[0], slot.value, slot)
+	}
+	firstDispatch(1)
+	if slot.value != 2 {
+		t.Fatalf("old dispatch after failed protected reducer = %v, want 2", slot.value)
+	}
+
+	clearErrorBoundary(boundary.errorBoundary)
+	runProtectedSubtreeTestAttempt(boundary, func() {
+		renderComponentInstance(owner)
+	})
+	firstDispatch(1)
+	if slot.value != 102 {
+		t.Fatalf("old dispatch after successful protected reducer = %v, want 102", slot.value)
+	}
+}
+
+func TestNestedProtectedStateCommitDefersToOutermostBoundary(t *testing.T) {
+	isolateLifecycleTestState(t)
+	outer := transactionTestBoundary()
+	inner := transactionTestBoundaryWithParent(outer)
+	initial := 1
+	reducerInitial := 2
+	observed := 0
+	owner := testComponentInstanceWithParent("NestedStateOwner", inner, func() Node {
+		observed, _ = UseState(initial)
+		_, _ = UseReducer(reducerInitial, func(state, action int) int {
+			return state + action
+		})
+		return Empty()
+	})
+
+	runProtectedSubtreeTestAttempt(outer, func() {
+		runProtectedSubtreeTestAttempt(inner, func() {
+			renderComponentInstance(owner)
+		})
+		if len(owner.stateSlots) != 0 || !owner.lifecycleAttempt.active {
+			t.Fatalf("nested state committed before outer result: slots=%d active=%v",
+				len(owner.stateSlots), owner.lifecycleAttempt.active)
+		}
+		renderComponentInstance(transactionTestRisky(outer, "outer state descendant boom"))
+	})
+	if len(owner.stateSlots) != 0 || owner.lifecycleAttempt.active {
+		t.Fatalf("outer rollback retained nested state slots=%d active=%v", len(owner.stateSlots), owner.lifecycleAttempt.active)
+	}
+
+	clearErrorBoundary(outer.errorBoundary)
+	initial = 99
+	reducerInitial = 100
+	runProtectedSubtreeTestAttempt(outer, func() {
+		runProtectedSubtreeTestAttempt(inner, func() {
+			renderComponentInstance(owner)
+		})
+	})
+	if observed != 99 || len(owner.stateSlots) != 2 || owner.stateSlots[0].value != 99 || owner.stateSlots[1].value != 100 {
+		t.Fatalf("nested protected retry observed=%d slots=%#v, want fresh 99/100", observed, owner.stateSlots)
+	}
+}
+
 func runProtectedSubtreeTestAttempt(boundary *componentInstance, reconcile func()) {
 	var state *errorBoundaryState
 	if boundary != nil &&

--- a/pkg/goframe/error_boundary_transaction_test.go
+++ b/pkg/goframe/error_boundary_transaction_test.go
@@ -985,9 +985,14 @@ func TestProtectedSubtreeStateSlotsRollBackAfterDescendantFailure(t *testing.T) 
 		}
 		renderComponentInstance(transactionTestRisky(boundary, "state descendant boom"))
 	})
-	if len(owner.stateSlots) != 0 || owner.lifecycleAttempt.active || owner.lifecycleAttempt.state.attempt != nil {
+	if len(owner.stateSlots) != 0 || owner.lifecycleAttempt.active ||
+		(owner.lifecycleAttempt.state != nil && owner.lifecycleAttempt.state.attempt != nil) {
+		var stateAttempt *renderLifecycleAttempt
+		if owner.lifecycleAttempt.state != nil {
+			stateAttempt = owner.lifecycleAttempt.state.attempt
+		}
 		t.Fatalf("failed protected state retained slots=%d active=%v transaction=%p",
-			len(owner.stateSlots), owner.lifecycleAttempt.active, owner.lifecycleAttempt.state.attempt)
+			len(owner.stateSlots), owner.lifecycleAttempt.active, stateAttempt)
 	}
 
 	clearErrorBoundary(boundary.errorBoundary)

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -2,6 +2,7 @@ package goframe
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 )
 
@@ -1072,14 +1073,152 @@ func TestUseResourceInitialFailedRenderStartsNoLoader(t *testing.T) {
 	}
 }
 
+func TestStateRenderTransactionKeepsResourceHookSequenceAligned(t *testing.T) {
+	isolateLifecycleTestState(t)
+	loader := &resourceTestLoader{}
+	fail := true
+	stateInitial := 1
+	reducerInitial := 2
+	unmounts := 0
+	effectSetups := 0
+	var resource Resource[string]
+	var failedControl *resourceControl[string]
+	instance := testComponentInstance("StateResourceTransaction", func() Node {
+		_, _ = UseState(stateInitial)
+		_, _ = UseReducer(reducerInitial, func(state, action int) int {
+			return state + action
+		})
+		resource, _ = UseResource("resource", loader.load)
+		UseEffect(func() Cleanup {
+			effectSetups++
+			return nil
+		})
+		UseUnmount(func() {
+			unmounts++
+		})
+		if fail {
+			failedControl, _ = currentComponent.lifecycleAttempt.state.slots[2].value.(*resourceControl[string])
+			panic("mixed state resource render failed")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	if len(instance.stateSlots) != 0 || len(instance.effectSlots) != 0 || len(instance.unmountSlots) != 0 {
+		t.Fatalf("failed mixed render committed state=%d effects=%d unmounts=%d, want 0/0/0",
+			len(instance.stateSlots), len(instance.effectSlots), len(instance.unmountSlots))
+	}
+	if failedControl == nil || failedControl.pending.attempt != nil || failedControl.committed || len(loader.starts) != 0 {
+		t.Fatalf("failed mixed resource control=%#v starts=%#v, want discarded and idle", failedControl, loader.starts)
+	}
+
+	stateInitial = 10
+	reducerInitial = 20
+	fail = false
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 3 {
+		t.Fatalf("successful mixed retry state slots = %d, want 3", len(instance.stateSlots))
+	}
+	wantKinds := []string{"UseState", "UseReducer", "UseResource"}
+	for index, kind := range wantKinds {
+		if instance.stateSlots[index].kind != kind {
+			t.Errorf("successful mixed retry slot %d kind = %q, want %q", index, instance.stateSlots[index].kind, kind)
+		}
+	}
+	control := resourceControlForTestAt[string](t, instance, 2)
+	if control == failedControl || !control.committed || control.owner != instance || control.key != "resource" || !resource.Loading() {
+		t.Fatalf("successful mixed retry resource/control = %#v/%#v", resource, control)
+	}
+	flushPendingEffects()
+	if got := loader.starts; len(got) != 1 || got[0] != "resource" || effectSetups != 1 {
+		t.Fatalf("successful mixed retry starts=%#v effect setups=%d, want [resource]/1", got, effectSetups)
+	}
+
+	deactivateComponent(instance)
+	if loader.cleanups != 1 || unmounts != 1 {
+		t.Fatalf("mixed retry unmount resource cleanups=%d unmounts=%d, want 1/1", loader.cleanups, unmounts)
+	}
+}
+
+func TestFailedReducerReplacementBesideResourcePreservesBothCommits(t *testing.T) {
+	isolateLifecycleTestState(t)
+	loader := &resourceTestLoader{}
+	useCandidate := false
+	fail := false
+	var resource Resource[string]
+	var firstDispatch func(int)
+	instance := testComponentInstance("ResourceReducerTransaction", func() Node {
+		resource, _ = UseResource("same", loader.load)
+		reducer := Reducer[int, int](func(state, action int) int {
+			return state + action
+		})
+		if useCandidate {
+			reducer = func(state, action int) int {
+				return state + action*100
+			}
+		}
+		_, dispatch := UseReducer(1, reducer)
+		if firstDispatch == nil {
+			firstDispatch = dispatch
+		}
+		if fail {
+			panic("resource reducer render failed")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	flushPendingEffects()
+	loader.resolves[0]("ready")
+	renderComponentInstance(instance)
+	control := resourceControlForTestAt[string](t, instance, 0)
+	reducerSlot := instance.stateSlots[1]
+	committedReducer := reflect.ValueOf(reducerSlot.reducer).Pointer()
+	committedLoader := reflect.ValueOf(control.loader).Pointer()
+	committedGeneration := control.generation
+	committedSnapshot := control.snapshot
+	committedRun := control.current
+
+	useCandidate = true
+	fail = true
+	renderComponentInstance(instance)
+	if control.key != "same" || control.generation != committedGeneration || control.snapshot != committedSnapshot || control.current != committedRun || reflect.ValueOf(control.loader).Pointer() != committedLoader {
+		t.Fatalf("failed reducer replacement disturbed resource: %#v", control)
+	}
+	if reflect.ValueOf(reducerSlot.reducer).Pointer() != committedReducer || reducerSlot.value != 1 {
+		t.Fatalf("failed reducer replacement changed slot reducer=%x value=%v, want %x/1",
+			reflect.ValueOf(reducerSlot.reducer).Pointer(), reducerSlot.value, committedReducer)
+	}
+	firstDispatch(1)
+	if reducerSlot.value != 2 {
+		t.Fatalf("old dispatch after failed mixed render = %v, want 2", reducerSlot.value)
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	firstDispatch(1)
+	if reducerSlot.value != 102 {
+		t.Fatalf("old dispatch after successful mixed render = %v, want 102", reducerSlot.value)
+	}
+	if !resource.Ready() || resource.Value != "ready" || len(loader.starts) != 1 || loader.cleanups != 0 {
+		t.Fatalf("resource after reducer commit = %#v starts=%#v cleanups=%d", resource, loader.starts, loader.cleanups)
+	}
+}
+
 func resourceControlForTest[T any](t *testing.T, instance *componentInstance) *resourceControl[T] {
 	t.Helper()
-	if len(instance.stateSlots) == 0 {
+	return resourceControlForTestAt[T](t, instance, 0)
+}
+
+func resourceControlForTestAt[T any](t *testing.T, instance *componentInstance, index int) *resourceControl[T] {
+	t.Helper()
+	if len(instance.stateSlots) <= index {
 		t.Fatal("component has no resource state slot")
 	}
-	control, ok := instance.stateSlots[0].value.(*resourceControl[T])
+	control, ok := instance.stateSlots[index].value.(*resourceControl[T])
 	if !ok || control == nil {
-		t.Fatalf("resource state slot = %#v, want *resourceControl", instance.stateSlots[0].value)
+		t.Fatalf("resource state slot = %#v, want *resourceControl", instance.stateSlots[index].value)
 	}
 	return control
 }

--- a/pkg/goframe/resource_test.go
+++ b/pkg/goframe/resource_test.go
@@ -1028,9 +1028,11 @@ func TestUseResourceInitialFailedRenderStartsNoLoader(t *testing.T) {
 	loader := &resourceTestLoader{}
 	fail := true
 	var resource Resource[string]
+	var failedControl *resourceControl[string]
 	instance := testComponentInstance("InitialResourceTransaction", func() Node {
 		resource, _ = UseResource("initial", loader.load)
 		if fail {
+			failedControl, _ = currentComponent.lifecycleAttempt.state.slots[0].value.(*resourceControl[string])
 			panic("failed render")
 		}
 		return Empty()
@@ -1038,17 +1040,26 @@ func TestUseResourceInitialFailedRenderStartsNoLoader(t *testing.T) {
 
 	renderComponentInstance(instance)
 	flushPendingEffects()
-	control := resourceControlForTest[string](t, instance)
-	if control.committed || control.owner != nil || control.loader != nil || control.key != "" || control.current != nil {
-		t.Fatalf("control after failed initial render = %#v, want no committed lifecycle state", control)
+	if len(instance.stateSlots) != 0 {
+		t.Fatalf("state slots after failed initial resource render = %d, want 0", len(instance.stateSlots))
 	}
-	if control.pending.attempt != nil || len(instance.effectSlots) != 0 || len(loader.starts) != 0 {
+	if failedControl == nil {
+		t.Fatal("failed initial resource render did not expose its speculative control")
+	}
+	if failedControl.committed || failedControl.owner != nil || failedControl.loader != nil || failedControl.key != "" || failedControl.current != nil {
+		t.Fatalf("control after failed initial render = %#v, want no committed lifecycle state", failedControl)
+	}
+	if failedControl.pending.attempt != nil || len(instance.effectSlots) != 0 || len(loader.starts) != 0 {
 		t.Fatalf("failed initial resource pending=%#v effect slots=%d starts=%d, want cleared/0/0",
-			control.pending, len(instance.effectSlots), len(loader.starts))
+			failedControl.pending, len(instance.effectSlots), len(loader.starts))
 	}
 
 	fail = false
 	renderComponentInstance(instance)
+	control := resourceControlForTest[string](t, instance)
+	if control == failedControl {
+		t.Fatal("successful retry reused the discarded resource control")
+	}
 	if !resource.Loading() || !control.committed || control.key != "initial" || control.owner != instance {
 		t.Fatalf("resource/control after successful retry = %#v/%#v, want committed loading initial", resource, control)
 	}

--- a/pkg/goframe/state.go
+++ b/pkg/goframe/state.go
@@ -151,9 +151,10 @@ func dispatchReducer[S any, A any](slot *stateSlot, action A) {
 	state := stateHandle[S]{slot: slot}
 	reducerValue := slot.reducer
 	if currentComponent == owner && currentComponent.lifecycleAttempt.active {
-		state := &currentComponent.lifecycleAttempt.state
-		if staged, stagedOK := state.reducerFor(slot); stagedOK {
-			reducerValue = staged
+		if pending := currentComponent.lifecycleAttempt.state; pending != nil {
+			if staged, stagedOK := pending.reducerFor(slot); stagedOK {
+				reducerValue = staged
+			}
 		}
 	}
 	reducer, ok := reducerValue.(Reducer[S, A])

--- a/pkg/goframe/state.go
+++ b/pkg/goframe/state.go
@@ -5,6 +5,7 @@ type stateSlot struct {
 	owner   *componentInstance
 	reducer any
 	kind    string
+	pending *stateRenderParticipant
 }
 
 type stateHandle[T any] struct {
@@ -70,12 +71,24 @@ func useStateSlot[T any](initial T, hookName string) stateHandle[T] {
 
 	index := instance.stateIndex
 	instance.stateIndex++
-	if index == len(instance.stateSlots) {
-		instance.stateSlots = append(instance.stateSlots, &stateSlot{
-			value: initial,
-			owner: instance,
-			kind:  hookName,
-		})
+	state := requireStateRenderParticipant(instance)
+	if index >= len(instance.stateSlots) {
+		pendingIndex := index - len(instance.stateSlots)
+		if pendingIndex == len(state.slots) {
+			state.addSlot(&stateSlot{
+				value: initial,
+				owner: instance,
+				kind:  hookName,
+			})
+		}
+		slot := state.slots[pendingIndex]
+		if slot.kind != hookName {
+			panic("goframe: hook at state slot " + ToString(index) + " changed from " + slot.kind + " to " + hookName)
+		}
+		if _, ok := slotValue[T](slot); !ok {
+			panic("goframe: " + hookName + " state type changed between component renders")
+		}
+		return stateHandle[T]{slot: slot}
 	}
 	slot := instance.stateSlots[index]
 	if slot.kind != hookName {
@@ -108,16 +121,25 @@ func (state stateHandle[T]) set(value T) {
 		return
 	}
 	state.slot.value = value
+	if pending := state.slot.pending; pending != nil {
+		pending.dirty = true
+		return
+	}
 	markComponentDirty(owner)
 }
 
 func setReducer[S any, A any](slot *stateSlot, reducer Reducer[S, A]) {
-	if slot.reducer != nil {
-		if _, ok := slot.reducer.(Reducer[S, A]); !ok {
+	state := requireStateRenderParticipant(currentComponent)
+	currentReducer := slot.reducer
+	if staged, ok := state.reducerFor(slot); ok {
+		currentReducer = staged
+	}
+	if currentReducer != nil {
+		if _, ok := currentReducer.(Reducer[S, A]); !ok {
 			panic("goframe: UseReducer reducer type changed between component renders")
 		}
 	}
-	slot.reducer = reducer
+	state.stageReducer(slot, reducer)
 }
 
 func dispatchReducer[S any, A any](slot *stateSlot, action A) {
@@ -127,7 +149,14 @@ func dispatchReducer[S any, A any](slot *stateSlot, action A) {
 		return
 	}
 	state := stateHandle[S]{slot: slot}
-	reducer, ok := slot.reducer.(Reducer[S, A])
+	reducerValue := slot.reducer
+	if currentComponent == owner && currentComponent.lifecycleAttempt.active {
+		state := &currentComponent.lifecycleAttempt.state
+		if staged, stagedOK := state.reducerFor(slot); stagedOK {
+			reducerValue = staged
+		}
+	}
+	reducer, ok := reducerValue.(Reducer[S, A])
 	if !ok {
 		panic("goframe: UseReducer reducer type changed between component renders")
 	}

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -9,6 +9,41 @@ type stateParticipantMemoProps struct {
 	ID int
 }
 
+type stateLifecycleOrderProbe struct {
+	instance        *componentInstance
+	slot            *stateSlot
+	control         *resourceControl[string]
+	commitSeen      bool
+	rollbackSeen    bool
+	stateReady      bool
+	stateCleared    bool
+	resourcePending bool
+}
+
+func (probe *stateLifecycleOrderProbe) finishRender(
+	attempt *renderLifecycleAttempt,
+	commit bool,
+) {
+	probe.resourcePending = probe.control != nil &&
+		probe.control.pending.attempt == attempt &&
+		!probe.control.committed
+	if commit {
+		probe.commitSeen = true
+		probe.stateReady = len(probe.instance.stateSlots) == 2 &&
+			probe.instance.stateSlots[0] == probe.slot &&
+			probe.slot.owner == probe.instance &&
+			probe.slot.pending == nil
+		return
+	}
+	probe.rollbackSeen = true
+	probe.stateCleared = probe.slot != nil &&
+		probe.slot.value == nil &&
+		probe.slot.owner == nil &&
+		probe.slot.reducer == nil &&
+		probe.slot.kind == "" &&
+		probe.slot.pending == nil
+}
+
 func (props stateParticipantMemoProps) MemoEqual(next stateParticipantMemoProps) bool {
 	return props.ID == next.ID
 }
@@ -188,23 +223,22 @@ func TestStateRenderParticipantStaysNilAfterFailedAndProtectedHookFreeRenders(t 
 
 func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 	tests := []struct {
-		name             string
-		render           func()
-		wantParticipants int
+		name                    string
+		render                  func()
+		wantGenericParticipants int
+		wantResourceParticipant bool
 	}{
 		{
 			name: "UseState",
 			render: func() {
 				_, _ = UseState(1)
 			},
-			wantParticipants: 1,
 		},
 		{
 			name: "UseReducer",
 			render: func() {
 				_, _ = UseReducer(1, func(value, action int) int { return value + action })
 			},
-			wantParticipants: 1,
 		},
 		{
 			name: "multiple state hooks",
@@ -212,7 +246,6 @@ func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 				_, _ = UseState(1)
 				_, _ = UseReducer(2, func(value, action int) int { return value + action })
 			},
-			wantParticipants: 1,
 		},
 		{
 			name: "UseResource",
@@ -221,7 +254,8 @@ func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 					return nil
 				})
 			},
-			wantParticipants: 2,
+			wantGenericParticipants: 1,
+			wantResourceParticipant: true,
 		},
 	}
 
@@ -230,13 +264,14 @@ func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 			isolateLifecycleTestState(t)
 			var participant *stateRenderParticipant
 			var registrations int
-			var stateRegisteredFirst bool
+			var resourceRegistered bool
 			instance := testComponentInstance("Stateful", func() Node {
 				test.render()
 				participant = currentComponent.lifecycleAttempt.state
 				registrations = len(currentComponent.lifecycleAttempt.participants)
-				stateRegisteredFirst = registrations > 0 &&
-					currentComponent.lifecycleAttempt.participants[0] == participant
+				if registrations == 1 {
+					_, resourceRegistered = currentComponent.lifecycleAttempt.participants[0].(*resourceControl[string])
+				}
 				return Empty()
 			}, nil)
 
@@ -245,11 +280,12 @@ func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 				t.Fatalf("state hook participant captured=%p retained=%p, want one retained participant",
 					participant, instance.lifecycleAttempt.state)
 			}
-			if registrations != test.wantParticipants {
-				t.Fatalf("render participants = %d, want %d", registrations, test.wantParticipants)
+			if registrations != test.wantGenericParticipants {
+				t.Fatalf("generic render participants = %d, want %d", registrations, test.wantGenericParticipants)
 			}
-			if !stateRegisteredFirst {
-				t.Fatal("state participant was not registered before dependent participants")
+			if resourceRegistered != test.wantResourceParticipant {
+				t.Fatalf("resource participant registered = %v, want %v",
+					resourceRegistered, test.wantResourceParticipant)
 			}
 			if len(instance.lifecycleAttempt.participants) != 0 {
 				t.Fatalf("finished attempt retained %d participant entries", len(instance.lifecycleAttempt.participants))
@@ -264,6 +300,101 @@ func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
 	}
 }
 
+func TestStateRenderParticipantDoesNotImplementLifecycleParticipant(t *testing.T) {
+	stateType := reflect.TypeOf((*stateRenderParticipant)(nil))
+	participantType := reflect.TypeOf((*lifecycleRenderParticipant)(nil)).Elem()
+	if stateType.Implements(participantType) {
+		t.Fatalf("%v implements %v; state must use its dedicated lifecycle path",
+			stateType, participantType)
+	}
+}
+
+func TestMultipleStateHooksShareOneStateRenderParticipant(t *testing.T) {
+	var first *stateRenderParticipant
+	var second *stateRenderParticipant
+	instance := testComponentInstance("SharedStateParticipant", func() Node {
+		_, _ = UseState(1)
+		first = currentComponent.lifecycleAttempt.state
+		_, _ = UseReducer(2, func(value, action int) int { return value + action })
+		second = currentComponent.lifecycleAttempt.state
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	if first == nil || second != first || instance.lifecycleAttempt.state != first {
+		t.Fatalf("state participants first=%p second=%p retained=%p, want one shared participant",
+			first, second, instance.lifecycleAttempt.state)
+	}
+	if len(instance.lifecycleAttempt.participants) != 0 {
+		t.Fatalf("multiple state hooks retained %d generic participants, want 0",
+			len(instance.lifecycleAttempt.participants))
+	}
+	assertStateRenderParticipantCleared(t, first)
+}
+
+func TestStateRenderParticipantFinishesBeforeGenericResourceParticipant(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		fail bool
+	}{
+		{name: "commit"},
+		{name: "rollback", fail: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			errorsSeen := captureRuntimeErrors(t)
+			probe := &stateLifecycleOrderProbe{}
+			var participantBacking []lifecycleRenderParticipant
+			instance := testComponentInstance("StateResourceOrder", func() Node {
+				_, _ = UseState(1)
+				state := currentComponent.lifecycleAttempt.state
+				probe.instance = currentComponent
+				probe.slot = state.slots[0]
+				currentComponent.lifecycleAttempt.participants = append(
+					currentComponent.lifecycleAttempt.participants,
+					probe,
+				)
+				_, _ = UseResource("resource", func(string, func(string), func(error)) Cleanup {
+					return nil
+				})
+				probe.control, _ = state.slots[1].value.(*resourceControl[string])
+				participantBacking = currentComponent.lifecycleAttempt.participants[:len(currentComponent.lifecycleAttempt.participants)]
+				if test.fail {
+					panic("state resource order rollback")
+				}
+				return Empty()
+			}, nil)
+
+			renderComponentInstance(instance)
+			assertLifecycleParticipantBackingCleared(t, participantBacking)
+			if !probe.resourcePending {
+				t.Fatal("resource participant finished before the state ordering probe")
+			}
+			if test.fail {
+				if !probe.rollbackSeen || !probe.stateCleared {
+					t.Fatalf("rollback probe seen=%v state cleared=%v, want true/true",
+						probe.rollbackSeen, probe.stateCleared)
+				}
+				if probe.control == nil || probe.control.pending.attempt != nil || probe.control.committed {
+					t.Fatalf("resource after rollback control=%p pending=%p committed=%v, want non-nil/nil/false",
+						probe.control, probe.control.pending.attempt, probe.control.committed)
+				}
+				requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "StateResourceOrder", "component render", "state resource order rollback")
+				return
+			}
+			if !probe.commitSeen || !probe.stateReady {
+				t.Fatalf("commit probe seen=%v state ready=%v, want true/true",
+					probe.commitSeen, probe.stateReady)
+			}
+			if probe.control == nil || probe.control.pending.attempt != nil || !probe.control.committed {
+				t.Fatalf("resource after commit control=%p pending=%p committed=%v, want non-nil/nil/true",
+					probe.control, probe.control.pending.attempt, probe.control.committed)
+			}
+			deactivateComponent(instance)
+		})
+	}
+}
+
 func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 	errorsSeen := captureRuntimeErrors(t)
 	initial := true
@@ -274,8 +405,6 @@ func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 	var reducerBacking []stateReducerRenderUpdate
 	var failedSlotBacking []*stateSlot
 	var failedReducerBacking []stateReducerRenderUpdate
-	var firstParticipantBacking []lifecycleRenderParticipant
-	var failedParticipantBacking []lifecycleRenderParticipant
 	var discarded *stateSlot
 	instance := testComponentInstance("ReusableStateParticipant", func() Node {
 		_, _ = UseState(1)
@@ -290,7 +419,6 @@ func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 		}
 		if initial {
 			firstSlotBacking = state.slots[:len(state.slots)]
-			firstParticipantBacking = currentComponent.lifecycleAttempt.participants[:len(currentComponent.lifecycleAttempt.participants)]
 		}
 		if !initial && !includeTrailing {
 			reducerBacking = state.reducers[:len(state.reducers)]
@@ -300,7 +428,6 @@ func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 			discarded = state.slots[len(state.slots)-1]
 			failedSlotBacking = state.slots[:len(state.slots)]
 			failedReducerBacking = state.reducers[:len(state.reducers)]
-			failedParticipantBacking = currentComponent.lifecycleAttempt.participants[:len(currentComponent.lifecycleAttempt.participants)]
 			if fail {
 				setTrailing(4)
 				panic("state participant rollback")
@@ -315,7 +442,6 @@ func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 	}
 	assertStateRenderParticipantCleared(t, participant)
 	assertStateSlotBackingCleared(t, firstSlotBacking)
-	assertLifecycleParticipantBackingCleared(t, firstParticipantBacking)
 
 	initial = false
 	renderComponentInstance(instance)
@@ -334,7 +460,6 @@ func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
 	assertStateRenderParticipantCleared(t, participant)
 	assertStateSlotBackingCleared(t, failedSlotBacking)
 	assertStateReducerBackingCleared(t, failedReducerBacking)
-	assertLifecycleParticipantBackingCleared(t, failedParticipantBacking)
 	if discarded == nil || discarded.owner != nil || discarded.pending != nil || discarded.value != nil || discarded.reducer != nil || discarded.kind != "" {
 		t.Fatalf("discarded slot retained state: %#v", discarded)
 	}

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -5,6 +5,14 @@ import (
 	"testing"
 )
 
+type stateParticipantMemoProps struct {
+	ID int
+}
+
+func (props stateParticipantMemoProps) MemoEqual(next stateParticipantMemoProps) bool {
+	return props.ID == next.ID
+}
+
 func TestUseStatePersistsWithinComponent(t *testing.T) {
 	var value int
 	var setValue func(int)
@@ -63,6 +71,369 @@ func TestUseStateSupportsMultipleSlots(t *testing.T) {
 
 	if count != 2 || label != "second" {
 		t.Fatalf("slots = %d, %q; want 2, second", count, label)
+	}
+}
+
+func TestStateRenderParticipantStaysNilForHookFreeComponents(t *testing.T) {
+	tests := []struct {
+		name string
+		new  func() *componentInstance
+	}{
+		{
+			name: "plain rendering",
+			new: func() *componentInstance {
+				return testComponentInstance("PlainHookFree", func() Node {
+					return Empty()
+				}, nil)
+			},
+		},
+		{
+			name: "effect only",
+			new: func() *componentInstance {
+				return testComponentInstance("EffectHookFree", func() Node {
+					UseEffect(func() Cleanup { return nil })
+					return Empty()
+				}, nil)
+			},
+		},
+		{
+			name: "unmount only",
+			new: func() *componentInstance {
+				return testComponentInstance("UnmountHookFree", func() Node {
+					UseUnmount(func() {})
+					return Empty()
+				}, nil)
+			},
+		},
+		{
+			name: "context only",
+			new: func() *componentInstance {
+				ctx := CreateContext(1)
+				return testComponentInstance("ContextHookFree", func() Node {
+					_ = UseContext(ctx)
+					return Empty()
+				}, nil)
+			},
+		},
+		{
+			name: "memo only",
+			new: func() *componentInstance {
+				node := Component(
+					"MemoHookFree",
+					stateParticipantMemoProps{ID: 1},
+					func(stateParticipantMemoProps) Node { return Empty() },
+				).(ComponentNode)
+				return newComponentInstance(node, "memo", nil, nil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			instance := test.new()
+			for render := 0; render < 2; render++ {
+				renderComponentInstance(instance)
+				if instance.lifecycleAttempt.state != nil {
+					t.Fatalf("hook-free render %d allocated state participant %p", render+1, instance.lifecycleAttempt.state)
+				}
+				flushPendingEffects()
+			}
+			deactivateComponent(instance)
+			if instance.lifecycleAttempt.state != nil {
+				t.Fatalf("hook-free deactivation retained state participant %p", instance.lifecycleAttempt.state)
+			}
+		})
+	}
+}
+
+func TestStateRenderParticipantStaysNilAfterFailedAndProtectedHookFreeRenders(t *testing.T) {
+	t.Run("failed render", func(t *testing.T) {
+		errorsSeen := captureRuntimeErrors(t)
+		instance := testComponentInstance("FailedHookFree", func() Node {
+			panic("hook-free render failed")
+		}, nil)
+
+		renderComponentInstance(instance)
+		if instance.lifecycleAttempt.state != nil {
+			t.Fatalf("failed hook-free render allocated state participant %p", instance.lifecycleAttempt.state)
+		}
+		requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "FailedHookFree", "component render", "hook-free render failed")
+	})
+
+	t.Run("protected render", func(t *testing.T) {
+		isolateLifecycleTestState(t)
+		boundary := transactionTestBoundary()
+		instance := testComponentInstance("ProtectedHookFree", func() Node {
+			return Empty()
+		}, nil)
+
+		runProtectedSubtreeTestAttempt(boundary, func() {
+			renderComponentInstance(instance)
+			if !instance.lifecycleAttempt.active {
+				t.Fatal("protected hook-free attempt committed before boundary result")
+			}
+			if instance.lifecycleAttempt.state != nil {
+				t.Fatalf("protected hook-free render allocated state participant %p", instance.lifecycleAttempt.state)
+			}
+		})
+		if instance.lifecycleAttempt.active || instance.lifecycleAttempt.state != nil {
+			t.Fatalf("protected hook-free commit active=%v state=%p, want false/nil",
+				instance.lifecycleAttempt.active, instance.lifecycleAttempt.state)
+		}
+		deactivateComponent(instance)
+		deactivateComponent(boundary)
+	})
+}
+
+func TestStateRenderParticipantAllocatesLazilyForStateHooks(t *testing.T) {
+	tests := []struct {
+		name             string
+		render           func()
+		wantParticipants int
+	}{
+		{
+			name: "UseState",
+			render: func() {
+				_, _ = UseState(1)
+			},
+			wantParticipants: 1,
+		},
+		{
+			name: "UseReducer",
+			render: func() {
+				_, _ = UseReducer(1, func(value, action int) int { return value + action })
+			},
+			wantParticipants: 1,
+		},
+		{
+			name: "multiple state hooks",
+			render: func() {
+				_, _ = UseState(1)
+				_, _ = UseReducer(2, func(value, action int) int { return value + action })
+			},
+			wantParticipants: 1,
+		},
+		{
+			name: "UseResource",
+			render: func() {
+				_, _ = UseResource("resource", func(string, func(string), func(error)) Cleanup {
+					return nil
+				})
+			},
+			wantParticipants: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolateLifecycleTestState(t)
+			var participant *stateRenderParticipant
+			var registrations int
+			var stateRegisteredFirst bool
+			instance := testComponentInstance("Stateful", func() Node {
+				test.render()
+				participant = currentComponent.lifecycleAttempt.state
+				registrations = len(currentComponent.lifecycleAttempt.participants)
+				stateRegisteredFirst = registrations > 0 &&
+					currentComponent.lifecycleAttempt.participants[0] == participant
+				return Empty()
+			}, nil)
+
+			renderComponentInstance(instance)
+			if participant == nil || instance.lifecycleAttempt.state != participant {
+				t.Fatalf("state hook participant captured=%p retained=%p, want one retained participant",
+					participant, instance.lifecycleAttempt.state)
+			}
+			if registrations != test.wantParticipants {
+				t.Fatalf("render participants = %d, want %d", registrations, test.wantParticipants)
+			}
+			if !stateRegisteredFirst {
+				t.Fatal("state participant was not registered before dependent participants")
+			}
+			if len(instance.lifecycleAttempt.participants) != 0 {
+				t.Fatalf("finished attempt retained %d participant entries", len(instance.lifecycleAttempt.participants))
+			}
+			assertStateRenderParticipantCleared(t, participant)
+			flushPendingEffects()
+			deactivateComponent(instance)
+			if instance.lifecycleAttempt.state != nil {
+				t.Fatalf("deactivation retained state participant %p", instance.lifecycleAttempt.state)
+			}
+		})
+	}
+}
+
+func TestStateRenderParticipantReusesStorageAndClearsReferences(t *testing.T) {
+	errorsSeen := captureRuntimeErrors(t)
+	initial := true
+	fail := false
+	includeTrailing := false
+	var participant *stateRenderParticipant
+	var firstSlotBacking []*stateSlot
+	var reducerBacking []stateReducerRenderUpdate
+	var failedSlotBacking []*stateSlot
+	var failedReducerBacking []stateReducerRenderUpdate
+	var firstParticipantBacking []lifecycleRenderParticipant
+	var failedParticipantBacking []lifecycleRenderParticipant
+	var discarded *stateSlot
+	instance := testComponentInstance("ReusableStateParticipant", func() Node {
+		_, _ = UseState(1)
+		_, _ = UseReducer(2, func(value, action int) int {
+			return value + action
+		})
+		state := currentComponent.lifecycleAttempt.state
+		if participant == nil {
+			participant = state
+		} else if state != participant {
+			panic("state participant was not reused")
+		}
+		if initial {
+			firstSlotBacking = state.slots[:len(state.slots)]
+			firstParticipantBacking = currentComponent.lifecycleAttempt.participants[:len(currentComponent.lifecycleAttempt.participants)]
+		}
+		if !initial && !includeTrailing {
+			reducerBacking = state.reducers[:len(state.reducers)]
+		}
+		if includeTrailing {
+			_, setTrailing := UseState(3)
+			discarded = state.slots[len(state.slots)-1]
+			failedSlotBacking = state.slots[:len(state.slots)]
+			failedReducerBacking = state.reducers[:len(state.reducers)]
+			failedParticipantBacking = currentComponent.lifecycleAttempt.participants[:len(currentComponent.lifecycleAttempt.participants)]
+			if fail {
+				setTrailing(4)
+				panic("state participant rollback")
+			}
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	if instance.lifecycleAttempt.state != participant {
+		t.Fatalf("first commit retained participant %p, want %p", instance.lifecycleAttempt.state, participant)
+	}
+	assertStateRenderParticipantCleared(t, participant)
+	assertStateSlotBackingCleared(t, firstSlotBacking)
+	assertLifecycleParticipantBackingCleared(t, firstParticipantBacking)
+
+	initial = false
+	renderComponentInstance(instance)
+	if instance.lifecycleAttempt.state != participant {
+		t.Fatalf("reducer-only update retained participant %p, want %p", instance.lifecycleAttempt.state, participant)
+	}
+	assertStateRenderParticipantCleared(t, participant)
+	assertStateReducerBackingCleared(t, reducerBacking)
+
+	includeTrailing = true
+	fail = true
+	renderComponentInstance(instance)
+	if instance.lifecycleAttempt.state != participant {
+		t.Fatalf("rollback retained participant %p, want %p", instance.lifecycleAttempt.state, participant)
+	}
+	assertStateRenderParticipantCleared(t, participant)
+	assertStateSlotBackingCleared(t, failedSlotBacking)
+	assertStateReducerBackingCleared(t, failedReducerBacking)
+	assertLifecycleParticipantBackingCleared(t, failedParticipantBacking)
+	if discarded == nil || discarded.owner != nil || discarded.pending != nil || discarded.value != nil || discarded.reducer != nil || discarded.kind != "" {
+		t.Fatalf("discarded slot retained state: %#v", discarded)
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	if instance.lifecycleAttempt.state != participant || len(instance.stateSlots) != 3 {
+		t.Fatalf("retry participant=%p slots=%d, want %p/3",
+			instance.lifecycleAttempt.state, len(instance.stateSlots), participant)
+	}
+	assertStateRenderParticipantCleared(t, participant)
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "ReusableStateParticipant", "component render", "state participant rollback")
+}
+
+func TestStateRenderParticipantReusesReducerOnlyRenders(t *testing.T) {
+	var first *stateRenderParticipant
+	instance := testComponentInstance("ReducerOnlyParticipant", func() Node {
+		_, _ = UseReducer(0, func(value, action int) int { return value + action })
+		state := currentComponent.lifecycleAttempt.state
+		if first == nil {
+			first = state
+		} else if state != first {
+			panic("reducer-only participant was not reused")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	renderComponentInstance(instance)
+	if instance.lifecycleAttempt.state != first {
+		t.Fatalf("reducer-only participant = %p, want reused %p", instance.lifecycleAttempt.state, first)
+	}
+	assertStateRenderParticipantCleared(t, first)
+}
+
+func TestStateRenderParticipantReleaseDropsPointer(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		release func(*componentInstance)
+	}{
+		{name: "release", release: releaseLifecycleRenderAttempt},
+		{name: "deactivate", release: deactivateComponent},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			instance := testComponentInstance("ReleasedParticipant", func() Node {
+				_, _ = UseState(1)
+				return Empty()
+			}, nil)
+			renderComponentInstance(instance)
+			participant := instance.lifecycleAttempt.state
+			if participant == nil {
+				t.Fatal("stateful render did not allocate a participant")
+			}
+
+			test.release(instance)
+			if instance.lifecycleAttempt.state != nil {
+				t.Fatalf("lifecycle release retained state participant %p", instance.lifecycleAttempt.state)
+			}
+			assertStateRenderParticipantCleared(t, participant)
+		})
+	}
+}
+
+func assertStateRenderParticipantCleared(t *testing.T, state *stateRenderParticipant) {
+	t.Helper()
+	if state == nil {
+		t.Fatal("state participant is nil")
+	}
+	if state.attempt != nil || state.instance != nil || len(state.slots) != 0 || len(state.reducers) != 0 || state.dirty {
+		t.Fatalf("state participant retained attempt=%p instance=%p slots=%d reducers=%d dirty=%v",
+			state.attempt, state.instance, len(state.slots), len(state.reducers), state.dirty)
+	}
+}
+
+func assertStateSlotBackingCleared(t *testing.T, slots []*stateSlot) {
+	t.Helper()
+	for index, slot := range slots {
+		if slot != nil {
+			t.Fatalf("state participant slot backing %d retained %p", index, slot)
+		}
+	}
+}
+
+func assertStateReducerBackingCleared(t *testing.T, reducers []stateReducerRenderUpdate) {
+	t.Helper()
+	for index, update := range reducers {
+		if update.slot != nil || update.reducer != nil {
+			t.Fatalf("state participant reducer backing %d retained slot=%p reducer=%T",
+				index, update.slot, update.reducer)
+		}
+	}
+}
+
+func assertLifecycleParticipantBackingCleared(t *testing.T, participants []lifecycleRenderParticipant) {
+	t.Helper()
+	for index, participant := range participants {
+		if participant != nil {
+			t.Fatalf("lifecycle participant backing %d retained %T", index, participant)
+		}
 	}
 }
 
@@ -280,7 +651,7 @@ func TestPendingStateClosuresAreInvalidatedByLifecycleRelease(t *testing.T) {
 					t.Fatalf("released speculative slot %d retained state: %#v", index, slot)
 				}
 			}
-			if instance.lifecycleAttempt.active || len(instance.lifecycleAttempt.participants) != 0 || instance.lifecycleAttempt.state.attempt != nil {
+			if instance.lifecycleAttempt.active || len(instance.lifecycleAttempt.participants) != 0 || instance.lifecycleAttempt.state != nil {
 				t.Fatalf("released lifecycle attempt retained state: %#v", instance.lifecycleAttempt)
 			}
 			state.set(2)

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -1,6 +1,9 @@
 package goframe
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestUseStatePersistsWithinComponent(t *testing.T) {
 	var value int
@@ -61,6 +64,44 @@ func TestUseStateSupportsMultipleSlots(t *testing.T) {
 	if count != 2 || label != "second" {
 		t.Fatalf("slots = %d, %q; want 2, second", count, label)
 	}
+}
+
+func TestFailedInitialStateRenderLeavesNoGhostSlot(t *testing.T) {
+	errorsSeen := captureRuntimeErrors(t)
+	initial := 1
+	fail := true
+	observed := 0
+	schedules := 0
+	var failedSetter func(int)
+	instance := testComponentInstance("TransactionalState", func() Node {
+		observed, failedSetter = UseState(initial)
+		if fail {
+			panic("state render failed")
+		}
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 0 {
+		t.Errorf("state slots after failed initial render = %d, want 0", len(instance.stateSlots))
+	}
+	failedSetter(7)
+	if instance.dirty || schedules != 0 {
+		t.Errorf("discarded setter dirty=%v schedules=%d, want false/0", instance.dirty, schedules)
+	}
+
+	initial = 99
+	fail = false
+	renderComponentInstance(instance)
+	if observed != 99 {
+		t.Errorf("retry observed state = %d, want 99", observed)
+	}
+	if len(instance.stateSlots) != 1 || instance.stateSlots[0].value != 99 {
+		t.Errorf("committed retry state slots = %#v, want one slot with 99", instance.stateSlots)
+	}
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "TransactionalState", "component render", "state render failed")
 }
 
 func TestUseStateOutsideComponentPanics(t *testing.T) {
@@ -272,6 +313,57 @@ func TestUseReducerStaleDispatchUsesLatestReducer(t *testing.T) {
 	if value != 11 {
 		t.Fatalf("stale dispatch used wrong reducer, state = %d, want 11", value)
 	}
+}
+
+func TestFailedReducerRenderKeepsCommittedReducer(t *testing.T) {
+	errorsSeen := captureRuntimeErrors(t)
+	useCandidate := false
+	fail := false
+	var firstDispatch func(int)
+	instance := testComponentInstance("TransactionalReducer", func() Node {
+		reducer := Reducer[int, int](func(state, action int) int {
+			return state + action
+		})
+		if useCandidate {
+			reducer = func(state, action int) int {
+				return state + action*100
+			}
+		}
+		_, dispatch := UseReducer(1, reducer)
+		if firstDispatch == nil {
+			firstDispatch = dispatch
+		}
+		if fail {
+			panic("reducer render failed")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	slot := instance.stateSlots[0]
+	committedReducer := reflect.ValueOf(slot.reducer).Pointer()
+
+	useCandidate = true
+	fail = true
+	renderComponentInstance(instance)
+	if instance.stateSlots[0] != slot {
+		t.Fatal("failed reducer render replaced committed slot pointer")
+	}
+	if got := reflect.ValueOf(slot.reducer).Pointer(); got != committedReducer {
+		t.Errorf("failed reducer render changed reducer pointer = %x, want %x", got, committedReducer)
+	}
+	firstDispatch(1)
+	if slot.value != 2 {
+		t.Errorf("old dispatch after failed render produced %v, want 2", slot.value)
+	}
+
+	fail = false
+	renderComponentInstance(instance)
+	firstDispatch(1)
+	if slot.value != 102 {
+		t.Errorf("old dispatch after successful render produced %v, want 102", slot.value)
+	}
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "TransactionalReducer", "component render", "reducer render failed")
 }
 
 func TestUseReducerStateTypeMismatchPanics(t *testing.T) {

--- a/pkg/goframe/state_test.go
+++ b/pkg/goframe/state_test.go
@@ -104,6 +104,195 @@ func TestFailedInitialStateRenderLeavesNoGhostSlot(t *testing.T) {
 	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "TransactionalState", "component render", "state render failed")
 }
 
+func TestStateRenderTransactionDiscardsMultipleSlotsAndCommitsRetryInOrder(t *testing.T) {
+	errorsSeen := captureRuntimeErrors(t)
+	countInitial := 1
+	reducerInitial := 2
+	labelInitial := "failed"
+	fail := true
+	schedules := 0
+	reducerCalls := 0
+	var failedSetter func(int)
+	var failedDispatch func(int)
+	var failedSlots []*stateSlot
+	instance := testComponentInstance("TransactionalSlots", func() Node {
+		_, failedSetter = UseState(countInitial)
+		_, failedDispatch = UseReducer(reducerInitial, func(state, action int) int {
+			reducerCalls++
+			return state + action
+		})
+		_, _ = UseState(labelInitial)
+		if fail {
+			failedSlots = append(failedSlots[:0], currentComponent.lifecycleAttempt.state.slots...)
+			panic("multiple state slots failed")
+		}
+		return Empty()
+	}, func(*componentInstance) {
+		schedules++
+	})
+
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 0 {
+		t.Fatalf("committed slots after failed multi-slot render = %d, want 0", len(instance.stateSlots))
+	}
+	if len(failedSlots) != 3 {
+		t.Fatalf("speculative slots = %d, want 3", len(failedSlots))
+	}
+	for index, slot := range failedSlots {
+		if slot.owner != nil || slot.pending != nil || slot.value != nil || slot.reducer != nil || slot.kind != "" {
+			t.Errorf("discarded slot %d retained state: %#v", index, slot)
+		}
+	}
+	failedSetter(9)
+	failedDispatch(9)
+	if instance.dirty || schedules != 0 || reducerCalls != 0 {
+		t.Fatalf("discarded closures dirty=%v schedules=%d reducer calls=%d, want false/0/0",
+			instance.dirty, schedules, reducerCalls)
+	}
+
+	countInitial = 10
+	reducerInitial = 20
+	labelInitial = "retry"
+	fail = false
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 3 {
+		t.Fatalf("committed retry slots = %d, want 3", len(instance.stateSlots))
+	}
+	wantKinds := []string{"UseState", "UseReducer", "UseState"}
+	wantValues := []any{10, 20, "retry"}
+	for index, slot := range instance.stateSlots {
+		if slot.kind != wantKinds[index] || slot.value != wantValues[index] || slot.owner != instance || slot.pending != nil {
+			t.Errorf("committed retry slot %d = %#v, want kind %s value %v owner %p", index, slot, wantKinds[index], wantValues[index], instance)
+		}
+	}
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "TransactionalSlots", "component render", "multiple state slots failed")
+}
+
+func TestStateRenderTransactionPreservesCommittedPrefixAfterTrailingFailure(t *testing.T) {
+	errorsSeen := captureRuntimeErrors(t)
+	includeTrailing := false
+	fail := false
+	trailingInitial := 2
+	instance := testComponentInstance("TransactionalPrefix", func() Node {
+		_, _ = UseState(1)
+		if includeTrailing {
+			_, _ = UseState(trailingInitial)
+		}
+		if fail {
+			panic("trailing slot failed")
+		}
+		return Empty()
+	}, nil)
+
+	renderComponentInstance(instance)
+	prefix := instance.stateSlots[0]
+	includeTrailing = true
+	fail = true
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 1 || instance.stateSlots[0] != prefix || prefix.value != 1 {
+		t.Fatalf("committed prefix after trailing failure = %#v, want unchanged slot %p value 1", instance.stateSlots, prefix)
+	}
+
+	trailingInitial = 3
+	fail = false
+	renderComponentInstance(instance)
+	if len(instance.stateSlots) != 2 || instance.stateSlots[0] != prefix || instance.stateSlots[1].value != 3 {
+		t.Fatalf("slots after trailing retry = %#v, want stable prefix and value 3", instance.stateSlots)
+	}
+	requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "TransactionalPrefix", "component render", "trailing slot failed")
+}
+
+func TestFailedInitialRenderTimeStateUpdatesLeaveNoSchedule(t *testing.T) {
+	tests := []struct {
+		name   string
+		render func()
+	}{
+		{
+			name: "state setter",
+			render: func() {
+				_, setValue := UseState(0)
+				setValue(1)
+			},
+		},
+		{
+			name: "reducer dispatch",
+			render: func() {
+				_, dispatch := UseReducer(0, func(state, action int) int {
+					return state + action
+				})
+				dispatch(1)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errorsSeen := captureRuntimeErrors(t)
+			schedules := 0
+			instance := testComponentInstance("FailedRenderUpdate", func() Node {
+				test.render()
+				panic("render-time update failed")
+			}, func(*componentInstance) {
+				schedules++
+			})
+
+			renderComponentInstance(instance)
+			if len(instance.stateSlots) != 0 || instance.dirty || schedules != 0 {
+				t.Fatalf("failed render-time update slots=%d dirty=%v schedules=%d, want 0/false/0",
+					len(instance.stateSlots), instance.dirty, schedules)
+			}
+			requireRuntimeError(t, errorsSeen(), ErrorPhaseRender, "FailedRenderUpdate", "component render", "render-time update failed")
+		})
+	}
+}
+
+func TestPendingStateClosuresAreInvalidatedByLifecycleRelease(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		release func(*componentInstance)
+	}{
+		{name: "release", release: releaseLifecycleRenderAttempt},
+		{name: "deactivate", release: deactivateComponent},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			schedules := 0
+			instance := testComponentInstance("PendingState", func() Node { return Empty() }, func(*componentInstance) {
+				schedules++
+			})
+			clearComponentDirty(instance)
+			beginLifecycleRenderAttempt(instance)
+			previous := currentComponent
+			currentComponent = instance
+			instance.stateIndex = 0
+			state := useStateSlot(1, "UseState")
+			reducer := useStateSlot(2, "UseReducer")
+			reducerCalls := 0
+			setReducer(reducer.slot, Reducer[int, int](func(value, action int) int {
+				reducerCalls++
+				return value + action
+			}))
+			currentComponent = previous
+			slots := []*stateSlot{state.slot, reducer.slot}
+
+			test.release(instance)
+			for index, slot := range slots {
+				if slot.owner != nil || slot.pending != nil || slot.value != nil || slot.reducer != nil || slot.kind != "" {
+					t.Fatalf("released speculative slot %d retained state: %#v", index, slot)
+				}
+			}
+			if instance.lifecycleAttempt.active || len(instance.lifecycleAttempt.participants) != 0 || instance.lifecycleAttempt.state.attempt != nil {
+				t.Fatalf("released lifecycle attempt retained state: %#v", instance.lifecycleAttempt)
+			}
+			state.set(2)
+			dispatchReducer[int, int](reducer.slot, 1)
+			if instance.dirty || schedules != 0 || reducerCalls != 0 {
+				t.Fatalf("released closures dirty=%v schedules=%d reducer calls=%d, want false/0/0",
+					instance.dirty, schedules, reducerCalls)
+			}
+		})
+	}
+}
+
 func TestUseStateOutsideComponentPanics(t *testing.T) {
 	currentComponent = nil
 	defer func() {
@@ -196,8 +385,9 @@ func TestStateSetDuringRenderRemainsDirty(t *testing.T) {
 
 	renderComponentInstance(instance)
 
-	if !instance.dirty || schedules != 1 {
-		t.Fatalf("dirty=%v schedules=%d, want dirty scheduled component", instance.dirty, schedules)
+	if !instance.dirty || schedules != 1 || instance.stateSlots[0].value != 1 {
+		t.Fatalf("dirty=%v schedules=%d value=%v, want dirty scheduled component with 1",
+			instance.dirty, schedules, instance.stateSlots[0].value)
 	}
 }
 
@@ -382,11 +572,16 @@ func TestUseReducerStateTypeMismatchPanics(t *testing.T) {
 	}, nil)
 
 	renderComponentInstance(instance)
+	slot := instance.stateSlots[0]
+	reducer := reflect.ValueOf(slot.reducer).Pointer()
 	useString = true
 
 	assertPanic(t, "goframe: UseReducer state type changed between component renders", func() {
 		renderComponentInstance(instance)
 	})
+	if len(instance.stateSlots) != 1 || instance.stateSlots[0] != slot || reflect.ValueOf(slot.reducer).Pointer() != reducer {
+		t.Fatal("state type mismatch changed committed reducer slot")
+	}
 }
 
 func TestStateHookKindMismatchPanics(t *testing.T) {
@@ -403,11 +598,15 @@ func TestStateHookKindMismatchPanics(t *testing.T) {
 	}, nil)
 
 	renderComponentInstance(instance)
+	slot := instance.stateSlots[0]
 	useReducer = true
 
 	assertPanic(t, "goframe: hook at state slot 0 changed from UseState to UseReducer", func() {
 		renderComponentInstance(instance)
 	})
+	if len(instance.stateSlots) != 1 || instance.stateSlots[0] != slot || slot.kind != "UseState" {
+		t.Fatal("state hook-kind mismatch changed committed slot")
+	}
 }
 
 func TestReducerHookKindMismatchPanics(t *testing.T) {
@@ -450,11 +649,16 @@ func TestUseReducerReducerTypeMismatchPanics(t *testing.T) {
 	}, nil)
 
 	renderComponentInstance(instance)
+	slot := instance.stateSlots[0]
+	reducer := reflect.ValueOf(slot.reducer).Pointer()
 	useStringAction = true
 
 	assertPanic(t, "goframe: UseReducer reducer type changed between component renders", func() {
 		renderComponentInstance(instance)
 	})
+	if len(instance.stateSlots) != 1 || instance.stateSlots[0] != slot || reflect.ValueOf(slot.reducer).Pointer() != reducer {
+		t.Fatal("reducer type mismatch changed committed reducer slot")
+	}
 }
 
 func TestUseReducerOutsideComponentPanics(t *testing.T) {
@@ -516,8 +720,9 @@ func TestUseReducerDispatchDuringRenderRemainsDirty(t *testing.T) {
 
 	renderComponentInstance(instance)
 
-	if !instance.dirty || schedules != 1 {
-		t.Fatalf("dirty=%v schedules=%d, want dirty scheduled component", instance.dirty, schedules)
+	if !instance.dirty || schedules != 1 || instance.stateSlots[0].value != 1 {
+		t.Fatalf("dirty=%v schedules=%d value=%v, want dirty scheduled component with 1",
+			instance.dirty, schedules, instance.stateSlots[0].value)
 	}
 }
 

--- a/pkg/goframe/state_transaction.go
+++ b/pkg/goframe/state_transaction.go
@@ -23,7 +23,6 @@ func requireStateRenderParticipant(instance *componentInstance) *stateRenderPart
 	if state.attempt == nil {
 		state.attempt = attempt
 		state.instance = instance
-		attempt.participants = append(attempt.participants, state)
 	}
 	return state
 }
@@ -59,7 +58,7 @@ func (state *stateRenderParticipant) reducerFor(slot *stateSlot) (any, bool) {
 	return nil, false
 }
 
-func (state *stateRenderParticipant) finishRender(attempt *renderLifecycleAttempt, commit bool) {
+func (state *stateRenderParticipant) finishStateRender(attempt *renderLifecycleAttempt, commit bool) {
 	if state.attempt != attempt {
 		return
 	}

--- a/pkg/goframe/state_transaction.go
+++ b/pkg/goframe/state_transaction.go
@@ -1,0 +1,93 @@
+package goframe
+
+type stateReducerRenderUpdate struct {
+	slot    *stateSlot
+	reducer any
+}
+
+type stateRenderParticipant struct {
+	attempt  *renderLifecycleAttempt
+	instance *componentInstance
+	slots    []*stateSlot
+	reducers []stateReducerRenderUpdate
+	dirty    bool
+}
+
+func requireStateRenderParticipant(instance *componentInstance) *stateRenderParticipant {
+	attempt := requireLifecycleRenderAttempt(instance)
+	state := &attempt.state
+	if state.attempt == nil {
+		state.attempt = attempt
+		state.instance = instance
+		attempt.participants = append(attempt.participants, state)
+	}
+	return state
+}
+
+func (state *stateRenderParticipant) addSlot(slot *stateSlot) {
+	slot.pending = state
+	state.slots = append(state.slots, slot)
+}
+
+func (state *stateRenderParticipant) stageReducer(slot *stateSlot, reducer any) {
+	if slot.pending == state {
+		slot.reducer = reducer
+		return
+	}
+	for index := range state.reducers {
+		if state.reducers[index].slot == slot {
+			state.reducers[index].reducer = reducer
+			return
+		}
+	}
+	state.reducers = append(state.reducers, stateReducerRenderUpdate{
+		slot:    slot,
+		reducer: reducer,
+	})
+}
+
+func (state *stateRenderParticipant) reducerFor(slot *stateSlot) (any, bool) {
+	for index := range state.reducers {
+		if state.reducers[index].slot == slot {
+			return state.reducers[index].reducer, true
+		}
+	}
+	return nil, false
+}
+
+func (state *stateRenderParticipant) finishRender(attempt *renderLifecycleAttempt, commit bool) {
+	if state.attempt != attempt {
+		return
+	}
+	instance := state.instance
+	dirty := state.dirty
+	if commit {
+		for _, slot := range state.slots {
+			slot.pending = nil
+			instance.stateSlots = append(instance.stateSlots, slot)
+		}
+		for _, update := range state.reducers {
+			update.slot.reducer = update.reducer
+		}
+	} else {
+		for _, slot := range state.slots {
+			slot.value = nil
+			slot.owner = nil
+			slot.reducer = nil
+			slot.kind = ""
+			slot.pending = nil
+		}
+	}
+
+	clear(state.slots)
+	clear(state.reducers)
+	state.attempt = nil
+	state.instance = nil
+	state.slots = state.slots[:0]
+	state.reducers = state.reducers[:0]
+	state.dirty = false
+
+	if commit && dirty {
+		markComponentDirty(instance)
+	}
+}

--- a/pkg/goframe/state_transaction.go
+++ b/pkg/goframe/state_transaction.go
@@ -15,7 +15,11 @@ type stateRenderParticipant struct {
 
 func requireStateRenderParticipant(instance *componentInstance) *stateRenderParticipant {
 	attempt := requireLifecycleRenderAttempt(instance)
-	state := &attempt.state
+	state := attempt.state
+	if state == nil {
+		state = &stateRenderParticipant{}
+		attempt.state = state
+	}
 	if state.attempt == nil {
 		state.attempt = attempt
 		state.instance = instance

--- a/scripts/browser-smoke.sh
+++ b/scripts/browser-smoke.sh
@@ -232,6 +232,12 @@ run_repeated_mount_browser() {
 	CHROME="$CHROME_BIN" node --experimental-websocket scripts/repeated-mount-browser-smoke.mjs "$url" "$compiler"
 }
 
+run_error_boundary_success_browser() {
+	local url="$1"
+	GOFRAME_ERROR_BOUNDARY_SUCCESS_ONLY=1 \
+		node --experimental-websocket scripts/error-boundary-browser-smoke.mjs "$url"
+}
+
 if [[ -z "$GOXC" ]]; then
 	GOBIN="$BIN_DIR" go install ./cmd/goxc
 	GOXC="$BIN_DIR/goxc"
@@ -291,6 +297,16 @@ export GOFRAME_ERROR_BOUNDARY_CHROME_DEBUG_PORT="${GOFRAME_ERROR_BOUNDARY_CHROME
 ERROR_BOUNDARY_URL="$(build_error_boundary_smoke_url "$ERROR_BOUNDARY_PORT")"
 run_with_server ./scripts/fixtures/error-boundary "$ERROR_BOUNDARY_PORT" "$ERROR_BOUNDARY_URL" \
 	node --experimental-websocket scripts/error-boundary-browser-smoke.mjs
+
+echo
+echo "== State transaction browser smoke (TinyGo successful path) =="
+"$GOXC" package ./scripts/fixtures/error-boundary --compiler=tinygo
+
+ERROR_BOUNDARY_TINYGO_PORT="$(resolve_port "${GOFRAME_ERROR_BOUNDARY_TINYGO_SMOKE_PORT:-}")"
+export GOFRAME_ERROR_BOUNDARY_CHROME_DEBUG_PORT="$(pick_free_port)"
+ERROR_BOUNDARY_TINYGO_URL="$(build_error_boundary_smoke_url "$ERROR_BOUNDARY_TINYGO_PORT")"
+run_with_server ./scripts/fixtures/error-boundary "$ERROR_BOUNDARY_TINYGO_PORT" "$ERROR_BOUNDARY_TINYGO_URL" \
+	run_error_boundary_success_browser
 
 echo
 echo "== Context selector topology browser smoke (standard Go) =="

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -8,6 +8,7 @@ if (typeof WebSocket === "undefined") {
 }
 
 const appURL = process.argv[2] ?? process.env.GOFRAME_ERROR_BOUNDARY_SMOKE_URL ?? "http://127.0.0.1:18080/";
+const successfulStateOnly = process.env.GOFRAME_ERROR_BOUNDARY_SUCCESS_ONLY === "1";
 const debugPort = Number(process.env.GOFRAME_ERROR_BOUNDARY_CHROME_DEBUG_PORT ?? "19241");
 const chrome = process.env.CHROME ?? "google-chrome";
 const profile = await mkdtemp(join(tmpdir(), "goframe-error-boundary-smoke-"));
@@ -43,6 +44,12 @@ try {
     await waitForProbe(client, (probe) => probe.effectCount === 1, "initial effect setup");
     await captureShell(client);
     await installListenerAudit(client);
+
+    const stateSuccessEvidence = await exerciseSuccessfulStateTransactions(client);
+    if (successfulStateOnly) {
+        console.log(`State transaction successful-path counters: ${JSON.stringify(stateSuccessEvidence)}`);
+    } else {
+        const stateFailureEvidence = await exerciseFailedStateTransactions(client);
 
     await waitForProbe(client, (current) =>
         current.local.ownerRenders >= 1 &&
@@ -573,18 +580,292 @@ try {
         nestedFallback: nestedFallbackEvidence,
         capturedDirtyBatch: dirtyBatchEvidence,
         protectedTeardown: protectedTeardownEvidence,
+        stateTransactions: stateFailureEvidence,
+        stateSuccess: stateSuccessEvidence,
         boundaryReports: transactionBoundaryReports,
         shellIdentityChanges: finalProbe.shellIdentityChanges,
         listenerAdditions: finalProbe.listenerAudit.add,
         listenerRemovals: finalProbe.listenerAudit.remove,
     })}`);
+    }
     client.close();
-    console.log("Error boundary browser smoke: ok");
+    console.log(successfulStateOnly
+        ? "State transaction TinyGo successful-path browser smoke: ok"
+        : "Error boundary browser smoke: ok");
 } finally {
     const exited = new Promise((resolve) => browser.once("exit", resolve));
     browser.kill("SIGTERM");
     await Promise.race([exited, wait(2000)]);
     await rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
+async function exerciseSuccessfulStateTransactions(client) {
+    await waitForText(client, "[data-testid='eb-state-success-first']", "2", "successful render-time state update");
+    await waitForText(client, "[data-testid='eb-state-success-second']", "second", "successful second state slot");
+    await waitForText(client, "[data-testid='eb-state-success-reducer']", "11", "successful render-time reducer dispatch");
+    await waitForText(
+        client,
+        "[data-testid='eb-state-success-resource']",
+        "ready:ready-aligned",
+        "successful state resource alignment",
+    );
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.renderTimeSetters === 1 &&
+        current.stateSuccess.renderTimeDispatches === 1 &&
+        current.stateSuccess.resourceStarts === 1 &&
+        current.stateSuccess.resourceCleanups === 0 &&
+        current.stateSuccess.firstValue === 2 &&
+        current.stateSuccess.secondValue === "second" &&
+        current.stateSuccess.reducerValue === 11 &&
+        current.stateSuccess.resourceStatus === "ready" &&
+        current.stateSuccess.resourceValue === "ready-aligned",
+    "initial successful state transaction");
+    await captureIdentity(client, "stateSuccessHost", "[data-testid='eb-state-success-host']");
+    await captureIdentity(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']");
+
+    const initial = await probe(client);
+    await click(client, "[data-testid='eb-state-success-update']");
+    await waitForText(client, "[data-testid='eb-state-success-first']", "3", "successful ordinary state update");
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.stateClicks === initial.stateSuccess.stateClicks + 1 &&
+        current.stateSuccess.ownerRenders === initial.stateSuccess.ownerRenders + 1 &&
+        current.stateSuccess.resourceStarts === initial.stateSuccess.resourceStarts,
+    "single successful state update");
+    await assertIdentitySame(client, "stateSuccessHost", "[data-testid='eb-state-success-host']", "successful host state update");
+    await assertIdentitySame(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']", "successful owner state update");
+
+    const beforeReplacement = await probe(client);
+    await click(client, "[data-testid='eb-state-success-replace-reducer']");
+    await waitForText(client, "[data-testid='eb-state-success-reducer-mode']", "candidate", "successful reducer replacement");
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.reducerReplaceClicks === beforeReplacement.stateSuccess.reducerReplaceClicks + 1 &&
+        current.stateSuccess.ownerRenders === beforeReplacement.stateSuccess.ownerRenders + 1 &&
+        current.stateSuccess.reducerValue === 11 &&
+        current.stateSuccess.resourceStarts === beforeReplacement.stateSuccess.resourceStarts,
+    "successful reducer replacement commit");
+    await assertIdentitySame(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']", "successful reducer replacement");
+
+    const beforeDispatch = await probe(client);
+    await click(client, "[data-testid='eb-state-success-dispatch']");
+    await waitForText(client, "[data-testid='eb-state-success-reducer']", "111", "old dispatch uses successful reducer replacement");
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.reducerDispatchClicks === beforeDispatch.stateSuccess.reducerDispatchClicks + 1 &&
+        current.stateSuccess.ownerRenders === beforeDispatch.stateSuccess.ownerRenders + 1 &&
+        current.stateSuccess.reducerValue === 111,
+    "old dispatch after successful reducer replacement");
+    await assertIdentitySame(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']", "successful reducer dispatch");
+
+    const beforeUnmount = await probe(client);
+    await click(client, "[data-testid='eb-state-success-toggle']");
+    await waitForAbsent(client, "[data-testid='eb-state-success-owner']", "successful state owner unmount");
+    await waitForText(client, "[data-testid='eb-state-success-unmounted']", "unmounted", "successful state owner unmounted marker");
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.resourceCleanups === beforeUnmount.stateSuccess.resourceCleanups + 1,
+    "successful state resource cleanup");
+    await assertIdentitySame(client, "stateSuccessHost", "[data-testid='eb-state-success-host']", "successful state owner unmount");
+
+    await click(client, "[data-testid='eb-state-success-toggle']");
+    await waitForText(client, "[data-testid='eb-state-success-first']", "2", "successful state owner replacement state");
+    await waitForText(client, "[data-testid='eb-state-success-reducer']", "11", "successful state owner replacement reducer");
+    await waitForText(
+        client,
+        "[data-testid='eb-state-success-resource']",
+        "ready:ready-aligned",
+        "successful state owner replacement resource",
+    );
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.resourceStarts === beforeUnmount.stateSuccess.resourceStarts + 1 &&
+        current.stateSuccess.resourceCleanups === beforeUnmount.stateSuccess.resourceCleanups + 1 &&
+        current.stateSuccess.renderTimeSetters === beforeUnmount.stateSuccess.renderTimeSetters + 1 &&
+        current.stateSuccess.renderTimeDispatches === beforeUnmount.stateSuccess.renderTimeDispatches + 1,
+    "successful state owner replacement lifecycle");
+    await assertIdentitySame(client, "stateSuccessHost", "[data-testid='eb-state-success-host']", "successful state owner replacement host");
+    await assertIdentityChanged(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']", "successful state owner replacement");
+
+    const beforeReplacementUpdate = await probe(client);
+    await click(client, "[data-testid='eb-state-success-update']");
+    await waitForText(client, "[data-testid='eb-state-success-first']", "3", "replacement state owner update");
+    await waitForProbe(client, (current) =>
+        current.stateSuccess.stateClicks === beforeReplacementUpdate.stateSuccess.stateClicks + 1 &&
+        current.stateSuccess.ownerRenders === beforeReplacementUpdate.stateSuccess.ownerRenders + 1,
+    "single replacement state owner update");
+    await assertIdentitySame(client, "stateSuccessOwner", "[data-testid='eb-state-success-owner']", "replacement state owner update");
+
+    const final = await probe(client);
+    const listenerAdditions = final.listenerAudit.add - initial.listenerAudit.add;
+    const listenerRemovals = final.listenerAudit.remove - initial.listenerAudit.remove;
+    if (listenerAdditions !== listenerRemovals) {
+        throw new Error(
+            `APP FAILURE: successful state listener delta add=${listenerAdditions} remove=${listenerRemovals}`,
+        );
+    }
+    return {
+        ...final.stateSuccess,
+        listenerAdditions,
+        listenerRemovals,
+        hostIdentityChanges: 0,
+        ownerReplacements: 1,
+    };
+}
+
+async function exerciseFailedStateTransactions(client) {
+    await captureIdentity(client, "stateInitialScenario", "[data-testid='eb-state-initial-scenario']");
+    await captureIdentity(client, "stateReducerScenario", "[data-testid='eb-state-reducer-scenario']");
+    await waitForText(client, "[data-testid='eb-state-reducer-value']", "1", "initial committed reducer value");
+    const initial = await probe(client);
+
+    await click(client, "[data-testid='eb-state-initial-start']");
+    await waitForSelector(client, "[data-testid='eb-state-initial-fallback']", "failed initial state fallback");
+    await waitForAbsent(client, "[data-testid='eb-state-initial-owner']", "failed initial state owner absent");
+    await waitForProbe(client, (current) =>
+        current.reports.length === initial.reports.length + 1 &&
+        current.reports.at(-1).component === "StateTransactionInitialOwner" &&
+        current.stateTransactions.initialOwnerRenders === initial.stateTransactions.initialOwnerRenders + 1 &&
+        current.stateTransactions.initialFailedRenders === initial.stateTransactions.initialFailedRenders + 1 &&
+        current.stateTransactions.initialFallbackRenders === initial.stateTransactions.initialFallbackRenders + 1,
+    "failed initial state rollback");
+    await assertIdentitySame(client, "stateInitialScenario", "[data-testid='eb-state-initial-scenario']", "failed initial state fallback");
+
+    const afterInitialFailure = await probe(client);
+    await click(client, "[data-testid='eb-state-initial-retry']");
+    await waitForText(client, "[data-testid='eb-state-initial-value']", "99", "failed initial state retry value");
+    await waitForText(client, "[data-testid='eb-state-initial-reducer']", "99", "failed initial reducer retry value");
+    await waitForProbe(client, (current) =>
+        current.reports.length === afterInitialFailure.reports.length &&
+        current.stateTransactions.initialRecoveredRenders === afterInitialFailure.stateTransactions.initialRecoveredRenders + 1,
+    "failed initial state retry commit");
+    await captureIdentity(client, "stateInitialOwner", "[data-testid='eb-state-initial-owner']");
+
+    const beforeFailedClosures = await probe(client);
+    await click(client, "[data-testid='eb-state-invoke-failed-closures']");
+    await waitForProbe(client, (current) =>
+        current.stateTransactions.failedClosureInvocations ===
+            beforeFailedClosures.stateTransactions.failedClosureInvocations + 1,
+    "discarded state closure invocation");
+    await wait(250);
+    const afterFailedClosures = await probe(client);
+    counterDelta(
+        afterFailedClosures.stateTransactions.initialRecoveredRenders,
+        beforeFailedClosures.stateTransactions.initialRecoveredRenders,
+        0,
+        "discarded state closure render",
+    );
+    counterDelta(
+        afterFailedClosures.reports.length,
+        beforeFailedClosures.reports.length,
+        0,
+        "discarded state closure report",
+    );
+    await waitForText(client, "[data-testid='eb-state-initial-value']", "99", "discarded setter remains inert");
+    await waitForText(client, "[data-testid='eb-state-initial-reducer']", "99", "discarded dispatch remains inert");
+    await assertIdentitySame(client, "stateInitialOwner", "[data-testid='eb-state-initial-owner']", "discarded state closures");
+
+    const beforeCurrentUpdate = await probe(client);
+    await click(client, "[data-testid='eb-state-update-current']");
+    await waitForText(client, "[data-testid='eb-state-initial-value']", "100", "committed state setter after retry");
+    await waitForText(client, "[data-testid='eb-state-initial-reducer']", "100", "committed reducer dispatch after retry");
+    await waitForProbe(client, (current) =>
+        current.stateTransactions.currentUpdateInvocations ===
+            beforeCurrentUpdate.stateTransactions.currentUpdateInvocations + 1 &&
+        current.stateTransactions.initialRecoveredRenders ===
+            beforeCurrentUpdate.stateTransactions.initialRecoveredRenders + 1,
+    "committed state closures after retry");
+    await assertIdentitySame(client, "stateInitialOwner", "[data-testid='eb-state-initial-owner']", "committed state closures");
+
+    await click(client, "[data-testid='eb-state-initial-finish']");
+    await waitForSelector(client, "[data-testid='eb-state-initial-start']", "failed initial state scenario reset");
+    await waitForAbsent(client, "[data-testid='eb-state-initial-owner']", "recovered initial state owner unmounted");
+    await waitForAbsent(client, "[data-testid='eb-state-initial-fallback']", "initial state fallback remains cleared");
+    await assertIdentitySame(client, "stateInitialScenario", "[data-testid='eb-state-initial-scenario']", "failed initial state scenario finish");
+
+    const beforeReducerFailure = await probe(client);
+    await click(client, "[data-testid='eb-state-reducer-fail']");
+    await waitForText(client, "[data-testid='eb-state-reducer-mode']", "failed", "failed reducer candidate mode");
+    await waitForAbsent(client, "[data-testid='eb-state-reducer-value']", "failed reducer candidate output");
+    await waitForProbe(client, (current) =>
+        current.reports.length === beforeReducerFailure.reports.length + 1 &&
+        current.reports.at(-1).component === "StateTransactionReducerOwner" &&
+        current.stateTransactions.reducerFailedRenders ===
+            beforeReducerFailure.stateTransactions.reducerFailedRenders + 1,
+    "failed reducer replacement rollback");
+    await assertIdentitySame(client, "stateReducerScenario", "[data-testid='eb-state-reducer-scenario']", "failed reducer replacement");
+
+    const afterReducerFailure = await probe(client);
+    await click(client, "[data-testid='eb-state-reducer-recover']");
+    await waitForText(client, "[data-testid='eb-state-reducer-mode']", "base", "reducer recovery mode");
+    await waitForText(client, "[data-testid='eb-state-reducer-value']", "1", "committed reducer retained after failure");
+    await waitForProbe(client, (current) => current.reports.length === afterReducerFailure.reports.length, "reducer recovery without report");
+    await captureIdentity(client, "stateReducerOwner", "[data-testid='eb-state-reducer-value']");
+
+    await click(client, "[data-testid='eb-state-reducer-dispatch']");
+    await waitForText(client, "[data-testid='eb-state-reducer-value']", "2", "old dispatch uses committed reducer after failure");
+    await assertIdentitySame(client, "stateReducerOwner", "[data-testid='eb-state-reducer-value']", "committed reducer dispatch after failure");
+
+    await click(client, "[data-testid='eb-state-reducer-commit']");
+    await waitForText(client, "[data-testid='eb-state-reducer-mode']", "candidate", "successful reducer candidate mode");
+    await waitForText(client, "[data-testid='eb-state-reducer-value']", "2", "successful reducer replacement retains state");
+    await assertIdentitySame(client, "stateReducerOwner", "[data-testid='eb-state-reducer-value']", "successful reducer replacement");
+
+    await click(client, "[data-testid='eb-state-reducer-dispatch']");
+    await waitForText(client, "[data-testid='eb-state-reducer-value']", "102", "old dispatch uses latest committed reducer");
+    await waitForProbe(client, (current) =>
+        current.stateTransactions.committedDispatchInvokes ===
+            beforeReducerFailure.stateTransactions.committedDispatchInvokes + 2 &&
+        current.stateTransactions.lastCommittedReducerValue === 102,
+    "latest committed reducer dispatch");
+    await assertIdentitySame(client, "stateReducerOwner", "[data-testid='eb-state-reducer-value']", "latest committed reducer dispatch");
+    await assertIdentitySame(client, "stateReducerScenario", "[data-testid='eb-state-reducer-scenario']", "reducer transaction scenario");
+
+    const final = await probe(client);
+    const listenerAdditions = final.listenerAudit.add - initial.listenerAudit.add;
+    const listenerRemovals = final.listenerAudit.remove - initial.listenerAudit.remove;
+    if (listenerAdditions !== listenerRemovals) {
+        throw new Error(
+            `APP FAILURE: failed state listener delta add=${listenerAdditions} remove=${listenerRemovals}`,
+        );
+    }
+    return {
+        ...final.stateTransactions,
+        initialBoundaryReports: afterInitialFailure.reports.length - initial.reports.length,
+        reducerReports: final.reports.length - beforeReducerFailure.reports.length,
+        listenerAdditions,
+        listenerRemovals,
+        scenarioIdentityChanges: 0,
+    };
+}
+
+async function captureIdentity(client, key, selector) {
+    const captured = await client.callFunction(`function(key, selector) {
+        const element = document.querySelector(selector);
+        if (!element) return false;
+        window.__errorBoundaryIdentities ||= {};
+        window.__errorBoundaryIdentities[key] = element;
+        return true;
+    }`, key, selector);
+    if (!captured) {
+        throw new Error(`APP FAILURE: missing ${selector} for ${key} identity capture`);
+    }
+}
+
+async function assertIdentitySame(client, key, selector, label) {
+    const same = await client.callFunction(`function(key, selector) {
+        return window.__errorBoundaryIdentities?.[key] === document.querySelector(selector);
+    }`, key, selector);
+    if (!same) {
+        throw new Error(`APP FAILURE: ${key} identity changed during ${label}`);
+    }
+}
+
+async function assertIdentityChanged(client, key, selector, label) {
+    const changed = await client.callFunction(`function(key, selector) {
+        const element = document.querySelector(selector);
+        if (!element || window.__errorBoundaryIdentities?.[key] === element) return false;
+        window.__errorBoundaryIdentities[key] = element;
+        return true;
+    }`, key, selector);
+    if (!changed) {
+        throw new Error(`APP FAILURE: ${key} identity did not change during ${label}`);
+    }
 }
 
 async function installListenerAudit(client) {
@@ -639,6 +920,8 @@ async function probe(client) {
         nestedFallback: globalThis.goframeNestedFallbackTransactionProbe || {},
         dirtyBatch: globalThis.goframeCapturedDirtyBatchProbe || {},
         teardown: globalThis.goframeProtectedTeardownProbe || {},
+        stateTransactions: globalThis.goframeStateTransactionProbe || {},
+        stateSuccess: globalThis.goframeStateTransactionSuccessProbe || {},
         shellIdentityChanges: globalThis.__errorBoundaryShellIdentityChanges || 0,
         listenerAudit: globalThis.__errorBoundaryListenerAudit || { add: 0, remove: 0 },
     }))()`);

--- a/scripts/error-boundary-browser-smoke.mjs
+++ b/scripts/error-boundary-browser-smoke.mjs
@@ -742,7 +742,7 @@ async function exerciseFailedStateTransactions(client) {
         current.stateTransactions.failedClosureInvocations ===
             beforeFailedClosures.stateTransactions.failedClosureInvocations + 1,
     "discarded state closure invocation");
-    await wait(250);
+    await waitForAnimationFrames(client, 2);
     const afterFailedClosures = await probe(client);
     counterDelta(
         afterFailedClosures.stateTransactions.initialRecoveredRenders,
@@ -980,6 +980,29 @@ async function click(client, selector) {
     }`, selector);
     if (!result) {
         throw new Error(`APP FAILURE: missing element for click ${selector}`);
+    }
+}
+
+async function waitForAnimationFrames(client, count = 2) {
+    if (!Number.isInteger(count) || count <= 0) {
+        throw new Error(`HARNESS FAILURE: animation frame count must be a positive integer; got ${count}`);
+    }
+    const completed = await client.callFunction(`function(count) {
+        return new Promise((resolve) => {
+            let remaining = count;
+            const next = () => {
+                remaining--;
+                if (remaining === 0) {
+                    resolve(true);
+                    return;
+                }
+                requestAnimationFrame(next);
+            };
+            requestAnimationFrame(next);
+        });
+    }`, count);
+    if (completed !== true) {
+        throw new Error(`HARNESS FAILURE: did not complete ${count} animation frames`);
     }
 }
 

--- a/scripts/fixtures/error-boundary/app.gox
+++ b/scripts/fixtures/error-boundary/app.gox
@@ -113,6 +113,10 @@ func App() gf.Node {
 			</gf.ErrorBoundary>
 			<DirtyBatchIndependentOwner />
 
+			<StateTransactionInitialScenario />
+			<StateTransactionReducerScenario />
+			<StateTransactionSuccessHost />
+
 			<button
 				data-testid="eb-trigger-no-boundary-error"
 				OnClick={func() {

--- a/scripts/fixtures/error-boundary/model.go
+++ b/scripts/fixtures/error-boundary/model.go
@@ -20,6 +20,13 @@ var (
 	localTransactionProbe        protectedTransactionProbe
 	nestedFallbackProbe          nestedFallbackTransactionProbe
 	dirtyBatchProbe              capturedDirtyBatchProbe
+	stateTransactionProbe        stateTransactionFailureProbe
+	stateTransactionSuccessProbe stateTransactionSuccessCounters
+	stateTransactionPhase        = "attempt"
+	failedStateSetter            func(int)
+	failedStateDispatch          func(int)
+	committedStateDispatch       func(int)
+	successfulStateDispatch      func(int)
 	setDirtyBatchFailingVersion  func(string)
 	setDirtyBatchLaterVersion    func(string)
 	setDirtyBatchIndependent     func(int)
@@ -102,6 +109,36 @@ type capturedDirtyBatchProbe struct {
 	attemptedBResourceStarts   int
 	attemptedBResourceCleanups int
 	independentOwnerRenders    int
+}
+
+type stateTransactionFailureProbe struct {
+	initialOwnerRenders       int
+	initialFailedRenders      int
+	initialRecoveredRenders   int
+	initialFallbackRenders    int
+	failedClosureInvocations  int
+	currentUpdateInvocations  int
+	reducerOwnerRenders       int
+	reducerFailedRenders      int
+	reducerSuccessfulRenders  int
+	committedDispatchInvokes  int
+	lastCommittedReducerValue int
+}
+
+type stateTransactionSuccessCounters struct {
+	ownerRenders          int
+	renderTimeSetters     int
+	renderTimeDispatches  int
+	stateClicks           int
+	reducerReplaceClicks  int
+	reducerDispatchClicks int
+	resourceStarts        int
+	resourceCleanups      int
+	firstValue            int
+	secondValue           string
+	reducerValue          int
+	resourceStatus        string
+	resourceValue         string
 }
 
 type RiskyPanelProps struct {
@@ -187,6 +224,382 @@ type DirtyBatchIndependentOwnerProps struct{}
 
 type DirtyBatchRiskyDescendantProps struct {
 	Broken bool
+}
+
+type StateTransactionInitialScenarioProps struct{}
+
+type StateTransactionInitialOwnerProps struct{}
+
+type StateTransactionReducerScenarioProps struct{}
+
+type StateTransactionReducerOwnerProps struct {
+	Mode string
+}
+
+type StateTransactionSuccessHostProps struct{}
+
+type StateTransactionSuccessOwnerProps struct{}
+
+func StateTransactionInitialScenario(StateTransactionInitialScenarioProps) gf.Node {
+	started, setStarted := gf.UseState(false)
+	children := []gf.Node{
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-initial-start",
+				"OnClick": func() {
+					stateTransactionPhase = "attempt"
+					setStarted(true)
+				},
+			},
+			gf.Text("Start failed initial state render"),
+		),
+	}
+	if started {
+		children = []gf.Node{
+			gf.El(
+				"button",
+				gf.Props{
+					"data-testid": "eb-state-initial-finish",
+					"OnClick": func() {
+						failedStateSetter = nil
+						failedStateDispatch = nil
+						stateTransactionPhase = "attempt"
+						setStarted(false)
+					},
+				},
+				gf.Text("Finish failed initial state render"),
+			),
+			gf.ErrorBoundary(gf.ErrorBoundaryProps{
+				Fallback: stateTransactionInitialFallback,
+				Children: []gf.Node{
+					gf.Component(
+						"StateTransactionInitialOwner",
+						StateTransactionInitialOwnerProps{},
+						StateTransactionInitialOwner,
+					),
+				},
+			}),
+		}
+	}
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-initial-scenario"},
+		children...,
+	)
+}
+
+func StateTransactionInitialOwner(StateTransactionInitialOwnerProps) gf.Node {
+	stateTransactionProbe.initialOwnerRenders++
+	initial := 1
+	if stateTransactionPhase == "retry" {
+		initial = 99
+	}
+	value, setValue := gf.UseState(initial)
+	reduced, dispatch := gf.UseReducer(initial, func(state, action int) int {
+		return state + action
+	})
+	if stateTransactionPhase == "attempt" {
+		failedStateSetter = setValue
+		failedStateDispatch = dispatch
+		stateTransactionProbe.initialFailedRenders++
+		syncBoundaryProbe()
+		panic("failed initial state transaction")
+	}
+
+	stateTransactionProbe.initialRecoveredRenders++
+	syncBoundaryProbe()
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-initial-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-state-initial-value"}, gf.Text(gf.ToString(value))),
+		gf.El("p", gf.Props{"data-testid": "eb-state-initial-reducer"}, gf.Text(gf.ToString(reduced))),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-invoke-failed-closures",
+				"OnClick": func() {
+					stateTransactionProbe.failedClosureInvocations++
+					if failedStateSetter != nil {
+						failedStateSetter(1000)
+					}
+					if failedStateDispatch != nil {
+						failedStateDispatch(1000)
+					}
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Invoke discarded state closures"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-update-current",
+				"OnClick": func() {
+					stateTransactionProbe.currentUpdateInvocations++
+					setValue(value + 1)
+					dispatch(1)
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Update committed state"),
+		),
+	)
+}
+
+func stateTransactionInitialFallback(ctx gf.ErrorBoundaryContext) gf.Node {
+	stateTransactionProbe.initialFallbackRenders++
+	syncBoundaryProbe()
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-initial-fallback"},
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-initial-retry",
+				"OnClick": func() {
+					stateTransactionPhase = "retry"
+					ctx.Reset()
+				},
+			},
+			gf.Text("Retry initial state transaction"),
+		),
+	)
+}
+
+func StateTransactionReducerScenario(StateTransactionReducerScenarioProps) gf.Node {
+	mode, setMode := gf.UseState("base")
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-reducer-scenario"},
+		gf.El("p", gf.Props{"data-testid": "eb-state-reducer-mode"}, gf.Text(mode)),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-reducer-fail",
+				"OnClick": func() {
+					setMode("failed")
+				},
+			},
+			gf.Text("Fail reducer replacement"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-reducer-recover",
+				"OnClick": func() {
+					setMode("base")
+				},
+			},
+			gf.Text("Recover reducer replacement"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-reducer-commit",
+				"OnClick": func() {
+					setMode("candidate")
+				},
+			},
+			gf.Text("Commit reducer replacement"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-reducer-dispatch",
+				"OnClick": func() {
+					stateTransactionProbe.committedDispatchInvokes++
+					if committedStateDispatch != nil {
+						committedStateDispatch(1)
+					}
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Dispatch through committed closure"),
+		),
+		gf.Component(
+			"StateTransactionReducerOwner",
+			StateTransactionReducerOwnerProps{Mode: mode},
+			StateTransactionReducerOwner,
+		),
+	)
+}
+
+func StateTransactionReducerOwner(props StateTransactionReducerOwnerProps) gf.Node {
+	stateTransactionProbe.reducerOwnerRenders++
+	reducer := gf.Reducer[int, int](func(state, action int) int {
+		return state + action
+	})
+	if props.Mode == "failed" || props.Mode == "candidate" {
+		reducer = func(state, action int) int {
+			return state + action*100
+		}
+	}
+	value, dispatch := gf.UseReducer(1, reducer)
+	if committedStateDispatch == nil {
+		committedStateDispatch = dispatch
+	}
+	if props.Mode == "failed" {
+		stateTransactionProbe.reducerFailedRenders++
+		syncBoundaryProbe()
+		panic("failed reducer replacement")
+	}
+	stateTransactionProbe.reducerSuccessfulRenders++
+	stateTransactionProbe.lastCommittedReducerValue = value
+	syncBoundaryProbe()
+	return gf.El(
+		"p",
+		gf.Props{"data-testid": "eb-state-reducer-value"},
+		gf.Text(gf.ToString(value)),
+	)
+}
+
+func StateTransactionSuccessHost(StateTransactionSuccessHostProps) gf.Node {
+	mounted, setMounted := gf.UseState(true)
+	children := []gf.Node{
+		gf.El(
+			"p",
+			gf.Props{"data-testid": "eb-state-success-unmounted"},
+			gf.Text("unmounted"),
+		),
+	}
+	if mounted {
+		children = []gf.Node{
+			gf.Component(
+				"StateTransactionSuccessOwner",
+				StateTransactionSuccessOwnerProps{},
+				StateTransactionSuccessOwner,
+			),
+		}
+	}
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-success-host"},
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-success-toggle",
+				"OnClick": func() {
+					if mounted {
+						successfulStateDispatch = nil
+					}
+					setMounted(!mounted)
+				},
+			},
+			gf.Text("Toggle successful state owner"),
+		),
+		gf.Fragment(children...),
+	)
+}
+
+func StateTransactionSuccessOwner(StateTransactionSuccessOwnerProps) gf.Node {
+	stateTransactionSuccessProbe.ownerRenders++
+	first, setFirst := gf.UseState(1)
+	second, _ := gf.UseState("second")
+	candidate, setCandidate := gf.UseState(false)
+	reducer := gf.Reducer[int, int](func(state, action int) int {
+		return state + action
+	})
+	if candidate {
+		reducer = func(state, action int) int {
+			return state + action*100
+		}
+	}
+	reduced, dispatch := gf.UseReducer(10, reducer)
+	if successfulStateDispatch == nil {
+		successfulStateDispatch = dispatch
+	}
+	resource, _ := gf.UseResource("aligned", func(
+		key string,
+		resolve func(string),
+		reject func(error),
+	) gf.Cleanup {
+		stateTransactionSuccessProbe.resourceStarts++
+		syncBoundaryProbe()
+		resolve("ready-" + key)
+		return func() {
+			stateTransactionSuccessProbe.resourceCleanups++
+			syncBoundaryProbe()
+		}
+	})
+
+	if first == 1 {
+		stateTransactionSuccessProbe.renderTimeSetters++
+		setFirst(2)
+	}
+	if reduced == 10 {
+		stateTransactionSuccessProbe.renderTimeDispatches++
+		dispatch(1)
+	}
+	resourceStatus := "loading"
+	resourceValue := ""
+	if resource.Ready() {
+		resourceStatus = "ready"
+		resourceValue = resource.Value
+	} else if resource.Failed() {
+		resourceStatus = "failed"
+	}
+	stateTransactionSuccessProbe.firstValue = first
+	stateTransactionSuccessProbe.secondValue = second
+	stateTransactionSuccessProbe.reducerValue = reduced
+	stateTransactionSuccessProbe.resourceStatus = resourceStatus
+	stateTransactionSuccessProbe.resourceValue = resourceValue
+	syncBoundaryProbe()
+
+	return gf.El(
+		"section",
+		gf.Props{"data-testid": "eb-state-success-owner"},
+		gf.El("p", gf.Props{"data-testid": "eb-state-success-first"}, gf.Text(gf.ToString(first))),
+		gf.El("p", gf.Props{"data-testid": "eb-state-success-second"}, gf.Text(second)),
+		gf.El("p", gf.Props{"data-testid": "eb-state-success-reducer"}, gf.Text(gf.ToString(reduced))),
+		gf.El("p", gf.Props{"data-testid": "eb-state-success-reducer-mode"}, gf.Text(successfulReducerMode(candidate))),
+		gf.El("p", gf.Props{"data-testid": "eb-state-success-resource"}, gf.Text(resourceStatus+":"+resourceValue)),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-success-update",
+				"OnClick": func() {
+					stateTransactionSuccessProbe.stateClicks++
+					setFirst(first + 1)
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Update successful state"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-success-replace-reducer",
+				"OnClick": func() {
+					stateTransactionSuccessProbe.reducerReplaceClicks++
+					setCandidate(true)
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Replace successful reducer"),
+		),
+		gf.El(
+			"button",
+			gf.Props{
+				"data-testid": "eb-state-success-dispatch",
+				"OnClick": func() {
+					stateTransactionSuccessProbe.reducerDispatchClicks++
+					if successfulStateDispatch != nil {
+						successfulStateDispatch(1)
+					}
+					syncBoundaryProbe()
+				},
+			},
+			gf.Text("Dispatch successful reducer"),
+		),
+	)
+}
+
+func successfulReducerMode(candidate bool) string {
+	if candidate {
+		return "candidate"
+	}
+	return "base"
 }
 
 func RiskyPanel(props RiskyPanelProps) gf.Node {
@@ -1047,6 +1460,13 @@ func initBoundaryProbe() {
 	localTransactionProbe = protectedTransactionProbe{}
 	nestedFallbackProbe = nestedFallbackTransactionProbe{}
 	dirtyBatchProbe = capturedDirtyBatchProbe{}
+	stateTransactionProbe = stateTransactionFailureProbe{}
+	stateTransactionSuccessProbe = stateTransactionSuccessCounters{}
+	stateTransactionPhase = "attempt"
+	failedStateSetter = nil
+	failedStateDispatch = nil
+	committedStateDispatch = nil
+	successfulStateDispatch = nil
 	setDirtyBatchFailingVersion = nil
 	setDirtyBatchLaterVersion = nil
 	setDirtyBatchIndependent = nil
@@ -1153,4 +1573,34 @@ func syncBoundaryProbe() {
 	dirtyBatch.Set("attemptedBResourceCleanups", dirtyBatchProbe.attemptedBResourceCleanups)
 	dirtyBatch.Set("independentOwnerRenders", dirtyBatchProbe.independentOwnerRenders)
 	js.Global().Set("goframeCapturedDirtyBatchProbe", dirtyBatch)
+
+	stateTransaction := js.Global().Get("Object").New()
+	stateTransaction.Set("initialOwnerRenders", stateTransactionProbe.initialOwnerRenders)
+	stateTransaction.Set("initialFailedRenders", stateTransactionProbe.initialFailedRenders)
+	stateTransaction.Set("initialRecoveredRenders", stateTransactionProbe.initialRecoveredRenders)
+	stateTransaction.Set("initialFallbackRenders", stateTransactionProbe.initialFallbackRenders)
+	stateTransaction.Set("failedClosureInvocations", stateTransactionProbe.failedClosureInvocations)
+	stateTransaction.Set("currentUpdateInvocations", stateTransactionProbe.currentUpdateInvocations)
+	stateTransaction.Set("reducerOwnerRenders", stateTransactionProbe.reducerOwnerRenders)
+	stateTransaction.Set("reducerFailedRenders", stateTransactionProbe.reducerFailedRenders)
+	stateTransaction.Set("reducerSuccessfulRenders", stateTransactionProbe.reducerSuccessfulRenders)
+	stateTransaction.Set("committedDispatchInvokes", stateTransactionProbe.committedDispatchInvokes)
+	stateTransaction.Set("lastCommittedReducerValue", stateTransactionProbe.lastCommittedReducerValue)
+	js.Global().Set("goframeStateTransactionProbe", stateTransaction)
+
+	stateSuccess := js.Global().Get("Object").New()
+	stateSuccess.Set("ownerRenders", stateTransactionSuccessProbe.ownerRenders)
+	stateSuccess.Set("renderTimeSetters", stateTransactionSuccessProbe.renderTimeSetters)
+	stateSuccess.Set("renderTimeDispatches", stateTransactionSuccessProbe.renderTimeDispatches)
+	stateSuccess.Set("stateClicks", stateTransactionSuccessProbe.stateClicks)
+	stateSuccess.Set("reducerReplaceClicks", stateTransactionSuccessProbe.reducerReplaceClicks)
+	stateSuccess.Set("reducerDispatchClicks", stateTransactionSuccessProbe.reducerDispatchClicks)
+	stateSuccess.Set("resourceStarts", stateTransactionSuccessProbe.resourceStarts)
+	stateSuccess.Set("resourceCleanups", stateTransactionSuccessProbe.resourceCleanups)
+	stateSuccess.Set("firstValue", stateTransactionSuccessProbe.firstValue)
+	stateSuccess.Set("secondValue", stateTransactionSuccessProbe.secondValue)
+	stateSuccess.Set("reducerValue", stateTransactionSuccessProbe.reducerValue)
+	stateSuccess.Set("resourceStatus", stateTransactionSuccessProbe.resourceStatus)
+	stateSuccess.Set("resourceValue", stateTransactionSuccessProbe.resourceValue)
+	js.Global().Set("goframeStateTransactionSuccessProbe", stateSuccess)
 }

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -130,14 +130,14 @@ bundle_path() {
 status=0
 check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
-check_app "todo" "$(bundle_path todo)" 122880 40960 56320 49152 || status=1
-check_app "dashboard" "$(bundle_path dashboard)" 171008 53248 71680 61440 || status=1
-check_app "context" "$(bundle_path context)" 117760 36864 46080 40960 || status=1
-check_app "virtualized" "$(bundle_path virtualized)" 124928 40960 49152 44032 || status=1
+check_app "todo" "$(bundle_path todo)" 123904 40960 56320 49152 || status=1
+check_app "dashboard" "$(bundle_path dashboard)" 175104 53248 71680 61440 || status=1
+check_app "context" "$(bundle_path context)" 120832 37888 46080 40960 || status=1
+check_app "virtualized" "$(bundle_path virtualized)" 128000 40960 50176 44032 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
-check_app "router" "$(bundle_path router)" 118784 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 235520 77824 94208 82944 || status=1
-check_app "resource" "$(bundle_path resource)" 157696 58368 69632 62464 || status=1
+check_app "router" "$(bundle_path router)" 119808 45056 58368 51200 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 240640 79872 96256 84992 || status=1
+check_app "resource" "$(bundle_path resource)" 162816 59392 70656 63488 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Fixes DR-04: a failed component render could append newly observed state slots
or replace a committed reducer before the lifecycle transaction succeeded.

New state slots and reducer replacements are now speculative. They commit only
with the render attempt; rollback preserves committed slots and reducers and
makes closures from discarded slots inert.

## What changed

The runtime now:

- stages new state slots in a lazy per-component render transaction;
- stages reducer replacements without changing the committed reducer;
- commits or rolls back state before generic resource participants and lifecycle
  hooks;
- preserves committed slot identity and the latest-successfully-committed
  reducer contract for old dispatch closures;
- defers protected-subtree state decisions to the owning ErrorBoundary
  transaction.

Focused host and browser regressions cover ghost slots, failed reducer
replacement, discarded closures, resource ordering, nested boundaries, retry,
and lifecycle cleanup.

## Compatibility

Successful `UseState`, `UseReducer`, and `UseResource` behavior remains
unchanged, including render-time updates, scheduling, same-value suppression,
stale committed closures, and unmount handling.

No public API, GOX, `goxc`, dependency, workflow, lockfile, or package-format
change is introduced.

Updates to values in already committed state slots are not generally rolled
back. TinyGo trap-style panics still cannot unwind into Go `recover`, so
failed-render browser evidence uses standard Go/WASM while TinyGo validates the
successful state, reducer, resource, and cleanup path.

## WASM size

A specialized state commit path removes about 18 KiB of accidental state-only
TinyGo growth caused by generic lifecycle-interface reachability.

All eleven applications pass the final size matrix. Fifteen measured absolute
ceilings are aligned to the next 1 KiB boundary. Gzip, Brotli, and Zstandard
ratio limits remain unchanged.

## Validation

Local validation covered:

- ordinary, debug-tag, and vet lanes on Go `1.22.12`, `1.25.12`, and `1.26.5`;
- focused high-count and race suites;
- ten fresh standard-Go/WASM rollback and retry runs;
- ten fresh TinyGo `0.41.1` successful-path runs;
- two complete Browser Smoke runs;
- the full eleven-application WASM matrix;
- `scripts/check.sh`, repository, documentation, extension, and Windows
  cross-compilation gates.

## Scope

This closes DR-04 for recover-capable render transactions.

It does not add general state-value rollback, concurrent rendering, scheduler
transactionality, TinyGo panic recovery, route loaders, or another application
model abstraction. Issue #117 remains independent.