### PR TITLE
feat(goxc): present dev build failures in browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-No changes have been recorded after `v0.3.0-preview.1`.
+- `goxc dev` now presents post-start package and build failures in connected
+  browsers while preserving the last successful interactive application;
+  later failures replace the message, and successful recovery clears it before
+  the normal full-page reload.
 
 ## v0.3.0-preview.1
 

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -200,7 +200,7 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 		if ctx.Err() != nil {
 			return nil
 		}
-		if _, err := server.activatePackageWithCommit(func() {
+		if _, err := server.activatePackageWithCommit(request.Number, func() {
 			if haveAttemptPlan {
 				collector.finishEmbedBuild(attemptPlan, true)
 			}
@@ -218,6 +218,16 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 		return nil
 	}
 
+	coordinatorHooks := dependencies.hooks
+	buildFinished := coordinatorHooks.BuildFinished
+	coordinatorHooks.BuildFinished = func(event devBuildEvent) {
+		if event.Err != nil && server.started() {
+			server.reload.publishBuildError(event.Request.Number, event.Err)
+		}
+		if buildFinished != nil {
+			buildFinished(event)
+		}
+	}
 	runErr := runDevCoordinator(ctx, devCoordinatorConfig{
 		scan:              collector.collect,
 		build:             build,
@@ -226,7 +236,7 @@ func runDev(ctx context.Context, options devOptions, dependencies devDependencie
 		debounce:          dependencies.debounce,
 		stdout:            dependencies.stdout,
 		stderr:            dependencies.stderr,
-		hooks:             dependencies.hooks,
+		hooks:             coordinatorHooks,
 		reconcileSnapshot: collector.reconcileEmbedSnapshot,
 	})
 	shutdownErr := server.shutdown()
@@ -305,7 +315,7 @@ func newDevServer(packageDir string, port int, dependencies devDependencies) (*d
 	}, nil
 }
 
-func (server *devServer) activatePackageWithCommit(commit func()) (uint64, error) {
+func (server *devServer) activatePackageWithCommit(build int, commit func()) (uint64, error) {
 	notify := server.started()
 	generation, err := server.generations.activatePackage(server.packageDir)
 	if err != nil {
@@ -317,7 +327,7 @@ func (server *devServer) activatePackageWithCommit(commit func()) (uint64, error
 	if commit != nil {
 		commit()
 	}
-	server.reload.activate(generation, notify)
+	server.reload.activateBuild(generation, build, notify)
 	if notify && server.hooks.ReloadPublished != nil {
 		server.hooks.ReloadPublished(generation)
 	}

--- a/cmd/goxc/dev_integration_test.go
+++ b/cmd/goxc/dev_integration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -20,6 +21,94 @@ const (
 	devIntegrationPoll     = 10 * time.Millisecond
 	devIntegrationDebounce = 50 * time.Millisecond
 )
+
+func TestDevRealWorkflowPublishesBuildErrorAndRecovers(t *testing.T) {
+	appDir := filepath.Join(t.TempDir(), "app")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	writeTestFile(t, appDir, manifestName, `{"compiler":"go"}`)
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar version = 1\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	builds := make(chan devBuildEvent, 8)
+	serverURLs := make(chan string, 1)
+	generations := make(chan uint64, 4)
+	reloads := make(chan uint64, 4)
+	packageCalls := 0
+	dependencies := devIntegrationDependencies(builds, serverURLs)
+	dependencies.hooks.GenerationActivated = func(generation uint64) {
+		generations <- generation
+	}
+	dependencies.hooks.ReloadPublished = func(generation uint64) {
+		reloads <- generation
+	}
+	dependencies.packageApp = func(options packageOptions) error {
+		packageCalls++
+		if packageCalls == 2 {
+			return errors.New("fixture build failed\n<em data-build-error-injection>literal markup</em>")
+		}
+		layout, err := newBuildLayout(layoutOptions{
+			appDir:    options.appDir,
+			compiler:  "go",
+			workspace: options.workspace,
+		})
+		if err != nil {
+			return err
+		}
+		if err := os.RemoveAll(layout.PackageDir); err != nil {
+			return err
+		}
+		writeCompleteCurrentPackage(t, layout.PackageDir)
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runDev(ctx, devOptions{
+			appDir: appDir, compiler: "go", workspace: workspace, port: 0,
+		}, dependencies)
+	}()
+
+	assertDevEvent(t, waitDevEvent(t, builds), 1, true, false)
+	assertDevGenerationEvent(t, generations, 1)
+	assertNoDevGenerationEvent(t, reloads)
+	serverURL := waitDevServerURL(t, serverURLs)
+	instance := devReloadInstanceFromIndex(t, readDevHTTPBody(t, serverURL+"/"))
+	response, reader := openDevIntegrationEventStream(t, serverURL, instance, 1)
+	defer response.Body.Close()
+
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar version = 2\n")
+	failed := waitDevEvent(t, builds)
+	assertDevEvent(t, failed, 2, false, true)
+	event, data := readDevIntegrationSSEEvent(t, reader)
+	if event != devBuildErrorEventName {
+		t.Fatalf("failed build SSE event = %q, want %q", event, devBuildErrorEventName)
+	}
+	var failure devBuildError
+	if err := json.Unmarshal([]byte(data), &failure); err != nil {
+		t.Fatalf("decode failed build SSE payload: %v\n%s", err, data)
+	}
+	if failure.Build != 2 || failure.Message != failed.Err.Error() {
+		t.Fatalf("failed build SSE payload = %+v, want build 2 message %q", failure, failed.Err)
+	}
+	assertNoDevGenerationEvent(t, generations)
+	assertNoDevGenerationEvent(t, reloads)
+
+	writeTestFile(t, appDir, "main.go", "package main\n\nvar version = 3\n")
+	assertDevEvent(t, waitDevEvent(t, builds), 3, false, false)
+	assertDevGenerationEvent(t, generations, 2)
+	assertDevGenerationEvent(t, reloads, 2)
+	event, data = readDevIntegrationSSEEvent(t, reader)
+	if event != devReloadEventName || data != "2" {
+		t.Fatalf("recovery SSE event = %q data=%q, want reload data=2", event, data)
+	}
+
+	cancel()
+	if err := waitDevRun(t, done); err != nil {
+		t.Fatalf("runDev() shutdown error: %v", err)
+	}
+	waitDevListenerClosed(t, serverURL)
+}
 
 func TestDevRealWorkflow(t *testing.T) {
 	repositoryRoot, ok := findRepositoryRoot(".")
@@ -892,6 +981,68 @@ func assertDevInjectedHTTPBody(t *testing.T, url, canonical string, generation u
 	if end := strings.IndexByte(instanceValue, '"'); end <= 0 {
 		t.Fatalf("GET %s body has an empty reload instance: %q", url, got)
 	}
+}
+
+func devReloadInstanceFromIndex(t *testing.T, content string) string {
+	t.Helper()
+	const prefix = `data-goframe-instance="`
+	start := strings.Index(content, prefix)
+	if start < 0 {
+		t.Fatalf("development index has no reload instance: %q", content)
+	}
+	value := content[start+len(prefix):]
+	end := strings.IndexByte(value, '"')
+	if end <= 0 {
+		t.Fatalf("development index has an empty reload instance: %q", content)
+	}
+	return value[:end]
+}
+
+func openDevIntegrationEventStream(t *testing.T, serverURL, instance string, generation uint64) (*http.Response, *bufio.Reader) {
+	t.Helper()
+	client := &http.Client{Timeout: 10 * time.Second}
+	response, err := client.Get(fmt.Sprintf(
+		"%s%s?instance=%s&generation=%d",
+		serverURL,
+		devEventsPath,
+		instance,
+		generation,
+	))
+	if err != nil {
+		t.Fatalf("connect development event stream: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		response.Body.Close()
+		t.Fatalf("development event stream status = %d, want 200", response.StatusCode)
+	}
+	reader := bufio.NewReader(response.Body)
+	if line, err := reader.ReadString('\n'); err != nil || line != ": connected\n" {
+		response.Body.Close()
+		t.Fatalf("development event stream greeting = %q, %v", line, err)
+	}
+	if line, err := reader.ReadString('\n'); err != nil || line != "\n" {
+		response.Body.Close()
+		t.Fatalf("development event stream greeting separator = %q, %v", line, err)
+	}
+	return response, reader
+}
+
+func readDevIntegrationSSEEvent(t *testing.T, reader *bufio.Reader) (string, string) {
+	t.Helper()
+	eventLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read development SSE event: %v", err)
+	}
+	dataLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read development SSE data: %v", err)
+	}
+	separator, err := reader.ReadString('\n')
+	if err != nil || separator != "\n" {
+		t.Fatalf("read development SSE separator = %q, %v", separator, err)
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(eventLine, "event: "), "\n"),
+		strings.TrimSuffix(strings.TrimPrefix(dataLine, "data: "), "\n")
 }
 
 func assertDevHTTPContains(t *testing.T, url, want string) {

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -47,8 +47,9 @@ const devReloadClient = `(function () {
         buildErrorMessage = null;
     }
     function ensureBuildErrorPanel() {
-        if (buildErrorPanel && buildErrorPanel.isConnected) return;
+        if (buildErrorPanel && buildErrorPanel.isConnected) return true;
         clearBuildErrorReferences();
+        if (!document.documentElement) return false;
         buildErrorPanel = document.createElement("section");
         buildErrorPanel.setAttribute("data-goframe-dev-build-error", "");
         buildErrorPanel.setAttribute("role", "alert");
@@ -63,7 +64,8 @@ const devReloadClient = `(function () {
         buildErrorMessage.style.cssText = "margin:0;white-space:pre-wrap;overflow-wrap:anywhere;font:inherit;";
         buildErrorPanel.appendChild(buildErrorHeading);
         buildErrorPanel.appendChild(buildErrorMessage);
-        (document.body || document.documentElement).appendChild(buildErrorPanel);
+        document.documentElement.appendChild(buildErrorPanel);
+        return true;
     }
     function removeBuildError() {
         if (buildErrorPanel && buildErrorPanel.isConnected) buildErrorPanel.remove();
@@ -77,7 +79,7 @@ const devReloadClient = `(function () {
             return;
         }
         if (!failure || !Number.isInteger(failure.build) || failure.build <= 0 || typeof failure.message !== "string") return;
-        ensureBuildErrorPanel();
+        if (!ensureBuildErrorPanel()) return;
         buildErrorPanel.setAttribute("data-goframe-dev-build", String(failure.build));
         buildErrorHeading.textContent = "Build " + failure.build + " failed";
         buildErrorMessage.textContent = failure.message;

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -38,9 +38,36 @@ const devReloadClient = `(function () {
     if (!instance || !generation || typeof window.EventSource !== "function") return;
     var source = new EventSource("/_goframe/dev/events?instance=" + encodeURIComponent(instance) + "&generation=" + encodeURIComponent(generation));
     var reloading = false;
+    var buildErrorPanel = null;
+    var buildErrorHeading = null;
+    var buildErrorMessage = null;
+    function clearBuildErrorReferences() {
+        buildErrorPanel = null;
+        buildErrorHeading = null;
+        buildErrorMessage = null;
+    }
+    function ensureBuildErrorPanel() {
+        if (buildErrorPanel && buildErrorPanel.isConnected) return;
+        clearBuildErrorReferences();
+        buildErrorPanel = document.createElement("section");
+        buildErrorPanel.setAttribute("data-goframe-dev-build-error", "");
+        buildErrorPanel.setAttribute("role", "alert");
+        buildErrorPanel.setAttribute("aria-live", "assertive");
+        buildErrorPanel.setAttribute("aria-atomic", "true");
+        buildErrorPanel.style.cssText = "position:fixed;right:1rem;bottom:1rem;z-index:2147483647;box-sizing:border-box;width:min(42rem,calc(100vw - 2rem));max-height:min(50vh,32rem);overflow:auto;padding:1rem;border:2px solid #f87171;border-radius:.5rem;background:#1f1013;color:#fff;font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;box-shadow:0 1rem 3rem rgba(0,0,0,.45);";
+        buildErrorHeading = document.createElement("strong");
+        buildErrorHeading.setAttribute("data-goframe-dev-build-error-heading", "");
+        buildErrorHeading.style.cssText = "display:block;margin:0 0 .75rem;color:#fca5a5;font:600 15px/1.3 system-ui,sans-serif;";
+        buildErrorMessage = document.createElement("pre");
+        buildErrorMessage.setAttribute("data-goframe-dev-build-error-message", "");
+        buildErrorMessage.style.cssText = "margin:0;white-space:pre-wrap;overflow-wrap:anywhere;font:inherit;";
+        buildErrorPanel.appendChild(buildErrorHeading);
+        buildErrorPanel.appendChild(buildErrorMessage);
+        (document.body || document.documentElement).appendChild(buildErrorPanel);
+    }
     function removeBuildError() {
-        var current = document.querySelector("[data-goframe-dev-build-error]");
-        if (current) current.remove();
+        if (buildErrorPanel && buildErrorPanel.isConnected) buildErrorPanel.remove();
+        clearBuildErrorReferences();
     }
     function showBuildError(event) {
         var failure;
@@ -50,27 +77,10 @@ const devReloadClient = `(function () {
             return;
         }
         if (!failure || !Number.isInteger(failure.build) || failure.build <= 0 || typeof failure.message !== "string") return;
-        var panel = document.querySelector("[data-goframe-dev-build-error]");
-        if (!panel) {
-            panel = document.createElement("section");
-            panel.setAttribute("data-goframe-dev-build-error", "");
-            panel.setAttribute("role", "alert");
-            panel.setAttribute("aria-live", "assertive");
-            panel.setAttribute("aria-atomic", "true");
-            panel.style.cssText = "position:fixed;right:1rem;bottom:1rem;z-index:2147483647;box-sizing:border-box;width:min(42rem,calc(100vw - 2rem));max-height:min(50vh,32rem);overflow:auto;padding:1rem;border:2px solid #f87171;border-radius:.5rem;background:#1f1013;color:#fff;font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;box-shadow:0 1rem 3rem rgba(0,0,0,.45);";
-            var heading = document.createElement("strong");
-            heading.setAttribute("data-goframe-dev-build-error-heading", "");
-            heading.style.cssText = "display:block;margin:0 0 .75rem;color:#fca5a5;font:600 15px/1.3 system-ui,sans-serif;";
-            var message = document.createElement("pre");
-            message.setAttribute("data-goframe-dev-build-error-message", "");
-            message.style.cssText = "margin:0;white-space:pre-wrap;overflow-wrap:anywhere;font:inherit;";
-            panel.appendChild(heading);
-            panel.appendChild(message);
-            (document.body || document.documentElement).appendChild(panel);
-        }
-        panel.setAttribute("data-goframe-dev-build", String(failure.build));
-        panel.querySelector("[data-goframe-dev-build-error-heading]").textContent = "Build " + failure.build + " failed";
-        panel.querySelector("[data-goframe-dev-build-error-message]").textContent = failure.message;
+        ensureBuildErrorPanel();
+        buildErrorPanel.setAttribute("data-goframe-dev-build", String(failure.build));
+        buildErrorHeading.textContent = "Build " + failure.build + " failed";
+        buildErrorMessage.textContent = failure.message;
     }
     source.addEventListener("build-error", showBuildError);
     source.addEventListener("reload", function () {

--- a/cmd/goxc/dev_reload.go
+++ b/cmd/goxc/dev_reload.go
@@ -3,8 +3,10 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,9 +16,19 @@ import (
 )
 
 const (
-	devEventsPath       = "/_goframe/dev/events"
-	devReloadScriptPath = "/_goframe/dev/reload.js"
-	devReloadMarker     = "data-goframe-dev-reload"
+	devEventsPath          = "/_goframe/dev/events"
+	devReloadScriptPath    = "/_goframe/dev/reload.js"
+	devReloadMarker        = "data-goframe-dev-reload"
+	devBuildErrorMarker    = "data-goframe-dev-build-error"
+	devReloadEventName     = "reload"
+	devBuildErrorEventName = "build-error"
+)
+
+type devReloadEventKind uint8
+
+const (
+	devReloadEventGeneration devReloadEventKind = iota + 1
+	devReloadEventBuildError
 )
 
 const devReloadClient = `(function () {
@@ -26,9 +38,45 @@ const devReloadClient = `(function () {
     if (!instance || !generation || typeof window.EventSource !== "function") return;
     var source = new EventSource("/_goframe/dev/events?instance=" + encodeURIComponent(instance) + "&generation=" + encodeURIComponent(generation));
     var reloading = false;
+    function removeBuildError() {
+        var current = document.querySelector("[data-goframe-dev-build-error]");
+        if (current) current.remove();
+    }
+    function showBuildError(event) {
+        var failure;
+        try {
+            failure = JSON.parse(event.data);
+        } catch (_) {
+            return;
+        }
+        if (!failure || !Number.isInteger(failure.build) || failure.build <= 0 || typeof failure.message !== "string") return;
+        var panel = document.querySelector("[data-goframe-dev-build-error]");
+        if (!panel) {
+            panel = document.createElement("section");
+            panel.setAttribute("data-goframe-dev-build-error", "");
+            panel.setAttribute("role", "alert");
+            panel.setAttribute("aria-live", "assertive");
+            panel.setAttribute("aria-atomic", "true");
+            panel.style.cssText = "position:fixed;right:1rem;bottom:1rem;z-index:2147483647;box-sizing:border-box;width:min(42rem,calc(100vw - 2rem));max-height:min(50vh,32rem);overflow:auto;padding:1rem;border:2px solid #f87171;border-radius:.5rem;background:#1f1013;color:#fff;font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;box-shadow:0 1rem 3rem rgba(0,0,0,.45);";
+            var heading = document.createElement("strong");
+            heading.setAttribute("data-goframe-dev-build-error-heading", "");
+            heading.style.cssText = "display:block;margin:0 0 .75rem;color:#fca5a5;font:600 15px/1.3 system-ui,sans-serif;";
+            var message = document.createElement("pre");
+            message.setAttribute("data-goframe-dev-build-error-message", "");
+            message.style.cssText = "margin:0;white-space:pre-wrap;overflow-wrap:anywhere;font:inherit;";
+            panel.appendChild(heading);
+            panel.appendChild(message);
+            (document.body || document.documentElement).appendChild(panel);
+        }
+        panel.setAttribute("data-goframe-dev-build", String(failure.build));
+        panel.querySelector("[data-goframe-dev-build-error-heading]").textContent = "Build " + failure.build + " failed";
+        panel.querySelector("[data-goframe-dev-build-error-message]").textContent = failure.message;
+    }
+    source.addEventListener("build-error", showBuildError);
     source.addEventListener("reload", function () {
         if (reloading) return;
         reloading = true;
+        removeBuildError();
         source.close();
         window.location.reload();
     });
@@ -36,10 +84,23 @@ const devReloadClient = `(function () {
 })();
 `
 
+type devBuildError struct {
+	Build   int    `json:"build"`
+	Message string `json:"message"`
+}
+
+type devReloadEvent struct {
+	kind       devReloadEventKind
+	generation uint64
+	buildError devBuildError
+}
+
 type devReloadBroker struct {
 	mu             sync.Mutex
 	instance       string
 	current        uint64
+	latestBuild    int
+	buildError     *devBuildError
 	nextSubscriber uint64
 	subscribers    map[uint64]*devReloadSubscriber
 	closed         bool
@@ -47,14 +108,15 @@ type devReloadBroker struct {
 
 type devReloadSubscriber struct {
 	id              uint64
-	events          chan uint64
+	events          chan devReloadEvent
 	generationFloor uint64
+	reloadRequired  bool
 }
 
 type devReloadSubscription struct {
 	broker *devReloadBroker
 	id     uint64
-	events <-chan uint64
+	events <-chan devReloadEvent
 	once   sync.Once
 }
 
@@ -74,18 +136,55 @@ func newDevReloadBroker(instance string) *devReloadBroker {
 }
 
 func (broker *devReloadBroker) activate(generation uint64, notify bool) {
+	broker.activateBuild(generation, 0, notify)
+}
+
+func (broker *devReloadBroker) activateBuild(generation uint64, build int, notify bool) {
 	broker.mu.Lock()
 	defer broker.mu.Unlock()
 	if broker.closed || generation <= broker.current {
 		return
 	}
+	if build > 0 && build <= broker.latestBuild {
+		return
+	}
 	broker.current = generation
+	if build > 0 {
+		broker.latestBuild = build
+	}
+	broker.buildError = nil
 	if !notify {
 		return
 	}
 	for _, subscriber := range broker.subscribers {
-		broker.queueLocked(subscriber, generation)
+		broker.queueReloadLocked(subscriber, generation)
 	}
+}
+
+func (broker *devReloadBroker) publishBuildError(build int, err error) {
+	if err == nil {
+		return
+	}
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if broker.closed || build <= broker.latestBuild {
+		return
+	}
+	broker.latestBuild = build
+	failure := devBuildError{Build: build, Message: err.Error()}
+	broker.buildError = &failure
+	for _, subscriber := range broker.subscribers {
+		broker.queueBuildErrorLocked(subscriber, failure)
+	}
+}
+
+func (broker *devReloadBroker) currentBuildError() (devBuildError, bool) {
+	broker.mu.Lock()
+	defer broker.mu.Unlock()
+	if broker.buildError == nil {
+		return devBuildError{}, false
+	}
+	return *broker.buildError, true
 }
 
 func (broker *devReloadBroker) subscribe(instance string, generation uint64) (*devReloadSubscription, error) {
@@ -101,12 +200,14 @@ func (broker *devReloadBroker) subscribe(instance string, generation uint64) (*d
 	broker.nextSubscriber++
 	subscriber := &devReloadSubscriber{
 		id:              broker.nextSubscriber,
-		events:          make(chan uint64, 1),
+		events:          make(chan devReloadEvent, 1),
 		generationFloor: generationFloor,
 	}
 	broker.subscribers[subscriber.id] = subscriber
 	if generationFloor < broker.current {
-		broker.queueLocked(subscriber, broker.current)
+		broker.queueReloadLocked(subscriber, broker.current)
+	} else if generationFloor == broker.current && broker.buildError != nil {
+		broker.queueBuildErrorLocked(subscriber, *broker.buildError)
 	}
 	return &devReloadSubscription{
 		broker: broker,
@@ -115,19 +216,39 @@ func (broker *devReloadBroker) subscribe(instance string, generation uint64) (*d
 	}, nil
 }
 
-func (broker *devReloadBroker) queueLocked(subscriber *devReloadSubscriber, generation uint64) {
+func (broker *devReloadBroker) queueReloadLocked(subscriber *devReloadSubscriber, generation uint64) {
 	if generation <= subscriber.generationFloor {
 		return
 	}
+	broker.replaceQueuedEventLocked(subscriber, newDevReloadEvent(generation))
+	subscriber.generationFloor = generation
+	subscriber.reloadRequired = true
+}
+
+func (broker *devReloadBroker) queueBuildErrorLocked(subscriber *devReloadSubscriber, failure devBuildError) {
+	if subscriber.reloadRequired || subscriber.generationFloor != broker.current {
+		return
+	}
+	broker.replaceQueuedEventLocked(subscriber, newDevBuildErrorEvent(failure))
+}
+
+func (broker *devReloadBroker) replaceQueuedEventLocked(subscriber *devReloadSubscriber, event devReloadEvent) {
 	select {
 	case <-subscriber.events:
 	default:
 	}
-	subscriber.events <- generation
-	subscriber.generationFloor = generation
+	subscriber.events <- event
 }
 
-func (subscription *devReloadSubscription) Events() <-chan uint64 {
+func newDevReloadEvent(generation uint64) devReloadEvent {
+	return devReloadEvent{kind: devReloadEventGeneration, generation: generation}
+}
+
+func newDevBuildErrorEvent(failure devBuildError) devReloadEvent {
+	return devReloadEvent{kind: devReloadEventBuildError, buildError: failure}
+}
+
+func (subscription *devReloadSubscription) Events() <-chan devReloadEvent {
 	return subscription.events
 }
 
@@ -161,8 +282,13 @@ func (broker *devReloadBroker) close() {
 		return
 	}
 	broker.closed = true
+	broker.buildError = nil
 	for id, subscriber := range broker.subscribers {
 		delete(broker.subscribers, id)
+		select {
+		case <-subscriber.events:
+		default:
+		}
 		close(subscriber.events)
 	}
 }
@@ -233,15 +359,32 @@ func serveDevEvents(response http.ResponseWriter, request *http.Request, broker 
 		select {
 		case <-request.Context().Done():
 			return
-		case generation, ok := <-subscription.Events():
+		case event, ok := <-subscription.Events():
 			if !ok {
 				return
 			}
-			if _, err := fmt.Fprintf(response, "event: reload\ndata: %d\n\n", generation); err != nil {
+			if err := writeDevReloadEvent(response, event); err != nil {
 				return
 			}
 			flusher.Flush()
 		}
+	}
+}
+
+func writeDevReloadEvent(output io.Writer, event devReloadEvent) error {
+	switch event.kind {
+	case devReloadEventGeneration:
+		_, err := fmt.Fprintf(output, "event: %s\ndata: %d\n\n", devReloadEventName, event.generation)
+		return err
+	case devReloadEventBuildError:
+		payload, err := json.Marshal(event.buildError)
+		if err != nil {
+			return fmt.Errorf("encode development build error: %w", err)
+		}
+		_, err = fmt.Fprintf(output, "event: %s\ndata: %s\n\n", devBuildErrorEventName, payload)
+		return err
+	default:
+		return errors.New("unknown development reload event")
 	}
 }
 

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -494,6 +494,12 @@ func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
 	if strings.Contains(response.Body.String(), "innerHTML") {
 		t.Fatalf("reload client renders build errors through innerHTML: %q", response.Body.String())
 	}
+	if !strings.Contains(response.Body.String(), `document.documentElement.appendChild(buildErrorPanel)`) {
+		t.Fatalf("reload client does not host build errors outside body: %q", response.Body.String())
+	}
+	if strings.Contains(response.Body.String(), "document.body") {
+		t.Fatalf("reload client hosts build errors inside body: %q", response.Body.String())
+	}
 	for _, lookup := range []string{
 		`document.querySelector("[` + devBuildErrorMarker + `]")`,
 		`document.querySelectorAll("[` + devBuildErrorMarker + `]")`,

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +18,147 @@ import (
 )
 
 const testDevReloadInstance = "0123456789abcdef0123456789abcdef"
+
+func TestDevReloadPublishesBuildErrorToCurrentSubscribers(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(1, 1, false)
+	first := mustDevReloadSubscription(t, broker, 1)
+	second := mustDevReloadSubscription(t, broker, 1)
+	defer first.Close()
+	defer second.Close()
+
+	broker.publishBuildError(2, errors.New("first line\nsecond line"))
+	assertDevBuildError(t, first, 2, "first line\nsecond line")
+	assertDevBuildError(t, second, 2, "first line\nsecond line")
+	assertNoQueuedDevReload(t, first)
+	assertNoQueuedDevReload(t, second)
+}
+
+func TestDevReloadRetainsLatestBuildErrorForCurrentGenerationReconnect(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(4, 4, false)
+	broker.publishBuildError(5, errors.New("retained failure"))
+
+	subscription := mustDevReloadSubscription(t, broker, 4)
+	defer subscription.Close()
+	assertDevBuildError(t, subscription, 5, "retained failure")
+	assertNoQueuedDevReload(t, subscription)
+}
+
+func TestDevReloadLatestBuildErrorReplacesEarlierFailure(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(1, 1, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	defer subscription.Close()
+
+	broker.publishBuildError(2, errors.New("first failure"))
+	broker.publishBuildError(3, errors.New("second failure"))
+	assertDevBuildError(t, subscription, 3, "second failure")
+	assertNoQueuedDevReload(t, subscription)
+
+	reconnected := mustDevReloadSubscription(t, broker, 1)
+	defer reconnected.Close()
+	assertDevBuildError(t, reconnected, 3, "second failure")
+}
+
+func TestDevReloadActivationClearsFailureAndSupersedesPendingError(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(1, 1, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	defer subscription.Close()
+
+	broker.publishBuildError(2, errors.New("broken"))
+	broker.activateBuild(2, 3, true)
+	assertDevReloadGeneration(t, subscription, 2)
+	assertNoQueuedDevReload(t, subscription)
+	if failure, ok := broker.currentBuildError(); ok {
+		t.Fatalf("retained build error after activation = %+v", failure)
+	}
+
+	current := mustDevReloadSubscription(t, broker, 2)
+	defer current.Close()
+	assertNoQueuedDevReload(t, current)
+
+	broker.publishBuildError(2, errors.New("stale failure"))
+	assertNoQueuedDevReload(t, current)
+	if failure, ok := broker.currentBuildError(); ok {
+		t.Fatalf("stale build error became current = %+v", failure)
+	}
+}
+
+func TestDevReloadStaleGenerationCatchesUpBeforeReceivingCurrentFailure(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(3, 3, false)
+	broker.publishBuildError(4, errors.New("current failure"))
+
+	stale := mustDevReloadSubscription(t, broker, 2)
+	defer stale.Close()
+	assertDevReloadGeneration(t, stale, 3)
+	assertNoQueuedDevReload(t, stale)
+
+	broker.publishBuildError(5, errors.New("replacement failure"))
+	assertNoQueuedDevReload(t, stale)
+
+	previousProcess, err := broker.subscribe("fedcba9876543210fedcba9876543210", 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer previousProcess.Close()
+	assertDevReloadGeneration(t, previousProcess, 3)
+	broker.publishBuildError(6, errors.New("latest failure"))
+	assertNoQueuedDevReload(t, previousProcess)
+
+	current := mustDevReloadSubscription(t, broker, 3)
+	defer current.Close()
+	assertDevBuildError(t, current, 6, "latest failure")
+}
+
+func TestDevReloadBuildErrorSSEEncodesMultilineAndMarkupText(t *testing.T) {
+	failure := devBuildError{
+		Build:   7,
+		Message: "first line\n</pre><img src=x onerror=window.injected=true>",
+	}
+	var output bytes.Buffer
+	if err := writeDevReloadEvent(&output, newDevBuildErrorEvent(failure)); err != nil {
+		t.Fatal(err)
+	}
+	const prefix = "event: build-error\ndata: "
+	content := output.String()
+	if !strings.HasPrefix(content, prefix) || !strings.HasSuffix(content, "\n\n") {
+		t.Fatalf("build-error SSE = %q", content)
+	}
+	data := strings.TrimSuffix(strings.TrimPrefix(content, prefix), "\n\n")
+	if strings.Contains(data, "\n") {
+		t.Fatalf("build-error JSON contains an unescaped newline: %q", data)
+	}
+	var decoded devBuildError
+	if err := json.Unmarshal([]byte(data), &decoded); err != nil {
+		t.Fatalf("decode build-error JSON: %v\n%s", err, data)
+	}
+	if decoded != failure {
+		t.Fatalf("decoded build error = %+v, want %+v", decoded, failure)
+	}
+}
+
+func TestDevReloadBuildErrorStateClearsOnShutdown(t *testing.T) {
+	broker := newDevReloadBroker(testDevReloadInstance)
+	broker.activateBuild(1, 1, false)
+	subscription := mustDevReloadSubscription(t, broker, 1)
+	broker.publishBuildError(2, errors.New("broken"))
+	broker.close()
+
+	if failure, ok := broker.currentBuildError(); ok {
+		t.Fatalf("retained build error after shutdown = %+v", failure)
+	}
+	if _, ok := <-subscription.Events(); ok {
+		t.Fatal("subscriber channel remained open after shutdown")
+	}
+	subscription.Close()
+	broker.publishBuildError(3, errors.New("ignored after shutdown"))
+	if _, err := broker.subscribe(testDevReloadInstance, 1); err == nil {
+		t.Fatal("subscribe after shutdown succeeded")
+	}
+}
 
 func TestDevReloadSameGenerationConnectionWaits(t *testing.T) {
 	broker := newDevReloadBroker(testDevReloadInstance)
@@ -333,10 +477,22 @@ func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
 	if response.Code != http.StatusOK || response.Header().Get("Cache-Control") != "no-store" {
 		t.Fatalf("reload client response = %d Cache-Control=%q", response.Code, response.Header().Get("Cache-Control"))
 	}
-	for _, want := range []string{"EventSource", "data-goframe-instance", "data-goframe-generation", "window.location.reload()"} {
+	for _, want := range []string{
+		"EventSource",
+		"data-goframe-instance",
+		"data-goframe-generation",
+		devBuildErrorEventName,
+		devBuildErrorMarker,
+		`setAttribute("role", "alert")`,
+		"textContent",
+		"window.location.reload()",
+	} {
 		if !strings.Contains(response.Body.String(), want) {
 			t.Fatalf("reload client missing %q: %q", want, response.Body.String())
 		}
+	}
+	if strings.Contains(response.Body.String(), "innerHTML") {
+		t.Fatalf("reload client renders build errors through innerHTML: %q", response.Body.String())
 	}
 
 	head := httptest.NewRecorder()
@@ -358,20 +514,33 @@ func mustDevReloadSubscription(t *testing.T, broker *devReloadBroker, generation
 func assertDevReloadGeneration(t *testing.T, subscription *devReloadSubscription, want uint64) {
 	t.Helper()
 	select {
-	case got, ok := <-subscription.Events():
-		if !ok || got != want {
-			t.Fatalf("reload event = %d, %v, want %d, true", got, ok, want)
+	case event, ok := <-subscription.Events():
+		if !ok || event.kind != devReloadEventGeneration || event.generation != want {
+			t.Fatalf("reload event = %+v, %v, want generation %d", event, ok, want)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for generation %d", want)
 	}
 }
 
+func assertDevBuildError(t *testing.T, subscription *devReloadSubscription, build int, message string) {
+	t.Helper()
+	select {
+	case event, ok := <-subscription.Events():
+		want := devBuildError{Build: build, Message: message}
+		if !ok || event.kind != devReloadEventBuildError || event.buildError != want {
+			t.Fatalf("build-error event = %+v, %v, want %+v", event, ok, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for build error %d", build)
+	}
+}
+
 func assertNoQueuedDevReload(t *testing.T, subscription *devReloadSubscription) {
 	t.Helper()
 	select {
-	case generation, ok := <-subscription.Events():
-		t.Fatalf("unexpected reload event = %d, %v", generation, ok)
+	case event, ok := <-subscription.Events():
+		t.Fatalf("unexpected development event = %+v, %v", event, ok)
 	default:
 	}
 }

--- a/cmd/goxc/dev_reload_test.go
+++ b/cmd/goxc/dev_reload_test.go
@@ -494,6 +494,14 @@ func TestDevReloadClientIsDevelopmentOnlyResponse(t *testing.T) {
 	if strings.Contains(response.Body.String(), "innerHTML") {
 		t.Fatalf("reload client renders build errors through innerHTML: %q", response.Body.String())
 	}
+	for _, lookup := range []string{
+		`document.querySelector("[` + devBuildErrorMarker + `]")`,
+		`document.querySelectorAll("[` + devBuildErrorMarker + `]")`,
+	} {
+		if strings.Contains(response.Body.String(), lookup) {
+			t.Fatalf("reload client adopts application markup through %q: %q", lookup, response.Body.String())
+		}
+	}
 
 	head := httptest.NewRecorder()
 	serveDevReloadClient(head, httptest.NewRequest(http.MethodHead, devReloadScriptPath, nil))

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -119,11 +119,13 @@ These are public-candidate because examples and docs rely on them, but their
 exact shapes can still change before stable 1.0.
 
 The high-level `goxc dev` contract is a loopback-only development server over
-verified completed full-package generations. Failed rebuilds preserve the last
-successful generation, and successful rebuilds trigger a full-page reload.
-Polling intervals, quiet-period timing, reload transport internals, and terminal
-wording are not compatibility contracts. `goxc dev` does not establish HMR,
-incremental compilation, a browser error overlay, or production hosting.
+verified completed full-package generations. Failed post-start builds preserve
+the last successful generation and present the failure in connected browsers;
+successful recovery activates a completed generation and triggers the normal
+full-page reload. Polling intervals, quiet-period timing, reload transport
+internals, and terminal wording are not compatibility contracts. `goxc dev`
+does not establish HMR, browser state preservation, incremental compilation,
+source maps, clickable diagnostics, or production hosting.
 
 The `goxc check --format=json` schema version 1 transport is a versioned
 tooling process contract. Consumers should reject unsupported schema versions,
@@ -284,8 +286,9 @@ VS Code extension:
 - Package manifest field stability.
 - Browser smoke scripts and debug probe output.
 - VS Code extension commands, snippets, and CLI-backed diagnostics behavior.
-- `goxc dev` watcher timing, reload transport, and generation bookkeeping below
-  the documented high-level command behavior.
+- `goxc dev` watcher timing; reload and build-error event names; private JSON
+  payload fields; presentation DOM, CSS, and build-number formatting; and
+  reload/error broker storage below the documented high-level command behavior.
 - `pkg/gox` AST/lexer/parser structures.
 
 These surfaces should be hardened, tested, and documented before wider

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -55,10 +55,11 @@ fail-closed legacy ownership, and dev-server symlink entries.
 
 The same Core `go test` gate covers the watched `goxc dev` workflow. Pure tests
 exercise option parsing, content snapshots, debounce, serialized coordination,
-failure recovery, and shutdown with injected dependencies. A focused integration
-test uses the real standard Go WASM package and static-server path in a temporary
-external application and workspace. Core CI does not claim a TinyGo dev-loop
-automation pass.
+retained browser build-error delivery, reload precedence, failure recovery, and
+shutdown with injected dependencies. A focused integration test uses the real
+standard Go WASM package and static-server path in a temporary external
+application and workspace. Core CI does not claim a TinyGo dev-loop automation
+pass.
 
 ### WASM Size
 
@@ -140,11 +141,14 @@ isolation scenario; its trap-style panic path makes the three recover-based
 validation cases not applicable.
 The suite also runs a focused `goxc dev` reload lifecycle against a temporary
 standard-Go browser/WASM application. It verifies the initial non-reloading
-connection, GOX, Go, and asset rebuild reloads, burst coalescing, failure
-preservation and recovery, two connected pages, current and stale generation
-reconnection, completed-generation serving during a later package attempt, and
-shutdown cleanup. This is standard-Go browser evidence; it does not claim a
-TinyGo development-reload pass.
+connection, GOX, Go, and asset rebuild reloads, burst coalescing, completed-
+generation serving during a later package attempt, and shutdown cleanup. Its
+failure matrix verifies one markup-safe alert presentation, application DOM
+identity and interaction during failure, consecutive-failure replacement,
+two-page delivery, current-generation retained-error delivery, stale-generation
+reload precedence, and clearing before the successful recovery reload. This is
+standard-Go browser evidence; it does not claim a TinyGo development-reload
+pass.
 The persistent `examples/server-backed` smoke records a narrow Go `net/http`
 backend integration boundary. A packaged GoFrame browser/WASM app is served by
 a same-origin Go backend and renders data from `/api/greeting` before and after

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,9 +96,16 @@ until the manifest can be parsed and the effective assets recomputed.
 After a successful package, ordinary GOX diagnostics, Go compiler errors, and
 manifest errors leave the last completed generation available. The server
 remains on the same listener, the failed snapshot is not retried indefinitely,
-and a later authored change starts a new package attempt. Successful recovery
-publishes and verifies the canonical package, activates a new completed
-generation, and reloads connected pages.
+and a later authored change starts a new package attempt. Connected pages show
+one development-only build-error presentation containing the latest failed
+build number and error text. A later failure replaces that presentation rather
+than stacking another one. The terminal still reports the build failure, and
+the running application remains mounted and interactive.
+
+Successful recovery publishes and verifies the canonical package, clears the
+retained failure, activates a new completed generation, removes the old-page
+presentation, and reloads each connected page once. The newly loaded page does
+not replay the cleared failure.
 
 This preservation guarantee does not override existing package publication or
 filesystem failure semantics. A failure that invalidates package ownership,
@@ -114,11 +121,13 @@ page connects without reloading itself. Every later successful accepted build
 activates one completed generation before publishing one reload event, and the
 browser performs an ordinary full-document reload.
 
-Failed builds publish no event, so the current page and last completed
-generation remain available. A successful recovery activates a new generation
-and reloads connected pages. A page reconnecting with the current generation
-waits for a later build; a page reconnecting with an older generation receives
-one catch-up reload.
+Post-start package and build failures publish a private browser event instead
+of a reload event, so the current page and last completed generation remain
+available. The injected client appends one alert-style, scrollable presentation
+outside the application root and renders multiline diagnostics as text. A page
+reconnecting with the current generation receives the latest active failure. A
+page reconnecting with an older generation first receives its required catch-up
+reload and then receives the failure on its current-generation connection.
 
 Reload injection changes only development HTTP responses. It does not modify
 the canonical `index.html`, asset manifest, package metadata, exported packages,
@@ -139,13 +148,16 @@ Each accepted change batch performs a full development package. The command
 does not provide:
 
 - browser auto-open;
-- an error overlay;
 - HMR or browser state preservation; a full-page reload resets browser state;
 - incremental compilation or an incremental build cache;
 - source maps;
+- source-code frames or clickable diagnostics;
 - file watching outside the effective app and module inputs;
 - remote-network binding, history-routing fallback, or production compression
   negotiation.
 
-Build failures are terminal output only. Release asset hashing, preload hints,
-gzip, and Brotli remain explicit `goxc package` concerns.
+Initial failures before the development server exists and watch-input scan
+errors that prevent a package attempt remain terminal-only. Browser
+presentation is limited to non-fatal package and build failures after a
+successful generation is active. Release asset hashing, preload hints, gzip,
+and Brotli remain explicit `goxc package` concerns.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -186,8 +186,8 @@ application-workflow evidence over existing public primitives
 The checkpoint includes:
 
 - `goxc dev` with serialized full-package rebuilds, last-successful-generation
-  preservation, verified generation activation, and successful-build page
-  reload;
+  preservation, post-start browser build-error presentation, verified
+  generation activation, and successful-build page reload;
 - server-backed and async-navigation evidence using existing router, resource,
   lifecycle, and example-local request coordination;
 - history-routing deployment characterization without changing the public hash
@@ -217,9 +217,10 @@ existing router, component ownership, resource lifecycle, and example-local
 request coordination sufficient for the audited flows. Those stages did not
 select a public route-loader, Action, Mutation, or cache-invalidation API.
 
-Browser build-error presentation remains a separate candidate. The current
-development loop reports failed builds in the terminal and keeps serving the
-last successful generation.
+Post-start browser build-error presentation is **Current / shipped**. The
+development loop keeps serving the last successful interactive generation,
+shows the latest failed package attempt in connected pages, retains terminal
+diagnostics, and clears the presentation on successful recovery.
 
 ## `v0.4.0-preview.*` - Modular Delivery & Bundle Splitting
 
@@ -335,9 +336,9 @@ Resumability, server components, and selective or streaming hydration remain
 
 ## `v0.7.0-preview.*` - Dev Loop & Language Services
 
-Status: **Candidate**, with the bounded watched development command and
-successful-build browser reload now **Current / shipped**. Browser build-error
-presentation remains **Candidate**.
+Status: **Candidate**, with the bounded watched development command,
+post-start browser build-error presentation, and successful-build browser
+reload now **Current / shipped**.
 
 The CLI-backed saved-source diagnostics in current `main` are
 **Current / shipped**. Semantic tooling remains future language-service work.
@@ -347,7 +348,7 @@ Candidate sequence:
 | Planning slot | Candidate capability |
 |---|---|
 | `preview.1` | Watched development command with serialized full-package rebuilds. |
-| `preview.2` | Successful-build browser reload is current; browser build-error overlay remains candidate. |
+| `preview.2` | Post-start browser build-error presentation and successful-build browser reload are current. |
 | `preview.3` | GOX-to-generated source maps. |
 | `preview.4` | Deterministic formatter. |
 | `preview.5` | LSP baseline. |
@@ -359,7 +360,8 @@ Potential surface, subject to design and evidence:
   work requiring separate evidence;
 - the current completed-generation serving and successful-build full-page
   reload workflow;
-- browser compiler and source error presentation as a separate candidate;
+- the current browser presentation for non-fatal post-start package and build
+  failures;
 - GOX-to-generated source maps shared by compiler and editor tooling;
 - a deterministic formatter with explicit syntax-governance rules;
 - diagnostics, hover, completion, definition, and references;
@@ -537,12 +539,12 @@ that defines behavior boundaries, evidence, cost, and non-goals.
 
 ## Immediate Sequence
 
-1. Retain the bounded watched `goxc dev`, completed-generation serving, and
-   successful-build reload contracts as current behavior.
+1. Retain the bounded watched `goxc dev`, completed-generation serving,
+   post-start browser build-error presentation, and successful-build reload
+   contracts as current behavior.
 2. Keep route loaders, transitions, mutations, document metadata, and history
    routing unselected until separate evidence justifies a public API.
 3. Keep issue #117 independent and non-blocking.
-4. Keep browser build-error presentation as a separate later candidate.
 
 The application-model evidence does not justify adding a loader, Action, or
 Mutation API. The selected development-loop slice does not imply incremental

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -189,6 +189,9 @@ try {
     const interactiveAfterFailure = await exerciseInteraction(client1, afterFailure);
     assert(interactiveAfterFailure.appRootIdentity === failureBaseline.appRootIdentity,
         `first failed build replaced the application root: ${JSON.stringify({ failureBaseline, interactiveAfterFailure })}`);
+    assertAuthoredMarker(interactiveAfterFailure, "first failed build interaction");
+    assert(interactiveAfterFailure.authoredMarkerIdentity === failureBaseline.authoredMarkerIdentity,
+        `first failed build interaction replaced the authored marker: ${JSON.stringify({ failureBaseline, interactiveAfterFailure })}`);
     console.log("first failed build presentation and interaction: ok");
 
     const failureSecondTarget = await client1.call("Target.createTarget", { url: "about:blank" });
@@ -209,7 +212,13 @@ try {
     assert(failureSecondRetained.buildErrorEvents === 1,
         `second page retained failure events = ${failureSecondRetained.buildErrorEvents}, want 1`);
 
+    await removeDevBuildErrorPanel(client1);
     const replacementBaseline1 = await pageState(client1);
+    assert(replacementBaseline1.buildErrorPresentations === 0 && replacementBaseline1.buildErrorMarkers === 1,
+        `external removal did not leave only the authored marker: ${JSON.stringify(replacementBaseline1)}`);
+    assertAuthoredMarker(replacementBaseline1, "external development-panel removal");
+    assert(replacementBaseline1.authoredMarkerIdentity === afterFailure.authoredMarkerIdentity,
+        `external development-panel removal replaced the authored marker: ${JSON.stringify({ afterFailure, replacementBaseline1 })}`);
     const replacementBaseline2 = await pageState(client2);
     const replacementFailureBuild = nextBuild;
     await writeReplacementBrokenGOX();
@@ -228,9 +237,16 @@ try {
         assert(!state.buildErrorMessage.includes("data-goframe-diagnostic-injected"),
             `${label} retained markup from the first failure`);
     }
+    assert(replacementFailure1.devPanelIdentity !== afterFailure.devPanelIdentity,
+        `page 1 reused its disconnected development panel: ${JSON.stringify({ afterFailure, replacementFailure1 })}`);
+    assert(replacementFailure2.devPanelIdentity === replacementBaseline2.devPanelIdentity,
+        `page 2 replaced its connected development panel: ${JSON.stringify({ replacementBaseline2, replacementFailure2 })}`);
     const interactiveSecondPage = await exerciseInteraction(client2, replacementFailure2);
     assert(interactiveSecondPage.appRootIdentity === replacementFailure2.appRootIdentity,
         `replacement failure interaction replaced page 2 root: ${JSON.stringify(interactiveSecondPage)}`);
+    assertAuthoredMarker(interactiveSecondPage, "replacement failure interaction");
+    assert(interactiveSecondPage.authoredMarkerIdentity === replacementFailure2.authoredMarkerIdentity,
+        `replacement failure interaction replaced page 2 authored marker: ${JSON.stringify({ replacementFailure2, interactiveSecondPage })}`);
     console.log("consecutive failure replacement on two pages: ok");
 
     const reconnectBaseline = await pageState(client1);
@@ -240,6 +256,8 @@ try {
     assertFailedBuildPreserved(reconnectBaseline, afterFailureReconnect, activeGeneration, "current-generation failure reconnect");
     assert(afterFailureReconnect.buildErrorEvents === reconnectBaseline.buildErrorEvents + 1,
         `current-generation reconnect events = ${afterFailureReconnect.buildErrorEvents}, want ${reconnectBaseline.buildErrorEvents + 1}`);
+    assert(afterFailureReconnect.devPanelIdentity !== reconnectBaseline.devPanelIdentity,
+        `current-generation reconnect adopted the removed development panel: ${JSON.stringify({ reconnectBaseline, afterFailureReconnect })}`);
     console.log("current-generation failure reconnect: ok");
 
     const malformedBaseline = await pageState(client1);
@@ -296,6 +314,12 @@ try {
             `${label} replayed a cleared failure after recovery: ${JSON.stringify({ baseline, state })}`);
         assert(state.panelCountBeforeUnload === 0,
             `${label} still had an error presentation when recovery reload was initiated: ${JSON.stringify(state)}`);
+        assert(state.authoredMarkerCountBeforeUnload === 1
+            && state.authoredMarkerIdentityBeforeUnload === baseline.authoredMarkerIdentity
+            && state.authoredHeadingBeforeUnload === "authored heading"
+            && state.authoredMessageBeforeUnload === "authored message",
+        `${label} changed the authored marker before recovery reload: ${JSON.stringify({ baseline, state })}`);
+        assertAuthoredMarker(state, `${label} recovery`);
     }
     assert(recovered1.generation === recoveryGeneration && recovered2.generation === recoveryGeneration,
         `recovery generations = ${recovered1.generation}/${recovered2.generation}, want ${recoveryGeneration}`);
@@ -465,6 +489,8 @@ try {
     const client2Final = await pageState(client2);
     assert(client1Final.buildErrorPresentations === 0 && client2Final.buildErrorPresentations === 0,
         `final pages retained build-error presentations: ${JSON.stringify({ client1Final, client2Final })}`);
+    assertAuthoredMarker(client1Final, "final page 1");
+    assertAuthoredMarker(client2Final, "final page 2");
     assert(client1.runtimeErrors.length === 0 && client2.runtimeErrors.length === 0,
         `browser runtime errors = ${JSON.stringify({ page1: client1.runtimeErrors, page2: client2.runtimeErrors })}`);
     const generationRoots = [...await listGenerationRoots()].filter((entry) => !generationRootsBefore.has(entry));
@@ -536,7 +562,7 @@ async function writeApplication(gox, go, index) {
 }
 
 async function writeGOX(value) {
-    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    interactionCount, setInteractionCount := gf.UseState(0)\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span><span id="embedded-value">{embeddedMessage}</span><button id="interaction-control" type="button" onClick={func() { setInteractionCount(interactionCount + 1) }}>Interaction <span id="interaction-count">{interactionCount}</span></button></main>\n}\n`);
+    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    interactionCount, setInteractionCount := gf.UseState(0)\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span><span id="embedded-value">{embeddedMessage}</span><section id="authored-build-error-marker" data-goframe-dev-build-error=""><strong data-goframe-dev-build-error-heading="">authored heading</strong><pre data-goframe-dev-build-error-message="">authored message</pre><button id="interaction-control" type="button" onClick={func() { setInteractionCount(interactionCount + 1) }}>Interaction <span id="interaction-count">{interactionCount}</span></button></section></main>\n}\n`);
 }
 
 async function writeBrokenGOX() {
@@ -611,9 +637,25 @@ function reloadEvidenceScript() {
         window.__goframeDevEventSources = [];
         window.__goframeDevDiagnosticExecuted = false;
         window.addEventListener("beforeunload", () => {
+            const authoredMarker = document.querySelector("#authored-build-error-marker");
+            const devPanels = [...document.querySelectorAll("[data-goframe-dev-build-error]")]
+                .filter((node) => node !== authoredMarker);
             sessionStorage.setItem(
                 "goframe-dev-panel-count-before-unload",
-                String(document.querySelectorAll("[data-goframe-dev-build-error]").length),
+                String(devPanels.length),
+            );
+            sessionStorage.setItem("goframe-dev-authored-marker-count-before-unload", String(authoredMarker ? 1 : 0));
+            sessionStorage.setItem(
+                "goframe-dev-authored-marker-identity-before-unload",
+                String(window.__goframeDevNodeIdentity?.(authoredMarker) || 0),
+            );
+            sessionStorage.setItem(
+                "goframe-dev-authored-heading-before-unload",
+                authoredMarker?.querySelector("[data-goframe-dev-build-error-heading]")?.textContent || "",
+            );
+            sessionStorage.setItem(
+                "goframe-dev-authored-message-before-unload",
+                authoredMarker?.querySelector("[data-goframe-dev-build-error-message]")?.textContent || "",
             );
         });
         const nodeIDs = new WeakMap();
@@ -656,7 +698,10 @@ async function pageState(client) {
     return await client.evaluate(`(() => {
         const script = document.querySelector("script[data-goframe-dev-reload]");
         const applicationRoot = document.querySelector("#app-version");
-        const panel = document.querySelector("[data-goframe-dev-build-error]");
+        const authoredMarker = document.querySelector("#authored-build-error-marker");
+        const buildErrorMarkers = [...document.querySelectorAll("[data-goframe-dev-build-error]")];
+        const devPanels = buildErrorMarkers.filter((node) => node !== authoredMarker);
+        const panel = devPanels[0] || null;
         return {
             href: location.href,
             readyState: document.readyState,
@@ -669,13 +714,24 @@ async function pageState(client) {
             buildErrorEvents: Number(sessionStorage.getItem("goframe-dev-build-error-events") || "0"),
             eventSourceOpens: Number(sessionStorage.getItem("goframe-dev-event-source-opens") || "0"),
             panelCountBeforeUnload: Number(sessionStorage.getItem("goframe-dev-panel-count-before-unload") || "-1"),
+            authoredMarkerCountBeforeUnload: Number(sessionStorage.getItem("goframe-dev-authored-marker-count-before-unload") || "-1"),
+            authoredMarkerIdentityBeforeUnload: Number(sessionStorage.getItem("goframe-dev-authored-marker-identity-before-unload") || "0"),
+            authoredHeadingBeforeUnload: sessionStorage.getItem("goframe-dev-authored-heading-before-unload") || "",
+            authoredMessageBeforeUnload: sessionStorage.getItem("goframe-dev-authored-message-before-unload") || "",
             generation: Number(script?.getAttribute("data-goframe-generation") || "0"),
             instance: script?.getAttribute("data-goframe-instance") || "",
             reloadTags: document.querySelectorAll("script[data-goframe-dev-reload]").length,
             appRootIdentity: window.__goframeDevNodeIdentity?.(applicationRoot) || 0,
             appRootCount: document.querySelectorAll("#app-version").length,
             interactionCount: Number(document.querySelector("#interaction-count")?.textContent || "0"),
-            buildErrorPresentations: document.querySelectorAll("[data-goframe-dev-build-error]").length,
+            authoredMarkerPresent: Boolean(authoredMarker),
+            authoredMarkerIdentity: window.__goframeDevNodeIdentity?.(authoredMarker) || 0,
+            authoredHeading: authoredMarker?.querySelector("[data-goframe-dev-build-error-heading]")?.textContent || "",
+            authoredMessage: authoredMarker?.querySelector("[data-goframe-dev-build-error-message]")?.textContent || "",
+            authoredMarkerInsideAppRoot: Boolean(authoredMarker?.closest("#app-version")),
+            buildErrorMarkers: buildErrorMarkers.length,
+            buildErrorPresentations: devPanels.length,
+            devPanelIdentity: window.__goframeDevNodeIdentity?.(panel) || 0,
             buildErrorBuild: Number(panel?.getAttribute("data-goframe-dev-build") || "0"),
             buildErrorHeading: panel?.querySelector("[data-goframe-dev-build-error-heading]")?.textContent || "",
             buildErrorMessage: panel?.querySelector("[data-goframe-dev-build-error-message]")?.textContent || "",
@@ -723,6 +779,9 @@ async function waitForBuildError(client, build, messageFragment) {
                 `build error accessibility = ${JSON.stringify({ role: last.buildErrorRole, live: last.buildErrorLive })}`);
             assert(!last.buildErrorInsideAppRoot, "build error presentation entered the application root");
             assert(last.appRootCount === 1, `application root count = ${last.appRootCount}, want 1`);
+            assertAuthoredMarker(last, `build ${build}`);
+            assert(last.buildErrorMarkers === 2,
+                `build ${build} marker count = ${last.buildErrorMarkers}, want authored marker plus one development panel`);
             return last;
         }
         await wait(25);
@@ -738,6 +797,16 @@ function assertFailedBuildPreserved(baseline, state, generation, label) {
         `${label} replaced the application root: ${JSON.stringify({ baseline, state })}`);
     assert(state.gox === baseline.gox && state.go === baseline.go && state.index === baseline.index,
         `${label} changed active application content: ${JSON.stringify({ baseline, state })}`);
+    assertAuthoredMarker(state, label);
+    assert(state.authoredMarkerIdentity === baseline.authoredMarkerIdentity,
+        `${label} replaced the authored marker: ${JSON.stringify({ baseline, state })}`);
+}
+
+function assertAuthoredMarker(state, label) {
+    assert(state.authoredMarkerPresent && state.authoredMarkerInsideAppRoot,
+        `${label} removed the authored build-error marker: ${JSON.stringify(state)}`);
+    assert(state.authoredHeading === "authored heading" && state.authoredMessage === "authored message",
+        `${label} changed authored build-error content: ${JSON.stringify(state)}`);
 }
 
 async function exerciseInteraction(client, baseline) {
@@ -760,11 +829,23 @@ async function dispatchMalformedBuildError(client) {
     })()`);
 }
 
+async function removeDevBuildErrorPanel(client) {
+    await client.evaluate(`(() => {
+        const authoredMarker = document.querySelector("#authored-build-error-marker");
+        for (const panel of document.querySelectorAll("[data-goframe-dev-build-error]")) {
+            if (panel !== authoredMarker) panel.remove();
+        }
+    })()`);
+}
+
 async function reconnectReloadClient(client, instance, generation, removeBuildError = false) {
     await client.evaluate(`(() => {
         for (const source of window.__goframeDevEventSources || []) source.close();
         if (${JSON.stringify(removeBuildError)}) {
-            document.querySelector("[data-goframe-dev-build-error]")?.remove();
+            const authoredMarker = document.querySelector("#authored-build-error-marker");
+            for (const panel of document.querySelectorAll("[data-goframe-dev-build-error]")) {
+                if (panel !== authoredMarker) panel.remove();
+            }
         }
         const script = document.createElement("script");
         script.src = ${JSON.stringify("/_goframe/dev/reload.js")} + "?reconnect=" + Date.now();

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -27,6 +27,7 @@ let client2 = null;
 let activationGapProbe = null;
 let devOutput = "";
 let browserError = "";
+let buildErrorEvidence = null;
 const lines = [];
 const counters = {
     successfulPackageAttempts: 0,
@@ -162,27 +163,171 @@ try {
 
     const failureBaseline = await pageState(client1);
     const failureStart = lines.length;
-    await writeFile(join(appDir, "app.gox"), `package main\n\nfunc App() { return <main>broken</main> }\n`);
-    await waitForBuild(nextBuild, "failed", failureStart);
+    const firstFailureBuild = nextBuild;
+    await writeBrokenGOX();
+    await waitForBuild(firstFailureBuild, "failed", failureStart);
     counters.failedPackageAttempts++;
     nextBuild++;
     const failureRoot = await fetch(`${serverURL}/`, { cache: "no-store" });
     const failureMetadata = await fetch(`${serverURL}/goframe-package.json`, { cache: "no-store" });
     assert(failureRoot.ok && failureMetadata.ok, `last successful package unavailable after failure: ${failureRoot.status}/${failureMetadata.status}`);
-    await wait(250);
-    const afterFailure = await pageState(client1);
-    assert(afterFailure.pageLoads === failureBaseline.pageLoads && afterFailure.reloadEvents === failureBaseline.reloadEvents,
-        `failed build reloaded the browser: ${JSON.stringify({ failureBaseline, afterFailure })}`);
-    assert(afterFailure.generation === activeGeneration, `failed build changed generation to ${afterFailure.generation}`);
-    console.log("failed build preservation: ok");
+    const failureRootText = await failureRoot.text();
+    const failureMetadataJSON = await failureMetadata.json();
+    assert(!failureRootText.includes("data-goframe-dev-build-error"), "development error presentation entered the served package index");
+    assert(failureMetadataJSON.version === 1, `last successful package metadata changed after failure: ${JSON.stringify(failureMetadataJSON)}`);
+    assert(!(await readFile(join(packageDir, "index.html"), "utf8")).includes("data-goframe-dev-build-error"),
+        "development error presentation entered the canonical package index");
 
-    const recoveryBaseline = afterFailure;
+    const afterFailure = await waitForBuildError(client1, firstFailureBuild, "empty expression for attribute");
+    assertFailedBuildPreserved(failureBaseline, afterFailure, activeGeneration, "first failed build");
+    assert(afterFailure.buildErrorEvents === failureBaseline.buildErrorEvents + 1,
+        `first failed build events = ${afterFailure.buildErrorEvents}, want ${failureBaseline.buildErrorEvents + 1}`);
+    assert(afterFailure.buildErrorMessage.includes("<img data-goframe-diagnostic-injected"),
+        `first failure omitted markup-like source text: ${JSON.stringify(afterFailure.buildErrorMessage)}`);
+    assert(afterFailure.injectedDiagnosticElements === 0 && !afterFailure.diagnosticExecuted,
+        `first failure executed markup-like diagnostic text: ${JSON.stringify(afterFailure)}`);
+    const interactiveAfterFailure = await exerciseInteraction(client1, afterFailure);
+    assert(interactiveAfterFailure.appRootIdentity === failureBaseline.appRootIdentity,
+        `first failed build replaced the application root: ${JSON.stringify({ failureBaseline, interactiveAfterFailure })}`);
+    console.log("first failed build presentation and interaction: ok");
+
+    const failureSecondTarget = await client1.call("Target.createTarget", { url: "about:blank" });
+    const failureSecondPage = await waitForTarget(debugPort, failureSecondTarget.targetId);
+    client2 = await connect(failureSecondPage.webSocketDebuggerUrl);
+    await prepareClient(client2);
+    await navigate(client2, `${serverURL}/?smoke=build-error-second-client`);
+    const failureSecondInitial = await waitForPageState(client2, {
+        gox: "burst-final",
+        go: "go-rebuild",
+        index: "index-rebuild",
+        generation: activeGeneration,
+    });
+    const failureSecondRetained = await waitForBuildError(client2, firstFailureBuild, "empty expression for attribute");
+    assert(failureSecondRetained.pageLoads === failureSecondInitial.pageLoads
+        && failureSecondRetained.reloadEvents === failureSecondInitial.reloadEvents,
+        `retained failure reloaded the second page: ${JSON.stringify(failureSecondRetained)}`);
+    assert(failureSecondRetained.buildErrorEvents === 1,
+        `second page retained failure events = ${failureSecondRetained.buildErrorEvents}, want 1`);
+
+    const replacementBaseline1 = await pageState(client1);
+    const replacementBaseline2 = await pageState(client2);
+    const replacementFailureBuild = nextBuild;
+    await writeReplacementBrokenGOX();
+    await waitForBuild(replacementFailureBuild, "failed");
+    counters.failedPackageAttempts++;
+    nextBuild++;
+    const [replacementFailure1, replacementFailure2] = await Promise.all([
+        waitForBuildError(client1, replacementFailureBuild, "data-replacement"),
+        waitForBuildError(client2, replacementFailureBuild, "data-replacement"),
+    ]);
+    assertFailedBuildPreserved(replacementBaseline1, replacementFailure1, activeGeneration, "replacement failed build on page 1");
+    assertFailedBuildPreserved(replacementBaseline2, replacementFailure2, activeGeneration, "replacement failed build on page 2");
+    for (const [label, state] of [["page 1", replacementFailure1], ["page 2", replacementFailure2]]) {
+        assert(state.buildErrorMessage !== afterFailure.buildErrorMessage,
+            `${label} retained the first failure message`);
+        assert(!state.buildErrorMessage.includes("data-goframe-diagnostic-injected"),
+            `${label} retained markup from the first failure`);
+    }
+    const interactiveSecondPage = await exerciseInteraction(client2, replacementFailure2);
+    assert(interactiveSecondPage.appRootIdentity === replacementFailure2.appRootIdentity,
+        `replacement failure interaction replaced page 2 root: ${JSON.stringify(interactiveSecondPage)}`);
+    console.log("consecutive failure replacement on two pages: ok");
+
+    const reconnectBaseline = await pageState(client1);
+    await reconnectReloadClient(client1, activeInstance, activeGeneration, true);
+    await waitForEventSourceOpen(client1, reconnectBaseline.eventSourceOpens + 1);
+    const afterFailureReconnect = await waitForBuildError(client1, replacementFailureBuild, "data-replacement");
+    assertFailedBuildPreserved(reconnectBaseline, afterFailureReconnect, activeGeneration, "current-generation failure reconnect");
+    assert(afterFailureReconnect.buildErrorEvents === reconnectBaseline.buildErrorEvents + 1,
+        `current-generation reconnect events = ${afterFailureReconnect.buildErrorEvents}, want ${reconnectBaseline.buildErrorEvents + 1}`);
+    console.log("current-generation failure reconnect: ok");
+
+    const malformedBaseline = await pageState(client1);
+    await dispatchMalformedBuildError(client1);
+    const afterMalformed = await pageState(client1);
+    assert(afterMalformed.buildErrorEvents === malformedBaseline.buildErrorEvents
+        && afterMalformed.buildErrorBuild === malformedBaseline.buildErrorBuild
+        && afterMalformed.buildErrorMessage === malformedBaseline.buildErrorMessage,
+        `malformed private event changed the presentation: ${JSON.stringify({ malformedBaseline, afterMalformed })}`);
+    assert(client1.runtimeErrors.length === 0, `malformed private event caused runtime errors: ${JSON.stringify(client1.runtimeErrors)}`);
+
+    const staleFailureBaseline = afterMalformed;
+    await reconnectReloadClient(client1, activeInstance, activeGeneration - 1, true);
+    const staleFailureCaughtUp = await waitForPageState(client1, {
+        gox: "burst-final",
+        go: "go-rebuild",
+        index: "index-rebuild",
+        pageLoads: staleFailureBaseline.pageLoads + 1,
+        reloadEvents: staleFailureBaseline.reloadEvents + 1,
+        generation: activeGeneration,
+    });
+    counters.catchUpReloads++;
+    const failureAfterCatchUp = await waitForBuildError(client1, replacementFailureBuild, "data-replacement");
+    assert(failureAfterCatchUp.buildErrorEvents === staleFailureBaseline.buildErrorEvents + 1,
+        `stale catch-up failure events = ${failureAfterCatchUp.buildErrorEvents}, want ${staleFailureBaseline.buildErrorEvents + 1}`);
+    assert(failureAfterCatchUp.pageLoads === staleFailureCaughtUp.pageLoads
+        && failureAfterCatchUp.reloadEvents === staleFailureCaughtUp.reloadEvents,
+        `current failure caused a second reload after stale catch-up: ${JSON.stringify(failureAfterCatchUp)}`);
+    console.log("stale-generation reload precedes retained failure: ok");
+
+    const recoveryBaseline1 = failureAfterCatchUp;
+    const recoveryBaseline2 = interactiveSecondPage;
     await writeGOX("recovered");
     await waitForBuild(nextBuild, "succeeded");
-    await assertSuccessfulReload(client1, recoveryBaseline, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" }, ++activeGeneration);
+    const recoveryGeneration = ++activeGeneration;
+    const [recovered1, recovered2] = await Promise.all([
+        assertSuccessfulReload(client1, recoveryBaseline1, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" }, recoveryGeneration),
+        assertSuccessfulReload(client2, recoveryBaseline2, { gox: "recovered", go: "go-rebuild", index: "index-rebuild" }, recoveryGeneration),
+    ]);
     recordSuccessfulReload();
     nextBuild++;
-    console.log("failed build recovery reload: ok");
+    await Promise.all([
+        waitForEventSourceOpen(client1, recoveryBaseline1.eventSourceOpens + 1),
+        waitForEventSourceOpen(client2, recoveryBaseline2.eventSourceOpens + 1),
+    ]);
+    const stableRecovery1 = await pageState(client1);
+    const stableRecovery2 = await pageState(client2);
+    for (const [label, baseline, state] of [
+        ["page 1", recoveryBaseline1, stableRecovery1],
+        ["page 2", recoveryBaseline2, stableRecovery2],
+    ]) {
+        assert(state.buildErrorPresentations === 0, `${label} retained an error presentation after recovery: ${JSON.stringify(state)}`);
+        assert(state.buildErrorEvents === baseline.buildErrorEvents,
+            `${label} replayed a cleared failure after recovery: ${JSON.stringify({ baseline, state })}`);
+        assert(state.panelCountBeforeUnload === 0,
+            `${label} still had an error presentation when recovery reload was initiated: ${JSON.stringify(state)}`);
+    }
+    assert(recovered1.generation === recoveryGeneration && recovered2.generation === recoveryGeneration,
+        `recovery generations = ${recovered1.generation}/${recovered2.generation}, want ${recoveryGeneration}`);
+
+    const clearedReconnectBaseline = stableRecovery1;
+    await reconnectReloadClient(client1, activeInstance, activeGeneration, true);
+    await waitForEventSourceOpen(client1, clearedReconnectBaseline.eventSourceOpens + 1);
+    await wait(100);
+    const afterClearedReconnect = await pageState(client1);
+    assert(afterClearedReconnect.pageLoads === clearedReconnectBaseline.pageLoads
+        && afterClearedReconnect.reloadEvents === clearedReconnectBaseline.reloadEvents
+        && afterClearedReconnect.buildErrorEvents === clearedReconnectBaseline.buildErrorEvents
+        && afterClearedReconnect.buildErrorPresentations === 0,
+        `cleared failure replayed on current-generation reconnect: ${JSON.stringify(afterClearedReconnect)}`);
+    assert(client1.runtimeErrors.length === 0 && client2.runtimeErrors.length === 0,
+        `application runtime errors during failed-build recovery: ${JSON.stringify({ page1: client1.runtimeErrors, page2: client2.runtimeErrors })}`);
+    buildErrorEvidence = {
+        builds: [firstFailureBuild, replacementFailureBuild],
+        firstPageEvents: afterClearedReconnect.buildErrorEvents,
+        secondPageEvents: stableRecovery2.buildErrorEvents,
+        recoveryGeneration,
+        firstPageLoads: stableRecovery1.pageLoads,
+        secondPageLoads: stableRecovery2.pageLoads,
+        firstPageReloads: stableRecovery1.reloadEvents,
+        secondPageReloads: stableRecovery2.reloadEvents,
+        interactionCounts: [interactiveAfterFailure.interactionCount, interactiveSecondPage.interactionCount],
+        runtimeErrors: 0,
+    };
+    client2.close();
+    await client1.call("Target.closeTarget", { targetId: failureSecondTarget.targetId });
+    client2 = null;
+    console.log("failed build recovery reload on two pages: ok");
 
     const embedBaseline = await pageState(client1);
     await writeEmbeddedMessage("embed-beta");
@@ -318,6 +463,10 @@ try {
 
     const client1Final = await pageState(client1);
     const client2Final = await pageState(client2);
+    assert(client1Final.buildErrorPresentations === 0 && client2Final.buildErrorPresentations === 0,
+        `final pages retained build-error presentations: ${JSON.stringify({ client1Final, client2Final })}`);
+    assert(client1.runtimeErrors.length === 0 && client2.runtimeErrors.length === 0,
+        `browser runtime errors = ${JSON.stringify({ page1: client1.runtimeErrors, page2: client2.runtimeErrors })}`);
     const generationRoots = [...await listGenerationRoots()].filter((entry) => !generationRootsBefore.has(entry));
     assert(generationRoots.length === 1, `development generation roots = ${JSON.stringify(generationRoots)}, want one`);
     dev.kill("SIGINT");
@@ -349,6 +498,7 @@ try {
     console.log(`new-generation index responses: ${counters.newGenerationIndexResponses}`);
     console.log(`404 responses during rebuild: ${counters.responses404DuringBuild}`);
     console.log(`partial responses during rebuild: ${counters.partialResponsesDuringBuild}`);
+    console.log(`build error evidence: ${JSON.stringify(buildErrorEvidence)}`);
     console.log("goxc dev reload browser smoke: ok");
 } catch (error) {
     throw new Error(`${error.message}\n\nDevelopment output:\n${devOutput.slice(-12000)}\n\nChrome stderr:\n${browserError.slice(-6000)}`);
@@ -386,7 +536,29 @@ async function writeApplication(gox, go, index) {
 }
 
 async function writeGOX(value) {
-    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span><span id="embedded-value">{embeddedMessage}</span></main>\n}\n`);
+    await writeFile(join(appDir, "app.gox"), `package main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc App() gf.Node {\n    interactionCount, setInteractionCount := gf.UseState(0)\n    return <main id="app-version"><span id="gox-version">${value}</span><span id="go-version">{message()}</span><span id="embedded-value">{embeddedMessage}</span><button id="interaction-control" type="button" onClick={func() { setInteractionCount(interactionCount + 1) }}>Interaction <span id="interaction-count">{interactionCount}</span></button></main>\n}\n`);
+}
+
+async function writeBrokenGOX() {
+    await writeFile(join(appDir, "app.gox"), `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+    return <main data-broken={}><img data-goframe-diagnostic-injected src="missing" onerror="window.__goframeDevDiagnosticExecuted=true" /></main>
+}
+`);
+}
+
+async function writeReplacementBrokenGOX() {
+    await writeFile(join(appDir, "app.gox"), `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+func App() gf.Node {
+    return <main data-replacement={}></main>
+}
+`);
 }
 
 async function writeGoMessage(value) {
@@ -415,6 +587,10 @@ document.querySelector("#page-load-count").textContent = String(count);
 }
 
 async function prepareClient(client) {
+    client.runtimeErrors = [];
+    client.on("Runtime.exceptionThrown", ({ exceptionDetails }) => {
+        client.runtimeErrors.push(exceptionDetails?.text || "unknown browser exception");
+    });
     await client.call("Runtime.enable");
     await client.call("Page.enable");
     await client.call("Network.enable");
@@ -433,6 +609,24 @@ function reloadEvidenceScript() {
         const NativeEventSource = window.EventSource;
         if (typeof NativeEventSource !== "function") return;
         window.__goframeDevEventSources = [];
+        window.__goframeDevDiagnosticExecuted = false;
+        window.addEventListener("beforeunload", () => {
+            sessionStorage.setItem(
+                "goframe-dev-panel-count-before-unload",
+                String(document.querySelectorAll("[data-goframe-dev-build-error]").length),
+            );
+        });
+        const nodeIDs = new WeakMap();
+        window.__goframeDevNodeIdentity = (node) => {
+            if (!node) return 0;
+            let identity = nodeIDs.get(node);
+            if (!identity) {
+                identity = Number(sessionStorage.getItem("goframe-dev-next-node-identity") || "0") + 1;
+                sessionStorage.setItem("goframe-dev-next-node-identity", String(identity));
+                nodeIDs.set(node, identity);
+            }
+            return identity;
+        };
         const increment = (key) => {
             const next = Number(sessionStorage.getItem(key) || "0") + 1;
             sessionStorage.setItem(key, String(next));
@@ -441,6 +635,14 @@ function reloadEvidenceScript() {
             const source = options === undefined ? new NativeEventSource(url) : new NativeEventSource(url, options);
             window.__goframeDevEventSources.push(source);
             source.addEventListener("open", () => increment("goframe-dev-event-source-opens"));
+            source.addEventListener("build-error", (event) => {
+                try {
+                    const failure = JSON.parse(event.data);
+                    if (failure && Number.isInteger(failure.build) && failure.build > 0 && typeof failure.message === "string") {
+                        increment("goframe-dev-build-error-events");
+                    }
+                } catch (_) {}
+            });
             source.addEventListener("reload", () => increment("goframe-dev-reload-events"));
             return source;
         }
@@ -453,6 +655,8 @@ function reloadEvidenceScript() {
 async function pageState(client) {
     return await client.evaluate(`(() => {
         const script = document.querySelector("script[data-goframe-dev-reload]");
+        const applicationRoot = document.querySelector("#app-version");
+        const panel = document.querySelector("[data-goframe-dev-build-error]");
         return {
             href: location.href,
             readyState: document.readyState,
@@ -462,10 +666,24 @@ async function pageState(client) {
             index: document.querySelector("#index-version")?.textContent || "",
             pageLoads: Number(sessionStorage.getItem("goframe-dev-page-loads") || "0"),
             reloadEvents: Number(sessionStorage.getItem("goframe-dev-reload-events") || "0"),
+            buildErrorEvents: Number(sessionStorage.getItem("goframe-dev-build-error-events") || "0"),
             eventSourceOpens: Number(sessionStorage.getItem("goframe-dev-event-source-opens") || "0"),
+            panelCountBeforeUnload: Number(sessionStorage.getItem("goframe-dev-panel-count-before-unload") || "-1"),
             generation: Number(script?.getAttribute("data-goframe-generation") || "0"),
             instance: script?.getAttribute("data-goframe-instance") || "",
             reloadTags: document.querySelectorAll("script[data-goframe-dev-reload]").length,
+            appRootIdentity: window.__goframeDevNodeIdentity?.(applicationRoot) || 0,
+            appRootCount: document.querySelectorAll("#app-version").length,
+            interactionCount: Number(document.querySelector("#interaction-count")?.textContent || "0"),
+            buildErrorPresentations: document.querySelectorAll("[data-goframe-dev-build-error]").length,
+            buildErrorBuild: Number(panel?.getAttribute("data-goframe-dev-build") || "0"),
+            buildErrorHeading: panel?.querySelector("[data-goframe-dev-build-error-heading]")?.textContent || "",
+            buildErrorMessage: panel?.querySelector("[data-goframe-dev-build-error-message]")?.textContent || "",
+            buildErrorRole: panel?.getAttribute("role") || "",
+            buildErrorLive: panel?.getAttribute("aria-live") || "",
+            buildErrorInsideAppRoot: Boolean(panel?.closest("#app-version")),
+            injectedDiagnosticElements: document.querySelectorAll("[data-goframe-diagnostic-injected]").length,
+            diagnosticExecuted: Boolean(window.__goframeDevDiagnosticExecuted),
         };
     })()`);
 }
@@ -489,11 +707,65 @@ async function assertSuccessfulReload(client, baseline, expected, generation) {
         generation,
     });
     assert(state.reloadTags === 1, `reload tag count = ${state.reloadTags}, want 1`);
+    return state;
 }
 
-async function reconnectReloadClient(client, instance, generation) {
+async function waitForBuildError(client, build, messageFragment) {
+    let last = null;
+    for (let attempt = 0; attempt < 200; attempt++) {
+        last = await pageState(client);
+        if (last.buildErrorPresentations === 1
+            && last.buildErrorBuild === build
+            && last.buildErrorMessage.includes(messageFragment)) {
+            assert(last.buildErrorHeading === `Build ${build} failed`,
+                `build error heading = ${JSON.stringify(last.buildErrorHeading)}, want build ${build}`);
+            assert(last.buildErrorRole === "alert" && last.buildErrorLive === "assertive",
+                `build error accessibility = ${JSON.stringify({ role: last.buildErrorRole, live: last.buildErrorLive })}`);
+            assert(!last.buildErrorInsideAppRoot, "build error presentation entered the application root");
+            assert(last.appRootCount === 1, `application root count = ${last.appRootCount}, want 1`);
+            return last;
+        }
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: build ${build} presentation did not contain ${JSON.stringify(messageFragment)}; last=${JSON.stringify(last)}`);
+}
+
+function assertFailedBuildPreserved(baseline, state, generation, label) {
+    assert(state.pageLoads === baseline.pageLoads && state.reloadEvents === baseline.reloadEvents,
+        `${label} reloaded the browser: ${JSON.stringify({ baseline, state })}`);
+    assert(state.generation === generation, `${label} changed generation to ${state.generation}, want ${generation}`);
+    assert(state.appRootIdentity === baseline.appRootIdentity,
+        `${label} replaced the application root: ${JSON.stringify({ baseline, state })}`);
+    assert(state.gox === baseline.gox && state.go === baseline.go && state.index === baseline.index,
+        `${label} changed active application content: ${JSON.stringify({ baseline, state })}`);
+}
+
+async function exerciseInteraction(client, baseline) {
+    await client.evaluate(`document.querySelector("#interaction-control").click()`);
+    return await waitForPageState(client, {
+        interactionCount: baseline.interactionCount + 1,
+        pageLoads: baseline.pageLoads,
+        reloadEvents: baseline.reloadEvents,
+        generation: baseline.generation,
+        appRootIdentity: baseline.appRootIdentity,
+    });
+}
+
+async function dispatchMalformedBuildError(client) {
+    await client.evaluate(`(() => {
+        const sources = window.__goframeDevEventSources || [];
+        const source = sources[sources.length - 1];
+        if (!source) throw new Error("no development EventSource to probe");
+        source.dispatchEvent(new MessageEvent("build-error", { data: "{malformed" }));
+    })()`);
+}
+
+async function reconnectReloadClient(client, instance, generation, removeBuildError = false) {
     await client.evaluate(`(() => {
         for (const source of window.__goframeDevEventSources || []) source.close();
+        if (${JSON.stringify(removeBuildError)}) {
+            document.querySelector("[data-goframe-dev-build-error]")?.remove();
+        }
         const script = document.createElement("script");
         script.src = ${JSON.stringify("/_goframe/dev/reload.js")} + "?reconnect=" + Date.now();
         script.setAttribute("data-goframe-instance", ${JSON.stringify(String(instance))});

--- a/scripts/goxc-dev-reload-browser-smoke.mjs
+++ b/scripts/goxc-dev-reload-browser-smoke.mjs
@@ -28,6 +28,7 @@ let activationGapProbe = null;
 let devOutput = "";
 let browserError = "";
 let buildErrorEvidence = null;
+let bodyRootEvidence = null;
 const lines = [];
 const counters = {
     successfulPackageAttempts: 0,
@@ -452,6 +453,7 @@ try {
     console.log("same-generation reconnect: ok");
 
     await reconnectReloadClient(client1, activeInstance, activeGeneration - 1);
+    await waitForEventSourceOpen(client1, afterCurrentReconnect.eventSourceOpens + 1);
     const caughtUp = await waitForPageState(client1, {
         gox: "recovered",
         go: "activation-gap-follow-up",
@@ -467,6 +469,7 @@ try {
     const previousProcessBaseline = caughtUp;
     const previousInstance = activeInstance === "f".repeat(32) ? "e".repeat(32) : "f".repeat(32);
     await reconnectReloadClient(client1, previousInstance, activeGeneration + 1000);
+    await waitForEventSourceOpen(client1, previousProcessBaseline.eventSourceOpens + 1);
     const previousProcessCaughtUp = await waitForPageState(client1, {
         gox: "recovered",
         go: "activation-gap-follow-up",
@@ -493,15 +496,117 @@ try {
     assertAuthoredMarker(client2Final, "final page 2");
     assert(client1.runtimeErrors.length === 0 && client2.runtimeErrors.length === 0,
         `browser runtime errors = ${JSON.stringify({ page1: client1.runtimeErrors, page2: client2.runtimeErrors })}`);
+
+    await closeEventSources(client2);
+    await waitForNoEventStreams(client2);
+    await client1.call("Target.closeTarget", { targetId: secondTarget.targetId });
+    client2.close();
+    client2 = null;
+
+    const bodyRootTransitionBaseline = client1Final;
+    await writeBodyRootIndex("body-root-index");
+    await waitForBuild(nextBuild, "succeeded");
+    const bodyRootGeneration = ++activeGeneration;
+    const bodyRootInitial = await waitForBodyRootState(client1, {
+        bodyRootVersion: "body-root-initial",
+        bodyRootAppVisible: true,
+        pageLoads: bodyRootTransitionBaseline.pageLoads + 1,
+        reloadEvents: bodyRootTransitionBaseline.reloadEvents + 1,
+        generation: bodyRootGeneration,
+    });
+    recordSuccessfulReload();
+    nextBuild++;
+    assert(bodyRootInitial.bodyRoot, `body-root fixture did not mount into body: ${JSON.stringify(bodyRootInitial)}`);
+    assert(bodyRootInitial.eventSourceCount === 1 && bodyRootInitial.eventSourceOpens === bodyRootTransitionBaseline.eventSourceOpens + 1,
+        `body-root reload client state = ${JSON.stringify(bodyRootInitial)}`);
+    assert(bodyRootInitial.buildErrorPresentations === 0,
+        `body-root fixture started with a build-error presentation: ${JSON.stringify(bodyRootInitial)}`);
+    const bodyRootInteractive = await exerciseBodyRootInteraction(client1, bodyRootInitial);
+
+    const bodyRootFailureBuild = nextBuild;
+    await writeBrokenBodyRootGo();
+    await waitForBuild(bodyRootFailureBuild, "failed");
+    counters.failedPackageAttempts++;
+    nextBuild++;
+    const bodyRootFailure = await waitForBodyRootBuildError(client1, bodyRootFailureBuild, "go WASM build failed");
+    assert(bodyRootFailure.pageLoads === bodyRootInteractive.pageLoads
+        && bodyRootFailure.reloadEvents === bodyRootInteractive.reloadEvents
+        && bodyRootFailure.generation === bodyRootGeneration,
+        `body-root failure changed the active page: ${JSON.stringify({ bodyRootInteractive, bodyRootFailure })}`);
+    assert(bodyRootFailure.buildErrorEvents === bodyRootInteractive.buildErrorEvents + 1,
+        `body-root failure events = ${bodyRootFailure.buildErrorEvents}, want ${bodyRootInteractive.buildErrorEvents + 1}`);
+    assert(bodyRootFailure.eventSourceCount === bodyRootInteractive.eventSourceCount
+        && bodyRootFailure.eventSourceOpens === bodyRootInteractive.eventSourceOpens,
+        `body-root failure reconnected EventSource: ${JSON.stringify({ bodyRootInteractive, bodyRootFailure })}`);
+
+    await client1.evaluate(`document.querySelector("#body-root-replace-control").click()`);
+    const bodyRootReplacement = await waitForBodyRootState(client1, {
+        bodyRootReplacementVisible: true,
+        bodyRootCleanupCount: 1,
+        pageLoads: bodyRootFailure.pageLoads,
+        reloadEvents: bodyRootFailure.reloadEvents,
+        buildErrorEvents: bodyRootFailure.buildErrorEvents,
+        eventSourceOpens: bodyRootFailure.eventSourceOpens,
+        eventSourceCount: bodyRootFailure.eventSourceCount,
+        generation: bodyRootGeneration,
+    });
+    assert(bodyRootReplacement.devPanelIdentity === bodyRootFailure.devPanelIdentity,
+        `body-root build-error presentation disappeared after repeated Mount: ${JSON.stringify({ bodyRootFailure, bodyRootReplacement })}`);
+    assert(bodyRootFailure.devPanelParent === "documentElement" && !bodyRootFailure.devPanelInsideBody,
+        `body-root failure panel was not outside body: ${JSON.stringify(bodyRootFailure)}`);
+    assert(bodyRootReplacement.devPanelParent === "documentElement" && !bodyRootReplacement.devPanelInsideBody,
+        `body-root replacement panel entered body: ${JSON.stringify(bodyRootReplacement)}`);
+    assert(bodyRootReplacement.buildErrorBuild === bodyRootFailureBuild
+        && bodyRootReplacement.buildErrorMessage === bodyRootFailure.buildErrorMessage,
+        `body-root replacement changed the retained failure: ${JSON.stringify({ bodyRootFailure, bodyRootReplacement })}`);
+    const bodyRootReplacementInteractive = await exerciseBodyRootReplacementInteraction(client1, bodyRootReplacement);
+
+    await writeBodyRootStatus("body-root-recovered");
+    await waitForBuild(nextBuild, "succeeded");
+    const bodyRootRecoveryGeneration = ++activeGeneration;
+    const bodyRootRecovered = await waitForBodyRootState(client1, {
+        bodyRootVersion: "body-root-recovered",
+        bodyRootAppVisible: true,
+        pageLoads: bodyRootReplacementInteractive.pageLoads + 1,
+        reloadEvents: bodyRootReplacementInteractive.reloadEvents + 1,
+        buildErrorEvents: bodyRootReplacementInteractive.buildErrorEvents,
+        eventSourceOpens: bodyRootReplacementInteractive.eventSourceOpens + 1,
+        eventSourceCount: 1,
+        generation: bodyRootRecoveryGeneration,
+        buildErrorPresentations: 0,
+    });
+    recordSuccessfulReload();
+    nextBuild++;
+    assert(bodyRootRecovered.panelCountBeforeUnload === 0,
+        `body-root panel remained when recovery reload began: ${JSON.stringify(bodyRootRecovered)}`);
+    assert(client1.runtimeErrors.length === 0,
+        `body-root scenario caused browser runtime errors: ${JSON.stringify(client1.runtimeErrors)}`);
+    bodyRootEvidence = {
+        failureBuild: bodyRootFailureBuild,
+        failureGeneration: bodyRootGeneration,
+        recoveryGeneration: bodyRootRecoveryGeneration,
+        buildErrorEvents: bodyRootRecovered.buildErrorEvents,
+        eventSourceOpens: bodyRootRecovered.eventSourceOpens,
+        pageLoads: bodyRootRecovered.pageLoads,
+        reloadEvents: bodyRootRecovered.reloadEvents,
+        initialInteractionCount: bodyRootInteractive.bodyRootInteractionCount,
+        replacementInteractionCount: bodyRootReplacementInteractive.bodyRootReplacementInteractionCount,
+        cleanupCount: bodyRootReplacementInteractive.bodyRootCleanupCount,
+        runtimeErrors: 0,
+    };
+    console.log("body-root build-error persistence and recovery: ok");
+
     const generationRoots = [...await listGenerationRoots()].filter((entry) => !generationRootsBefore.has(entry));
     assert(generationRoots.length === 1, `development generation roots = ${JSON.stringify(generationRoots)}, want one`);
+    const shutdownBaseline = await pageState(client1);
+    await closeEventSourcesOnError(client1);
     dev.kill("SIGINT");
     const devExit = await waitForExit(dev, 15_000);
     assert(devExit.code === 0, `goxc dev exited with ${JSON.stringify(devExit)}\n${devOutput}`);
     dev = null;
     await waitForHTTPShutdown(serverURL);
+    await waitForEventSourceError(client1, shutdownBaseline.eventSourceErrors + 1);
     await waitForNoEventStreams(client1);
-    await waitForNoEventStreams(client2);
     for (const generationRoot of generationRoots) {
         assert(!existsSync(join(tmpdir(), generationRoot)), `generation root remained after shutdown: ${generationRoot}`);
     }
@@ -525,6 +630,7 @@ try {
     console.log(`404 responses during rebuild: ${counters.responses404DuringBuild}`);
     console.log(`partial responses during rebuild: ${counters.partialResponsesDuringBuild}`);
     console.log(`build error evidence: ${JSON.stringify(buildErrorEvidence)}`);
+    console.log(`body-root evidence: ${JSON.stringify(bodyRootEvidence)}`);
     console.log("goxc dev reload browser smoke: ok");
 } catch (error) {
     throw new Error(`${error.message}\n\nDevelopment output:\n${devOutput.slice(-12000)}\n\nChrome stderr:\n${browserError.slice(-6000)}`);
@@ -552,11 +658,13 @@ async function writeApplication(gox, go, index) {
     await mkdir(join(appDir, "assets"), { recursive: true });
     await writeFile(join(appDir, "go.mod"), `module example.com/goframe-dev-reload\n\ngo 1.22\n\nrequire github.com/graybuton/goframe v0.0.0\n\nreplace github.com/graybuton/goframe => ${repositoryRoot}\n`);
     await writeFile(join(appDir, "goframe.json"), `{"name":"dev-reload-smoke","entry":".","compiler":"go","assets":"assets"}\n`);
-    await writeFile(join(appDir, "main.go"), `//go:build js && wasm\n\npackage main\n\nimport gf "github.com/graybuton/goframe/pkg/goframe"\n\nfunc main() {\n    done := make(chan struct{})\n    gf.Mount("root", App)\n    <-done\n}\n`);
+    await writeFile(join(appDir, "main.go"), `//go:build js && wasm\n\npackage main\n\nimport (\n    "syscall/js"\n\n    gf "github.com/graybuton/goframe/pkg/goframe"\n)\n\nfunc main() {\n    done := make(chan struct{})\n    app := App\n    body := js.Global().Get("document").Get("body")\n    if !body.IsUndefined() && !body.IsNull() && body.Get("id").String() == "root" {\n        app = BodyRootApp\n    }\n    gf.Mount("root", app)\n    <-done\n}\n`);
     await writeGoMessage(go);
     await writeFile(join(appDir, "embedded.go"), `package main\n\nimport _ "embed"\n\n//go:embed embedded-message.txt\nvar embeddedMessage string\n`);
     await writeEmbeddedMessage("embed-alpha");
     await writeGOX(gox);
+    await writeBodyRootGOX();
+    await writeBodyRootStatus("body-root-initial");
     await writeIndex(index);
     await writeFile(join(appDir, "assets", "marker.txt"), "complete asset\n");
 }
@@ -587,6 +695,34 @@ func App() gf.Node {
 `);
 }
 
+async function writeBodyRootGOX() {
+    await writeFile(join(appDir, "body_root.gox"), `package main
+
+import gf "github.com/graybuton/goframe/pkg/goframe"
+
+var bodyRootCleanupCount int
+
+func BodyRootApp() gf.Node {
+    interactionCount, setInteractionCount := gf.UseState(0)
+    gf.UseUnmount(func() { bodyRootCleanupCount++ })
+    return <main id="body-root-app"><span id="body-root-version">{bodyRootBuildStatus()}</span><button id="body-root-interaction" type="button" onClick={func() { setInteractionCount(interactionCount + 1) }}>Initial interaction <span id="body-root-interaction-count">{interactionCount}</span></button><button id="body-root-replace-control" type="button" onClick={func() { gf.Mount("root", BodyRootReplacementApp) }}>Replace body application</button></main>
+}
+
+func BodyRootReplacementApp() gf.Node {
+    interactionCount, setInteractionCount := gf.UseState(0)
+    return <main id="body-root-replacement"><span id="body-root-cleanup-count">{bodyRootCleanupCount}</span><button id="body-root-replacement-interaction" type="button" onClick={func() { setInteractionCount(interactionCount + 1) }}>Replacement interaction <span id="body-root-replacement-interaction-count">{interactionCount}</span></button></main>
+}
+`);
+}
+
+async function writeBrokenBodyRootGo() {
+    await writeFile(join(appDir, "body_root_status.go"), `package main\n\nfunc bodyRootBuildStatus() string { return bodyRootBroken }\n`);
+}
+
+async function writeBodyRootStatus(value) {
+    await writeFile(join(appDir, "body_root_status.go"), `package main\n\nfunc bodyRootBuildStatus() string { return ${JSON.stringify(value)} }\n`);
+}
+
 async function writeGoMessage(value) {
     await writeFile(join(appDir, "message.go"), `package main\n\nfunc message() string { return ${JSON.stringify(value)} }\n`);
 }
@@ -608,6 +744,22 @@ document.querySelector("#page-load-count").textContent = String(count);
 </script>
 <script src="wasm_exec.js"></script>
 <script>var go = new Go(); WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject).then(function (result) { go.run(result.instance); });</script>
+</body></html>
+`);
+}
+
+async function writeBodyRootIndex(value) {
+    await writeFile(join(appDir, "assets", "index.html"), `<!doctype html>
+<html><body id="root">
+<div id="index-version">${value}</div>
+<div id="page-load-count"></div>
+<script>
+var count = Number(sessionStorage.getItem("goframe-dev-page-loads") || "0") + 1;
+sessionStorage.setItem("goframe-dev-page-loads", String(count));
+document.querySelector("#page-load-count").textContent = String(count);
+</script>
+<script src="wasm_exec.js"></script>
+<script>window.addEventListener("load", function () { var go = new Go(); WebAssembly.instantiateStreaming(fetch("bundle.wasm"), go.importObject).then(function (result) { go.run(result.instance); }); }, { once: true });</script>
 </body></html>
 `);
 }
@@ -677,6 +829,7 @@ function reloadEvidenceScript() {
             const source = options === undefined ? new NativeEventSource(url) : new NativeEventSource(url, options);
             window.__goframeDevEventSources.push(source);
             source.addEventListener("open", () => increment("goframe-dev-event-source-opens"));
+            source.addEventListener("error", () => increment("goframe-dev-event-source-errors"));
             source.addEventListener("build-error", (event) => {
                 try {
                     const failure = JSON.parse(event.data);
@@ -697,6 +850,12 @@ function reloadEvidenceScript() {
 async function pageState(client) {
     return await client.evaluate(`(() => {
         const script = document.querySelector("script[data-goframe-dev-reload]");
+        const eventSources = window.__goframeDevEventSources || [];
+        const activeEventSource = eventSources[eventSources.length - 1];
+        let activeEventSourceURL = null;
+        try {
+            activeEventSourceURL = activeEventSource ? new URL(activeEventSource.url, location.href) : null;
+        } catch (_) {}
         const applicationRoot = document.querySelector("#app-version");
         const authoredMarker = document.querySelector("#authored-build-error-marker");
         const buildErrorMarkers = [...document.querySelectorAll("[data-goframe-dev-build-error]")];
@@ -713,14 +872,16 @@ async function pageState(client) {
             reloadEvents: Number(sessionStorage.getItem("goframe-dev-reload-events") || "0"),
             buildErrorEvents: Number(sessionStorage.getItem("goframe-dev-build-error-events") || "0"),
             eventSourceOpens: Number(sessionStorage.getItem("goframe-dev-event-source-opens") || "0"),
+            eventSourceErrors: Number(sessionStorage.getItem("goframe-dev-event-source-errors") || "0"),
             panelCountBeforeUnload: Number(sessionStorage.getItem("goframe-dev-panel-count-before-unload") || "-1"),
             authoredMarkerCountBeforeUnload: Number(sessionStorage.getItem("goframe-dev-authored-marker-count-before-unload") || "-1"),
             authoredMarkerIdentityBeforeUnload: Number(sessionStorage.getItem("goframe-dev-authored-marker-identity-before-unload") || "0"),
             authoredHeadingBeforeUnload: sessionStorage.getItem("goframe-dev-authored-heading-before-unload") || "",
             authoredMessageBeforeUnload: sessionStorage.getItem("goframe-dev-authored-message-before-unload") || "",
-            generation: Number(script?.getAttribute("data-goframe-generation") || "0"),
-            instance: script?.getAttribute("data-goframe-instance") || "",
+            generation: Number(script?.getAttribute("data-goframe-generation") || activeEventSourceURL?.searchParams.get("generation") || "0"),
+            instance: script?.getAttribute("data-goframe-instance") || activeEventSourceURL?.searchParams.get("instance") || "",
             reloadTags: document.querySelectorAll("script[data-goframe-dev-reload]").length,
+            eventSourceCount: eventSources.length,
             appRootIdentity: window.__goframeDevNodeIdentity?.(applicationRoot) || 0,
             appRootCount: document.querySelectorAll("#app-version").length,
             interactionCount: Number(document.querySelector("#interaction-count")?.textContent || "0"),
@@ -732,6 +893,12 @@ async function pageState(client) {
             buildErrorMarkers: buildErrorMarkers.length,
             buildErrorPresentations: devPanels.length,
             devPanelIdentity: window.__goframeDevNodeIdentity?.(panel) || 0,
+            devPanelParent: panel?.parentNode === document.documentElement
+                ? "documentElement"
+                : panel?.parentNode === document.body
+                    ? "body"
+                    : "",
+            devPanelInsideBody: Boolean(panel && document.body?.contains(panel)),
             buildErrorBuild: Number(panel?.getAttribute("data-goframe-dev-build") || "0"),
             buildErrorHeading: panel?.querySelector("[data-goframe-dev-build-error-heading]")?.textContent || "",
             buildErrorMessage: panel?.querySelector("[data-goframe-dev-build-error-message]")?.textContent || "",
@@ -740,8 +907,26 @@ async function pageState(client) {
             buildErrorInsideAppRoot: Boolean(panel?.closest("#app-version")),
             injectedDiagnosticElements: document.querySelectorAll("[data-goframe-diagnostic-injected]").length,
             diagnosticExecuted: Boolean(window.__goframeDevDiagnosticExecuted),
+            bodyRoot: document.body?.id === "root",
+            bodyRootAppVisible: Boolean(document.querySelector("#body-root-app")),
+            bodyRootVersion: document.querySelector("#body-root-version")?.textContent || "",
+            bodyRootInteractionCount: Number(document.querySelector("#body-root-interaction-count")?.textContent || "0"),
+            bodyRootReplacementVisible: Boolean(document.querySelector("#body-root-replacement")),
+            bodyRootReplacementInteractionCount: Number(document.querySelector("#body-root-replacement-interaction-count")?.textContent || "0"),
+            bodyRootCleanupCount: Number(document.querySelector("#body-root-cleanup-count")?.textContent || "0"),
         };
     })()`);
+}
+
+async function waitForBodyRootState(client, expected) {
+    let last = null;
+    for (let attempt = 0; attempt < 300; attempt++) {
+        last = await pageState(client);
+        const matches = Object.entries(expected).every(([key, value]) => last[key] === value);
+        if (matches && last.readyState === "complete" && last.bodyRoot) return last;
+        await wait(50);
+    }
+    throw new Error(`HARNESS FAILURE: body-root state did not match ${JSON.stringify(expected)}; last=${JSON.stringify(last)}`);
 }
 
 async function waitForPageState(client, expected) {
@@ -789,6 +974,25 @@ async function waitForBuildError(client, build, messageFragment) {
     throw new Error(`HARNESS FAILURE: build ${build} presentation did not contain ${JSON.stringify(messageFragment)}; last=${JSON.stringify(last)}`);
 }
 
+async function waitForBodyRootBuildError(client, build, messageFragment) {
+    let last = null;
+    for (let attempt = 0; attempt < 200; attempt++) {
+        last = await pageState(client);
+        if (last.bodyRoot
+            && last.buildErrorPresentations === 1
+            && last.buildErrorBuild === build
+            && last.buildErrorMessage.includes(messageFragment)) {
+            assert(last.buildErrorHeading === `Build ${build} failed`,
+                `body-root build error heading = ${JSON.stringify(last.buildErrorHeading)}, want build ${build}`);
+            assert(last.buildErrorRole === "alert" && last.buildErrorLive === "assertive",
+                `body-root build error accessibility = ${JSON.stringify({ role: last.buildErrorRole, live: last.buildErrorLive })}`);
+            return last;
+        }
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: body-root build ${build} presentation did not contain ${JSON.stringify(messageFragment)}; last=${JSON.stringify(last)}`);
+}
+
 function assertFailedBuildPreserved(baseline, state, generation, label) {
     assert(state.pageLoads === baseline.pageLoads && state.reloadEvents === baseline.reloadEvents,
         `${label} reloaded the browser: ${JSON.stringify({ baseline, state })}`);
@@ -817,6 +1021,27 @@ async function exerciseInteraction(client, baseline) {
         reloadEvents: baseline.reloadEvents,
         generation: baseline.generation,
         appRootIdentity: baseline.appRootIdentity,
+    });
+}
+
+async function exerciseBodyRootInteraction(client, baseline) {
+    await client.evaluate(`document.querySelector("#body-root-interaction").click()`);
+    return await waitForBodyRootState(client, {
+        bodyRootInteractionCount: baseline.bodyRootInteractionCount + 1,
+        pageLoads: baseline.pageLoads,
+        reloadEvents: baseline.reloadEvents,
+        generation: baseline.generation,
+    });
+}
+
+async function exerciseBodyRootReplacementInteraction(client, baseline) {
+    await client.evaluate(`document.querySelector("#body-root-replacement-interaction").click()`);
+    return await waitForBodyRootState(client, {
+        bodyRootReplacementVisible: true,
+        bodyRootReplacementInteractionCount: baseline.bodyRootReplacementInteractionCount + 1,
+        pageLoads: baseline.pageLoads,
+        reloadEvents: baseline.reloadEvents,
+        generation: baseline.generation,
     });
 }
 
@@ -862,6 +1087,29 @@ async function waitForEventSourceOpen(client, want) {
         await wait(25);
     }
     throw new Error(`HARNESS FAILURE: EventSource open count did not reach ${want}`);
+}
+
+async function waitForEventSourceError(client, want) {
+    for (let attempt = 0; attempt < 200; attempt++) {
+        const state = await pageState(client);
+        if (state.eventSourceErrors >= want) return;
+        await wait(25);
+    }
+    throw new Error(`HARNESS FAILURE: EventSource error count did not reach ${want}`);
+}
+
+async function closeEventSources(client) {
+    await client.evaluate(`(() => {
+        for (const source of window.__goframeDevEventSources || []) source.close();
+    })()`);
+}
+
+async function closeEventSourcesOnError(client) {
+    await client.evaluate(`(() => {
+        for (const source of window.__goframeDevEventSources || []) {
+            source.addEventListener("error", () => source.close(), { once: true });
+        }
+    })()`);
 }
 
 async function probeCompletedGenerationUntilBuildCompletes(serverURL, wasmPath, generation, build) {
@@ -1171,7 +1419,7 @@ async function connect(url) {
 }
 
 async function waitForNoEventStreams(client) {
-    for (let attempt = 0; attempt < 100; attempt++) {
+    for (let attempt = 0; attempt < 400; attempt++) {
         if (client.eventStreams.size === 0) return;
         await wait(25);
     }


### PR DESCRIPTION
## Summary

Adds browser build-error presentation to `goxc dev` after the first successful
development generation is active.

Failed rebuilds keep the last successful application running and interactive,
while connected pages show the latest build failure without reloading.

## Behavior

- publishes post-start build failures through the existing development SSE
  channel;
- shows one markup-safe browser error presentation outside the application UI;
- replaces an earlier failure instead of stacking messages;
- preserves the active generation, DOM identity, and application interaction;
- delivers the latest failure to current-generation reconnects;
- preserves stale-generation catch-up reload precedence;
- clears retained failure state on successful recovery and reloads each page
  exactly once.

Initial build failures and watch/scan failures remain terminal-only.

## Validation

Covered by focused Go tests, race/debug runs, a real dev-workflow integration
test, and repeated Chrome browser evidence for:

- consecutive failures and replacement;
- two connected pages;
- interaction while a build is broken;
- reconnect and stale-generation behavior;
- markup-safe diagnostic rendering;
- successful recovery and failure clearing.

Ordinary package artifacts and all 44 WASM size streams remain byte-identical
to the base; no size budgets or ratio limits change.

## Boundaries

This is development-server behavior only. It does not add HMR, browser state
preservation, incremental compilation, source maps, clickable diagnostics, a
public diagnostics protocol, or production-server behavior.

No runtime, GOX, manifest, dependency, or public GoFrame API changes are
included.

## Review focus

- build-error versus reload ordering;
- retained-failure and reconnect semantics;
- browser presentation isolation and markup safety;
- successful recovery without stale failure replay;
- development-only/package-output isolation.