### PR TITLE
docs(release): prepare v0.4.0 preview 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,25 @@
 
 ## Unreleased
 
+## v0.4.0-preview.1
+
+### Added
+
 - Added read-only `goxc inspect` package graph reports with deterministic text
   output and a versioned schema-v1 JSON process contract.
+
+### Fixed
+
 - `goxc dev` now presents post-start package and build failures in connected
   browsers while preserving the last successful interactive application;
   later failures replace the message, and successful recovery clears it before
   the normal full-page reload.
+- Current-package verification, ownership classification, export, cleanup, and
+  inspection now agree on canonical generated logical names and package paths.
+- Inspection rejects physical artifact aliases and completion-marker changes
+  before emitting a report.
+- Browser asset extensions now use ASCII-only case-insensitive matching across
+  package, inspection, legacy recognition, compression, and static serving.
 
 ## v0.3.0-preview.1
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -66,8 +66,10 @@ Migration notes are required when:
 
 Migration notes should follow `docs/migrations.md`.
 
-The release-specific actions for generated-workspace compiler isolation and
-repeated-Mount descendant rejection are recorded in
+The current release-specific actions for malformed generated package metadata
+and browser-extension recognition are recorded in
+[the v0.4.0-preview.1 migration notes](migration-v0.4.0-preview.1.md). The prior
+generated-workspace compiler isolation and repeated-Mount actions remain in
 [the v0.3.0-preview.1 migration notes](migration-v0.3.0-preview.1.md).
 
 ## Exceptions

--- a/docs/evaluator-guide.md
+++ b/docs/evaluator-guide.md
@@ -1,6 +1,6 @@
 # Evaluator Guide
 
-This guide is for evaluating the `v0.3.0-preview.1` browser/WASM layer. GitHub
+This guide is for evaluating the `v0.4.0-preview.1` browser/WASM layer. GitHub
 Releases remains authoritative for whether that exact preview is published. It
 is not a production deployment guide.
 
@@ -22,10 +22,11 @@ Linux/Chrome-first.
 
 ## Install goxc
 
-After the exact preview is published, install it with:
+Git tags and GitHub Releases determine availability of the exact preview.
+Install it with:
 
 ```bash
-go install github.com/graybuton/goframe/cmd/goxc@v0.3.0-preview.1
+go install github.com/graybuton/goframe/cmd/goxc@v0.4.0-preview.1
 goxc doctor
 ```
 
@@ -49,6 +50,31 @@ schemaVersion: 1
 ok: true
 diagnostics: []
 ```
+
+## Evaluate Package Inspection
+
+Create one current standalone package, then inspect its declared graph:
+
+```bash
+goxc package ./examples/counter \
+  --compiler=tinygo \
+  --asset-hash \
+  --preload \
+  --compress=gzip,br
+
+goxc inspect ./examples/counter
+goxc inspect ./examples/counter --format=json
+```
+
+The text report is human-oriented. The JSON report is a separate schema-v1
+tooling process contract; it does not change the schema-v1
+`asset-manifest.json` or `goframe-package.json` files. Repeating the JSON
+command against unchanged package bytes should produce byte-identical output.
+
+Inspection reads one existing current standalone package. It validates the
+declared artifacts, entrypoints, compressed sidecars, hashes, paths, and
+completion marker without building, repairing, or mutating the package. It is
+not a source dependency graph, bundle splitter, or legacy-package reader.
 
 ## Recommended Evaluation Path
 
@@ -108,13 +134,14 @@ goxc dev ./examples/counter --compiler=tinygo --port=8080
 Open the printed loopback URL, edit `examples/counter/app.gox`, and save. A
 successful full-package rebuild activates one verified generation and reloads
 the page. Introduce a temporary GOX or Go compiler error to confirm that the
-terminal reports the failure while the previous successful generation remains
-served; correct the source to confirm recovery and reload.
+terminal reports the failure, the connected page presents it, and the previous
+successful generation remains served and interactive. Correct the source to
+confirm that the presentation clears before recovery reload.
 
 This is serialized full-package rebuilding with full-page reload. It is not
-incremental compilation, HMR, or an in-browser build-error overlay. The
-generated compiler workspace does not inherit a parent `go.work` or ambient
-`GOFLAGS`.
+incremental compilation or HMR. Initial package failures and watch or scan
+failures remain terminal-only. The generated compiler workspace does not
+inherit a parent `go.work` or ambient `GOFLAGS`.
 
 ## Evaluate The Server-Backed Reference
 
@@ -228,11 +255,15 @@ app. It is not a cross-browser certification suite.
 - Resources are component-scoped and do not include cache, dedupe, Suspense, or
   route loaders.
 - `goxc serve` is development-only.
-- `goxc dev` performs full package rebuilds and full-page reload; it does not
-  provide HMR, incremental compilation, or browser build-error presentation.
+- `goxc inspect` reports one declared current standalone package; it does not
+  infer source dependencies or produce a split bundle graph.
+- `goxc dev` performs full package rebuilds and full-page reload. Browser
+  presentation covers post-start package and build failures; initial package
+  failures and watch or scan failures remain terminal-only. There is no HMR,
+  incremental compilation, or source-map contract.
 - Production deployment infrastructure, TLS, cache negotiation, and server
   fallback rules are outside this preview.
 
 For the guided walkthrough, read the [tutorial](tutorial.md). For release scope
 and limitations, read the
-[v0.3.0-preview.1 release notes](release-notes-v0.3.0-preview.1.md).
+[v0.4.0-preview.1 release notes](release-notes-v0.4.0-preview.1.md).

--- a/docs/migration-v0.4.0-preview.1.md
+++ b/docs/migration-v0.4.0-preview.1.md
@@ -1,0 +1,105 @@
+# Migrating to v0.4.0-preview.1
+
+## Status / Scope
+
+Valid applications and standalone packages produced by
+`v0.3.0-preview.1` require no source or package-layout migration for
+`v0.4.0-preview.1`. The public `pkg/goframe` and `pkg/gox` export sets,
+generated package metadata schemas, valid package publication protocol, and
+ordinary package artifacts remain unchanged.
+
+This preview adds the `goxc inspect` command and tightens validation of
+malformed generated package metadata and browser-extension spellings. The
+actions below apply only where an existing workflow relied on the previously
+accepted edge behavior.
+
+## Valid Applications
+
+No application-source migration is required for valid applications using the
+documented runtime, GOX, manifest, package, export, serve, and development
+contracts.
+
+`goxc inspect` is additive. Existing commands retain their previous flags and
+help contracts. To inspect an existing current package, first create or locate
+the package and then run:
+
+```bash
+goxc package ./examples/counter --compiler=tinygo
+goxc inspect ./examples/counter
+goxc inspect ./examples/counter --format=json
+```
+
+## Generated Package Metadata
+
+### Affected Surface
+
+Manually edited standalone packages, external tools that produce GoFrame-like
+package metadata, and damaged or non-canonical package directories.
+
+### Current Behavior
+
+Current-package readers require generated logical names and package paths to
+use the canonical slash-only forms produced by `goxc package`. Malformed or
+non-canonical metadata is classified as incomplete. Inspection also rejects
+invalid entrypoint roles, declared hashes, sidecars, collisions, containment,
+physical aliases, and changed completion markers before report output.
+
+The generated `asset-manifest.json` and `goframe-package.json` schemas remain
+version 1. The separate `goxc inspect --format=json` report is a schema-v1
+tooling process contract and does not alter either package metadata schema.
+
+### Migration
+
+- Regenerate the standalone package with the current `goxc package` command.
+- Do not repair generated package metadata by hand.
+- Use `goxc inspect` to validate the resulting current package.
+- Treat an incomplete-package result as a request to regenerate, not as
+  destructive ownership evidence.
+
+Valid current packages and exported copies require no metadata rewrite.
+
+## Browser Extension Recognition
+
+### Affected Surface
+
+Package inputs or generated metadata that relied on Unicode case-fold
+lookalikes such as `.waſm`, `.jſ`, or `.csſ` being treated as WASM,
+JavaScript, or CSS.
+
+### Current Behavior
+
+Browser asset extensions are matched case-insensitively for ASCII letters
+only. ASCII forms such as `.WASM`, `.JS`, `.CSS`, and `.HTML` keep their
+browser roles. Unicode lookalikes remain ordinary assets and do not become
+browser entrypoints through case folding.
+
+### Migration
+
+Rename a browser entrypoint to an ASCII extension with the intended role, then
+regenerate the package. No migration is needed for lowercase or mixed-case
+ASCII extensions.
+
+## Development Failure Presentation
+
+After `goxc dev` has started successfully, package and build failures continue
+to be printed in the terminal and are also presented in connected browser
+pages. The last successful generation remains served and interactive. A later
+failure replaces the development message; successful recovery clears it before
+the normal full-page reload.
+
+No application-source migration is required. Automation that reads terminal
+diagnostics may continue to do so. Initial package failures and watch or scan
+failures remain terminal-only. This behavior does not add HMR, incremental
+compilation, or source maps.
+
+## Rollback
+
+During preview evaluation, pin the previous published module when a migration
+or regression cannot be evaluated immediately:
+
+```bash
+go install github.com/graybuton/goframe/cmd/goxc@v0.3.0-preview.1
+```
+
+Keep the CLI and application module on the same intended preview while
+comparing behavior. GoFrame remains pre-1.0 and experimental.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -20,7 +20,12 @@ Security hardening still needs a note when users may see new rejections.
 
 ## Current Preview Migration
 
-The user-action notes for `v0.3.0-preview.1` are in
+The user-action notes for `v0.4.0-preview.1` are in
+[Migrating to v0.4.0-preview.1](migration-v0.4.0-preview.1.md). They cover
+malformed generated package metadata, ASCII-only browser-extension recognition,
+and the bounded post-start development failure presentation.
+
+The previous `v0.3.0-preview.1` actions remain in
 [Migrating to v0.3.0-preview.1](migration-v0.3.0-preview.1.md). They cover
 generated-workspace compiler environment isolation and the narrowed repeated
 Mount descendant-target contract.

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -4,7 +4,7 @@
 > prepared the first `v0.1.0-preview.1` evaluator preview. Its statements about
 > an uncut first preview tag are historical, not current publication status.
 > Current release scope is recorded in the
-> [v0.3.0-preview.1 release notes](release-notes-v0.3.0-preview.1.md), the
+> [v0.4.0-preview.1 release notes](release-notes-v0.4.0-preview.1.md), the
 > [release process](release.md), the [roadmap](roadmap.md), and the
 > [evaluator guide](evaluator-guide.md). GitHub Releases remains authoritative
 > for published tags.

--- a/docs/release-notes-v0.4.0-preview.1.md
+++ b/docs/release-notes-v0.4.0-preview.1.md
@@ -24,6 +24,36 @@ GoFrame remains pre-1.0, experimental, and focused on interactive browser/WASM
 applications. This preview is not a production-readiness, stable API,
 fullstack, SSR, hydration, or broad browser-support claim.
 
+## Maturity And Contract Tiers
+
+The existing [API stability tiers](api-stability.md) apply to this release:
+
+- **Public-Candidate:** documented high-level `goxc inspect` and `goxc dev`
+  command behavior. The `goxc inspect --format=json` report is a versioned
+  schema-v1 tooling process contract; incompatible field or semantic changes
+  require a schema version increment.
+- **Experimental Frontier:** default human-readable inspect formatting and
+  exact error wording; generated package metadata field stability and deeper
+  preview package semantics; and `goxc dev` watcher timing, event names,
+  private payload fields, presentation DOM/CSS, and build-number formatting.
+- **Compiler-Facing / Low-Level:** existing `pkg/gox` compiler exports,
+  including the in-memory generation boundary and trusted-filesystem
+  convenience helpers, plus the documented `goframe.json` and generated
+  package metadata tooling boundaries. This release adds no compiler-facing
+  export.
+- **Internal:** private inspect graph structs, package-root resolution,
+  filesystem traversal, sorting, hashing, physical-alias registry,
+  generation-fence implementation, and the development broker transport,
+  storage, and presentation implementation.
+- **Outside Current Contract / Inactive:** source dependency and bundle graphs,
+  asset splitting, multi-entry WASM, route-lazy delivery, HMR, incremental
+  compilation, SSR, hydration, fullstack APIs, LSP or formatter behavior,
+  Player/Engine, and `.gfapp`.
+
+Private implementation details are not compatibility contracts. These tiers
+classify individual surfaces; they do not classify the entire release as
+Public-Candidate.
+
 ## Highlights
 
 ### Package Graph Inspection
@@ -76,6 +106,14 @@ fullstack, SSR, hydration, or broad browser-support claim.
 
 - `pkg/goframe` and `pkg/gox` have no exported API additions, removals, or
   signature changes across the release range.
+- No new deprecations are introduced. Existing legacy and deprecated surfaces
+  retain the replacement guidance in [API stability](api-stability.md) and
+  [compatibility policy](compatibility.md).
+- This release does not expand the existing component-identity promise.
+  Generated identity remains evidenced within the documented application and
+  package composition boundaries of one app/module tree; a broad reusable
+  external package ecosystem and full multi-module identity compatibility
+  remain outside this preview contract.
 - `goxc inspect` is the only CLI command addition. Executable comparisons found
   no help, flag, or unchanged-command exit-behavior differences for the
   previously available commands.
@@ -92,6 +130,12 @@ fullstack, SSR, hydration, or broad browser-support claim.
   the release range. See the
   [v0.4.0-preview.1 migration notes](migration-v0.4.0-preview.1.md) for the
   bounded compatibility actions.
+- Supply-chain and tooling evidence remains lightweight: read-only repository
+  contents permissions, Dependabot coverage for GitHub Actions, Go modules,
+  and the VS Code extension, lockfile-based extension installation, artifact
+  and module gates, and successful CodeQL code-scanning checks. This preview
+  does not claim an SBOM, signed binary distribution, comprehensive dependency
+  attestation, or a general supply-chain or vulnerability-scanner guarantee.
 
 ## Validation
 
@@ -101,9 +145,10 @@ The release baseline passed:
   `1.26.5`, plus race lanes on Go `1.25.12` and `1.26.5`;
 - GOX golden and error-golden tests, `scripts/check.sh`, artifact, module-path,
   documentation, WASM-size, workflow-lint, and clean-diff gates;
-- two complete Chrome `149` Browser Smoke runs and a focused development-loop
-  browser pass covering failure replacement, retained interaction, two-page
-  delivery, reconnects, body-root isolation, recovery, and zero runtime errors;
+- two complete Linux/Chrome `149` Browser Smoke runs and a focused
+  development-loop browser pass covering failure replacement, retained
+  interaction, two-page delivery, reconnects, body-root isolation, recovery,
+  and zero runtime errors;
 - VS Code extension installation and tests under Node.js `24.18.1`, with its
   lockfile unchanged;
 - TinyGo `0.41.1` representative packages for counter and router-dashboard
@@ -112,9 +157,10 @@ The release baseline passed:
 - repeated text/JSON inspection, copied-root identity, exported-package graph
   identity, and valid completion metadata for all three representative
   packages;
-- local Windows amd64 test-binary compilation and successful post-merge Core
-  CI on Windows, alongside green post-merge Core, Browser Smoke, WASM Size,
-  and VS Code Extension workflows for the included feature merges.
+- local Windows amd64 test-binary compilation and successful Go `1.26.5` Core
+  host-evidence lanes on `macos-15-intel` and `windows-latest`. Each host lane
+  runs formatting, ordinary tests, vet, debug-tag tests, and selected GOX
+  golden tests; neither lane claims TinyGo or browser-smoke evidence.
 
 Publication requires the release pull request to pass the normal Core, Browser
 Smoke, WASM Size, and VS Code Extension workflows. Local evidence does not
@@ -131,8 +177,10 @@ substitute for those workflows.
 - `goxc dev` presents post-start package and build failures only. Initial
   package failures and watch or scan failures remain terminal-only, and the
   workflow has no HMR, incremental compilation, or source maps.
-- Chrome/Chromium remains the strongest browser evidence. Firefox and
-  Safari/WebKit do not have equivalent automated coverage.
+- Linux with Chrome/Chromium remains the strongest combined host and browser
+  evidence. macOS and Windows have minimal Core host evidence only; neither has
+  TinyGo or browser-smoke evidence. Firefox and Safari/WebKit do not have
+  equivalent automated coverage.
 - Static package output is not a production server, deployment platform, SSR,
   hydration, bundle-splitting, or fullstack framework.
 - The VS Code extension remains repository-local tooling and is not published

--- a/docs/release-notes-v0.4.0-preview.1.md
+++ b/docs/release-notes-v0.4.0-preview.1.md
@@ -3,9 +3,15 @@
 ## Status / Scope
 
 `v0.4.0-preview.1` is an experimental browser/WASM pre-release and a package
-inspection and development-feedback checkpoint. Its release range is
-`v0.3.0-preview.1` (`898179a15e2fe577992ad557b60cff490ddfa5aa`) through
+inspection and development-feedback checkpoint.
+
+The product changes audited for this checkpoint span `v0.3.0-preview.1`
+(`898179a15e2fe577992ad557b60cff490ddfa5aa`) through
 `0ef6d45b3b715d890731e98010aedfa9458e2e30`.
+
+The signed `v0.4.0-preview.1` Git tag is authoritative for the final release
+boundary. Release-only documentation commits are outside the product-change
+baseline above.
 
 The primary capability is read-only inspection of one existing current
 standalone package. The secondary capability presents post-start `goxc dev`

--- a/docs/release-notes-v0.4.0-preview.1.md
+++ b/docs/release-notes-v0.4.0-preview.1.md
@@ -1,0 +1,208 @@
+# GoFrame v0.4.0-preview.1
+
+## Status / Scope
+
+`v0.4.0-preview.1` is an experimental browser/WASM pre-release and a package
+inspection and development-feedback checkpoint. Its release range is
+`v0.3.0-preview.1` (`898179a15e2fe577992ad557b60cff490ddfa5aa`) through
+`0ef6d45b3b715d890731e98010aedfa9458e2e30`.
+
+The primary capability is read-only inspection of one existing current
+standalone package. The secondary capability presents post-start `goxc dev`
+package and build failures in connected browser pages while preserving the
+last successful interactive generation.
+
+This versioned document records the `v0.4.0-preview.1` release contract. Git
+tags and GitHub Releases are authoritative for publication and availability.
+GoFrame remains pre-1.0, experimental, and focused on interactive browser/WASM
+applications. This preview is not a production-readiness, stable API,
+fullstack, SSR, hydration, or broad browser-support claim.
+
+## Highlights
+
+### Package Graph Inspection
+
+- `goxc inspect <app-or-package>` reports the declared graph of an existing
+  current standalone package as deterministic text or schema-v1 JSON.
+- Application workspaces, current package directories, exported packages, and
+  explicit `--dir` package roots use the same read-only inspection contract.
+- Reports include package metadata, artifacts, entrypoints, compression
+  sidecars, byte sizes, full SHA-256 values, and metadata-declared edges.
+- Inspection validates canonical logical names and package paths, entrypoint
+  roles and media types, declared hashes, physical aliases, containment, and
+  completion-marker consistency before emitting a report.
+- A package generation change detected before output returns a retry error and
+  emits zero report bytes. Inspection does not build, repair, or mutate the
+  package.
+
+### Browser Development Feedback
+
+- After `goxc dev` has started successfully, a failed package or build attempt
+  is reported in the terminal and presented in connected browser pages.
+- The last successful generation remains served and interactive. Consecutive
+  failures replace the development message, and successful recovery clears it
+  before the normal full-page reload.
+- The development presentation is owned outside the application mount root,
+  preserves authored elements with similar attributes, and works across
+  multiple pages and reconnects.
+- Initial package failures and watch or scan failures remain terminal-only.
+  The workflow remains serialized full-package rebuilding with full-page
+  reload, not HMR or incremental compilation.
+
+### Package And Delivery Contract
+
+- Browser asset extensions use ASCII-only case-insensitive recognition.
+  `.WASM`, `.JS`, `.CSS`, and `.HTML` variants retain their browser roles;
+  Unicode lookalikes remain ordinary assets.
+- Generated logical asset names and generated package paths have separate,
+  slash-only validation contracts. Drive-looking logical names are namespace
+  data under `assets/`; drive-prefixed package paths remain invalid.
+- Current-package metadata readers shared by package verification, ownership,
+  export, cleanup, and inspection reject malformed or non-canonical generated
+  names and paths as incomplete package metadata.
+- The `asset-manifest.json` and `goframe-package.json` schemas remain version
+  1. The separate `goxc inspect --format=json` process contract is also schema
+  version 1; it does not change either package metadata schema.
+- Package completion-marker publication, ownership, export, cleanup, and
+  serving behavior for valid current packages remain unchanged.
+
+## Compatibility
+
+- `pkg/goframe` and `pkg/gox` have no exported API additions, removals, or
+  signature changes across the release range.
+- `goxc inspect` is the only CLI command addition. Executable comparisons found
+  no help, flag, or unchanged-command exit-behavior differences for the
+  previously available commands.
+- All eleven ordinary package outputs matched `v0.3.0-preview.1`: package
+  manifests and HTML were byte-identical, completion metadata was equivalent
+  after excluding `generatedAt`, and all 44 raw, gzip, Brotli, and Zstandard
+  WASM streams were byte-identical.
+- Existing raw and compressed WASM ceilings and ratio gates pass without a
+  budget change.
+- Valid current packages remain compatible. Manually edited, damaged, or
+  externally produced package metadata can now be classified as incomplete
+  when generated names or paths are malformed or non-canonical.
+- `go.mod`, `go.sum`, and the VS Code extension lockfile are unchanged across
+  the release range. See the
+  [v0.4.0-preview.1 migration notes](migration-v0.4.0-preview.1.md) for the
+  bounded compatibility actions.
+
+## Validation
+
+The release baseline passed:
+
+- ordinary, `goframe_debug`, and vet lanes on Go `1.22.12`, `1.25.12`, and
+  `1.26.5`, plus race lanes on Go `1.25.12` and `1.26.5`;
+- GOX golden and error-golden tests, `scripts/check.sh`, artifact, module-path,
+  documentation, WASM-size, workflow-lint, and clean-diff gates;
+- two complete Chrome `149` Browser Smoke runs and a focused development-loop
+  browser pass covering failure replacement, retained interaction, two-page
+  delivery, reconnects, body-root isolation, recovery, and zero runtime errors;
+- VS Code extension installation and tests under Node.js `24.18.1`, with its
+  lockfile unchanged;
+- TinyGo `0.41.1` representative packages for counter and router-dashboard
+  with asset hashing, preload, gzip, and Brotli, plus a standard-Go
+  server-backed package;
+- repeated text/JSON inspection, copied-root identity, exported-package graph
+  identity, and valid completion metadata for all three representative
+  packages;
+- local Windows amd64 test-binary compilation and successful post-merge Core
+  CI on Windows, alongside green post-merge Core, Browser Smoke, WASM Size,
+  and VS Code Extension workflows for the included feature merges.
+
+Publication requires the release pull request to pass the normal Core, Browser
+Smoke, WASM Size, and VS Code Extension workflows. Local evidence does not
+substitute for those workflows.
+
+## Known Limitations And Follow-Ups
+
+- `goxc inspect` describes one declared current standalone package. It does not
+  infer source dependencies, build a source or bundle graph, split assets or
+  WASM, define lazy loading, or inspect legacy packages.
+- The inspection generation fence follows GoFrame's completion-marker
+  publication protocol. It is not a general package lock for arbitrary
+  external artifact mutation.
+- `goxc dev` presents post-start package and build failures only. Initial
+  package failures and watch or scan failures remain terminal-only, and the
+  workflow has no HMR, incremental compilation, or source maps.
+- Chrome/Chromium remains the strongest browser evidence. Firefox and
+  Safari/WebKit do not have equivalent automated coverage.
+- Static package output is not a production server, deployment platform, SSR,
+  hydration, bundle-splitting, or fullstack framework.
+- The VS Code extension remains repository-local tooling and is not published
+  to the Marketplace.
+- Related external evaluation
+  [#117](https://github.com/graybuton/goframe/issues/117) remains independent
+  and non-blocking. It is not used as release evidence.
+- Preview users can revert to `v0.3.0-preview.1` while evaluating a migration
+  or regression. No stable 1.0 compatibility guarantee applies.
+
+## Install
+
+Install the exact preview with:
+
+```bash
+go install \
+  github.com/graybuton/goframe/cmd/goxc@v0.4.0-preview.1
+```
+
+Availability of this exact command is determined by the published tag shown in
+GitHub Releases.
+
+## Verification
+
+Run:
+
+```bash
+goxc version
+goxc doctor
+goxc inspect --help
+```
+
+The first line from an exact tagged install should be:
+
+```text
+goxc version v0.4.0-preview.1
+```
+
+Create and inspect a current package:
+
+```bash
+goxc package ./examples/counter \
+  --compiler=tinygo \
+  --asset-hash \
+  --preload \
+  --compress=gzip,br
+
+goxc inspect ./examples/counter
+goxc inspect ./examples/counter --format=json
+```
+
+For browser development feedback from a repository checkout:
+
+```bash
+goxc dev ./examples/counter --compiler=tinygo --port=8080
+```
+
+## Links
+
+- [README](../README.md)
+- [Evaluator guide](evaluator-guide.md)
+- [Migration notes](migration-v0.4.0-preview.1.md)
+- [Deployment and packaging](deployment.md)
+- [Manifest compatibility](manifest-compatibility.md)
+- [API stability](api-stability.md)
+- [Platform support](platform-support.md)
+- [Release process](release.md)
+- [Roadmap](roadmap.md)
+- [Previous preview: v0.3.0-preview.1](release-notes-v0.3.0-preview.1.md)
+- [Release-range comparison](https://github.com/graybuton/goframe/compare/v0.3.0-preview.1...v0.4.0-preview.1)
+
+## Non-Goals
+
+This preview does not add a public inspection Go API, schema v2, bundle graph,
+asset splitting, multi-entry WASM, route-lazy delivery, HMR, incremental
+compilation, source maps, a production server, SSR, hydration, or a fullstack
+API. It does not select Application Model II APIs, change Issue #117, publish
+the VS Code extension, broaden automated browser coverage, or establish stable
+1.0 or production-readiness guarantees.

--- a/docs/release.md
+++ b/docs/release.md
@@ -101,9 +101,15 @@ Versioned preview release records in this repository:
 - `docs/release-notes-v0.2.0-preview.5.md`
 - `docs/release-notes-v0.2.0-preview.6.md`
 - `docs/release-notes-v0.3.0-preview.1.md`
+- `docs/release-notes-v0.4.0-preview.1.md`
 
 This list identifies repository records; Git tags and GitHub Releases determine
 whether each version is published.
+
+Versioned preview migration records in this repository:
+
+- `docs/migration-v0.3.0-preview.1.md`
+- `docs/migration-v0.4.0-preview.1.md`
 
 `CHANGELOG.md` remains the factual change log; release notes should summarize
 preview scope, maturity tiers, validation evidence, compatibility notes, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,7 +127,8 @@ Future features do not become delivery promises by appearing in this document.
 | `v0.2.0-preview.6` | Diagnostics & Editor DX checkpoint | Published the CLI/editor diagnostic boundary as a bounded preview checkpoint. | **Current / shipped** |
 | `v0.3.0-preview.1` | Application workflow & dev loop checkpoint | Watched full-build development loop and integrated application evidence without selected new application-model APIs. | **Current / shipped** |
 | Later `v0.3.0-preview.*` slots | Application Model II | Route-driven data, transitions, loaders, mutations, and document state remain unselected directions. | **Research** |
-| `v0.4.0-preview.*` | Modular Delivery & Bundle Splitting | Explicit asset, multi-entry WASM, and route-lazy delivery boundaries. | **Candidate** |
+| `v0.4.0-preview.1` | Package inspection & development feedback checkpoint | Read-only standalone package graphs and post-start browser build-error presentation without package splitting. | **Current / shipped** |
+| Later `v0.4.0-preview.*` slots | Modular Delivery & Bundle Splitting | Explicit asset, multi-entry WASM, and route-lazy delivery boundaries. | **Candidate** |
 | `v0.5.0-preview.*` | Server Rendering & Prerender | A DOM-independent HTML-rendering subset, static prerender, and evaluated SSR adapters. | **Research** |
 | `v0.6.0-preview.*` | Hydration & Islands | Deterministic attachment, state handoff, recovery, and partial activation. | **Research** |
 | `v0.7.0-preview.*` | Dev Loop & Language Services | Incremental development, source mapping, formatting, language services, and distribution. | **Candidate** |
@@ -187,8 +188,8 @@ application-workflow evidence over existing public primitives
 The checkpoint includes:
 
 - `goxc dev` with serialized full-package rebuilds, last-successful-generation
-  preservation, post-start browser build-error presentation, verified
-  generation activation, and successful-build page reload;
+  preservation, verified generation activation, and successful-build page
+  reload;
 - server-backed and async-navigation evidence using existing router, resource,
   lifecycle, and example-local request coordination;
 - history-routing deployment characterization without changing the public hash
@@ -218,16 +219,21 @@ existing router, component ownership, resource lifecycle, and example-local
 request coordination sufficient for the audited flows. Those stages did not
 select a public route-loader, Action, Mutation, or cache-invalidation API.
 
-Post-start browser build-error presentation is **Current / shipped**. The
-development loop keeps serving the last successful interactive generation,
-shows the latest failed package attempt in connected pages, retains terminal
-diagnostics, and clears the presentation on successful recovery.
+## `v0.4.0-preview.1` - Package Inspection And Development Feedback Checkpoint
 
-## `v0.4.0-preview.*` - Modular Delivery & Bundle Splitting
+Status: **Current / shipped** capability scope. Read-only standalone package
+graph inspection and post-start browser build-error presentation exist on
+current `main`; this status does not assert that the versioned tag is
+published. Git tags and GitHub Releases are authoritative for publication
+state. Asset splitting, multi-entry WASM, route-lazy bundles, and shared-runtime
+designs remain separate Candidate or Research work.
 
-Status: **Current / shipped** for read-only standalone package graph inspection;
-**Candidate** for asset splitting, multi-entry WASM, and route-lazy bundles.
-These delivery concepts remain separate.
+Purpose:
+
+```text
+one deterministic current-package inspection boundary plus bounded browser
+feedback for failed post-start development builds
+```
 
 ### Package Graph Inspection
 
@@ -241,6 +247,20 @@ Current scope:
 
 The current graph is the declared graph of one standalone package. It does not
 infer source dependencies, split assets or WASM, or define lazy loading.
+
+### Development Failure Presentation
+
+Current scope:
+
+- post-start package and build failures remain in terminal diagnostics and are
+  also presented in connected browser pages;
+- the last successful generation remains served and interactive;
+- later failures replace the message, and successful recovery clears it before
+  the normal full-page reload;
+- initial package failures and watch or scan failures remain terminal-only.
+
+This is still serialized full-package rebuilding and full-page reload. It does
+not add HMR, incremental compilation, or source maps.
 
 ### Asset Splitting
 
@@ -281,11 +301,10 @@ heap/state, and WebAssembly component-model implications. These require
 feasibility, size, lifecycle, and compatibility evidence before an
 implementation commitment.
 
-Candidate preview slots:
+Candidate preview slots after `preview.1`:
 
 | Planning slot | Candidate capability |
 |---|---|
-| `preview.1` | Unselected checkpoint; standalone package graph inspection is current behavior. |
 | `preview.2` | Lazy static chunks. |
 | `preview.3` | Multi-entry WASM packaging. |
 | `preview.4` | Route-lazy bundles. |


### PR DESCRIPTION
## Summary

Prepare the publication-neutral release records for `v0.4.0-preview.1` and
align the changelog, roadmap, evaluator guidance, compatibility notes, and
migration indexes with the final release scope.

This PR contains release documentation only. It does not create the version
tag or publish a GitHub Release.

## Release scope

`v0.4.0-preview.1` is the **Package Inspection and Development Feedback
Checkpoint**.

The primary capability is the new read-only `goxc inspect` workflow, including
deterministic text output and a separate schema-v1 JSON process contract for
one existing current standalone package.

The release also includes post-start `goxc dev` browser presentation for failed
package and build attempts while preserving the last successful interactive
generation.

Asset splitting, multi-entry WASM, route-lazy delivery, HMR, SSR, hydration,
and fullstack APIs remain outside this checkpoint.

## Compatibility

- `pkg/goframe` exports are unchanged.
- `pkg/gox` exports are unchanged.
- `goxc inspect` is an additive CLI command.
- `asset-manifest.json` and `goframe-package.json` remain schema version 1.
- The inspect JSON report is a separate schema-v1 tooling contract.
- Valid applications require no source migration.
- Valid ordinary package output remains compatible with `v0.3.0-preview.1`.
- All 44 audited raw and compressed WASM streams remain byte-identical.
- No WASM size ceiling or compression-ratio budget changes are included.
- Dependencies and lockfiles are unchanged.

The migration record documents the bounded compatibility changes for malformed
or non-canonical generated package metadata and Unicode browser-extension
lookalikes.

## Validation

Release-preparation evidence includes:

- supported Go ordinary, debug-tag, race, and vet matrices;
- GOX golden and error-golden tests;
- repository, artifact, module-path, documentation, and WASM-size gates;
- two complete Chrome Browser Smoke runs;
- focused `goxc dev` failure/recovery browser evidence;
- representative TinyGo and standard-Go package inspection;
- repeated, copied-root, and exported-package inspect determinism;
- VS Code extension installation and tests under the documented Node baseline;
- local Windows amd64 test-binary compilation.

The release PR must still pass the normal remote:

- Core
- Browser Smoke
- WASM Size
- VS Code Extension

workflows before merge.

## Release boundary

The product changes audited for this checkpoint span `v0.3.0-preview.1` through
`0ef6d45b3b715d890731e98010aedfa9458e2e30`.

The signed `v0.4.0-preview.1` tag will be authoritative for the final release
boundary after this release PR is reviewed and merged.

Git tags and GitHub Releases remain authoritative for publication and
availability.

## Publication boundary

This PR does **not**:

- create `v0.4.0-preview.1`;
- publish a GitHub Release;
- upload release assets;
- change the stable/latest release designation.

Tagging and publication remain explicit maintainer actions after merge and
final verification.

## Non-goals

This PR does not change runtime, compiler, CLI implementation, package schemas,
tests, workflows, dependencies, lockfiles, examples, generated output, or WASM
budgets.

It does not add:

- a public Go inspection API;
- schema v2;
- source dependency analysis;
- asset or WASM splitting;
- route-lazy bundles;
- HMR or incremental compilation;
- SSR or hydration;
- fullstack APIs;
- stable 1.0 or production-readiness guarantees.

## Review focus

Please focus review on:

- the `v0.4.0-preview.1` scope and version-line classification;
- release-note accuracy against the merged product range;
- compatibility and migration wording;
- the distinction between logical asset names and package paths;
- publication-neutral wording;
- the separation between this checkpoint and later modular-delivery work.