### PR TITLE
fix(goxc): canonicalize authored manifest paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- User-authored `goframe.json` paths now canonicalize `/`, `\`, and mixed
+  separator spellings to one portable slash representation at ingestion,
+  including `output` and `wasm`. Filesystem conversion is explicit at host
+  boundaries, raw parent/root/drive rejection is preserved, and gzip sidecars
+  no longer encode source filenames that reject valid Unicode asset paths.
 - Added read-only `goxc inspect` package graph reports with deterministic text
   output and a versioned schema-v1 JSON process contract.
 - `goxc dev` now presents post-start package and build failures in connected

--- a/cmd/goxc/build.go
+++ b/cmd/goxc/build.go
@@ -143,7 +143,7 @@ func buildOutputPath(options buildOptions, manifest projectManifest, layout Buil
 	if directory == "" {
 		directory = layout.BuildDir
 	}
-	return filepath.Join(directory, manifest.WASM)
+	return filepath.Join(directory, filepath.FromSlash(manifest.WASM))
 }
 
 func compileWASM(compiler, entryPath, outputPath string) error {

--- a/cmd/goxc/dev.go
+++ b/cmd/goxc/dev.go
@@ -519,7 +519,7 @@ func (collector *devSnapshotCollector) collect() (devSnapshot, error) {
 	if err != nil {
 		return snapshot, collector.collectRetainedAssets(&snapshot, errors.Join(err, embedErr))
 	}
-	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
+	wasmLogicalName := path.Base(manifest.WASM)
 	_, planErr := planPackageAssets(collector.appDir, manifest, wasmLogicalName, packageOptions{compress: map[string]bool{}})
 	if planErr != nil {
 		return snapshot, collector.collectRetainedAssets(&snapshot, errors.Join(planErr, embedErr))

--- a/cmd/goxc/filesystem_safety_test.go
+++ b/cmd/goxc/filesystem_safety_test.go
@@ -1285,6 +1285,27 @@ func TestCleanPackageArtifactsRemovesManagedIndex(t *testing.T) {
 	assertFileContent(t, filepath.Join(destination, "user.txt"), "keep")
 }
 
+func TestCleanPackageArtifactsRejectsIntermediateSymlink(t *testing.T) {
+	requireSymlinkSupport(t)
+
+	destination := t.TempDir()
+	external := t.TempDir()
+	for _, name := range []string{"bundle.wasm", "bundle.wasm.gz", "bundle.wasm.br"} {
+		writeTestFile(t, external, name, "preserve external "+name+"\n")
+	}
+	if err := os.Symlink(external, filepath.Join(destination, "nested")); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cleanPackageArtifacts(destination, "nested/bundle.wasm")
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("cleanPackageArtifacts() error = %v, want intermediate symlink rejection", err)
+	}
+	for _, name := range []string{"bundle.wasm", "bundle.wasm.gz", "bundle.wasm.br"} {
+		assertFileContent(t, filepath.Join(external, name), "preserve external "+name+"\n")
+	}
+}
+
 func TestVerifyPublishedPackageInvalidatesIncompleteMarker(t *testing.T) {
 	directory := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(directory, assetDirectoryName), 0o755); err != nil {

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -232,16 +232,19 @@ func cleanManifestChildPath(value string) (string, error) {
 }
 
 func cleanAuthoredManifestPath(value string, allowApplicationRoot bool) (string, error) {
-	if value == "" || manifestPathIsAbs(value) {
+	logical := manifestPath(value)
+	if value == "" || authoredManifestPathIsRootedOrDriveLike(logical) {
 		return "", errors.New("manifest path must be relative")
 	}
-	logical := manifestPath(value)
 	for _, part := range strings.Split(logical, "/") {
 		if part == ".." {
 			return "", errors.New("manifest path must not contain a parent component")
 		}
 	}
 	cleaned := path.Clean(logical)
+	if authoredManifestPathIsRootedOrDriveLike(cleaned) {
+		return "", errors.New("manifest path must be relative")
+	}
 	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
 		return "", errors.New("manifest path must stay inside the application")
 	}
@@ -272,14 +275,21 @@ func manifestPath(value string) string {
 	return strings.ReplaceAll(filepath.ToSlash(value), "\\", "/")
 }
 
-func manifestPathIsAbs(value string) bool {
-	logical := manifestPath(value)
-	if strings.HasPrefix(logical, "/") || filepath.IsAbs(value) {
+func authoredManifestPathIsRootedOrDriveLike(logical string) bool {
+	if strings.HasPrefix(logical, "/") {
 		return true
 	}
-	if len(logical) >= 2 && logical[1] == ':' {
-		drive := logical[0]
-		return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+	if len(logical) < 2 || logical[1] != ':' {
+		return false
+	}
+	drive := logical[0]
+	return (drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')
+}
+
+func manifestPathIsAbs(value string) bool {
+	logical := manifestPath(value)
+	if authoredManifestPathIsRootedOrDriveLike(logical) || filepath.IsAbs(value) {
+		return true
 	}
 	return false
 }

--- a/cmd/goxc/manifest.go
+++ b/cmd/goxc/manifest.go
@@ -118,15 +118,18 @@ func loadManifest(appDir string) (projectManifest, error) {
 		return projectManifest{}, fmt.Errorf("entry %q in %s %s", manifest.Entry, manifestName, err)
 	}
 	manifest.Entry = entry
-	for name, value := range map[string]string{
-		"output": manifest.Output,
-		"wasm":   manifest.WASM,
+	for name, destination := range map[string]*string{
+		"output": &manifest.Output,
+		"wasm":   &manifest.WASM,
 	} {
-		if !safeChildPath(value) {
-			return projectManifest{}, fmt.Errorf("%s %q in %s must be a child path inside the application", name, value, manifestName)
+		value := *destination
+		cleaned, err := cleanManifestChildPath(value)
+		if err != nil {
+			return projectManifest{}, fmt.Errorf("%s %q in %s %s", name, value, manifestName, err)
 		}
+		*destination = cleaned
 	}
-	if classifyBrowserAsset(manifestPath(manifest.WASM)) != browserAssetWASM {
+	if classifyBrowserAsset(manifest.WASM) != browserAssetWASM {
 		return projectManifest{}, fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
 	}
 	if manifest.Compiler != "go" && manifest.Compiler != "tinygo" {
@@ -174,32 +177,14 @@ func rejectExplicitEmptyEntry(content []byte) error {
 }
 
 func cleanManifestEntry(entry string) (string, error) {
-	logicalEntry := manifestPath(entry)
-	if logicalEntry == "." {
-		return ".", nil
-	}
-	if entry == "" || manifestPathIsAbs(entry) {
+	entry, err := cleanAuthoredManifestPath(entry, true)
+	if err != nil {
 		return "", fmt.Errorf("must be a relative child package inside the application")
 	}
-	rawParts := strings.Split(logicalEntry, "/")
-	for _, part := range rawParts {
-		if part == ".." {
-			return "", fmt.Errorf("must be a relative child package inside the application")
-		}
-	}
-	entry = path.Clean(logicalEntry)
 	if entry == "." {
 		return ".", nil
 	}
 	parts := strings.Split(entry, "/")
-	for _, part := range parts {
-		if part == ".." {
-			return "", fmt.Errorf("must be a relative child package inside the application")
-		}
-	}
-	if strings.HasPrefix(entry, "../") || entry == ".." {
-		return "", fmt.Errorf("must be a relative child package inside the application")
-	}
 	if isToolOwnedEntryRoot(parts[0]) {
 		return "", fmt.Errorf("points to a GoFrame-owned or tool-owned directory")
 	}
@@ -227,13 +212,41 @@ func cleanManifestAssetDirectory(directory string) (string, error) {
 }
 
 func cleanManifestAssetPath(value string) (string, error) {
-	if !safeChildPath(value) {
+	cleaned, err := cleanManifestChildPath(value)
+	if err != nil {
 		return "", fmt.Errorf("must be a child path inside the application")
 	}
-	cleaned := path.Clean(manifestPath(value))
 	parts := strings.Split(cleaned, "/")
 	if len(parts) > 0 && isToolOwnedEntryRoot(parts[0]) {
 		return "", fmt.Errorf("points to a GoFrame-owned or tool-owned directory")
+	}
+	return cleaned, nil
+}
+
+func cleanManifestChildPath(value string) (string, error) {
+	cleaned, err := cleanAuthoredManifestPath(value, false)
+	if err != nil {
+		return "", fmt.Errorf("must be a child path inside the application")
+	}
+	return cleaned, nil
+}
+
+func cleanAuthoredManifestPath(value string, allowApplicationRoot bool) (string, error) {
+	if value == "" || manifestPathIsAbs(value) {
+		return "", errors.New("manifest path must be relative")
+	}
+	logical := manifestPath(value)
+	for _, part := range strings.Split(logical, "/") {
+		if part == ".." {
+			return "", errors.New("manifest path must not contain a parent component")
+		}
+	}
+	cleaned := path.Clean(logical)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", errors.New("manifest path must stay inside the application")
+	}
+	if cleaned == "." && !allowApplicationRoot {
+		return "", errors.New("manifest path must name a child")
 	}
 	return cleaned, nil
 }

--- a/cmd/goxc/manifest_path_integration_test.go
+++ b/cmd/goxc/manifest_path_integration_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestCanonicalAuthoredPathsReachExplicitBoundaries(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "cmd/app/main.go", "package main\n")
+	writeTestFile(t, appDir, "assets/styles/app.css", "body{}\n")
+	writeManifestPathFixture(t, appDir, map[string]any{
+		"entry":  `cmd\app`,
+		"output": `dist\site`,
+		"wasm":   `nested\bundle.wasm`,
+		"assets": []string{`assets\styles\app.css`},
+	})
+
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest() error: %v", err)
+	}
+	entryDir, err := resolveEntryPackageDir(appDir, manifest.Entry)
+	if err != nil {
+		t.Fatalf("resolveEntryPackageDir() error: %v", err)
+	}
+	if want := filepath.Join(appDir, "cmd", "app"); entryDir != want {
+		t.Fatalf("entry directory = %q, want %q", entryDir, want)
+	}
+
+	layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buildOutputPath(buildOptions{}, manifest, layout), filepath.Join(layout.BuildDir, "nested", "bundle.wasm"); got != want {
+		t.Fatalf("build output = %q, want %q", got, want)
+	}
+
+	plan, err := planPackageAssets(appDir, manifest, "bundle.wasm", packageOptions{compress: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("planPackageAssets() error: %v", err)
+	}
+	if len(plan.Assets) != 1 {
+		t.Fatalf("planned assets = %#v, want one", plan.Assets)
+	}
+	asset := plan.Assets[0]
+	if asset.LogicalName != "assets/styles/app.css" {
+		t.Fatalf("asset logical name = %q", asset.LogicalName)
+	}
+	if want := filepath.Join(appDir, "assets", "styles", "app.css"); asset.SourcePath != want {
+		t.Fatalf("asset source = %q, want %q", asset.SourcePath, want)
+	}
+}
+
+func TestCanonicalAssetDirectoryReachesFilesystemBoundary(t *testing.T) {
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "static/styles/app.css", "body{}\n")
+	writeManifestPathFixture(t, appDir, map[string]any{"assets": `static\styles\..\styles`})
+	if _, err := loadManifest(appDir); err == nil {
+		t.Fatal("loadManifest() accepted a raw parent component")
+	}
+
+	writeManifestPathFixture(t, appDir, map[string]any{"assets": `static\styles`})
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest() error: %v", err)
+	}
+	plan, err := planPackageAssets(appDir, manifest, "bundle.wasm", packageOptions{compress: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("planPackageAssets() error: %v", err)
+	}
+	if len(plan.Assets) != 1 || plan.Assets[0].LogicalName != "app.css" {
+		t.Fatalf("directory asset plan = %#v", plan.Assets)
+	}
+	if want := filepath.Join(appDir, "static", "styles", "app.css"); plan.Assets[0].SourcePath != want {
+		t.Fatalf("directory asset source = %q, want %q", plan.Assets[0].SourcePath, want)
+	}
+}
+
+func TestSeparatorEquivalentStandaloneGraphs(t *testing.T) {
+	spellings := []struct {
+		name   string
+		entry  string
+		output string
+		wasm   string
+		asset  string
+	}{
+		{name: "slash", entry: "./", output: "./dist/site", wasm: "./nested/bundle.wasm", asset: "./assets/styles/app.css"},
+		{name: "backslash", entry: `.\`, output: `.\dist\site`, wasm: `.\nested\bundle.wasm`, asset: `.\assets\styles\app.css`},
+		{name: "mixed", entry: ".", output: `dist\site`, wasm: `nested\bundle.wasm`, asset: `assets\styles/app.css`},
+	}
+
+	type result struct {
+		manifest     projectManifest
+		packageFiles map[string][]byte
+		exportFiles  map[string][]byte
+		inspectText  string
+		inspectJSON  string
+	}
+	results := make(map[string]result, len(spellings))
+	for _, spelling := range spellings {
+		appDir := filepath.Join(t.TempDir(), "app")
+		if err := os.MkdirAll(appDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeMinimalPackageApp(t, appDir)
+		writeTestFile(t, appDir, "assets/styles/app.css", "body { color: navy; }\n")
+		writeManifestPathFixture(t, appDir, map[string]any{
+			"name":     "separator-equivalent",
+			"entry":    spelling.entry,
+			"output":   spelling.output,
+			"compiler": "go",
+			"wasm":     spelling.wasm,
+			"assets":   []string{"index.html", spelling.asset},
+		})
+
+		manifest, err := loadManifest(appDir)
+		if err != nil {
+			t.Fatalf("%s loadManifest() error: %v", spelling.name, err)
+		}
+		if err := packageApp(packageOptions{appDir: appDir, compiler: "go", compress: map[string]bool{}}); err != nil {
+			t.Fatalf("%s packageApp() error: %v", spelling.name, err)
+		}
+		layout, err := newBuildLayout(layoutOptions{appDir: appDir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		normalizePackageGeneratedAtForComparison(t, layout.PackageDir)
+		if _, err := inspectPackageGraph(layout.PackageDir); err != nil {
+			t.Fatalf("%s inspectPackageGraph(package) error: %v", spelling.name, err)
+		}
+		var inspectText bytes.Buffer
+		if err := runInspectCommand([]string{"--dir", layout.PackageDir}, &inspectText); err != nil {
+			t.Fatalf("%s text inspect error: %v", spelling.name, err)
+		}
+		var inspectJSON bytes.Buffer
+		if err := runInspectCommand([]string{"--dir", layout.PackageDir, "--format=json"}, &inspectJSON); err != nil {
+			t.Fatalf("%s JSON inspect error: %v", spelling.name, err)
+		}
+
+		exportDir := filepath.Join(t.TempDir(), "export")
+		if err := exportApp(exportOptions{appDir: appDir, outDir: exportDir}); err != nil {
+			t.Fatalf("%s exportApp() error: %v", spelling.name, err)
+		}
+		if _, err := inspectPackageGraph(exportDir); err != nil {
+			t.Fatalf("%s inspectPackageGraph(export) error: %v", spelling.name, err)
+		}
+
+		results[spelling.name] = result{
+			manifest:     manifest,
+			packageFiles: semanticPackageFileContents(t, layout.PackageDir),
+			exportFiles:  semanticPackageFileContents(t, exportDir),
+			inspectText:  inspectText.String(),
+			inspectJSON:  inspectJSON.String(),
+		}
+	}
+
+	want := results["slash"]
+	for _, name := range []string{"backslash", "mixed"} {
+		got := results[name]
+		if !reflect.DeepEqual(got.manifest, want.manifest) {
+			t.Fatalf("%s manifest differs from slash form:\ngot:  %+v\nwant: %+v", name, got.manifest, want.manifest)
+		}
+		if !reflect.DeepEqual(got.packageFiles, want.packageFiles) {
+			t.Fatalf("%s package files differ from slash form", name)
+		}
+		if !reflect.DeepEqual(got.exportFiles, want.exportFiles) {
+			t.Fatalf("%s export files differ from slash form", name)
+		}
+		if got.inspectText != want.inspectText || got.inspectJSON != want.inspectJSON {
+			t.Fatalf("%s inspect output differs from slash form", name)
+		}
+	}
+}
+
+func normalizePackageGeneratedAtForComparison(t *testing.T, root string) {
+	t.Helper()
+	metadataPath := filepath.Join(root, packageMetadataName)
+	content, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata packageMetadata
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	metadata.GeneratedAt = "2000-01-01T00:00:00Z"
+	if err := writeJSONFile(metadataPath, metadata, "normalized package metadata fixture"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func semanticPackageFileContents(t *testing.T, root string) map[string][]byte {
+	t.Helper()
+	contents := map[string][]byte{}
+	if err := filepath.WalkDir(root, func(file string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(root, file)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		if filepath.ToSlash(relative) == packageMetadataName {
+			var metadata packageMetadata
+			if err := json.Unmarshal(content, &metadata); err != nil {
+				return err
+			}
+			metadata.GeneratedAt = ""
+			content, err = json.Marshal(metadata)
+			if err != nil {
+				return err
+			}
+		}
+		contents[filepath.ToSlash(relative)] = content
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return contents
+}

--- a/cmd/goxc/manifest_path_test.go
+++ b/cmd/goxc/manifest_path_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLoadManifestCanonicalizesAuthoredPathFields(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		entry  string
+		output string
+		wasm   string
+		assets any
+		want   projectManifest
+	}{
+		{
+			name:   "canonical slash",
+			entry:  "cmd/app",
+			output: "dist/output",
+			wasm:   "nested/bundle.wasm",
+			assets: []string{"assets/styles/app.css"},
+			want: projectManifest{
+				Entry:  "cmd/app",
+				Output: "dist/output",
+				WASM:   "nested/bundle.wasm",
+				Assets: listManifestAssets([]string{"assets/styles/app.css"}),
+			},
+		},
+		{
+			name:   "leading dot slash",
+			entry:  "./cmd/app",
+			output: "./dist/output",
+			wasm:   "./nested/bundle.wasm",
+			assets: []string{"./assets/styles/app.css"},
+			want: projectManifest{
+				Entry:  "cmd/app",
+				Output: "dist/output",
+				WASM:   "nested/bundle.wasm",
+				Assets: listManifestAssets([]string{"assets/styles/app.css"}),
+			},
+		},
+		{
+			name:   "backslash separators",
+			entry:  `cmd\app`,
+			output: `dist\output`,
+			wasm:   `nested\bundle.wasm`,
+			assets: []string{`assets\styles\app.css`},
+			want: projectManifest{
+				Entry:  "cmd/app",
+				Output: "dist/output",
+				WASM:   "nested/bundle.wasm",
+				Assets: listManifestAssets([]string{"assets/styles/app.css"}),
+			},
+		},
+		{
+			name:   "leading dot backslash",
+			entry:  `.\cmd\app`,
+			output: `.\dist\output`,
+			wasm:   `.\nested\bundle.wasm`,
+			assets: `.\assets\styles`,
+			want: projectManifest{
+				Entry:  "cmd/app",
+				Output: "dist/output",
+				WASM:   "nested/bundle.wasm",
+				Assets: directoryManifestAssets("assets/styles"),
+			},
+		},
+		{
+			name:   "mixed and repeated separators",
+			entry:  `cmd\nested//./app`,
+			output: `dist//nested\output`,
+			wasm:   `nested\more//bundle.wasm`,
+			assets: []string{`assets\styles//./app.css`},
+			want: projectManifest{
+				Entry:  "cmd/nested/app",
+				Output: "dist/nested/output",
+				WASM:   "nested/more/bundle.wasm",
+				Assets: listManifestAssets([]string{"assets/styles/app.css"}),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			appDir := t.TempDir()
+			writeManifestPathFixture(t, appDir, map[string]any{
+				"entry":  test.entry,
+				"output": test.output,
+				"wasm":   test.wasm,
+				"assets": test.assets,
+			})
+
+			manifest, err := loadManifest(appDir)
+			if err != nil {
+				t.Fatalf("loadManifest() error: %v", err)
+			}
+			if manifest.Entry != test.want.Entry ||
+				manifest.Output != test.want.Output ||
+				manifest.WASM != test.want.WASM ||
+				!reflect.DeepEqual(manifest.Assets, test.want.Assets) {
+				t.Fatalf(
+					"canonical paths = entry:%q output:%q wasm:%q assets:%+v; want entry:%q output:%q wasm:%q assets:%+v",
+					manifest.Entry,
+					manifest.Output,
+					manifest.WASM,
+					manifest.Assets,
+					test.want.Entry,
+					test.want.Output,
+					test.want.WASM,
+					test.want.Assets,
+				)
+			}
+		})
+	}
+}
+
+func TestLoadManifestCanonicalPathDefaults(t *testing.T) {
+	appDir := t.TempDir()
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest() error: %v", err)
+	}
+	if manifest.Entry != "." || manifest.Output != "dist" || manifest.WASM != "bundle.wasm" {
+		t.Fatalf("defaults = entry:%q output:%q wasm:%q", manifest.Entry, manifest.Output, manifest.WASM)
+	}
+	if manifest.Assets.Mode != manifestAssetsAuto {
+		t.Fatalf("assets mode = %v, want auto", manifest.Assets.Mode)
+	}
+}
+
+func TestLoadManifestRejectsPortableUnsafeAuthoredPaths(t *testing.T) {
+	unsafe := []string{
+		"..",
+		"../a",
+		"a/..",
+		"a/../b",
+		`a\..\b`,
+		`a/..\b`,
+		"/foo",
+		`\foo`,
+		"//server/share",
+		`\\server\share`,
+		"C:",
+		"C:foo",
+		"C:/foo",
+		`C:\foo`,
+		"c:",
+		"c:foo",
+		"c:/foo",
+		`c:\foo`,
+	}
+	fields := []struct {
+		name  string
+		value func(string) map[string]any
+	}{
+		{name: "entry", value: func(value string) map[string]any { return map[string]any{"entry": value} }},
+		{name: "output", value: func(value string) map[string]any { return map[string]any{"output": value} }},
+		{name: "wasm", value: func(value string) map[string]any { return map[string]any{"wasm": value} }},
+		{name: "assets directory", value: func(value string) map[string]any { return map[string]any{"assets": value} }},
+		{name: "assets list", value: func(value string) map[string]any { return map[string]any{"assets": []string{value}} }},
+	}
+
+	for _, field := range fields {
+		for _, value := range unsafe {
+			t.Run(field.name+"/"+strings.ReplaceAll(value, "/", "_"), func(t *testing.T) {
+				appDir := t.TempDir()
+				writeManifestPathFixture(t, appDir, field.value(value))
+				if _, err := loadManifest(appDir); err == nil {
+					t.Fatalf("loadManifest() accepted unsafe %s path %q", field.name, value)
+				}
+			})
+		}
+	}
+}
+
+func writeManifestPathFixture(t *testing.T, appDir string, values map[string]any) {
+	t.Helper()
+	content, err := json.Marshal(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, manifestName), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/goxc/manifest_path_test.go
+++ b/cmd/goxc/manifest_path_test.go
@@ -176,6 +176,145 @@ func TestLoadManifestRejectsPortableUnsafeAuthoredPaths(t *testing.T) {
 	}
 }
 
+func TestLoadManifestRejectsCanonicalizedDriveLikeAuthoredPaths(t *testing.T) {
+	forms := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "uppercase slash drive root", prefix: "./C:/"},
+		{name: "uppercase slash drive relative", prefix: "./C:"},
+		{name: "uppercase backslash drive root", prefix: ".\\C:\\"},
+		{name: "uppercase backslash drive relative", prefix: ".\\C:"},
+		{name: "lowercase slash drive root", prefix: "./c:/"},
+		{name: "lowercase slash drive relative", prefix: "./c:"},
+		{name: "lowercase backslash drive root", prefix: ".\\c:\\"},
+		{name: "lowercase backslash drive relative", prefix: ".\\c:"},
+	}
+	fields := []struct {
+		name  string
+		value func(string) map[string]any
+	}{
+		{name: "entry", value: func(prefix string) map[string]any { return map[string]any{"entry": prefix + "child"} }},
+		{name: "output", value: func(prefix string) map[string]any { return map[string]any{"output": prefix + "child"} }},
+		{name: "wasm", value: func(prefix string) map[string]any { return map[string]any{"wasm": prefix + "bundle.wasm"} }},
+		{name: "assets directory", value: func(prefix string) map[string]any { return map[string]any{"assets": prefix + "assets"} }},
+		{name: "assets list", value: func(prefix string) map[string]any { return map[string]any{"assets": []string{prefix + "style.css"}} }},
+	}
+
+	for _, field := range fields {
+		for _, form := range forms {
+			t.Run(field.name+"/"+form.name, func(t *testing.T) {
+				appDir := t.TempDir()
+				writeManifestPathFixture(t, appDir, field.value(form.prefix))
+				if _, err := loadManifest(appDir); err == nil {
+					t.Fatalf("loadManifest() accepted canonicalized drive-like %s path with prefix %q", field.name, form.prefix)
+				}
+			})
+		}
+	}
+}
+
+func TestLoadManifestCanonicalPathValuesAreFixedPoints(t *testing.T) {
+	fields := []struct {
+		name       string
+		input      string
+		want       string
+		value      func(string) map[string]any
+		storedPath func(projectManifest) string
+	}{
+		{
+			name:       "entry",
+			input:      "./nested/file",
+			want:       "nested/file",
+			value:      func(value string) map[string]any { return map[string]any{"entry": value} },
+			storedPath: func(manifest projectManifest) string { return manifest.Entry },
+		},
+		{
+			name:       "output",
+			input:      "nested\\file",
+			want:       "nested/file",
+			value:      func(value string) map[string]any { return map[string]any{"output": value} },
+			storedPath: func(manifest projectManifest) string { return manifest.Output },
+		},
+		{
+			name:       "wasm",
+			input:      "nested//./bundle.wasm",
+			want:       "nested/bundle.wasm",
+			value:      func(value string) map[string]any { return map[string]any{"wasm": value} },
+			storedPath: func(manifest projectManifest) string { return manifest.WASM },
+		},
+		{
+			name:       "assets directory",
+			input:      "nested/mixed\\file",
+			want:       "nested/mixed/file",
+			value:      func(value string) map[string]any { return map[string]any{"assets": value} },
+			storedPath: func(manifest projectManifest) string { return manifest.Assets.Directory },
+		},
+		{
+			name:       "assets list",
+			input:      "./nested/style.css",
+			want:       "nested/style.css",
+			value:      func(value string) map[string]any { return map[string]any{"assets": []string{value}} },
+			storedPath: func(manifest projectManifest) string { return manifest.Assets.List[0] },
+		},
+	}
+
+	for _, field := range fields {
+		t.Run(field.name, func(t *testing.T) {
+			appDir := t.TempDir()
+			writeManifestPathFixture(t, appDir, field.value(field.input))
+			first, err := loadManifest(appDir)
+			if err != nil {
+				t.Fatalf("first loadManifest() error: %v", err)
+			}
+			stored := field.storedPath(first)
+			if stored != field.want {
+				t.Fatalf("first canonical value = %q, want %q", stored, field.want)
+			}
+
+			writeManifestPathFixture(t, appDir, field.value(stored))
+			second, err := loadManifest(appDir)
+			if err != nil {
+				t.Fatalf("second loadManifest() error: %v", err)
+			}
+			if got := field.storedPath(second); got != stored {
+				t.Fatalf("canonical value after revalidation = %q, want %q", got, stored)
+			}
+		})
+	}
+}
+
+func TestCleanAuthoredManifestPathClassifiesOnlyDrivePrefixes(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		value     string
+		want      string
+		wantError bool
+	}{
+		{name: "colon in relative name", value: "name:asset.css", want: "name:asset.css"},
+		{name: "colon data in relative name", value: "foo:bar", want: "foo:bar"},
+		{name: "uppercase drive relative", value: "C:asset.css", wantError: true},
+		{name: "lowercase drive relative", value: "c:asset.css", wantError: true},
+		{name: "rooted", value: "/asset.css", wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := cleanAuthoredManifestPath(test.value, false)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("cleanAuthoredManifestPath(%q) = %q, want error", test.value, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("cleanAuthoredManifestPath(%q) error: %v", test.value, err)
+			}
+			if got != test.want {
+				t.Fatalf("cleanAuthoredManifestPath(%q) = %q, want %q", test.value, got, test.want)
+			}
+		})
+	}
+}
+
 func writeManifestPathFixture(t *testing.T, appDir string, values map[string]any) {
 	t.Helper()
 	content, err := json.Marshal(values)

--- a/cmd/goxc/manifest_path_unix_test.go
+++ b/cmd/goxc/manifest_path_unix_test.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUnixAuthoredBackslashSelectsSeparatorPath(t *testing.T) {
+	appDir := t.TempDir()
+	nested := filepath.Join(appDir, "assets", "styles.css")
+	if err := os.MkdirAll(filepath.Dir(nested), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(nested, []byte("nested\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	literal := filepath.Join(appDir, `assets\styles.css`)
+	if err := os.WriteFile(literal, []byte("literal backslash\n"), 0o644); err != nil {
+		t.Skipf("filesystem cannot create literal-backslash filename: %v", err)
+	}
+	writeManifestPathFixture(t, appDir, map[string]any{"assets": []string{`assets\styles.css`}})
+
+	manifest, err := loadManifest(appDir)
+	if err != nil {
+		t.Fatalf("loadManifest() error: %v", err)
+	}
+	if len(manifest.Assets.List) != 1 || manifest.Assets.List[0] != "assets/styles.css" {
+		t.Fatalf("canonical asset list = %#v", manifest.Assets.List)
+	}
+	plan, err := planPackageAssets(appDir, manifest, "bundle.wasm", packageOptions{compress: map[string]bool{}})
+	if err != nil {
+		t.Fatalf("planPackageAssets() error: %v", err)
+	}
+	if len(plan.Assets) != 1 || plan.Assets[0].SourcePath != nested {
+		t.Fatalf("planned source = %#v, want nested separator path %q", plan.Assets, nested)
+	}
+	content, err := os.ReadFile(plan.Assets[0].SourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "nested\n" {
+		t.Fatalf("selected content = %q, want nested path content", content)
+	}
+}

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -1085,7 +1085,6 @@ func gzipFile(sourcePath, destinationPath string) error {
 		return fmt.Errorf("create gzip writer: %w", err)
 	}
 	writer.Header.ModTime = time.Unix(0, 0)
-	writer.Header.Name = filepath.Base(sourcePath)
 
 	_, copyErr := io.Copy(writer, source)
 	writerErr := writer.Close()

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -187,8 +187,8 @@ func packageApp(options packageOptions) error {
 	if err := ensureAppDirectory(options.appDir); err != nil {
 		return err
 	}
-	wasmLogicalName := path.Base(filepath.ToSlash(filepath.Clean(manifest.WASM)))
-	if classifyBrowserAsset(filepath.ToSlash(manifest.WASM)) != browserAssetWASM || classifyBrowserAsset(wasmLogicalName) != browserAssetWASM {
+	wasmLogicalName := path.Base(manifest.WASM)
+	if classifyBrowserAsset(manifest.WASM) != browserAssetWASM || classifyBrowserAsset(wasmLogicalName) != browserAssetWASM {
 		return fmt.Errorf("wasm %q in %s must end with .wasm", manifest.WASM, manifestName)
 	}
 	if wasmLogicalName == runtimeAssetName {
@@ -356,7 +356,7 @@ func packageApp(options packageOptions) error {
 	} else if err := mkdirAllBelowRoot(layout.WorkspaceRoot, options.outDir, "package output directory"); err != nil {
 		return err
 	}
-	if err := cleanPackageArtifacts(options.outDir, manifest.WASM); err != nil {
+	if err := cleanPackageArtifacts(options.outDir, wasmLogicalName); err != nil {
 		return err
 	}
 	if err := publishPackageArtifacts(stageDir, options.outDir); err != nil {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -356,7 +356,7 @@ func packageApp(options packageOptions) error {
 	} else if err := mkdirAllBelowRoot(layout.WorkspaceRoot, options.outDir, "package output directory"); err != nil {
 		return err
 	}
-	if err := cleanPackageArtifacts(options.outDir, wasmLogicalName); err != nil {
+	if err := cleanPackageArtifacts(options.outDir, manifest.WASM, wasmLogicalName); err != nil {
 		return err
 	}
 	if err := publishPackageArtifacts(stageDir, options.outDir); err != nil {
@@ -636,14 +636,25 @@ func packageOutputDirectory(options packageOptions, layout BuildLayout) string {
 	return layout.PackageDir
 }
 
-func cleanPackageArtifacts(directory, wasmName string) error {
+func cleanPackageArtifacts(directory string, wasmNames ...string) error {
 	if err := os.Remove(filepath.Join(directory, packageMetadataName)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("remove stale package artifact %s: %w", packageMetadataName, err)
 	}
-	names := []string{
-		wasmName,
-		wasmName + ".gz",
-		wasmName + ".br",
+	seen := make(map[string]struct{})
+	names := make([]string, 0, len(wasmNames)*3+20)
+	addName := func(name string) {
+		if _, exists := seen[name]; exists {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for _, wasmName := range wasmNames {
+		addName(wasmName)
+		addName(wasmName + ".gz")
+		addName(wasmName + ".br")
+	}
+	for _, name := range []string{
 		"bundle.wasm",
 		"bundle.wasm.gz",
 		"bundle.wasm.br",
@@ -662,9 +673,18 @@ func cleanPackageArtifacts(directory, wasmName string) error {
 		"styles.css",
 		legacyPackageManifest,
 		assetManifestName,
+	} {
+		addName(name)
 	}
 	for _, name := range names {
-		if err := os.Remove(filepath.Join(directory, name)); errors.Is(err, os.ErrNotExist) {
+		if manifestPath(name) != name || path.Clean(name) != name || !safeChildPath(name) {
+			return fmt.Errorf("remove stale package artifact %s: cleanup path must be canonical and package-relative", name)
+		}
+		target := filepath.Join(directory, filepath.FromSlash(name))
+		if err := validatePathBelowRoot(directory, filepath.Dir(target), "stale package artifact parent", true); err != nil {
+			return fmt.Errorf("remove stale package artifact %s: %w", name, err)
+		}
+		if err := os.Remove(target); errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
 			return fmt.Errorf("remove stale package artifact %s: %w", name, err)

--- a/cmd/goxc/package_test.go
+++ b/cmd/goxc/package_test.go
@@ -185,6 +185,125 @@ func TestPackageGeneratedBrowserURLsResolveToExactUnixAssets(t *testing.T) {
 	}
 }
 
+func TestPackageCleansAuthoredNestedWASMArtifacts(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		authoredWASM   string
+		standaloneWASM string
+	}{
+		{name: "default basename", authoredWASM: "nested/bundle.wasm", standaloneWASM: "bundle.wasm"},
+		{name: "custom basename", authoredWASM: "nested/custom.wasm", standaloneWASM: "custom.wasm"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			appDir := t.TempDir()
+			writeMinimalPackageApp(t, appDir)
+			manifestContent, err := json.Marshal(map[string]any{
+				"name": "nested-wasm", "compiler": "go", "wasm": test.authoredWASM, "assets": []string{},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeTestFile(t, appDir, manifestName, string(manifestContent))
+
+			outDir := filepath.Join(t.TempDir(), "package")
+			options := packageOptions{
+				appDir: appDir, compiler: "go", outDir: outDir, compress: map[string]bool{},
+			}
+			if err := packageApp(options); err != nil {
+				t.Fatalf("packageApp(initial) error: %v", err)
+			}
+			staleNames := []string{
+				test.authoredWASM,
+				test.authoredWASM + ".gz",
+				test.authoredWASM + ".br",
+				test.standaloneWASM,
+				test.standaloneWASM + ".gz",
+				test.standaloneWASM + ".br",
+			}
+			for _, name := range staleNames {
+				writeTestFile(t, outDir, name, "stale "+name+"\n")
+			}
+			writeTestFile(t, outDir, "nested/notes.txt", "preserve unrelated content\n")
+			if _, err := inspectPackageGraph(outDir); err != nil {
+				t.Fatalf("inspectPackageGraph(package with undeclared stale WASM) error: %v", err)
+			}
+
+			staleBefore := httptest.NewRecorder()
+			staticHandler(outDir).ServeHTTP(staleBefore, httptest.NewRequest(http.MethodGet, "/"+test.authoredWASM, nil))
+			if staleBefore.Code != http.StatusOK {
+				t.Fatalf("stale nested WASM status before repackaging = %d, want 200", staleBefore.Code)
+			}
+
+			if err := packageApp(options); err != nil {
+				t.Fatalf("packageApp(repackage) error: %v", err)
+			}
+			if _, err := inspectPackageGraph(outDir); err != nil {
+				t.Fatalf("inspectPackageGraph(repackaged) error: %v", err)
+			}
+			for _, name := range staleNames {
+				if _, err := os.Lstat(filepath.Join(outDir, filepath.FromSlash(name))); !os.IsNotExist(err) {
+					t.Fatalf("stale package artifact %s still exists after repackaging: %v", name, err)
+				}
+			}
+			assertFileContent(t, filepath.Join(outDir, "nested", "notes.txt"), "preserve unrelated content\n")
+
+			staleAfter := httptest.NewRecorder()
+			staticHandler(outDir).ServeHTTP(staleAfter, httptest.NewRequest(http.MethodGet, "/"+test.authoredWASM, nil))
+			if staleAfter.Code != http.StatusNotFound {
+				t.Fatalf("stale nested WASM status after repackaging = %d, want 404", staleAfter.Code)
+			}
+
+			var manifest assetManifest
+			readInspectJSONFixture(t, outDir, assetManifestName, &manifest)
+			if _, exists := manifest.Assets[test.standaloneWASM]; !exists {
+				t.Fatalf("standalone WASM logical name %q missing from manifest", test.standaloneWASM)
+			}
+			current := httptest.NewRecorder()
+			staticHandler(outDir).ServeHTTP(current, httptest.NewRequest(http.MethodGet, "/"+manifest.Entrypoints.WASM, nil))
+			if current.Code != http.StatusOK {
+				t.Fatalf("current declared WASM status = %d, want 200", current.Code)
+			}
+		})
+	}
+}
+
+func TestCleanPackageArtifactsCleansWASMIdentities(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		wasmNames  []string
+		staleNames []string
+	}{
+		{
+			name:       "nested custom basename",
+			wasmNames:  []string{"nested/custom.wasm", "custom.wasm"},
+			staleNames: []string{"nested/custom.wasm", "nested/custom.wasm.gz", "nested/custom.wasm.br", "custom.wasm", "custom.wasm.gz", "custom.wasm.br"},
+		},
+		{
+			name:       "non-nested duplicate identity",
+			wasmNames:  []string{"bundle.wasm", "bundle.wasm"},
+			staleNames: []string{"bundle.wasm", "bundle.wasm.gz", "bundle.wasm.br"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			for _, name := range test.staleNames {
+				writeTestFile(t, directory, name, "stale "+name+"\n")
+			}
+			writeTestFile(t, directory, "nested/notes.txt", "preserve unrelated content\n")
+
+			if err := cleanPackageArtifacts(directory, test.wasmNames...); err != nil {
+				t.Fatalf("cleanPackageArtifacts() error: %v", err)
+			}
+			for _, name := range test.staleNames {
+				if _, err := os.Lstat(filepath.Join(directory, filepath.FromSlash(name))); !os.IsNotExist(err) {
+					t.Fatalf("stale package artifact %s still exists: %v", name, err)
+				}
+			}
+			assertFileContent(t, filepath.Join(directory, "nested", "notes.txt"), "preserve unrelated content\n")
+		})
+	}
+}
+
 func TestBrowserAssetProducerIntegration(t *testing.T) {
 	appDir := t.TempDir()
 	writeMinimalPackageApp(t, appDir)

--- a/cmd/goxc/package_test.go
+++ b/cmd/goxc/package_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -249,6 +251,48 @@ func TestBrowserAssetProducerIntegration(t *testing.T) {
 	}
 	if output.Len() == 0 {
 		t.Error("successful producer-to-inspector path emitted no JSON")
+	}
+}
+
+func TestGzipSidecarsArePathNeutral(t *testing.T) {
+	content := []byte("same package bytes\n")
+	var compressed [][]byte
+	for _, name := range []string{"bundle.wasm", "renamed.wasm"} {
+		directory := t.TempDir()
+		source := filepath.Join(directory, name)
+		destination := source + ".gz"
+		if err := os.WriteFile(source, content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := gzipFile(source, destination); err != nil {
+			t.Fatalf("gzipFile(%q) error: %v", name, err)
+		}
+		encoded, err := os.ReadFile(destination)
+		if err != nil {
+			t.Fatal(err)
+		}
+		compressed = append(compressed, encoded)
+
+		reader, err := gzip.NewReader(bytes.NewReader(encoded))
+		if err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if reader.Header.Name != "" {
+			t.Fatalf("gzip header name = %q, want path-neutral empty value", reader.Header.Name)
+		}
+		if !bytes.Equal(decoded, content) {
+			t.Fatalf("decoded content = %q, want %q", decoded, content)
+		}
+	}
+	if !bytes.Equal(compressed[0], compressed[1]) {
+		t.Fatal("gzip sidecar bytes changed with the source filename")
 	}
 }
 

--- a/cmd/goxc/package_unix_test.go
+++ b/cmd/goxc/package_unix_test.go
@@ -191,3 +191,39 @@ func TestPackageRejectsUnixLiteralBackslashAssetNames(t *testing.T) {
 		})
 	}
 }
+
+func TestPackageUnicodeManifestAssetWithGzip(t *testing.T) {
+	const (
+		logicalName = "данные.css"
+		content     = "body { color: rebeccapurple; }\n"
+	)
+	appDir := t.TempDir()
+	writeMinimalPackageApp(t, appDir)
+	writeTestFile(t, appDir, manifestName, `{"name":"unicode-asset","compiler":"go","assets":"assets"}`)
+	writeTestFile(t, appDir, "assets/"+logicalName, content)
+
+	plainDir := filepath.Join(t.TempDir(), "plain")
+	if err := packageApp(packageOptions{
+		appDir: appDir, compiler: "go", outDir: plainDir, compress: map[string]bool{},
+	}); err != nil {
+		t.Fatalf("packageApp(plain Unicode asset) error: %v", err)
+	}
+	if _, err := inspectPackageGraph(plainDir); err != nil {
+		t.Fatalf("inspectPackageGraph(plain Unicode asset) error: %v", err)
+	}
+	assertFileContent(t, filepath.Join(plainDir, "assets", logicalName), content)
+
+	gzipDir := filepath.Join(t.TempDir(), "gzip")
+	if err := packageApp(packageOptions{
+		appDir: appDir, compiler: "go", outDir: gzipDir,
+		compress: map[string]bool{"gzip": true},
+	}); err != nil {
+		t.Fatalf("packageApp(gzip Unicode asset) error: %v", err)
+	}
+	if _, err := inspectPackageGraph(gzipDir); err != nil {
+		t.Fatalf("inspectPackageGraph(gzip Unicode asset) error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(gzipDir, "assets", logicalName+".gz")); err != nil {
+		t.Fatalf("Unicode gzip sidecar missing: %v", err)
+	}
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,6 +114,16 @@ The recommended preview manifest uses an asset directory:
 }
 ```
 
+All user-authored `goframe.json` path fields use portable relative syntax.
+`/` is the canonical separator. A backslash is accepted as alternate separator
+syntax and canonicalized during manifest loading, so `"assets\\styles.css"`
+means `assets/styles.css` on every host and cannot address a literal
+backslash-containing Unix filename. Absolute, rooted, drive-like, and raw
+parent-component paths remain rejected. Canonical manifest paths become native
+paths only at contained filesystem boundaries; package logical names,
+generated package paths, and browser URLs retain their separate slash-oriented
+contracts.
+
 Files inside that directory are packaged relative to the directory root:
 `assets/styles.css` becomes package `assets/styles.css`, and
 `assets/data/issues.txt` becomes package `assets/data/issues.txt`. If
@@ -384,13 +394,14 @@ not an independent package path.
 Generated package paths are a separate entity. They use `/` exclusively, must
 be canonical and package-relative, and reject absolute or drive-prefixed forms.
 An asset with logical name `C:logo.svg` therefore has the contained package path
-`assets/C:logo.svg`. Authored `goframe.json` entries remain filesystem paths and
-retain their existing absolute and drive-prefix checks; the drive-looking name
-is produced when such a filename is discovered below an asset directory on a
-filesystem that permits it. A package containing that filename is not promised
-to be portable to Windows or another filesystem that reserves the character.
-Inspection schema-version-1 path fields and edge endpoints use the same
-slash-only package-path representation.
+`assets/C:logo.svg`. Authored `goframe.json` paths are canonical portable input,
+not generated logical names: rooted and drive-like authored forms are rejected,
+and host filesystem conversion happens only after manifest ingestion. The
+drive-looking generated name can still be discovered below an asset directory
+on a filesystem that permits it. A package containing that filename is not
+promised to be portable to Windows or another filesystem that reserves the
+character. Inspection schema-version-1 path fields and edge endpoints use the
+same slash-only package-path representation.
 
 Schema-version-1 string ordering is ascending lexical order of the raw UTF-8
 bytes. This applies to style entrypoints, artifact paths and roles, and each

--- a/docs/manifest-compatibility.md
+++ b/docs/manifest-compatibility.md
@@ -26,11 +26,11 @@ Supported fields:
 | Field | Default | Contract |
 |---|---|---|
 | `name` | app directory base name | Human-readable package name. Empty means default. |
-| `entry` | `.` | Go package entry. Supports `.` and relative child package directories such as `./cmd/app`, `cmd/app`, `./src/app`, and `app`. |
-| `output` | `dist` | Legacy/export-oriented output hint. Current package output defaults to `.goframe/package/standalone`; explicit package/export flags are preferred. |
+| `entry` | `.` | Go package entry. Supports `.` and canonical relative child package directories such as `cmd/app`, with authored `./cmd/app` and `cmd\app` spellings normalized at load time. |
+| `output` | `dist` | Canonical relative legacy/export-oriented output hint. Current package output defaults to `.goframe/package/standalone`; explicit package/export flags are preferred. |
 | `compiler` | `go` | Must be `go` or `tinygo`. CLI `--compiler` overrides it. |
-| `wasm` | `bundle.wasm` | Logical WASM filename. Must be a relative `.wasm` child path. `main.wasm` remains accepted for legacy apps. |
-| `assets` | auto | Static assets contract. Recommended form is a relative directory string such as `"./assets"`. Legacy explicit lists such as `["index.html", "styles.css"]` remain supported. Omitted or `null` auto-detects `./assets`, then root `index.html`, then generated default HTML. Empty `[]` means no user static assets and still generates runnable default HTML. |
+| `wasm` | `bundle.wasm` | Canonical relative WASM child path. The final package still uses its basename. `main.wasm` remains accepted for legacy apps. |
+| `assets` | auto | Static assets contract. Recommended form is a relative directory string such as `"./assets"`. Legacy explicit lists such as `["index.html", "styles.css"]` remain supported. Authored separators are canonicalized before either mode is consumed. Omitted or `null` auto-detects `./assets`, then root `index.html`, then generated default HTML. Empty `[]` means no user static assets and still generates runnable default HTML. |
 
 Validation evidence:
 
@@ -44,10 +44,20 @@ Current input behavior:
 - unknown fields are rejected with `DisallowUnknownFields`;
 - malformed JSON and trailing JSON are rejected;
 - empty explicit `entry` is rejected;
-- path fields must be relative child paths;
+- authored path fields use portable relative syntax. `/` is the canonical
+  separator; `\` is accepted as alternate separator syntax and canonicalized
+  to `/` exactly once during manifest loading. A successful load stores `entry`,
+  `output`, `wasm`, the asset directory, and every listed asset in canonical
+  slash form;
+- a backslash in a manifest path is never a literal Unix filename byte. For
+  example, `"assets\\styles.css"` selects `assets/styles.css`, not one file
+  named `assets\styles.css`;
 - absolute paths, raw `..` components, parent traversal, and tool-owned entry
   roots such as `.goframe`, `build`, `dist`, `node_modules`, and `.git` are
   rejected;
+- canonical manifest paths cross into host filesystem operations through
+  platform-native conversion below the application root. Logical package
+  names, generated package paths, and browser URLs remain separate contracts;
 - `wasm` must end in `.wasm`; names such as `main.go`, `go.mod`,
   `bundle.wasm.gz`, and `wasm_exec.js` are rejected;
 - `assets` accepts omitted/`null`, a directory string, or an explicit path
@@ -265,7 +275,9 @@ publication, while a remaining literal backslash is rejected. This does not
 promise that every generated logical name is portable to filesystems that
 reserve its characters. The inspection schema remains version 1, and its
 fields and both generated metadata schemas remain unchanged. Authored
-`goframe.json` path normalization is unchanged.
+`goframe.json` paths have their own portable ingestion contract: backslashes
+are separator syntax and successful loads store canonical slash paths before
+filesystem or package consumers run.
 
 For graph inspection, every asset logical key must use the exact canonical
 relative-name representation returned by the current package producer helper

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -25,6 +25,22 @@ The user-action notes for `v0.3.0-preview.1` are in
 generated-workspace compiler environment isolation and the narrowed repeated
 Mount descendant-target contract.
 
+## `v0.4.0-preview.1`: portable authored manifest paths
+
+All path-like `goframe.json` values now become canonical slash-relative paths
+during manifest loading. `/` remains the recommended authored separator, and
+`\` remains accepted for compatibility but always means a separator on every
+host. Absolute, rooted, drive-like, and raw `..` component spellings remain
+rejected.
+
+Canonical slash manifests need no changes. Manifests that used backslashes as
+separators now resolve consistently on Unix and Windows, including `output` and
+`wasm`, which previously retained their raw authored spelling after validation.
+A manifest can no longer use `\` to address a literal backslash-containing Unix
+filename; rename that file or select it with portable path components. This
+changes only authored input interpretation. Generated package metadata and
+package/inspection schemas remain version 1.
+
 ## Template
 
 ```md


### PR DESCRIPTION
## Summary

Canonicalize user-authored `goframe.json` path fields at manifest ingestion so
the same manifest has one portable meaning across supported hosts.

`entry`, `output`, `wasm`, asset directories, and explicit asset paths now
share the same canonical slash-oriented representation before filesystem,
package, or browser-facing consumers see them.

The change also removes filename metadata from gzip sidecars so valid Unicode
package assets are not rejected by compression metadata.

No public Go API, manifest schema, package schema, or inspect schema changes are
introduced.

## Behavior

Authored manifest paths now follow one portable contract:

- `/` is the canonical separator;
- `\` remains accepted as authored separator syntax and is normalized to `/`;
- slash, backslash, and mixed-separator spellings resolve to the same canonical
  manifest value;
- raw parent components, rooted paths, UNC-like forms, and ASCII drive-prefixed
  paths remain rejected;
- rooted and drive-like forms are validated across canonicalization, so inputs
  such as `./C:/bundle.wasm` cannot normalize into an otherwise forbidden
  stored value;
- filesystem conversion happens only at explicit host-filesystem boundaries;
- package logical names, generated package paths, and browser URLs retain their
  existing independent contracts.

A successful manifest load therefore leaves path-like fields in canonical form
rather than mixing raw authored spelling with normalized values.

On Unix, a backslash in `goframe.json` is separator syntax and does not address
a literal backslash-containing filename.

## Package and compression compatibility

Existing canonical slash manifests keep their behavior.

Generated package logical names are not reclassified as authored filesystem
paths. Existing generated names such as `C:logo.svg` therefore retain their
current package semantics.

The configured `wasm` path is canonicalized for filesystem access, while the
published standalone WASM layout keeps its existing basename behavior.

Gzip sidecars no longer embed the source filename in `gzip.Header.Name`. This
keeps compressed output path-neutral and allows valid Unicode asset names
without changing the decompressed content or package metadata contract.

No WASM size budget or compression-ratio limit changes.

## Changed Files / Areas

The implementation is limited to:

- manifest path ingestion and validation in `cmd/goxc`;
- explicit filesystem-boundary handling for build/package/dev consumers;
- focused manifest, package, Unix, and integration regressions;
- gzip sidecar filename metadata;
- manifest compatibility, deployment, migration, and changelog documentation.

No runtime or GOX behavior changes are included.

## Validation

Local validation includes:

- focused high-count authored-path regressions on Go `1.26.6` and `1.27.0`;
- race-enabled focused tests;
- five-field drive/root canonicalization coverage for `entry`, `output`,
  `wasm`, asset directories, and explicit asset lists;
- canonical fixed-point coverage for successfully loaded manifest paths;
- generated logical-name and separator-equivalence compatibility checks;
- full ordinary, `goframe_debug`, race, and vet suites on Go `1.26.6` and
  `1.27.0`;
- `scripts/check.sh`;
- documentation, artifact, and module-path checks;
- the complete 44-stream WASM size matrix;
- one complete Browser Smoke run;
- Windows `cmd/goxc` cross-compilation.

`actionlint` was unavailable in the local environment, so workflow validation
is left to hosted CI. No workflow files are changed by this PR.

Hosted Windows execution and the complete exact-head PR matrix remain the
authoritative remote platform evidence.

## Non-Goals

This PR does not:

- add a manifest version or new manifest field;
- change generated package or inspect schema versions;
- change package logical-name semantics;
- redesign package layout or nested WASM publication;
- introduce a new filesystem abstraction or symlink policy;
- change custom-index rewriting or browser URL semantics;
- add bundle splitting, multi-entry WASM, or route-lazy delivery;
- add SSR, hydration, or language-service functionality;
- change supported toolchain versions;
- create or publish a release.

## Review focus

Please focus on:

- the boundary between authored manifest paths and generated package paths;
- canonicalization before downstream consumption;
- rejection of rooted and drive-like values both before and after `path.Clean`;
- OS-independent authored drive-prefix classification;
- explicit `filepath.FromSlash` use at host-filesystem boundaries;
- preservation of generated logical names such as `C:logo.svg`;
- gzip sidecar path neutrality and Unicode asset compatibility.

## Related

- #143
- Milestone: `v0.4.0-preview.1`