### PR TITLE
fix(goxc): resolve runtime shim from selected Go toolchain

### DIFF
--- a/cmd/goxc/doctor.go
+++ b/cmd/goxc/doctor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -53,7 +52,7 @@ func doctorCommand(args []string) error {
 	if path, err := wasmExecPath("go"); err == nil {
 		fmt.Printf("wasm_exec.js: found, %s\n", path)
 	} else {
-		fmt.Printf("wasm_exec.js: not found below %s\n", runtime.GOROOT())
+		fmt.Printf("wasm_exec.js: error, %v\n", err)
 		failures++
 	}
 	if tinyGoFound {

--- a/cmd/goxc/helpers.go
+++ b/cmd/goxc/helpers.go
@@ -8,11 +8,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
 func wasmExecPath(compiler string) (string, error) {
+	return wasmExecPathForWorkingDirectory(compiler, "")
+}
+
+func wasmExecPathForWorkingDirectory(compiler, workingDirectory string) (string, error) {
 	if compiler == "tinygo" {
 		command := exec.Command("tinygo", "env", "TINYGOROOT")
 		output, err := command.Output()
@@ -26,15 +29,53 @@ func wasmExecPath(compiler string) (string, error) {
 		return path, nil
 	}
 
+	goRoot, err := selectedGoToolchainRoot(workingDirectory)
+	if err != nil {
+		return "", err
+	}
 	for _, path := range []string{
-		filepath.Join(runtime.GOROOT(), "lib", "wasm", "wasm_exec.js"),
-		filepath.Join(runtime.GOROOT(), "misc", "wasm", "wasm_exec.js"),
+		filepath.Join(goRoot, "lib", "wasm", "wasm_exec.js"),
+		filepath.Join(goRoot, "misc", "wasm", "wasm_exec.js"),
 	} {
 		if _, err := os.Stat(path); err == nil {
 			return path, nil
 		}
 	}
-	return "", fmt.Errorf("locate Go wasm_exec.js below %s", runtime.GOROOT())
+	return "", fmt.Errorf("locate Go wasm_exec.js below selected GOROOT %s", goRoot)
+}
+
+func selectedGoToolchainRoot(workingDirectory string) (string, error) {
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		return "", fmt.Errorf("locate Go compiler in PATH for wasm_exec.js discovery: %w", err)
+	}
+	command := exec.Command(goPath, "env", "GOROOT")
+	if workingDirectory != "" {
+		if err := configureWorkspaceCompilerCommand(command, compilerEnvironmentOptions{
+			Compiler:         "go",
+			Invocation:       compilerInvocationBuild,
+			WorkingDirectory: workingDirectory,
+			GoFlags:          workspaceCompilerBaseGoFlags,
+			StandardGoTarget: true,
+		}); err != nil {
+			return "", err
+		}
+	}
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	if err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return "", fmt.Errorf("query selected Go toolchain GOROOT with %s: %s", goPath, detail)
+	}
+	goRoot := strings.TrimSpace(string(output))
+	if goRoot == "" {
+		return "", fmt.Errorf("query selected Go toolchain GOROOT with %s: empty output", goPath)
+	}
+	return goRoot, nil
 }
 
 func copyFile(sourcePath, destinationPath string) error {

--- a/cmd/goxc/package.go
+++ b/cmd/goxc/package.go
@@ -264,7 +264,7 @@ func packageApp(options packageOptions) error {
 	assets[wasmLogicalName] = wasmAsset
 	entrypoints.WASM = wasmAsset.Path
 
-	runtimeSource, err := wasmExecPath(options.compiler)
+	runtimeSource, err := wasmExecPathForWorkingDirectory(options.compiler, workspaceResult.EntryPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/goxc/toolchain_runtime_test.go
+++ b/cmd/goxc/toolchain_runtime_test.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	fakeGoProcessEnvironment         = "GOXC_TEST_FAKE_GO_PROCESS"
+	fakeGoRootEnvironment            = "GOXC_TEST_FAKE_GO_ROOT"
+	fakeGoRootErrorEnvironment       = "GOXC_TEST_FAKE_GO_ROOT_ERROR"
+	fakeGoDirectoryEnvironment       = "GOXC_TEST_FAKE_GO_DIRECTORY"
+	fakeGoCompilerContextEnvironment = "GOXC_TEST_FAKE_GO_COMPILER_CONTEXT"
+	fakeGoBuildDirectoryEnvironment  = "GOXC_TEST_FAKE_GO_BUILD_DIRECTORY_FILE"
+	fakeGoRootDirectoryEnvironment   = "GOXC_TEST_FAKE_GO_ROOT_DIRECTORY_FILE"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(fakeGoProcessEnvironment) == "1" {
+		os.Exit(runFakeGoCommand(os.Args[1:]))
+	}
+	os.Exit(m.Run())
+}
+
+func TestWasmExecPathUsesPATHSelectedGoToolchain(t *testing.T) {
+	for _, layout := range []string{
+		filepath.Join("lib", "wasm", runtimeAssetName),
+		filepath.Join("misc", "wasm", runtimeAssetName),
+	} {
+		t.Run(filepath.ToSlash(layout), func(t *testing.T) {
+			want := installFakeSelectedGo(t, layout, "selected runtime")
+
+			got, err := wasmExecPath("go")
+			if err != nil {
+				t.Fatalf("wasmExecPath(go) error: %v", err)
+			}
+			if got != want {
+				t.Fatalf("wasmExecPath(go) = %q, want PATH-selected runtime %q", got, want)
+			}
+		})
+	}
+}
+
+func TestWasmExecPathRejectsMissingSelectedGoToolchain(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("GOROOT", "")
+
+	_, err := wasmExecPath("go")
+	if err == nil {
+		t.Fatal("wasmExecPath(go) succeeded without a selected Go executable")
+	}
+	for _, want := range []string{"Go", "PATH"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("wasmExecPath(go) error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestWasmExecPathRejectsSelectedGoWithoutRuntime(t *testing.T) {
+	root := t.TempDir()
+	installFakeGoCommand(t, root)
+
+	_, err := wasmExecPath("go")
+	if err == nil {
+		t.Fatal("wasmExecPath(go) succeeded without wasm_exec.js in the selected GOROOT")
+	}
+	for _, want := range []string{"selected GOROOT", root} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("wasmExecPath(go) error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestSelectedGoToolchainRootRejectsEmptyOutput(t *testing.T) {
+	installFakeGoCommand(t, "")
+
+	_, err := selectedGoToolchainRoot("")
+	if err == nil {
+		t.Fatal("selectedGoToolchainRoot() accepted empty go env GOROOT output")
+	}
+	if !strings.Contains(err.Error(), "empty output") {
+		t.Fatalf("selectedGoToolchainRoot() error = %q, want empty-output context", err)
+	}
+}
+
+func TestSelectedGoToolchainRootReportsGoEnvFailure(t *testing.T) {
+	installFakeGoCommand(t, t.TempDir())
+	t.Setenv(fakeGoRootErrorEnvironment, "selected go env failed")
+
+	_, err := selectedGoToolchainRoot("")
+	if err == nil {
+		t.Fatal("selectedGoToolchainRoot() succeeded after go env GOROOT failed")
+	}
+	for _, want := range []string{"query selected Go toolchain GOROOT", "selected go env failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("selectedGoToolchainRoot() error %q does not contain %q", err, want)
+		}
+	}
+}
+
+func TestWasmExecPathUsesCompilerWorkingDirectory(t *testing.T) {
+	want := installFakeSelectedGo(
+		t,
+		filepath.Join("lib", "wasm", runtimeAssetName),
+		"selected runtime",
+	)
+	workingDirectory := filepath.Join(t.TempDir(), "workspace", "app")
+	if err := os.MkdirAll(workingDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(fakeGoDirectoryEnvironment, workingDirectory)
+
+	got, err := wasmExecPathForWorkingDirectory("go", workingDirectory)
+	if err != nil {
+		t.Fatalf("wasmExecPathForWorkingDirectory() error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("wasmExecPathForWorkingDirectory() = %q, want %q", got, want)
+	}
+}
+
+func TestPackageUsesPATHSelectedGoRuntime(t *testing.T) {
+	wantRuntime := "runtime from selected Go toolchain"
+	installFakeSelectedGo(t, filepath.Join("lib", "wasm", runtimeAssetName), wantRuntime)
+
+	appDir := t.TempDir()
+	writeTestFile(t, appDir, "go.mod", "module example.com/selected-runtime\n\ngo 1.26.6\n")
+	writeTestFile(t, appDir, manifestName, `{"name":"selected-runtime","compiler":"go","assets":[]}`)
+	writeTestFile(t, appDir, "main.go", "package main\n\nfunc main() {}\n")
+	outDir := filepath.Join(t.TempDir(), "package")
+
+	if err := packageApp(packageOptions{
+		appDir: appDir, compiler: "go", outDir: outDir, compress: map[string]bool{},
+	}); err != nil {
+		t.Fatalf("packageApp() error: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(outDir, assetDirectoryName, runtimeAssetName))
+	if err != nil {
+		t.Fatalf("read packaged runtime: %v", err)
+	}
+	if string(content) != wantRuntime {
+		t.Fatalf("packaged runtime = %q, want selected-toolchain content %q", content, wantRuntime)
+	}
+}
+
+func TestPackageRuntimeDiscoveryUsesCompilerSelectionContext(t *testing.T) {
+	wantRuntime := "runtime from context-selected Go toolchain"
+	installFakeSelectedGo(t, filepath.Join("lib", "wasm", runtimeAssetName), wantRuntime)
+
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTestFile(t, root, "go.work", "go 1.26.6\n\nuse ./app\n")
+	writeTestFile(t, appDir, "go.mod", "module example.com/context-selected-runtime\n\ngo 1.26.6\n")
+	writeTestFile(t, appDir, manifestName, `{"name":"context-selected-runtime","compiler":"go","assets":[]}`)
+	writeTestFile(t, appDir, "main.go", "package main\n\nfunc main() {}\n")
+
+	buildDirectoryFile := filepath.Join(t.TempDir(), "build-directory")
+	rootDirectoryFile := filepath.Join(t.TempDir(), "root-directory")
+	t.Setenv("GOWORK", filepath.Join(root, "go.work"))
+	t.Setenv("GO111MODULE", "off")
+	t.Setenv("GOFLAGS", "-mod=vendor")
+	t.Setenv(fakeGoCompilerContextEnvironment, "1")
+	t.Setenv(fakeGoBuildDirectoryEnvironment, buildDirectoryFile)
+	t.Setenv(fakeGoRootDirectoryEnvironment, rootDirectoryFile)
+
+	if err := packageApp(packageOptions{
+		appDir: appDir, compiler: "go", outDir: filepath.Join(t.TempDir(), "package"), compress: map[string]bool{},
+	}); err != nil {
+		t.Fatalf("packageApp() error: %v", err)
+	}
+
+	buildDirectory, err := os.ReadFile(buildDirectoryFile)
+	if err != nil {
+		t.Fatalf("read compiler working-directory observation: %v", err)
+	}
+	rootDirectory, err := os.ReadFile(rootDirectoryFile)
+	if err != nil {
+		t.Fatalf("read runtime-root working-directory observation: %v", err)
+	}
+	if string(rootDirectory) != string(buildDirectory) {
+		t.Fatalf(
+			"runtime-root working directory = %q, compiler working directory = %q",
+			rootDirectory,
+			buildDirectory,
+		)
+	}
+}
+
+func TestDoctorReportsPATHSelectedGoRuntime(t *testing.T) {
+	want := installFakeSelectedGo(
+		t,
+		filepath.Join("lib", "wasm", runtimeAssetName),
+		"selected runtime",
+	)
+
+	var err error
+	output := captureStdout(t, func() {
+		err = doctorCommand(nil)
+	})
+	if err != nil {
+		t.Fatalf("doctorCommand() error: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "wasm_exec.js: found, "+want) {
+		t.Fatalf("doctor output does not report the PATH-selected runtime %q:\n%s", want, output)
+	}
+}
+
+func TestRelocatedTrimpathGoxcUsesPATHSelectedGoRuntime(t *testing.T) {
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildDir := t.TempDir()
+	binaryName := "goxc"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	builtPath := filepath.Join(buildDir, binaryName)
+	command := exec.Command("go", "build", "-trimpath", "-o", builtPath, "./cmd/goxc")
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build trimpath goxc: %v\n%s", err, output)
+	}
+
+	relocatedDir := t.TempDir()
+	relocatedPath := filepath.Join(relocatedDir, binaryName)
+	if err := os.Rename(builtPath, relocatedPath); err != nil {
+		t.Fatalf("relocate goxc: %v", err)
+	}
+	want := installFakeSelectedGo(
+		t,
+		filepath.Join("lib", "wasm", runtimeAssetName),
+		"selected runtime",
+	)
+
+	command = exec.Command(relocatedPath, "doctor")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run relocated goxc doctor: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "wasm_exec.js: found, "+want) {
+		t.Fatalf("relocated goxc did not report PATH-selected runtime %q:\n%s", want, output)
+	}
+}
+
+func installFakeSelectedGo(t *testing.T, runtimeRelativePath, runtimeContent string) string {
+	t.Helper()
+	root := t.TempDir()
+	runtimePath := filepath.Join(root, runtimeRelativePath)
+	if err := os.MkdirAll(filepath.Dir(runtimePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimePath, []byte(runtimeContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	installFakeGoCommand(t, root)
+	return runtimePath
+}
+
+func installFakeGoCommand(t *testing.T, root string) {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	goName := "go"
+	if runtime.GOOS == "windows" {
+		goName += ".exe"
+	}
+	if err := copyExecutableForTest(executable, filepath.Join(binDir, goName)); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir)
+	t.Setenv("GOROOT", "")
+	t.Setenv(fakeGoProcessEnvironment, "1")
+	t.Setenv(fakeGoRootEnvironment, root)
+}
+
+func copyExecutableForTest(sourcePath, destinationPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o755)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(destination, source)
+	closeErr := destination.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+func runFakeGoCommand(args []string) int {
+	root := os.Getenv(fakeGoRootEnvironment)
+	switch {
+	case len(args) == 1 && args[0] == "version":
+		fmt.Println("go version go1.26.6 test/amd64")
+		return 0
+	case len(args) == 2 && args[0] == "env" && args[1] == "GOROOT":
+		if err := validateFakeGoCompilerContext(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if err := recordFakeGoWorkingDirectory(fakeGoRootDirectoryEnvironment); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if message := os.Getenv(fakeGoRootErrorEnvironment); message != "" {
+			fmt.Fprintln(os.Stderr, message)
+			return 1
+		}
+		if want := os.Getenv(fakeGoDirectoryEnvironment); want != "" {
+			got, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 1
+			}
+			if got != want {
+				fmt.Fprintf(os.Stderr, "go env GOROOT directory = %q, want %q\n", got, want)
+				return 1
+			}
+		}
+		fmt.Println(root)
+		return 0
+	case len(args) == 2 && args[0] == "env" && args[1] == "GOVERSION":
+		fmt.Println("go1.26.6")
+		return 0
+	case len(args) > 0 && args[0] == "list":
+		return 0
+	case len(args) > 0 && args[0] == "build":
+		if err := validateFakeGoCompilerContext(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if err := recordFakeGoWorkingDirectory(fakeGoBuildDirectoryEnvironment); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		for index := 1; index+1 < len(args); index++ {
+			if args[index] != "-o" {
+				continue
+			}
+			if err := os.WriteFile(args[index+1], []byte("\x00asmfake"), 0o600); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				return 1
+			}
+			return 0
+		}
+		fmt.Fprintln(os.Stderr, "fake go build did not receive -o")
+		return 2
+	default:
+		fmt.Fprintf(os.Stderr, "unsupported fake go command: %q\n", args)
+		return 2
+	}
+}
+
+func validateFakeGoCompilerContext() error {
+	if os.Getenv(fakeGoCompilerContextEnvironment) != "1" {
+		return nil
+	}
+	for _, expected := range []struct {
+		key   string
+		value string
+	}{
+		{key: "GOWORK", value: "off"},
+		{key: "GO111MODULE", value: "on"},
+		{key: "GOFLAGS", value: workspaceCompilerBaseGoFlags},
+		{key: "GOOS", value: "js"},
+		{key: "GOARCH", value: "wasm"},
+		{key: "CGO_ENABLED", value: "0"},
+	} {
+		if got := os.Getenv(expected.key); got != expected.value {
+			return fmt.Errorf("%s = %q, want %q", expected.key, got, expected.value)
+		}
+	}
+	return nil
+}
+
+func recordFakeGoWorkingDirectory(environmentKey string) error {
+	path := os.Getenv(environmentKey)
+	if path == "" {
+		return nil
+	}
+	directory, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(directory), 0o644)
+}


### PR DESCRIPTION
## Summary

Resolve the standard Go WebAssembly runtime shim from the Go toolchain selected
for the current `goxc` invocation instead of the toolchain that happened to
build the `goxc` binary.

Standard-Go packaging now queries `go env GOROOT` through the selected Go
command in the same controlled compiler context used for the WASM build.
This keeps `wasm_exec.js` discovery aligned with effective Go toolchain
selection for relocated binaries, workspace isolation, and explicit Go
environment configuration.

`goxc doctor` reports the same selected-toolchain result.

No public Go API, manifest schema, package schema, runtime, or GOX behavior
changes are introduced.

## Behavior

Standard-Go runtime-shim discovery now:

- resolves `go` through the active `PATH`;
- obtains the authoritative runtime root from `go env GOROOT`;
- runs that query in the generated entry package context used by compilation;
- applies the same controlled compiler environment, including `GOWORK=off`,
  `GO111MODULE=on`, the owned `GOFLAGS`, and the standard `js/wasm` target;
- preserves inherited `GOROOT` and `GOTOOLCHAIN` semantics instead of
  reimplementing Go toolchain selection;
- checks `lib/wasm/wasm_exec.js` first and retains the existing
  `misc/wasm/wasm_exec.js` compatibility fallback;
- fails with the selected-toolchain discovery error when Go or its runtime shim
  cannot be resolved instead of falling back to `runtime.GOROOT()`.

Packaging therefore uses a runtime shim from the same effective standard Go
toolchain context that produces the application WASM.

TinyGo discovery is unchanged and continues to use `tinygo env TINYGOROOT`.

## Compatibility

Existing standard-Go package layout and published runtime asset names are
unchanged.

The change only affects how the source `wasm_exec.js` installation is selected.
A `goxc` binary built with one Go installation, including a relocated
`-trimpath` binary, can now package against another valid Go toolchain selected
at execution time without depending on its build-time GOROOT.

The current and legacy standard-Go runtime layouts remain supported:

- `lib/wasm/wasm_exec.js`;
- `misc/wasm/wasm_exec.js`.

No fallback to the Go installation that built `goxc` remains in the
release-visible runtime-shim discovery path.

## Validation

Local validation includes:

- focused selected-toolchain, runtime-layout, missing-toolchain, package,
  doctor, and relocated `-trimpath` regressions;
- repeated compiler/discovery-context regression coverage, including hostile
  ambient `go.work`, `GOWORK`, `GO111MODULE`, and `GOFLAGS` state;
- portable fake-Go execution without POSIX-shell dependencies;
- full ordinary, `goframe_debug`, race, vet, and GOX golden/error-golden suites
  on Go `1.26.6` and `1.27.0`;
- repository-wide Staticcheck `SA*` checks for ordinary and
  `goframe_debug` host builds;
- production-only Staticcheck `SA*` checks for ordinary and
  `goframe_debug` `js/wasm` builds;
- focused TinyGo/package regressions;
- `scripts/artifact-check.sh`;
- `scripts/module-path-check.sh`;
- Windows `cmd/goxc` test-binary cross-compilation.

The remaining unfiltered Staticcheck `ST1005` and `S1016` diagnostics are
unrelated style/simplification findings and are not changed or suppressed by
this PR.

Hosted Windows execution and the complete exact-head PR matrix remain the
authoritative remote platform evidence.

## Scope

This PR changes only the selected standard-Go toolchain contract used for
runtime-shim discovery and its regression coverage.

It does not:

- change Go, TinyGo, or Node version baselines;
- change TinyGo toolchain discovery;
- change runtime or GOX behavior;
- change manifest, package, export, or inspect schemas;
- change package ownership or authored-path semantics;
- add or modify security-analysis workflows;
- pin GitHub Actions or downloaded toolchain artifacts;
- change CI topology;
- create or publish a release.

## Review focus

Please focus on:

- selected `go env GOROOT` as the source of truth instead of
  `runtime.GOROOT()`;
- equivalence between compilation and runtime-shim toolchain-selection
  contexts;
- `GOWORK`, `GO111MODULE`, `GOFLAGS`, `GOROOT`, and `GOTOOLCHAIN` semantics;
- relocated / `-trimpath` `goxc` behavior;
- preservation of `lib/wasm` and `misc/wasm` runtime layouts;
- deterministic failure without a build-time GOROOT fallback;
- portability of the selected-toolchain regression fixtures;
- unchanged TinyGo discovery.

## Related

- #143
- Milestone: `v0.4.0-preview.1`