### PR TITLE
ci(security): establish release security-analysis gates

### DIFF
--- a/.github/scripts/gosec-report.go
+++ b/.github/scripts/gosec-report.go
@@ -179,7 +179,7 @@ func writeGosecSummary(writer io.Writer, report gosecReport, repositoryRoot stri
 		fmt.Fprintf(writer, "gosec: %s=%d\n", rule, counts[rule])
 	}
 	for _, issue := range issues {
-		fmt.Fprintf(writer, "gosec: advisory %s %s:%s:%s: %s\n",
+		fmt.Fprintf(writer, "gosec: advisory %s %s (line %s, column %s): %s\n",
 			issue.RuleID, issue.File, issue.Line, issue.Column, issue.Details)
 	}
 	if len(issues) == 0 {

--- a/.github/scripts/gosec-report.go
+++ b/.github/scripts/gosec-report.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type gosecIssue struct {
+	RuleID  string `json:"rule_id"`
+	Details string `json:"details"`
+	File    string `json:"file"`
+	Line    string `json:"line"`
+	Column  string `json:"column"`
+}
+
+type gosecProcessingError struct {
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+	Error  string `json:"error"`
+}
+
+type gosecStats struct {
+	Files *int `json:"files"`
+	Lines *int `json:"lines"`
+	NoSec *int `json:"nosec"`
+	Found *int `json:"found"`
+}
+
+type gosecReport struct {
+	Version          string
+	ProcessingErrors map[string][]gosecProcessingError
+	Issues           []gosecIssue
+	Stats            gosecStats
+}
+
+func main() {
+	reportPath := flag.String("report", "", "path to the gosec JSON report")
+	repositoryRoot := flag.String("root", "", "repository root used to shorten finding paths")
+	packageCount := flag.Int("packages", 0, "number of Go packages supplied to gosec")
+	flag.Parse()
+
+	if *reportPath == "" || *repositoryRoot == "" || *packageCount <= 0 || flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "usage: gosec-report -report <path> -root <path> -packages <positive count>")
+		os.Exit(2)
+	}
+	report, err := readGosecReport(*reportPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gosec report: %v\n", err)
+		os.Exit(1)
+	}
+	if err := writeGosecSummary(os.Stdout, report, *repositoryRoot, *packageCount); err != nil {
+		fmt.Fprintf(os.Stderr, "gosec report: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func readGosecReport(path string) (gosecReport, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return gosecReport{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(content)) == 0 {
+		return gosecReport{}, errors.New("report is empty")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	var fields map[string]json.RawMessage
+	if err := decoder.Decode(&fields); err != nil {
+		return gosecReport{}, fmt.Errorf("decode JSON: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return gosecReport{}, errors.New("report contains more than one JSON value")
+		}
+		return gosecReport{}, fmt.Errorf("decode trailing JSON: %w", err)
+	}
+
+	var report gosecReport
+	if err := decodeRequiredGosecField(fields, "GosecVersion", &report.Version); err != nil {
+		return gosecReport{}, err
+	}
+	if strings.TrimSpace(report.Version) == "" {
+		return gosecReport{}, errors.New("GosecVersion must be a non-empty string")
+	}
+	if err := decodeRequiredGosecField(fields, "Golang errors", &report.ProcessingErrors); err != nil {
+		return gosecReport{}, err
+	}
+	if report.ProcessingErrors == nil {
+		return gosecReport{}, errors.New("Golang errors must be an object")
+	}
+	if err := decodeRequiredGosecField(fields, "Issues", &report.Issues); err != nil {
+		return gosecReport{}, err
+	}
+	if report.Issues == nil {
+		return gosecReport{}, errors.New("Issues must be an array")
+	}
+	if err := decodeRequiredGosecField(fields, "Stats", &report.Stats); err != nil {
+		return gosecReport{}, err
+	}
+	return report, nil
+}
+
+func decodeRequiredGosecField(fields map[string]json.RawMessage, name string, destination any) error {
+	raw, ok := fields[name]
+	if !ok {
+		return fmt.Errorf("missing required field %q", name)
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return fmt.Errorf("required field %q is null", name)
+	}
+	if err := json.Unmarshal(raw, destination); err != nil {
+		return fmt.Errorf("decode field %q: %w", name, err)
+	}
+	return nil
+}
+
+func writeGosecSummary(writer io.Writer, report gosecReport, repositoryRoot string, packageCount int) error {
+	if packageCount <= 0 {
+		return errors.New("package coverage is empty or unproven")
+	}
+	if err := validateGosecStats(report); err != nil {
+		return err
+	}
+	if len(report.ProcessingErrors) != 0 {
+		return formatGosecProcessingErrors(report.ProcessingErrors)
+	}
+
+	issues := append([]gosecIssue(nil), report.Issues...)
+	for index := range issues {
+		if strings.TrimSpace(issues[index].RuleID) == "" ||
+			strings.TrimSpace(issues[index].Details) == "" ||
+			strings.TrimSpace(issues[index].File) == "" ||
+			strings.TrimSpace(issues[index].Line) == "" ||
+			strings.TrimSpace(issues[index].Column) == "" {
+			return fmt.Errorf("issue %d is missing a required rule, location, or message field", index)
+		}
+		issues[index].File = displayGosecPath(repositoryRoot, issues[index].File)
+	}
+	sort.Slice(issues, func(first, second int) bool {
+		left := issues[first]
+		right := issues[second]
+		if left.RuleID != right.RuleID {
+			return left.RuleID < right.RuleID
+		}
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		if left.Column != right.Column {
+			return left.Column < right.Column
+		}
+		return left.Details < right.Details
+	})
+
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		counts[issue.RuleID]++
+	}
+	rules := make([]string, 0, len(counts))
+	for rule := range counts {
+		rules = append(rules, rule)
+	}
+	sort.Strings(rules)
+
+	fmt.Fprintf(writer, "gosec: version=%s packages=%d files=%d lines=%d findings=%d\n",
+		report.Version, packageCount, *report.Stats.Files, *report.Stats.Lines, len(issues))
+	for _, rule := range rules {
+		fmt.Fprintf(writer, "gosec: %s=%d\n", rule, counts[rule])
+	}
+	for _, issue := range issues {
+		fmt.Fprintf(writer, "gosec: advisory %s %s:%s:%s: %s\n",
+			issue.RuleID, issue.File, issue.Line, issue.Column, issue.Details)
+	}
+	if len(issues) == 0 {
+		fmt.Fprintln(writer, "gosec: no findings")
+	} else {
+		fmt.Fprintln(writer, "gosec: findings are advisory; analyzer health and package coverage passed")
+	}
+	return nil
+}
+
+func validateGosecStats(report gosecReport) error {
+	stats := report.Stats
+	if stats.Files == nil || stats.Lines == nil || stats.NoSec == nil || stats.Found == nil {
+		return errors.New("Stats is missing files, lines, nosec, or found")
+	}
+	if *stats.Files <= 0 {
+		return errors.New("report proves no analyzed files")
+	}
+	if *stats.Lines < 0 || *stats.NoSec < 0 || *stats.Found < 0 {
+		return errors.New("Stats contains a negative value")
+	}
+	if *stats.NoSec != 0 {
+		return fmt.Errorf("report contains %d source suppressions", *stats.NoSec)
+	}
+	if *stats.Found != len(report.Issues) {
+		return fmt.Errorf("Stats found=%d does not match Issues count=%d", *stats.Found, len(report.Issues))
+	}
+	return nil
+}
+
+func formatGosecProcessingErrors(processingErrors map[string][]gosecProcessingError) error {
+	paths := make([]string, 0, len(processingErrors))
+	for path := range processingErrors {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	messages := make([]string, 0)
+	for _, path := range paths {
+		errorsForPath := processingErrors[path]
+		if len(errorsForPath) == 0 {
+			messages = append(messages, fmt.Sprintf("%s: unspecified processing error", path))
+			continue
+		}
+		for _, processingError := range errorsForPath {
+			message := strings.TrimSpace(processingError.Error)
+			if message == "" {
+				message = "unspecified processing error"
+			}
+			messages = append(messages, fmt.Sprintf("%s:%d:%d: %s", path, processingError.Line, processingError.Column, message))
+		}
+	}
+	return fmt.Errorf("Go/package processing errors: %s", strings.Join(messages, "; "))
+}
+
+func displayGosecPath(repositoryRoot, path string) string {
+	relative, err := filepath.Rel(repositoryRoot, path)
+	if err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(relative)
+	}
+	return filepath.ToSlash(path)
+}

--- a/.github/scripts/gosec-report.go
+++ b/.github/scripts/gosec-report.go
@@ -13,6 +13,13 @@ import (
 	"strings"
 )
 
+var workflowLogFieldReplacer = strings.NewReplacer("\r", `\r`, "\n", `\n`, "##[", `##\[`)
+
+// Keep analyzer data inside formatter-owned lines and out of both Actions command syntaxes.
+func sanitizeWorkflowLogField(value string) string {
+	return workflowLogFieldReplacer.Replace(value)
+}
+
 type gosecIssue struct {
 	RuleID  string `json:"rule_id"`
 	Details string `json:"details"`
@@ -53,11 +60,11 @@ func main() {
 	}
 	report, err := readGosecReport(*reportPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "gosec report: %v\n", err)
+		fmt.Fprintf(os.Stderr, "gosec report: %s\n", sanitizeWorkflowLogField(err.Error()))
 		os.Exit(1)
 	}
 	if err := writeGosecSummary(os.Stdout, report, *repositoryRoot, *packageCount); err != nil {
-		fmt.Fprintf(os.Stderr, "gosec report: %v\n", err)
+		fmt.Fprintf(os.Stderr, "gosec report: %s\n", sanitizeWorkflowLogField(err.Error()))
 		os.Exit(1)
 	}
 }
@@ -174,13 +181,14 @@ func writeGosecSummary(writer io.Writer, report gosecReport, repositoryRoot stri
 	sort.Strings(rules)
 
 	fmt.Fprintf(writer, "gosec: version=%s packages=%d files=%d lines=%d findings=%d\n",
-		report.Version, packageCount, *report.Stats.Files, *report.Stats.Lines, len(issues))
+		sanitizeWorkflowLogField(report.Version), packageCount, *report.Stats.Files, *report.Stats.Lines, len(issues))
 	for _, rule := range rules {
-		fmt.Fprintf(writer, "gosec: %s=%d\n", rule, counts[rule])
+		fmt.Fprintf(writer, "gosec: %s=%d\n", sanitizeWorkflowLogField(rule), counts[rule])
 	}
 	for _, issue := range issues {
 		fmt.Fprintf(writer, "gosec: advisory %s %s (line %s, column %s): %s\n",
-			issue.RuleID, issue.File, issue.Line, issue.Column, issue.Details)
+			sanitizeWorkflowLogField(issue.RuleID), sanitizeWorkflowLogField(issue.File),
+			sanitizeWorkflowLogField(issue.Line), sanitizeWorkflowLogField(issue.Column), sanitizeWorkflowLogField(issue.Details))
 	}
 	if len(issues) == 0 {
 		fmt.Fprintln(writer, "gosec: no findings")
@@ -231,7 +239,7 @@ func formatGosecProcessingErrors(processingErrors map[string][]gosecProcessingEr
 			messages = append(messages, fmt.Sprintf("%s:%d:%d: %s", path, processingError.Line, processingError.Column, message))
 		}
 	}
-	return fmt.Errorf("Go/package processing errors: %s", strings.Join(messages, "; "))
+	return fmt.Errorf("Go/package processing errors: %s", sanitizeWorkflowLogField(strings.Join(messages, "; ")))
 }
 
 func displayGosecPath(repositoryRoot, path string) string {

--- a/.github/scripts/gosec-report_test.go
+++ b/.github/scripts/gosec-report_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGosecReportFindingsAreAdvisory(t *testing.T) {
+	report := readTestGosecReport(t, `{
+  "Golang errors": {},
+  "Issues": [
+    {"rule_id":"G304","details":"file path provided as input","file":"/repo/z.go","line":"9","column":"3"},
+    {"rule_id":"G204","details":"subprocess launched with variable","file":"/repo/a.go","line":"4","column":"2"},
+    {"rule_id":"G204","details":"subprocess launched with variable","file":"/repo/b.go","line":"5","column":"2"}
+  ],
+  "Stats": {"files":2,"lines":20,"nosec":0,"found":3},
+  "GosecVersion":"dev"
+}`)
+	var output bytes.Buffer
+	if err := writeGosecSummary(&output, report, "/repo", 2); err != nil {
+		t.Fatalf("writeGosecSummary() error = %v", err)
+	}
+	want := []string{
+		"packages=2 files=2 lines=20 findings=3",
+		"gosec: G204=2",
+		"gosec: G304=1",
+		"gosec: advisory G204 a.go:4:2",
+		"gosec: findings are advisory; analyzer health and package coverage passed",
+	}
+	for _, fragment := range want {
+		if !strings.Contains(output.String(), fragment) {
+			t.Fatalf("summary missing %q:\n%s", fragment, output.String())
+		}
+	}
+}
+
+func TestGosecReportCleanScanPasses(t *testing.T) {
+	report := readTestGosecReport(t, `{
+  "Golang errors": {},
+  "Issues": [],
+  "Stats": {"files":1,"lines":8,"nosec":0,"found":0},
+  "GosecVersion":"dev"
+}`)
+	var output bytes.Buffer
+	if err := writeGosecSummary(&output, report, "/repo", 1); err != nil {
+		t.Fatalf("writeGosecSummary() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "gosec: no findings") {
+		t.Fatalf("summary = %q, want clean result", output.String())
+	}
+}
+
+func TestGosecReportRejectsProcessingErrors(t *testing.T) {
+	report := readTestGosecReport(t, `{
+  "Golang errors": {"pkg/broken":[{"line":0,"column":0,"error":"mixed packages"}]},
+  "Issues": [],
+  "Stats": {"files":1,"lines":8,"nosec":0,"found":0},
+  "GosecVersion":"dev"
+}`)
+	if err := writeGosecSummary(&bytes.Buffer{}, report, "/repo", 1); err == nil || !strings.Contains(err.Error(), "mixed packages") {
+		t.Fatalf("writeGosecSummary() error = %v, want processing failure", err)
+	}
+}
+
+func TestGosecReportRejectsMalformedOrIncompleteInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "empty", content: "", want: "report is empty"},
+		{name: "malformed", content: "{", want: "decode JSON"},
+		{name: "missing issues", content: `{"Golang errors":{},"Stats":{},"GosecVersion":"dev"}`, want: `missing required field "Issues"`},
+		{name: "null issues", content: `{"Golang errors":{},"Issues":null,"Stats":{},"GosecVersion":"dev"}`, want: `required field "Issues" is null`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "report.json")
+			if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := readGosecReport(path)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("readGosecReport() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestGosecReportRejectsMissingInput(t *testing.T) {
+	_, err := readGosecReport(filepath.Join(t.TempDir(), "missing.json"))
+	if err == nil || !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("readGosecReport() error = %v, want missing file failure", err)
+	}
+}
+
+func TestGosecReportRejectsUnprovenCoverage(t *testing.T) {
+	report := readTestGosecReport(t, `{
+  "Golang errors": {},
+  "Issues": [],
+  "Stats": {"files":1,"lines":8,"nosec":0,"found":0},
+  "GosecVersion":"dev"
+}`)
+	if err := writeGosecSummary(&bytes.Buffer{}, report, "/repo", 0); err == nil || !strings.Contains(err.Error(), "empty or unproven") {
+		t.Fatalf("writeGosecSummary() error = %v, want coverage failure", err)
+	}
+}
+
+func TestGosecReportRejectsZeroAnalyzedFiles(t *testing.T) {
+	report := readTestGosecReport(t, `{
+  "Golang errors": {},
+  "Issues": [],
+  "Stats": {"files":0,"lines":0,"nosec":0,"found":0},
+  "GosecVersion":"dev"
+}`)
+	if err := writeGosecSummary(&bytes.Buffer{}, report, "/repo", 1); err == nil || !strings.Contains(err.Error(), "no analyzed files") {
+		t.Fatalf("writeGosecSummary() error = %v, want files failure", err)
+	}
+}
+
+func readTestGosecReport(t *testing.T, content string) gosecReport {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "report.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	report, err := readGosecReport(path)
+	if err != nil {
+		t.Fatalf("readGosecReport() error = %v", err)
+	}
+	return report
+}

--- a/.github/scripts/gosec-report_test.go
+++ b/.github/scripts/gosec-report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestGosecReportFindingsAreAdvisory(t *testing.T) {
   "Issues": [
     {"rule_id":"G304","details":"file path provided as input","file":"/repo/z.go","line":"9","column":"3"},
     {"rule_id":"G204","details":"subprocess launched with variable","file":"/repo/a.go","line":"4","column":"2"},
-    {"rule_id":"G204","details":"subprocess launched with variable","file":"/repo/b.go","line":"5","column":"2"}
+    {"rule_id":"G204","details":"subprocess launched with variable","file":"/repo/b.go","line":"5-7","column":"02"}
   ],
   "Stats": {"files":2,"lines":20,"nosec":0,"found":3},
   "GosecVersion":"dev"
@@ -23,11 +24,18 @@ func TestGosecReportFindingsAreAdvisory(t *testing.T) {
 	if err := writeGosecSummary(&output, report, "/repo", 2); err != nil {
 		t.Fatalf("writeGosecSummary() error = %v", err)
 	}
+	if diagnostic := regexp.MustCompile(`(?m)^gosec: advisory .*\.go:[0-9-]+:[0-9-]+:`).FindString(output.String()); diagnostic != "" {
+		t.Fatalf("advisory output contains compiler-diagnostic location syntax %q:\n%s", diagnostic, output.String())
+	}
 	want := []string{
 		"packages=2 files=2 lines=20 findings=3",
 		"gosec: G204=2",
 		"gosec: G304=1",
-		"gosec: advisory G204 a.go:4:2",
+		strings.Join([]string{
+			"gosec: advisory G204 a.go (line 4, column 2): subprocess launched with variable",
+			"gosec: advisory G204 b.go (line 5-7, column 02): subprocess launched with variable",
+			"gosec: advisory G304 z.go (line 9, column 3): file path provided as input",
+		}, "\n"),
 		"gosec: findings are advisory; analyzer health and package coverage passed",
 	}
 	for _, fragment := range want {
@@ -35,6 +43,7 @@ func TestGosecReportFindingsAreAdvisory(t *testing.T) {
 			t.Fatalf("summary missing %q:\n%s", fragment, output.String())
 		}
 	}
+	t.Log(output.String())
 }
 
 func TestGosecReportCleanScanPasses(t *testing.T) {

--- a/.github/scripts/gosec-report_test.go
+++ b/.github/scripts/gosec-report_test.go
@@ -2,12 +2,172 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
 )
+
+var workflowLogPayloads = []struct {
+	name string
+	raw  string
+	want string
+}{
+	{"V2 warning LF", "\n::warning file=fake.go,line=1::forged", `\n::warning file=fake.go,line=1::forged`},
+	{"V2 error CR", "\r::error::forged", `\r::error::forged`},
+	{"V2 mask CRLF", "\r\n::add-mask::secret", `\r\n::add-mask::secret`},
+	{"V2 stop LF", "\n::stop-commands::TOKEN", `\n::stop-commands::TOKEN`},
+	{"legacy warning", "##[warning]forged", `##\[warning]forged`},
+	{"legacy error", "prefix ##[error]forged", `prefix ##\[error]forged`},
+	{"legacy mask", "##[add-mask]secret", `##\[add-mask]secret`},
+	{"legacy stop", "##[stop-commands]TOKEN", `##\[stop-commands]TOKEN`},
+	{"bare prefix", "##[", `##\[`},
+	{"three hashes", "###[", `###\[`},
+	{"four hashes", "####[", `####\[`},
+	{"repeated prefix", "##[\n##[", `##\[\n##\[`},
+	{"CR prefix", "\r##[", `\r##\[`},
+	{"LF prefix", "\n##[warning]", `\n##\[warning]`},
+}
+
+func TestSanitizeWorkflowLogField(t *testing.T) {
+	for _, payload := range workflowLogPayloads {
+		t.Run(payload.name, func(t *testing.T) {
+			got := sanitizeWorkflowLogField(payload.raw)
+			if got != payload.want {
+				t.Errorf("sanitized field = %q, want %q", got, payload.want)
+			}
+			if strings.ContainsAny(got, "\r\n") || strings.Contains(got, "##[") {
+				t.Errorf("unsafe sanitized field %q", got)
+			}
+			if sanitizeWorkflowLogField(got) != got {
+				t.Errorf("sanitizing already-encoded field changed %q", got)
+			}
+		})
+	}
+	for _, safe := range []string{"", "G204 a.go (line 4, column 2): message", "data ::warning::text", `C:\repo\file.go`, `literal \r\n ##\[ text`} {
+		if got := sanitizeWorkflowLogField(safe); got != safe {
+			t.Errorf("safe text changed: %q became %q", safe, got)
+		}
+	}
+}
+
+func TestGosecReportWorkflowLogFields(t *testing.T) {
+	for _, field := range []string{"GosecVersion", "rule_id", "file", "line", "column", "details"} {
+		for _, payload := range workflowLogPayloads {
+			t.Run(field+"/"+payload.name, func(t *testing.T) {
+				issue := map[string]string{
+					"rule_id": "G204", "file": "/repo/a.go", "line": "4", "column": "2", "details": "message",
+				}
+				version := "dev"
+				if field == "GosecVersion" {
+					version += payload.raw
+				} else {
+					issue[field] += payload.raw
+				}
+				report := readWorkflowLogTestReport(t, version, issue, map[string][]gosecProcessingError{})
+				before, err := json.Marshal(report)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var output bytes.Buffer
+				if err := writeGosecSummary(&output, report, "/repo", 1); err != nil {
+					t.Fatalf("advisory report rejected: %v", err)
+				}
+				assertWorkflowLogSafe(t, output.String(), 4)
+				if !strings.Contains(output.String(), payload.want) {
+					t.Errorf("escaped payload %q missing from %q", payload.want, output.String())
+				}
+				if !strings.Contains(output.String(), "gosec: findings are advisory; analyzer health and package coverage passed\n") {
+					t.Errorf("advisory conclusion missing: %q", output.String())
+				}
+				after, err := json.Marshal(report)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(before, after) {
+					t.Fatal("logging mutated raw report data")
+				}
+			})
+		}
+	}
+}
+
+func TestGosecReportWorkflowLogProcessingErrors(t *testing.T) {
+	for _, field := range []string{"path", "message", "path without details"} {
+		for _, payload := range workflowLogPayloads {
+			t.Run(field+"/"+payload.name, func(t *testing.T) {
+				path, message := "pkg/broken", "mixed packages"
+				if field == "message" {
+					message += payload.raw
+				} else {
+					path += payload.raw
+				}
+				processingErrors := map[string][]gosecProcessingError{
+					path: {{Line: 4, Column: 2, Error: message}},
+				}
+				if field == "path without details" {
+					processingErrors[path] = nil
+					message = "unspecified processing error"
+				}
+				report := readWorkflowLogTestReport(t, "dev", nil, processingErrors)
+				var output bytes.Buffer
+				err := writeGosecSummary(&output, report, "/repo", 1)
+				if err == nil {
+					t.Fatal("processing error did not block report")
+				}
+				if output.Len() != 0 {
+					t.Errorf("processing failure emitted a success summary: %q", output.String())
+				}
+				logged := "gosec report: " + err.Error() + "\n"
+				assertWorkflowLogSafe(t, logged, 1)
+				for _, want := range []string{"Go/package processing errors", "pkg/broken", payload.want} {
+					if !strings.Contains(logged, want) {
+						t.Errorf("processing diagnostic missing %q: %q", want, logged)
+					}
+				}
+				if field == "path without details" && !strings.Contains(logged, message) {
+					t.Errorf("unspecified processing diagnostic missing: %q", logged)
+				}
+				if field != "path without details" && !strings.Contains(logged, ":4:2: mixed packages") {
+					t.Errorf("blocking location/message changed: %q", logged)
+				}
+			})
+		}
+	}
+}
+
+func assertWorkflowLogSafe(t *testing.T, output string, records int) {
+	t.Helper()
+	if strings.Contains(output, "\r") || strings.Contains(output, "##[") {
+		t.Errorf("unsafe workflow log token in %q", output)
+	}
+	if strings.Count(output, "\n") != records || !strings.HasSuffix(output, "\n") {
+		t.Errorf("expected %d formatter-owned lines, got %q", records, output)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "::") {
+			t.Errorf("workflow command at start of physical line: %q", line)
+		}
+	}
+}
+
+func readWorkflowLogTestReport(t *testing.T, version string, issue map[string]string, processingErrors map[string][]gosecProcessingError) gosecReport {
+	t.Helper()
+	issues := []map[string]string{}
+	if issue != nil {
+		issues = append(issues, issue)
+	}
+	content, err := json.Marshal(map[string]any{
+		"GosecVersion": version, "Golang errors": processingErrors, "Issues": issues,
+		"Stats": map[string]int{"files": 1, "lines": 8, "nosec": 0, "found": len(issues)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return readTestGosecReport(t, string(content))
+}
 
 func TestGosecReportFindingsAreAdvisory(t *testing.T) {
 	report := readTestGosecReport(t, `{
@@ -28,7 +188,7 @@ func TestGosecReportFindingsAreAdvisory(t *testing.T) {
 		t.Fatalf("advisory output contains compiler-diagnostic location syntax %q:\n%s", diagnostic, output.String())
 	}
 	want := []string{
-		"packages=2 files=2 lines=20 findings=3",
+		"gosec: version=dev packages=2 files=2 lines=20 findings=3",
 		"gosec: G204=2",
 		"gosec: G304=1",
 		strings.Join([]string{
@@ -38,10 +198,8 @@ func TestGosecReportFindingsAreAdvisory(t *testing.T) {
 		}, "\n"),
 		"gosec: findings are advisory; analyzer health and package coverage passed",
 	}
-	for _, fragment := range want {
-		if !strings.Contains(output.String(), fragment) {
-			t.Fatalf("summary missing %q:\n%s", fragment, output.String())
-		}
+	if expected := strings.Join(want, "\n") + "\n"; output.String() != expected {
+		t.Fatalf("summary = %q, want unchanged ordinary output %q", output.String(), expected)
 	}
 	t.Log(output.String())
 }

--- a/.github/scripts/security-analysis-runner.tests.sh
+++ b/.github/scripts/security-analysis-runner.tests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+source "$ROOT_DIR/scripts/security-analysis.sh"
+
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/goframe-security-runner-tests.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+write_fake_go() {
+	local path="$1"
+	local mode="$2"
+	cat >"$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" != list ]]; then
+  exit 97
+fi
+case '$mode' in
+  failure)
+    exit 1
+    ;;
+  empty)
+    exit 0
+    ;;
+  valid)
+    printf 'example.test/project/one\\t%s\\n' '$TEST_DIR/repository/one'
+    printf 'example.test/project/two\\t%s\\n' '$TEST_DIR/repository/two'
+    ;;
+esac
+EOF
+	chmod +x "$path"
+}
+
+mkdir -p "$TEST_DIR/repository/one" "$TEST_DIR/repository/two"
+
+write_fake_go "$TEST_DIR/go-valid" valid
+enumerate_gosec_packages \
+	"$TEST_DIR/repository" \
+	"example.test/project" \
+	"$TEST_DIR/valid.txt" \
+	"$TEST_DIR/go-valid"
+if ((${#GOSEC_PACKAGE_DIRS[@]} != 2)); then
+	echo 'runner test: valid package coverage count mismatch' >&2
+	exit 1
+fi
+
+write_fake_go "$TEST_DIR/go-failure" failure
+if enumerate_gosec_packages \
+	"$TEST_DIR/repository" \
+	"example.test/project" \
+	"$TEST_DIR/failure.txt" \
+	"$TEST_DIR/go-failure"; then
+	echo 'runner test: failed package enumeration was accepted' >&2
+	exit 1
+fi
+
+write_fake_go "$TEST_DIR/go-empty" empty
+if enumerate_gosec_packages \
+	"$TEST_DIR/repository" \
+	"example.test/project" \
+	"$TEST_DIR/empty.txt" \
+	"$TEST_DIR/go-empty"; then
+	echo 'runner test: empty package enumeration was accepted' >&2
+	exit 1
+fi
+
+echo 'security analysis runner tests: ok'

--- a/.github/scripts/security-analysis-runner.tests.sh
+++ b/.github/scripts/security-analysis-runner.tests.sh
@@ -10,11 +10,18 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 write_fake_go() {
 	local path="$1"
 	local mode="$2"
+	local expected_pattern="$3"
+	local expected_goos="$4"
+	local expected_goarch="$5"
+	local expected_cgo_enabled="$6"
 	cat >"$path" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "\${1:-}" != list ]]; then
+if [[ "\${1:-}" != list || "\${!#}" != '$expected_pattern' ]]; then
   exit 97
+fi
+if [[ "\${GOOS:-}" != '$expected_goos' || "\${GOARCH:-}" != '$expected_goarch' || "\${CGO_ENABLED:-}" != '$expected_cgo_enabled' ]]; then
+  exit 96
 fi
 case '$mode' in
   failure)
@@ -23,45 +30,134 @@ case '$mode' in
   empty)
     exit 0
     ;;
-  valid)
+  host)
     printf 'example.test/project/one\\t%s\\n' '$TEST_DIR/repository/one'
     printf 'example.test/project/two\\t%s\\n' '$TEST_DIR/repository/two'
+    ;;
+  browser)
+    printf 'example.test/project/browser\\t%s\\n' '$TEST_DIR/repository/browser'
     ;;
 esac
 EOF
 	chmod +x "$path"
 }
 
-mkdir -p "$TEST_DIR/repository/one" "$TEST_DIR/repository/two"
+write_fake_gosec() {
+	local path="$1"
+	local mode="$2"
+	local expected_goos="$3"
+	local expected_goarch="$4"
+	local expected_cgo_enabled="$5"
+	cat >"$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${GOOS:-}" != '$expected_goos' || "\${GOARCH:-}" != '$expected_goarch' || "\${CGO_ENABLED:-}" != '$expected_cgo_enabled' ]]; then
+  exit 96
+fi
+if [[ '$mode' == failure ]]; then
+  exit 1
+fi
+if [[ '$mode' == no-report ]]; then
+  exit 0
+fi
+report=''
+for argument in "\$@"; do
+  case "\$argument" in
+    -out=*) report="\${argument#-out=}" ;;
+  esac
+done
+if [[ -z "\$report" ]]; then
+  exit 95
+fi
+printf '%s\\n' '{"Golang errors":{},"Issues":[],"Stats":{"files":1,"lines":1,"nosec":0,"found":0},"GosecVersion":"dev"}' >"\$report"
+EOF
+	chmod +x "$path"
+}
 
-write_fake_go "$TEST_DIR/go-valid" valid
-enumerate_gosec_packages \
+mkdir -p \
+	"$TEST_DIR/repository/one" \
+	"$TEST_DIR/repository/two" \
+	"$TEST_DIR/repository/browser"
+
+write_fake_go "$TEST_DIR/go-host" host ./... linux amd64 1
+GOOS=linux GOARCH=amd64 CGO_ENABLED=1 enumerate_gosec_packages \
 	"$TEST_DIR/repository" \
 	"example.test/project" \
-	"$TEST_DIR/valid.txt" \
-	"$TEST_DIR/go-valid"
+	"$TEST_DIR/host.txt" \
+	"$TEST_DIR/go-host" \
+	./...
 if ((${#GOSEC_PACKAGE_DIRS[@]} != 2)); then
-	echo 'runner test: valid package coverage count mismatch' >&2
+	echo 'runner test: host package coverage count mismatch' >&2
+	exit 1
+fi
+host_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+
+write_fake_go "$TEST_DIR/go-browser" browser ./pkg/goframe js wasm 0
+GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \
+	"$TEST_DIR/repository" \
+	"example.test/project" \
+	"$TEST_DIR/browser.txt" \
+	"$TEST_DIR/go-browser" \
+	./pkg/goframe
+if ((${#GOSEC_PACKAGE_DIRS[@]} != 1)) || [[ "${GOSEC_PACKAGE_IMPORTS[0]}" != example.test/project/browser ]]; then
+	echo 'runner test: browser package scope was not isolated' >&2
+	exit 1
+fi
+browser_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+if ((${#host_package_dirs[@]} != 2)) || [[ "${host_package_dirs[0]}" == "${GOSEC_PACKAGE_DIRS[0]}" ]]; then
+	echo 'runner test: host package coverage was contaminated by browser coverage' >&2
 	exit 1
 fi
 
-write_fake_go "$TEST_DIR/go-failure" failure
-if enumerate_gosec_packages \
+write_fake_go "$TEST_DIR/go-browser-failure" failure ./pkg/goframe js wasm 0
+if GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \
 	"$TEST_DIR/repository" \
 	"example.test/project" \
-	"$TEST_DIR/failure.txt" \
-	"$TEST_DIR/go-failure"; then
-	echo 'runner test: failed package enumeration was accepted' >&2
+	"$TEST_DIR/browser-failure.txt" \
+	"$TEST_DIR/go-browser-failure" \
+	./pkg/goframe; then
+	echo 'runner test: failed browser package enumeration was accepted' >&2
 	exit 1
 fi
 
-write_fake_go "$TEST_DIR/go-empty" empty
-if enumerate_gosec_packages \
+write_fake_go "$TEST_DIR/go-browser-empty" empty ./pkg/goframe js wasm 0
+if GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \
 	"$TEST_DIR/repository" \
 	"example.test/project" \
-	"$TEST_DIR/empty.txt" \
-	"$TEST_DIR/go-empty"; then
-	echo 'runner test: empty package enumeration was accepted' >&2
+	"$TEST_DIR/browser-empty.txt" \
+	"$TEST_DIR/go-browser-empty" \
+	./pkg/goframe; then
+	echo 'runner test: empty browser package enumeration was accepted' >&2
+	exit 1
+fi
+
+write_fake_gosec "$TEST_DIR/gosec-host" success linux amd64 1
+GOOS=linux GOARCH=amd64 CGO_ENABLED=1 run_gosec_analysis \
+	"$TEST_DIR/gosec-host.json" \
+	"$TEST_DIR/gosec-host" \
+	"${host_package_dirs[@]}"
+
+write_fake_gosec "$TEST_DIR/gosec-browser" success js wasm 0
+GOOS=js GOARCH=wasm CGO_ENABLED=0 run_gosec_analysis \
+	"$TEST_DIR/gosec-browser.json" \
+	"$TEST_DIR/gosec-browser" \
+	"${browser_package_dirs[@]}"
+
+write_fake_gosec "$TEST_DIR/gosec-browser-failure" failure js wasm 0
+if GOOS=js GOARCH=wasm CGO_ENABLED=0 run_gosec_analysis \
+	"$TEST_DIR/gosec-browser-failure.json" \
+	"$TEST_DIR/gosec-browser-failure" \
+	"${browser_package_dirs[@]}"; then
+	echo 'runner test: failed browser gosec execution was accepted' >&2
+	exit 1
+fi
+
+write_fake_gosec "$TEST_DIR/gosec-browser-no-report" no-report js wasm 0
+if GOOS=js GOARCH=wasm CGO_ENABLED=0 run_gosec_analysis \
+	"$TEST_DIR/gosec-browser-no-report.json" \
+	"$TEST_DIR/gosec-browser-no-report" \
+	"${browser_package_dirs[@]}"; then
+	echo 'runner test: missing browser gosec report was accepted' >&2
 	exit 1
 fi
 

--- a/.github/scripts/security-analysis-runner.tests.sh
+++ b/.github/scripts/security-analysis-runner.tests.sh
@@ -161,4 +161,215 @@ if GOOS=js GOARCH=wasm CGO_ENABLED=0 run_gosec_analysis \
 	exit 1
 fi
 
+# Exercise main in a fresh shell so errexit and command-local environments are
+# tested at the policy call sites, not just on the individual helpers.
+mkdir -p "$TEST_DIR/policy-bin" "$TEST_DIR/repository/windows" "$TEST_DIR/repository/three"
+cat >"$TEST_DIR/policy-bin/fake-tool" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+tool="$(basename "$0")"
+printf '%s|%s|%s|%s|%s\n' "$tool" "${GOOS:-}" "${GOARCH:-}" "${CGO_ENABLED:-}" "$*" >>"$CALL_LOG"
+
+require_host() {
+  [[ "${GOOS:-}/${GOARCH:-}/${CGO_ENABLED:-}" == linux/amd64/1 ]]
+}
+
+selected_target() {
+  case "${GOOS:-}/${GOARCH:-}/${CGO_ENABLED:-}" in
+    linux/amd64/1) printf host ;;
+    windows/amd64/0) printf windows ;;
+    js/wasm/0) printf browser ;;
+    *) echo 'fake tool: unexpected target environment' >&2; exit 96 ;;
+  esac
+}
+
+if [[ "$tool" == go ]]; then
+  case "$1" in
+    env)
+      case "$2" in
+        GOVERSION) echo go1.26.6 ;;
+        GOHOSTOS) echo linux ;;
+        GOHOSTARCH) echo amd64 ;;
+        GOMOD) require_host; echo "$FAKE_ROOT/go.mod" ;;
+        *) exit 95 ;;
+      esac
+      ;;
+    version|install)
+      require_host
+      ;;
+    list)
+      if [[ "$2" == -m ]]; then
+        require_host
+        echo github.com/graybuton/goframe
+        exit
+      fi
+      target="$(selected_target)"
+      if [[ "$target" == browser ]]; then
+        [[ "${!#}" == ./pkg/goframe ]]
+        names=(browser)
+      else
+        [[ "${!#}" == ./... ]]
+        names=(one two)
+        if [[ "$target" == windows ]]; then
+          [[ "$FAIL_MODE" != enumeration-failure ]] || exit 41
+          [[ "$FAIL_MODE" != enumeration-empty ]] || exit 0
+          names=(windows two three)
+        fi
+      fi
+      for name in "${names[@]}"; do
+        printf 'github.com/graybuton/goframe/%s\t%s/%s\n' "$name" "$FAKE_ROOT" "$name"
+      done
+      ;;
+    run)
+      require_host
+      [[ "$2" == ./.github/scripts/gosec-report.go && "$3" == -report && "$5" == -root && "$6" == "$FAKE_ROOT" && "$7" == -packages ]]
+      case "$4" in
+        */gosec-host.json) target=host; count=2 ;;
+        */gosec-windows.json) target=windows; count=3 ;;
+        */gosec-wasm-runtime.json) target=browser; count=1 ;;
+        *) exit 94 ;;
+      esac
+      [[ "$8" == "$count" ]]
+      grep -Fq '"target":"'"$target"'"' "$4"
+      if [[ "$target" == windows && "$FAIL_MODE" == classifier-failure ]]; then
+        echo 'fake Windows report validation failed' >&2
+        exit 42
+      fi
+      echo "classified $target"
+      ;;
+    *) exit 93 ;;
+  esac
+  exit
+fi
+
+if [[ "$1" == -version ]]; then
+  require_host
+  exit
+fi
+target="$(selected_target)"
+case "$tool" in
+  staticcheck)
+    [[ "$1" == '-checks=SA*' ]]
+    if [[ "$target" == browser ]]; then
+      [[ "$2" == -tests=false && "${!#}" == ./pkg/goframe ]]
+    else
+      [[ "$*" != *-tests=false* && "${!#}" == ./... ]]
+    fi
+    if [[ "$target" == windows ]]; then
+      [[ "$FAIL_MODE" != staticcheck-failure ]] || exit 43
+      if [[ "$*" == *-tags=goframe_debug* && "$FAIL_MODE" == staticcheck-debug-failure ]]; then
+        exit 43
+      fi
+    fi
+    ;;
+  govulncheck)
+    [[ "$1" == -scan=symbol ]]
+    if [[ "$target" == browser ]]; then
+      [[ "$2" == ./pkg/goframe ]]
+    else
+      [[ "$2" == ./... ]]
+    fi
+    [[ "$target/$FAIL_MODE" != windows/vulnerability-failure ]] || exit 44
+    ;;
+  gosec)
+    [[ "$1" == -no-fail && "$2" == -fmt=json && "$3" == -log=* && "$4" == -out=* ]]
+    report="${4#-out=}"
+    shift 4
+    case "$target" in
+      host) [[ "$*" == "$FAKE_ROOT/one $FAKE_ROOT/two" && "$report" == */gosec-host.json ]] ;;
+      windows) [[ "$*" == "$FAKE_ROOT/windows $FAKE_ROOT/two $FAKE_ROOT/three" && "$report" == */gosec-windows.json ]] ;;
+      browser) [[ "$*" == "$FAKE_ROOT/browser" && "$report" == */gosec-wasm-runtime.json ]] ;;
+    esac
+    if [[ "$target" == windows ]]; then
+      case "$FAIL_MODE" in
+        analyzer-failure) exit 45 ;;
+        missing-report) exit 0 ;;
+        empty-report) : >"$report"; exit 0 ;;
+      esac
+    fi
+    printf '{"target":"%s","Golang errors":{},"Issues":[],"Stats":{"files":1,"lines":1,"nosec":0,"found":0},"GosecVersion":"dev"}\n' "$target" >"$report"
+    ;;
+  *) exit 92 ;;
+esac
+EOF
+chmod +x "$TEST_DIR/policy-bin/fake-tool"
+for tool in go staticcheck govulncheck gosec; do
+	ln -s fake-tool "$TEST_DIR/policy-bin/$tool"
+done
+
+run_policy_control() {
+	local mode="$1"
+	local status=0
+	if PATH="$TEST_DIR/policy-bin:$PATH" \
+		GOOS=freebsd GOARCH=arm64 CGO_ENABLED=1 \
+		RUNNER_SOURCE="$ROOT_DIR/scripts/security-analysis.sh" \
+		FAKE_ROOT="$TEST_DIR/repository" FAIL_MODE="$mode" \
+		CALL_LOG="$TEST_DIR/$mode.calls" \
+		bash -c 'source "$RUNNER_SOURCE"; ROOT_DIR="$FAKE_ROOT"; main' >"$TEST_DIR/$mode.output" 2>&1; then
+		status=0
+	else
+		status=$?
+	fi
+	if [[ "$mode" == success ]]; then
+		if ((status != 0)); then
+			cat "$TEST_DIR/$mode.output" >&2
+			echo "runner test: successful target policy failed ($status)" >&2
+			exit 1
+		fi
+	else
+		if ((status == 0)) || grep -Fq 'security analysis: ok' "$TEST_DIR/$mode.output"; then
+			echo "runner test: Windows $mode did not block the runner" >&2
+			exit 1
+		fi
+	fi
+}
+
+require_policy_call() {
+	if ! grep -Fxq "$1" "$TEST_DIR/success.calls"; then
+		echo "runner test: missing policy call: $1" >&2
+		exit 1
+	fi
+}
+
+run_policy_control success
+for target in 'linux|amd64|1' 'windows|amd64|0' 'js|wasm|0'; do
+	pattern=./...
+	test_flag=''
+	if [[ "$target" == 'js|wasm|0' ]]; then
+		pattern=./pkg/goframe
+		test_flag='-tests=false '
+	fi
+	require_policy_call "staticcheck|$target|-checks=SA* $test_flag$pattern"
+	require_policy_call "staticcheck|$target|-checks=SA* ${test_flag}-tags=goframe_debug $pattern"
+	require_policy_call "govulncheck|$target|-scan=symbol $pattern"
+	require_policy_call "go|$target|list -buildvcs=false -f {{.ImportPath}}{{\"\t\"}}{{.Dir}} $pattern"
+done
+for target in host windows browser; do
+	if ! grep -Fxq "classified $target" "$TEST_DIR/success.output"; then
+		echo "runner test: $target report was not independently classified" >&2
+		exit 1
+	fi
+done
+grep -Fxq 'security analysis: ok' "$TEST_DIR/success.output"
+
+for mode in enumeration-failure enumeration-empty analyzer-failure missing-report empty-report classifier-failure staticcheck-failure staticcheck-debug-failure vulnerability-failure; do
+	run_policy_control "$mode"
+	case "$mode" in
+		enumeration-failure|enumeration-empty|analyzer-failure|missing-report|empty-report|classifier-failure)
+			grep -Fxq 'classified host' "$TEST_DIR/$mode.output"
+			;;
+	esac
+	case "$mode" in
+		enumeration-failure) expected='Go package enumeration failed' ;;
+		enumeration-empty) expected='Go package enumeration returned no packages' ;;
+		analyzer-failure) expected='gosec execution failed' ;;
+		missing-report|empty-report) expected='gosec did not produce a non-empty JSON report' ;;
+		classifier-failure) expected='fake Windows report validation failed' ;;
+		*) expected='' ;;
+	esac
+	if [[ -n "$expected" ]]; then
+		grep -Fq "$expected" "$TEST_DIR/$mode.output"
+	fi
+done
+
 echo 'security analysis runner tests: ok'

--- a/.github/scripts/security-analysis-runner.tests.sh
+++ b/.github/scripts/security-analysis-runner.tests.sh
@@ -242,7 +242,7 @@ if [[ "$tool" == go ]]; then
   case "$1" in
     env)
       case "$2" in
-        GOVERSION) echo go1.26.6 ;;
+        GOVERSION) echo "$FAKE_GO_VERSION" ;;
         GOHOSTOS) echo linux ;;
         GOHOSTARCH) echo amd64 ;;
         GOMOD) require_host; echo "$FAKE_ROOT/go.mod" ;;
@@ -266,10 +266,12 @@ if [[ "$tool" == go ]]; then
         [[ "${!#}" == ./... ]]
         names=(one two)
         if [[ "$target" == windows ]]; then
-          [[ "$FAIL_MODE" != enumeration-failure ]] || exit 41
-          [[ "$FAIL_MODE" != enumeration-empty ]] || exit 0
           names=(windows two three)
         fi
+      fi
+      if [[ "$target" == "$FAIL_TARGET" ]]; then
+        [[ "$FAIL_MODE" != enumeration-failure ]] || exit 41
+        [[ "$FAIL_MODE" != enumeration-empty ]] || exit 0
       fi
       for name in "${names[@]}"; do
         printf 'github.com/graybuton/goframe/%s\t%s/%s\n' "$name" "$FAKE_ROOT" "$name"
@@ -286,8 +288,8 @@ if [[ "$tool" == go ]]; then
       esac
       [[ "$8" == "$count" ]]
       grep -Fq '"target":"'"$target"'"' "$4"
-      if [[ "$target" == windows && "$FAIL_MODE" == classifier-failure ]]; then
-        echo 'fake Windows report validation failed' >&2
+      if [[ "$target" == "$FAIL_TARGET" && "$FAIL_MODE" == classifier-failure ]]; then
+        echo "fake $target report validation failed" >&2
         exit 42
       fi
       echo "classified $target"
@@ -297,6 +299,11 @@ if [[ "$tool" == go ]]; then
   exit
 fi
 
+[[ "$(go env GOVERSION)" == "$FAKE_GO_VERSION" ]]
+case "$FAKE_GO_VERSION" in
+  go1.26.6|go1.27.0) ;;
+  *) echo 'fake analyzer: unsupported toolchain selected' >&2; exit 91 ;;
+esac
 if [[ "$1" == -version ]]; then
   require_host
   exit
@@ -310,7 +317,7 @@ case "$tool" in
     else
       [[ "$*" != *-tests=false* && "${!#}" == ./... ]]
     fi
-    if [[ "$target" == windows ]]; then
+    if [[ "$target" == "$FAIL_TARGET" ]]; then
       [[ "$FAIL_MODE" != staticcheck-failure ]] || exit 43
       if [[ "$*" == *-tags=goframe_debug* && "$FAIL_MODE" == staticcheck-debug-failure ]]; then
         exit 43
@@ -324,7 +331,7 @@ case "$tool" in
     else
       [[ "$2" == ./... ]]
     fi
-    [[ "$target/$FAIL_MODE" != windows/vulnerability-failure ]] || exit 44
+    [[ "$target/$FAIL_MODE" != "$FAIL_TARGET/vulnerability-failure" ]] || exit 44
     ;;
   gosec)
     [[ "$1" == -no-fail && "$2" == -fmt=json && "$3" == -log=* && "$4" == -out=* ]]
@@ -335,7 +342,7 @@ case "$tool" in
       windows) [[ "$#" == 3 && "$1" == "$FAKE_ROOT/windows" && "$2" == "$FAKE_ROOT/two" && "$3" == "$FAKE_ROOT/three" && "$report" == */gosec-windows.json ]] ;;
       browser) [[ "$#" == 1 && "$1" == "$FAKE_ROOT/browser" && "$report" == */gosec-wasm-runtime.json ]] ;;
     esac
-    if [[ "$target" == windows ]]; then
+    if [[ "$target" == "$FAIL_TARGET" ]]; then
       case "$FAIL_MODE" in
         analyzer-failure) exit 45 ;;
         missing-report) exit 0 ;;
@@ -354,11 +361,15 @@ done
 
 run_policy_control() {
 	local mode="$1"
+	local version="${2:-go1.26.6}"
+	local failure_target="${3:-windows}"
 	local status=0
+	: >"$TEST_DIR/$mode.calls"
 	if PATH="$TEST_DIR/policy-bin:$PATH" \
 		GOOS=freebsd GOARCH=arm64 CGO_ENABLED=1 \
 		RUNNER_SOURCE="$ROOT_DIR/scripts/security-analysis.sh" \
 		FAKE_ROOT="$TEST_DIR/repository" FAIL_MODE="$mode" \
+		FAKE_GO_VERSION="$version" FAIL_TARGET="$failure_target" \
 		CALL_LOG="$TEST_DIR/$mode.calls" \
 		"$BASH" -c 'source "$RUNNER_SOURCE"; ROOT_DIR="$FAKE_ROOT"; main' >"$TEST_DIR/$mode.output" 2>&1; then
 		status=0
@@ -368,12 +379,12 @@ run_policy_control() {
 	if [[ "$mode" == success ]]; then
 		if ((status != 0)); then
 			cat "$TEST_DIR/$mode.output" >&2
-			echo "runner test: successful target policy failed ($status)" >&2
+			echo "runner test: successful $version target policy failed ($status)" >&2
 			exit 1
 		fi
 	else
 		if ((status == 0)) || grep -Fq 'security analysis: ok' "$TEST_DIR/$mode.output"; then
-			echo "runner test: Windows $mode did not block the runner" >&2
+			echo "runner test: $version $failure_target $mode did not block the runner" >&2
 			exit 1
 		fi
 	fi
@@ -386,45 +397,61 @@ require_policy_call() {
 	fi
 }
 
-run_policy_control success
-for target in 'linux|amd64|1' 'windows|amd64|0' 'js|wasm|0'; do
-	pattern=./...
-	test_flag=''
-	if [[ "$target" == 'js|wasm|0' ]]; then
-		pattern=./pkg/goframe
-		test_flag='-tests=false '
-	fi
-	require_policy_call "staticcheck|$target|-checks=SA* $test_flag$pattern"
-	require_policy_call "staticcheck|$target|-checks=SA* ${test_flag}-tags=goframe_debug $pattern"
-	require_policy_call "govulncheck|$target|-scan=symbol $pattern"
-	require_policy_call "go|$target|list -buildvcs=false -f {{.ImportPath}}{{\"\t\"}}{{.Dir}} $pattern"
+for version in go1.26.6 go1.27.0; do
+	run_policy_control success "$version"
+	for target in 'linux|amd64|1' 'windows|amd64|0' 'js|wasm|0'; do
+		pattern=./...
+		test_flag=''
+		if [[ "$target" == 'js|wasm|0' ]]; then
+			pattern=./pkg/goframe
+			test_flag='-tests=false '
+		fi
+		require_policy_call "staticcheck|$target|-checks=SA* $test_flag$pattern"
+		require_policy_call "staticcheck|$target|-checks=SA* ${test_flag}-tags=goframe_debug $pattern"
+		require_policy_call "govulncheck|$target|-scan=symbol $pattern"
+		require_policy_call "go|$target|list -buildvcs=false -f {{.ImportPath}}{{\"\t\"}}{{.Dir}} $pattern"
+	done
+	for target in host windows browser; do
+		if ! grep -Fxq "classified $target" "$TEST_DIR/success.output"; then
+			echo "runner test: $target report was not independently classified" >&2
+			exit 1
+		fi
+	done
+	grep -Fxq 'security analysis: ok' "$TEST_DIR/success.output"
+	echo "runner test: full target policy passed under $version"
 done
-for target in host windows browser; do
-	if ! grep -Fxq "classified $target" "$TEST_DIR/success.output"; then
-		echo "runner test: $target report was not independently classified" >&2
+
+for version in go1.26.7 go1.27.1 go1.28.0; do
+	run_policy_control unsupported "$version"
+	grep -Fq "unsupported active Go version $version" "$TEST_DIR/unsupported.output"
+	if grep -Eq '^(staticcheck|govulncheck|gosec)\||\|install ' "$TEST_DIR/unsupported.calls"; then
+		echo "runner test: unsupported $version reached analyzer installation or execution" >&2
 		exit 1
 	fi
 done
-grep -Fxq 'security analysis: ok' "$TEST_DIR/success.output"
 
-for mode in enumeration-failure enumeration-empty analyzer-failure missing-report empty-report classifier-failure staticcheck-failure staticcheck-debug-failure vulnerability-failure; do
-	run_policy_control "$mode"
-	case "$mode" in
-		enumeration-failure|enumeration-empty|analyzer-failure|missing-report|empty-report|classifier-failure)
-			grep -Fxq 'classified host' "$TEST_DIR/$mode.output"
-			;;
-	esac
-	case "$mode" in
-		enumeration-failure) expected='Go package enumeration failed' ;;
-		enumeration-empty) expected='Go package enumeration returned no packages' ;;
-		analyzer-failure) expected='gosec execution failed' ;;
-		missing-report|empty-report) expected='gosec did not produce a non-empty JSON report' ;;
-		classifier-failure) expected='fake Windows report validation failed' ;;
-		*) expected='' ;;
-	esac
-	if [[ -n "$expected" ]]; then
-		grep -Fq "$expected" "$TEST_DIR/$mode.output"
-	fi
+for version in go1.26.6 go1.27.0; do
+	for failure_target in windows browser; do
+		for mode in enumeration-failure enumeration-empty analyzer-failure missing-report empty-report classifier-failure staticcheck-failure staticcheck-debug-failure vulnerability-failure; do
+			run_policy_control "$mode" "$version" "$failure_target"
+			case "$mode" in
+				enumeration-failure|enumeration-empty|analyzer-failure|missing-report|empty-report|classifier-failure)
+					grep -Fxq 'classified host' "$TEST_DIR/$mode.output"
+					;;
+			esac
+			case "$mode" in
+				enumeration-failure) expected='Go package enumeration failed' ;;
+				enumeration-empty) expected='Go package enumeration returned no packages' ;;
+				analyzer-failure) expected='gosec execution failed' ;;
+				missing-report|empty-report) expected='gosec did not produce a non-empty JSON report' ;;
+				classifier-failure) expected="fake $failure_target report validation failed" ;;
+				*) expected='' ;;
+			esac
+			if [[ -n "$expected" ]]; then
+				grep -Fq "$expected" "$TEST_DIR/$mode.output"
+			fi
+		done
+	done
 done
 
 echo 'security analysis runner tests: ok'

--- a/.github/scripts/security-analysis-runner.tests.sh
+++ b/.github/scripts/security-analysis-runner.tests.sh
@@ -4,8 +4,19 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 source "$ROOT_DIR/scripts/security-analysis.sh"
 
+# Catch known unsupported commands at command position, not in comments.
+if grep -nE '^[[:space:]]*((local|declare)[[:space:]]+-[^[:space:]]*A|mapfile|readarray)([[:space:]]|$)' "$ROOT_DIR/scripts/security-analysis.sh"; then
+	echo 'runner test: canonical runner requires Bash newer than 3.2' >&2
+	exit 1
+fi
+
 TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/goframe-security-runner-tests.XXXXXX")"
 trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Keep fake-tool shebangs and child shells on the interpreter under test.
+mkdir -p "$TEST_DIR/shell-bin"
+ln -s "$BASH" "$TEST_DIR/shell-bin/bash"
+export PATH="$TEST_DIR/shell-bin:$PATH"
 
 write_fake_go() {
 	local path="$1"
@@ -36,6 +47,14 @@ case '$mode' in
     ;;
   browser)
     printf 'example.test/project/browser\\t%s\\n' '$TEST_DIR/repository/browser'
+    ;;
+  duplicate-import)
+    printf 'example.test/project/one\\t%s\\n' '$TEST_DIR/repository/one'
+    printf 'example.test/project/one\\t%s\\n' '$TEST_DIR/repository/two'
+    ;;
+  duplicate-directory)
+    printf 'example.test/project/one\\t%s\\n' '$TEST_DIR/repository/one'
+    printf 'example.test/project/two\\t%s\\n' '$TEST_DIR/repository/one'
     ;;
 esac
 EOF
@@ -91,6 +110,42 @@ if ((${#GOSEC_PACKAGE_DIRS[@]} != 2)); then
 	exit 1
 fi
 host_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+
+for mode in duplicate-import duplicate-directory; do
+	write_fake_go "$TEST_DIR/go-$mode" "$mode" ./... linux amd64 1
+	if GOOS=linux GOARCH=amd64 CGO_ENABLED=1 enumerate_gosec_packages \
+		"$TEST_DIR/repository" example.test/project "$TEST_DIR/$mode.txt" "$TEST_DIR/go-$mode" ./... >"$TEST_DIR/$mode.output" 2>&1; then
+		echo "runner test: $mode was accepted" >&2
+		exit 1
+	fi
+	grep -Fq 'duplicate Go package coverage row:' "$TEST_DIR/$mode.output"
+done
+
+check_module_control() (
+	mode="$1"
+	go() {
+		[[ "$*" == 'list -m all' ]] || return 97
+		case "$mode" in
+			failure) return 1 ;;
+			empty) ;;
+			extra) printf '%s\n' "$MAIN_MODULE" example.test/dependency ;;
+			wrong) printf '%s\n' example.test/project ;;
+			whitespace) printf ' %s\n' "$MAIN_MODULE" ;;
+			blank-line) printf '%s\n\n' "$MAIN_MODULE" ;;
+			unterminated) printf '%s' "$MAIN_MODULE" ;;
+			success) printf '%s\n' "$MAIN_MODULE" ;;
+		esac
+	}
+	if [[ "$mode" == success || "$mode" == unterminated ]]; then
+		verify_root_module_surface "$TEST_DIR/modules.txt"
+	elif verify_root_module_surface "$TEST_DIR/modules.txt"; then
+		echo "runner test: $mode module graph was accepted" >&2
+		exit 1
+	fi
+)
+for mode in success unterminated failure empty extra wrong whitespace blank-line; do
+	check_module_control "$mode"
+done
 
 write_fake_go "$TEST_DIR/go-browser" browser ./pkg/goframe js wasm 0
 GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \
@@ -276,9 +331,9 @@ case "$tool" in
     report="${4#-out=}"
     shift 4
     case "$target" in
-      host) [[ "$*" == "$FAKE_ROOT/one $FAKE_ROOT/two" && "$report" == */gosec-host.json ]] ;;
-      windows) [[ "$*" == "$FAKE_ROOT/windows $FAKE_ROOT/two $FAKE_ROOT/three" && "$report" == */gosec-windows.json ]] ;;
-      browser) [[ "$*" == "$FAKE_ROOT/browser" && "$report" == */gosec-wasm-runtime.json ]] ;;
+      host) [[ "$#" == 2 && "$1" == "$FAKE_ROOT/one" && "$2" == "$FAKE_ROOT/two" && "$report" == */gosec-host.json ]] ;;
+      windows) [[ "$#" == 3 && "$1" == "$FAKE_ROOT/windows" && "$2" == "$FAKE_ROOT/two" && "$3" == "$FAKE_ROOT/three" && "$report" == */gosec-windows.json ]] ;;
+      browser) [[ "$#" == 1 && "$1" == "$FAKE_ROOT/browser" && "$report" == */gosec-wasm-runtime.json ]] ;;
     esac
     if [[ "$target" == windows ]]; then
       case "$FAIL_MODE" in
@@ -305,7 +360,7 @@ run_policy_control() {
 		RUNNER_SOURCE="$ROOT_DIR/scripts/security-analysis.sh" \
 		FAKE_ROOT="$TEST_DIR/repository" FAIL_MODE="$mode" \
 		CALL_LOG="$TEST_DIR/$mode.calls" \
-		bash -c 'source "$RUNNER_SOURCE"; ROOT_DIR="$FAKE_ROOT"; main' >"$TEST_DIR/$mode.output" 2>&1; then
+		"$BASH" -c 'source "$RUNNER_SOURCE"; ROOT_DIR="$FAKE_ROOT"; main' >"$TEST_DIR/$mode.output" 2>&1; then
 		status=0
 	else
 		status=$?

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -57,6 +57,14 @@ jobs:
         shell: pwsh
         run: ./.github/scripts/ensure-go-toolchain.tests.ps1
 
+      - name: Test security runner with system Bash
+        if: runner.os == 'macOS'
+        run: |
+          /bin/bash --version
+          /bin/bash -n scripts/security-analysis.sh
+          /bin/bash -n .github/scripts/security-analysis-runner.tests.sh
+          /bin/bash .github/scripts/security-analysis-runner.tests.sh
+
       - name: Setup Node.js
         if: matrix.full
         uses: actions/setup-node@v6

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,34 @@
+name: Security Analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security-analysis:
+    name: Security analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.6'
+          cache: true
+
+      - name: Test security policy helpers
+        run: |
+          go test ./.github/scripts
+          .github/scripts/security-analysis-runner.tests.sh
+
+      - name: Run security analysis
+        run: scripts/security-analysis.sh

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -19,16 +19,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Go
+      - name: Setup Go 1.26.6
         uses: actions/setup-go@v6
         with:
           go-version: '1.26.6'
           cache: true
 
-      - name: Test security policy helpers
+      - name: Verify selected Go 1.26.6
+        run: '[[ "$(GOTOOLCHAIN=local go env GOVERSION)" == "go1.26.6" ]]'
+
+      - name: Test security policy helpers (Go 1.26.6)
         run: |
           go test ./.github/scripts
           .github/scripts/security-analysis-runner.tests.sh
 
-      - name: Run security analysis
+      - name: Run security analysis (Go 1.26.6)
+        run: scripts/security-analysis.sh
+
+      - name: Setup Go 1.27.0
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27.0'
+          cache: true
+
+      - name: Verify selected Go 1.27.0
+        run: '[[ "$(GOTOOLCHAIN=local go env GOVERSION)" == "go1.27.0" ]]'
+
+      - name: Test security policy helpers (Go 1.27.0)
+        run: go test ./.github/scripts
+
+      - name: Run security analysis (Go 1.27.0)
         run: scripts/security-analysis.sh

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -365,15 +365,25 @@ canonical local policy runner:
 scripts/security-analysis.sh
 ```
 
+The canonical job executes on Linux and additionally analyzes the supported
+Windows amd64 package configuration. Windows package loading and analyzers use
+command-local `GOOS=windows GOARCH=amd64 CGO_ENABLED=0`; no supported Windows
+production source currently depends on cgo. This is cross-target static
+analysis, not native Windows execution. Core CI retains the native Windows
+runtime and platform evidence.
+
 The runner installs Staticcheck `v0.8.1`, govulncheck `v1.7.0`, and gosec
 `v2.29.0` into a temporary `GOBIN`. It rejects a different active Go version
 instead of allowing analyzer toolchain drift. The release-blocking checks are:
 
 - Staticcheck's `SA*` correctness class across ordinary and `goframe_debug`
   host builds;
+- the same `SA*` class across ordinary and `goframe_debug` Windows-target
+  `./...` builds, retaining normal test participation;
 - the same `SA*` class for ordinary and `goframe_debug` `js/wasm`
   `pkg/goframe` builds, with tests disabled for that target;
 - `govulncheck -scan=symbol ./...` for the host package graph;
+- `govulncheck -scan=symbol ./...` under the Windows target;
 - `govulncheck -scan=symbol ./pkg/goframe` under `GOOS=js`, `GOARCH=wasm`,
   and `CGO_ENABLED=0` for the browser runtime;
 - `GOWORK=off go list -m all`, which must enumerate exactly the main
@@ -381,27 +391,32 @@ instead of allowing analyzer toolchain drift. The release-blocking checks are:
   dependencies.
 
 Reachable vulnerabilities and scanner, database, network, or package-loading
-failures in either govulncheck target fail the job.
+failures in any govulncheck target fail the job.
 
 Full Staticcheck is not a release gate because its style and simplification
 classes are separate from the selected correctness contract.
 
 Gosec runs its complete default rule set separately over package directories
-derived from the host `go list ./...` graph and from the browser-runtime
-`go list ./pkg/goframe` graph under `GOOS=js`, `GOARCH=wasm`, and
-`CGO_ENABLED=0`.
+derived from each target's package graph:
+
+| Configuration | Package enumeration | Analyzer environment |
+| --- | --- | --- |
+| Native host | `go list ./...` | native host, Linux in the canonical job |
+| Windows target | `go list ./...` | `GOOS=windows GOARCH=amd64 CGO_ENABLED=0` |
+| Browser runtime | `go list ./pkg/goframe` | `GOOS=js GOARCH=wasm CGO_ENABLED=0` |
+
+Enumeration and gosec execution use the same target environment. Each target
+has its own package list and JSON report; the report classifier runs on the
+native host. Analyzer installation and root-module verification also remain
+host-native.
 Filesystem recursion and nested `testdata` trees are not package authorities.
 Ordinary findings are visible and advisory, while package enumeration failure,
 analyzer execution failure, package-processing errors, missing or malformed
-JSON, invalid report structure, and empty or unproven coverage fail either
-target independently. At this revision the host characterization is 40
-packages, 119 files, 27,722 lines, and 90 findings; the browser-runtime
-characterization is one package, 24 files, 4,789 lines, and no findings. The
-host findings comprise 29 `G703`, 23 `G304`, 13 `G301`, 11 `G204`, 3 each of
-`G104` and `G115`, and 2 each of `G112`, `G114`, `G306`, and `G705`. These
-numbers are characterization, not suppression baselines or acceptance
-thresholds; every run reports target-specific totals and deterministic
-per-rule counts.
+JSON, invalid report structure, source suppressions, and empty or unproven
+coverage fail each target independently. Every run reports separate
+target-specific totals and deterministic per-rule counts. These are
+characterization, not suppression baselines or acceptance thresholds; findings
+shared by targets are not combined into a cross-target total.
 
 The clean-checkout browser analyzer surface is the production
 `pkg/goframe` runtime. Generated GOX applications are not claimed as

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -373,25 +373,43 @@ instead of allowing analyzer toolchain drift. The release-blocking checks are:
   host builds;
 - the same `SA*` class for ordinary and `goframe_debug` `js/wasm`
   `pkg/goframe` builds, with tests disabled for that target;
-- `govulncheck -scan=symbol ./...`, where reachable vulnerabilities and
-  scanner, database, network, or package-loading failures all fail the job;
+- `govulncheck -scan=symbol ./...` for the host package graph;
+- `govulncheck -scan=symbol ./pkg/goframe` under `GOOS=js`, `GOARCH=wasm`,
+  and `CGO_ENABLED=0` for the browser runtime;
 - `GOWORK=off go list -m all`, which must enumerate exactly the main
   `github.com/graybuton/goframe` module and no additional root-module
   dependencies.
 
+Reachable vulnerabilities and scanner, database, network, or package-loading
+failures in either govulncheck target fail the job.
+
 Full Staticcheck is not a release gate because its style and simplification
 classes are separate from the selected correctness contract.
 
-Gosec runs its complete default rule set over the package directories derived
-from `go list ./...`; filesystem recursion and nested `testdata` trees are not
-package authorities. Ordinary findings are visible and advisory, while package
-enumeration failure, analyzer execution failure, package-processing errors,
-missing or malformed JSON, invalid report structure, and empty or unproven
-coverage fail the job. The accepted-base characterization contains 90
-findings: 29 `G703`, 23 `G304`, 13 `G301`, 11 `G204`, 3 each of `G104` and
-`G115`, and 2 each of `G112`, `G114`, `G306`, and `G705`. That count is not a
-suppression baseline; every run reports the current findings and deterministic
-per-rule totals.
+Gosec runs its complete default rule set separately over package directories
+derived from the host `go list ./...` graph and from the browser-runtime
+`go list ./pkg/goframe` graph under `GOOS=js`, `GOARCH=wasm`, and
+`CGO_ENABLED=0`.
+Filesystem recursion and nested `testdata` trees are not package authorities.
+Ordinary findings are visible and advisory, while package enumeration failure,
+analyzer execution failure, package-processing errors, missing or malformed
+JSON, invalid report structure, and empty or unproven coverage fail either
+target independently. At this revision the host characterization is 40
+packages, 119 files, 27,722 lines, and 90 findings; the browser-runtime
+characterization is one package, 24 files, 4,789 lines, and no findings. The
+host findings comprise 29 `G703`, 23 `G304`, 13 `G301`, 11 `G204`, 3 each of
+`G104` and `G115`, and 2 each of `G112`, `G114`, `G306`, and `G705`. These
+numbers are characterization, not suppression baselines or acceptance
+thresholds; every run reports target-specific totals and deterministic
+per-rule counts.
+
+The clean-checkout browser analyzer surface is the production
+`pkg/goframe` runtime. Generated GOX applications are not claimed as
+whole-program static-security analyzer roots in this gate: their generated Go
+declarations exist only after `goxc` materializes a compiler workspace. Browser
+Smoke and build/package checks provide separate application evidence; they do
+not substitute for govulncheck or gosec, and this gate does not claim static
+analysis of every generated application executable.
 
 No source suppressions implement this policy. GitHub-managed CodeQL remains a
 separate repository control, and Core continues to own vet and race coverage.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -355,6 +355,47 @@ prefixes, specific unsupported-syntax messages, and source snippets. They are
 part of the compiler/toolchain contract even though the broader GOX syntax
 surface remains experimental.
 
+### Security Analysis
+
+`.github/workflows/ci-security.yml` runs on pull requests, pushes to `main`,
+and manual dispatch. One focused Linux job uses Go `1.26.6` and invokes the
+canonical local policy runner:
+
+```bash
+scripts/security-analysis.sh
+```
+
+The runner installs Staticcheck `v0.8.1`, govulncheck `v1.7.0`, and gosec
+`v2.29.0` into a temporary `GOBIN`. It rejects a different active Go version
+instead of allowing analyzer toolchain drift. The release-blocking checks are:
+
+- Staticcheck's `SA*` correctness class across ordinary and `goframe_debug`
+  host builds;
+- the same `SA*` class for ordinary and `goframe_debug` `js/wasm`
+  `pkg/goframe` builds, with tests disabled for that target;
+- `govulncheck -scan=symbol ./...`, where reachable vulnerabilities and
+  scanner, database, network, or package-loading failures all fail the job;
+- `GOWORK=off go list -m all`, which must enumerate exactly the main
+  `github.com/graybuton/goframe` module and no additional root-module
+  dependencies.
+
+Full Staticcheck is not a release gate because its style and simplification
+classes are separate from the selected correctness contract.
+
+Gosec runs its complete default rule set over the package directories derived
+from `go list ./...`; filesystem recursion and nested `testdata` trees are not
+package authorities. Ordinary findings are visible and advisory, while package
+enumeration failure, analyzer execution failure, package-processing errors,
+missing or malformed JSON, invalid report structure, and empty or unproven
+coverage fail the job. The accepted-base characterization contains 90
+findings: 29 `G703`, 23 `G304`, 13 `G301`, 11 `G204`, 3 each of `G104` and
+`G115`, and 2 each of `G112`, `G114`, `G306`, and `G705`. That count is not a
+suppression baseline; every run reports the current findings and deterministic
+per-rule totals.
+
+No source suppressions implement this policy. GitHub-managed CodeQL remains a
+separate repository control, and Core continues to own vet and race coverage.
+
 ### VS Code Extension
 
 `.github/workflows/ci-vscode.yml` runs on pull requests and pushes to `main`.
@@ -393,11 +434,12 @@ Current supply-chain evidence is lightweight:
   dependencies;
 - the VS Code extension workflow installs from `package-lock.json` with
   `npm ci`;
-- the root Go module currently has no third-party module requirements beyond
-  the standard library.
+- the Security Analysis workflow enforces the root Go module's current
+  standard-library-only dependency surface and runs pinned correctness,
+  vulnerability, and advisory security analyzers.
 
-No SBOM, package signing, or heavyweight dependency scanner is part of the
-current preview CI contract.
+No SBOM, package signing, license scanner, or Action/artifact pinning policy is
+part of this security-analysis stage.
 
 ## Local Checks
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -358,12 +358,22 @@ surface remains experimental.
 ### Security Analysis
 
 `.github/workflows/ci-security.yml` runs on pull requests, pushes to `main`,
-and manual dispatch. One focused Linux job uses Go `1.26.6` and invokes the
-canonical local policy runner:
+and manual dispatch. One focused Linux job sequentially selects and verifies
+Go `1.26.6` and `1.27.0`, invoking the same canonical local policy runner under
+each toolchain:
 
 ```bash
 scripts/security-analysis.sh
 ```
+
+Each invocation evaluates the complete native-host, Windows amd64 cross-target,
+and `js/wasm` browser-runtime analyzer policy. The required job/context remains
+`Security analysis`.
+
+The local runner is compatible with the stock Bash 3.2 baseline of the
+supported macOS host. The existing macOS Core lane checks its syntax and runs
+the hermetic policy controls through `/bin/bash`; it does not install or run
+the full analyzer suite there.
 
 The canonical job executes on Linux and additionally analyzes the supported
 Windows amd64 package configuration. Windows package loading and analyzers use
@@ -372,9 +382,12 @@ production source currently depends on cgo. This is cross-target static
 analysis, not native Windows execution. Core CI retains the native Windows
 runtime and platform evidence.
 
-The runner installs Staticcheck `v0.8.1`, govulncheck `v1.7.0`, and gosec
-`v2.29.0` into a temporary `GOBIN`. It rejects a different active Go version
-instead of allowing analyzer toolchain drift. The release-blocking checks are:
+Each runner invocation installs Staticcheck `v0.8.1`, govulncheck `v1.7.0`, and
+gosec `v2.29.0` into its own temporary `GOBIN`, using the active Go toolchain.
+It accepts only the explicitly supported Go versions `1.26.6` and `1.27.0`
+and rejects any other active version, retaining `GOTOOLCHAIN=local` to prevent
+automatic toolchain switching. The release-blocking checks under each
+supported toolchain are:
 
 - Staticcheck's `SA*` correctness class across ordinary and `goframe_debug`
   host builds;

--- a/docs/release.md
+++ b/docs/release.md
@@ -49,6 +49,9 @@ Before creating a tag:
 - `actionlint` passes at the workflow baseline;
 - `scripts/artifact-check.sh` passes;
 - `scripts/module-path-check.sh` passes;
+- the `Security Analysis` workflow passes on the exact release HEAD, including
+  its blocking Staticcheck `SA*`, govulncheck, root Go module, and analyzer-
+  health checks;
 - release package layout is checked with `goxc package --asset-hash --preload`
   for affected examples;
 - filesystem/package safety spot checks pass for symlink rejection, ownership
@@ -205,6 +208,7 @@ announcement.
 - dashboard DOM pressure;
 - artifact and module path gates;
 - docs consistency;
+- `Security Analysis` on the exact reviewed release HEAD;
 - package matrix for all examples with TinyGo and selected Go compiler paths.
 
 ### Docs
@@ -250,8 +254,9 @@ announcement.
 - reusable/multi-module component identity scope stated explicitly;
 - experimental surfaces named rather than hidden;
 - compatibility/deprecation notes included;
-- supply-chain/tooling evidence stated as lightweight CI/Dependabot/lockfile
-  coverage, with no SBOM or scanner claim in the current preview contract;
+- security-analysis and supply-chain evidence stated explicitly, including the
+  blocking/advisory analyzer split and root Go module dependency check, with no
+  SBOM, signing, attestation, or complete supply-chain claim;
 - migration notes linked;
 - rollback/revert plan noted for preview users.
 

--- a/scripts/security-analysis.sh
+++ b/scripts/security-analysis.sh
@@ -27,8 +27,13 @@ enumerate_gosec_packages() {
 	local module_path="$2"
 	local output_path="$3"
 	local go_command="$4"
+	local package_pattern="$5"
 
-	if ! GOWORK=off "$go_command" list -buildvcs=false -f '{{.ImportPath}}{{"\t"}}{{.Dir}}' ./... >"$output_path"; then
+	if [[ -z "$package_pattern" ]]; then
+		security_error "Go package enumeration requires an explicit package pattern"
+		return 1
+	fi
+	if ! GOWORK=off "$go_command" list -buildvcs=false -f '{{.ImportPath}}{{"\t"}}{{.Dir}}' "$package_pattern" >"$output_path"; then
 		security_error "Go package enumeration failed"
 		return 1
 	fi
@@ -82,6 +87,35 @@ enumerate_gosec_packages() {
 	printf '  %s\n' "${GOSEC_PACKAGE_IMPORTS[@]}"
 }
 
+run_gosec_analysis() {
+	local report_path="$1"
+	local gosec_command="$2"
+	shift 2
+
+	if (($# == 0)); then
+		security_error "gosec package coverage is empty"
+		return 1
+	fi
+	local log_path="$report_path.log"
+	rm -f -- "$report_path" "$log_path"
+	# gosec v2.29.0 suppresses a clean JSON report under -quiet. Keep the
+	# structured report mandatory while sending progress logs to a temporary file.
+	if ! "$gosec_command" -no-fail -fmt=json -log="$log_path" -out="$report_path" "$@"; then
+		if [[ -s "$log_path" ]]; then
+			cat "$log_path" >&2
+		fi
+		security_error "gosec execution failed"
+		return 1
+	fi
+	if [[ ! -s "$report_path" ]]; then
+		if [[ -s "$log_path" ]]; then
+			cat "$log_path" >&2
+		fi
+		security_error "gosec did not produce a non-empty JSON report"
+		return 1
+	fi
+}
+
 verify_root_module_surface() {
 	local output_path="$1"
 	local -a modules=()
@@ -126,8 +160,10 @@ main() {
 	trap cleanup_security_analysis EXIT
 	local tool_dir="$SECURITY_WORK_DIR/bin"
 	local module_report="$SECURITY_WORK_DIR/modules.txt"
-	local package_report="$SECURITY_WORK_DIR/packages.txt"
-	local gosec_report="$SECURITY_WORK_DIR/gosec.json"
+	local host_package_report="$SECURITY_WORK_DIR/packages-host.txt"
+	local browser_package_report="$SECURITY_WORK_DIR/packages-wasm-runtime.txt"
+	local host_gosec_report="$SECURITY_WORK_DIR/gosec-host.json"
+	local browser_gosec_report="$SECURITY_WORK_DIR/gosec-wasm-runtime.json"
 	mkdir -p "$tool_dir"
 
 	echo '== Install pinned analyzers =='
@@ -145,25 +181,45 @@ main() {
 	echo '== Root Go module dependency surface =='
 	verify_root_module_surface "$module_report"
 
-	echo '== Staticcheck SA correctness =='
+	echo '== Host Staticcheck SA correctness =='
 	staticcheck -checks='SA*' ./...
 	staticcheck -checks='SA*' -tags='goframe_debug' ./...
-	GOOS=js GOARCH=wasm staticcheck -checks='SA*' -tests=false ./pkg/goframe
-	GOOS=js GOARCH=wasm staticcheck -checks='SA*' -tests=false -tags='goframe_debug' ./pkg/goframe
 
-	echo '== Reachable vulnerability analysis =='
+	echo '== Browser runtime Staticcheck SA correctness =='
+	GOOS=js GOARCH=wasm CGO_ENABLED=0 staticcheck -checks='SA*' -tests=false ./pkg/goframe
+	GOOS=js GOARCH=wasm CGO_ENABLED=0 staticcheck -checks='SA*' -tests=false -tags='goframe_debug' ./pkg/goframe
+
+	echo '== Host reachable vulnerability analysis =='
 	govulncheck -scan=symbol ./...
 
-	echo '== Gosec advisory analysis =='
-	enumerate_gosec_packages "$ROOT_DIR" "$MAIN_MODULE" "$package_report" go
-	if ! gosec -quiet -no-fail -fmt=json -out="$gosec_report" "${GOSEC_PACKAGE_DIRS[@]}"; then
-		security_error "gosec execution failed"
-		return 1
-	fi
+	echo '== Browser runtime reachable vulnerability analysis =='
+	GOOS=js GOARCH=wasm CGO_ENABLED=0 govulncheck -scan=symbol ./pkg/goframe
+
+	echo '== Host gosec advisory analysis =='
+	enumerate_gosec_packages "$ROOT_DIR" "$MAIN_MODULE" "$host_package_report" go ./...
+	local -a host_gosec_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+	run_gosec_analysis "$host_gosec_report" gosec "${host_gosec_package_dirs[@]}"
 	go run ./.github/scripts/gosec-report.go \
-		-report "$gosec_report" \
+		-report "$host_gosec_report" \
 		-root "$ROOT_DIR" \
-		-packages "${#GOSEC_PACKAGE_DIRS[@]}"
+		-packages "${#host_gosec_package_dirs[@]}"
+
+	echo '== Browser runtime gosec advisory analysis =='
+	GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \
+		"$ROOT_DIR" \
+		"$MAIN_MODULE" \
+		"$browser_package_report" \
+		go \
+		./pkg/goframe
+	local -a browser_gosec_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+	GOOS=js GOARCH=wasm CGO_ENABLED=0 run_gosec_analysis \
+		"$browser_gosec_report" \
+		gosec \
+		"${browser_gosec_package_dirs[@]}"
+	go run ./.github/scripts/gosec-report.go \
+		-report "$browser_gosec_report" \
+		-root "$ROOT_DIR" \
+		-packages "${#browser_gosec_package_dirs[@]}"
 
 	echo 'security analysis: ok'
 }

--- a/scripts/security-analysis.sh
+++ b/scripts/security-analysis.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+EXPECTED_GO_VERSION="go1.26.6"
+MAIN_MODULE="github.com/graybuton/goframe"
+STATICCHECK_VERSION="v0.8.1"
+GOVULNCHECK_VERSION="v1.7.0"
+GOSEC_VERSION="v2.29.0"
+
+GOSEC_PACKAGE_DIRS=()
+GOSEC_PACKAGE_IMPORTS=()
+SECURITY_WORK_DIR=""
+
+security_error() {
+	printf 'security analysis: %s\n' "$*" >&2
+}
+
+cleanup_security_analysis() {
+	if [[ -n "$SECURITY_WORK_DIR" ]]; then
+		rm -rf -- "$SECURITY_WORK_DIR"
+	fi
+}
+
+enumerate_gosec_packages() {
+	local repository_root="$1"
+	local module_path="$2"
+	local output_path="$3"
+	local go_command="$4"
+
+	if ! GOWORK=off "$go_command" list -buildvcs=false -f '{{.ImportPath}}{{"\t"}}{{.Dir}}' ./... >"$output_path"; then
+		security_error "Go package enumeration failed"
+		return 1
+	fi
+
+	GOSEC_PACKAGE_DIRS=()
+	GOSEC_PACKAGE_IMPORTS=()
+	local row import_path directory
+	local -A seen_imports=()
+	local -A seen_directories=()
+	while IFS= read -r row; do
+		if [[ "$row" != *$'\t'* ]]; then
+			security_error "invalid Go package row: $row"
+			return 1
+		fi
+		import_path="${row%%$'\t'*}"
+		directory="${row#*$'\t'}"
+		if [[ -z "$import_path" || -z "$directory" || "$directory" == *$'\t'* ]]; then
+			security_error "invalid Go package row: $row"
+			return 1
+		fi
+		if [[ "$import_path" != "$module_path" && "$import_path" != "$module_path/"* ]]; then
+			security_error "package $import_path is outside the main module"
+			return 1
+		fi
+		if [[ ! -d "$directory" ]]; then
+			security_error "package directory does not exist: $directory"
+			return 1
+		fi
+		case "$directory/" in
+			"$repository_root/"*) ;;
+			*)
+				security_error "package directory is outside the repository: $directory"
+				return 1
+				;;
+		esac
+		if [[ -n "${seen_imports[$import_path]:-}" || -n "${seen_directories[$directory]:-}" ]]; then
+			security_error "duplicate Go package coverage row: $row"
+			return 1
+		fi
+		seen_imports["$import_path"]=1
+		seen_directories["$directory"]=1
+		GOSEC_PACKAGE_IMPORTS+=("$import_path")
+		GOSEC_PACKAGE_DIRS+=("$directory")
+	done <"$output_path"
+
+	if ((${#GOSEC_PACKAGE_DIRS[@]} == 0)); then
+		security_error "Go package enumeration returned no packages"
+		return 1
+	fi
+	printf 'gosec package coverage: %d first-party packages\n' "${#GOSEC_PACKAGE_DIRS[@]}"
+	printf '  %s\n' "${GOSEC_PACKAGE_IMPORTS[@]}"
+}
+
+verify_root_module_surface() {
+	local output_path="$1"
+	local -a modules=()
+	if ! GOWORK=off go list -m all >"$output_path"; then
+		security_error "root Go module enumeration failed"
+		return 1
+	fi
+	mapfile -t modules <"$output_path"
+	printf 'root Go module graph:\n'
+	printf '  %s\n' "${modules[@]}"
+	if ((${#modules[@]} != 1)) || [[ "${modules[0]:-}" != "$MAIN_MODULE" ]]; then
+		security_error "root Go module graph must contain only $MAIN_MODULE"
+		return 1
+	fi
+}
+
+main() {
+	cd "$ROOT_DIR"
+	export GOTOOLCHAIN=local
+	export GOWORK=off
+	export GOFLAGS=-buildvcs=false
+
+	local actual_go_version
+	local host_goos
+	local host_goarch
+	actual_go_version="$(go env GOVERSION)"
+	host_goos="$(go env GOHOSTOS)"
+	host_goarch="$(go env GOHOSTARCH)"
+	export GOOS="$host_goos"
+	export GOARCH="$host_goarch"
+	go version
+	if [[ "$actual_go_version" != "$EXPECTED_GO_VERSION" ]]; then
+		security_error "requires $EXPECTED_GO_VERSION, found $actual_go_version"
+		return 1
+	fi
+	if [[ "$(go env GOMOD)" != "$ROOT_DIR/go.mod" ]]; then
+		security_error "repository root module is not selected"
+		return 1
+	fi
+
+	SECURITY_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/goframe-security-analysis.XXXXXX")"
+	trap cleanup_security_analysis EXIT
+	local tool_dir="$SECURITY_WORK_DIR/bin"
+	local module_report="$SECURITY_WORK_DIR/modules.txt"
+	local package_report="$SECURITY_WORK_DIR/packages.txt"
+	local gosec_report="$SECURITY_WORK_DIR/gosec.json"
+	mkdir -p "$tool_dir"
+
+	echo '== Install pinned analyzers =='
+	GOBIN="$tool_dir" go install "honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION"
+	GOBIN="$tool_dir" go install "golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION"
+	GOBIN="$tool_dir" go install "github.com/securego/gosec/v2/cmd/gosec@$GOSEC_VERSION"
+	export PATH="$tool_dir:$PATH"
+	staticcheck -version
+	govulncheck -version
+	gosec -version
+	go version -m "$tool_dir/staticcheck"
+	go version -m "$tool_dir/govulncheck"
+	go version -m "$tool_dir/gosec"
+
+	echo '== Root Go module dependency surface =='
+	verify_root_module_surface "$module_report"
+
+	echo '== Staticcheck SA correctness =='
+	staticcheck -checks='SA*' ./...
+	staticcheck -checks='SA*' -tags='goframe_debug' ./...
+	GOOS=js GOARCH=wasm staticcheck -checks='SA*' -tests=false ./pkg/goframe
+	GOOS=js GOARCH=wasm staticcheck -checks='SA*' -tests=false -tags='goframe_debug' ./pkg/goframe
+
+	echo '== Reachable vulnerability analysis =='
+	govulncheck -scan=symbol ./...
+
+	echo '== Gosec advisory analysis =='
+	enumerate_gosec_packages "$ROOT_DIR" "$MAIN_MODULE" "$package_report" go
+	if ! gosec -quiet -no-fail -fmt=json -out="$gosec_report" "${GOSEC_PACKAGE_DIRS[@]}"; then
+		security_error "gosec execution failed"
+		return 1
+	fi
+	go run ./.github/scripts/gosec-report.go \
+		-report "$gosec_report" \
+		-root "$ROOT_DIR" \
+		-packages "${#GOSEC_PACKAGE_DIRS[@]}"
+
+	echo 'security analysis: ok'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/scripts/security-analysis.sh
+++ b/scripts/security-analysis.sh
@@ -161,8 +161,10 @@ main() {
 	local tool_dir="$SECURITY_WORK_DIR/bin"
 	local module_report="$SECURITY_WORK_DIR/modules.txt"
 	local host_package_report="$SECURITY_WORK_DIR/packages-host.txt"
+	local windows_package_report="$SECURITY_WORK_DIR/packages-windows.txt"
 	local browser_package_report="$SECURITY_WORK_DIR/packages-wasm-runtime.txt"
 	local host_gosec_report="$SECURITY_WORK_DIR/gosec-host.json"
+	local windows_gosec_report="$SECURITY_WORK_DIR/gosec-windows.json"
 	local browser_gosec_report="$SECURITY_WORK_DIR/gosec-wasm-runtime.json"
 	mkdir -p "$tool_dir"
 
@@ -185,12 +187,19 @@ main() {
 	staticcheck -checks='SA*' ./...
 	staticcheck -checks='SA*' -tags='goframe_debug' ./...
 
+	echo '== Windows target Staticcheck SA correctness =='
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 staticcheck -checks='SA*' ./...
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 staticcheck -checks='SA*' -tags='goframe_debug' ./...
+
 	echo '== Browser runtime Staticcheck SA correctness =='
 	GOOS=js GOARCH=wasm CGO_ENABLED=0 staticcheck -checks='SA*' -tests=false ./pkg/goframe
 	GOOS=js GOARCH=wasm CGO_ENABLED=0 staticcheck -checks='SA*' -tests=false -tags='goframe_debug' ./pkg/goframe
 
 	echo '== Host reachable vulnerability analysis =='
 	govulncheck -scan=symbol ./...
+
+	echo '== Windows target reachable vulnerability analysis =='
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 govulncheck -scan=symbol ./...
 
 	echo '== Browser runtime reachable vulnerability analysis =='
 	GOOS=js GOARCH=wasm CGO_ENABLED=0 govulncheck -scan=symbol ./pkg/goframe
@@ -203,6 +212,23 @@ main() {
 		-report "$host_gosec_report" \
 		-root "$ROOT_DIR" \
 		-packages "${#host_gosec_package_dirs[@]}"
+
+	echo '== Windows target gosec advisory analysis =='
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 enumerate_gosec_packages \
+		"$ROOT_DIR" \
+		"$MAIN_MODULE" \
+		"$windows_package_report" \
+		go \
+		./...
+	local -a windows_gosec_package_dirs=("${GOSEC_PACKAGE_DIRS[@]}")
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 run_gosec_analysis \
+		"$windows_gosec_report" \
+		gosec \
+		"${windows_gosec_package_dirs[@]}"
+	go run ./.github/scripts/gosec-report.go \
+		-report "$windows_gosec_report" \
+		-root "$ROOT_DIR" \
+		-packages "${#windows_gosec_package_dirs[@]}"
 
 	echo '== Browser runtime gosec advisory analysis =='
 	GOOS=js GOARCH=wasm CGO_ENABLED=0 enumerate_gosec_packages \

--- a/scripts/security-analysis.sh
+++ b/scripts/security-analysis.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-EXPECTED_GO_VERSION="go1.26.6"
+SUPPORTED_GO_VERSIONS=(go1.26.6 go1.27.0)
 MAIN_MODULE="github.com/graybuton/goframe"
 STATICCHECK_VERSION="v0.8.1"
 GOVULNCHECK_VERSION="v1.7.0"
@@ -142,6 +142,8 @@ main() {
 	export GOFLAGS=-buildvcs=false
 
 	local actual_go_version
+	local supported_go_version
+	local go_version_supported=false
 	local host_goos
 	local host_goarch
 	actual_go_version="$(go env GOVERSION)"
@@ -150,8 +152,14 @@ main() {
 	export GOOS="$host_goos"
 	export GOARCH="$host_goarch"
 	go version
-	if [[ "$actual_go_version" != "$EXPECTED_GO_VERSION" ]]; then
-		security_error "requires $EXPECTED_GO_VERSION, found $actual_go_version"
+	for supported_go_version in "${SUPPORTED_GO_VERSIONS[@]}"; do
+		if [[ "$actual_go_version" == "$supported_go_version" ]]; then
+			go_version_supported=true
+			break
+		fi
+	done
+	if [[ "$go_version_supported" != true ]]; then
+		security_error "unsupported active Go version $actual_go_version; supported: ${SUPPORTED_GO_VERSIONS[*]}"
 		return 1
 	fi
 	if [[ "$(go env GOMOD)" != "$ROOT_DIR/go.mod" ]]; then

--- a/scripts/security-analysis.sh
+++ b/scripts/security-analysis.sh
@@ -40,9 +40,7 @@ enumerate_gosec_packages() {
 
 	GOSEC_PACKAGE_DIRS=()
 	GOSEC_PACKAGE_IMPORTS=()
-	local row import_path directory
-	local -A seen_imports=()
-	local -A seen_directories=()
+	local row import_path directory index
 	while IFS= read -r row; do
 		if [[ "$row" != *$'\t'* ]]; then
 			security_error "invalid Go package row: $row"
@@ -69,12 +67,12 @@ enumerate_gosec_packages() {
 				return 1
 				;;
 		esac
-		if [[ -n "${seen_imports[$import_path]:-}" || -n "${seen_directories[$directory]:-}" ]]; then
-			security_error "duplicate Go package coverage row: $row"
-			return 1
-		fi
-		seen_imports["$import_path"]=1
-		seen_directories["$directory"]=1
+		for ((index = 0; index < ${#GOSEC_PACKAGE_IMPORTS[@]}; index++)); do
+			if [[ "$import_path" == "${GOSEC_PACKAGE_IMPORTS[index]}" || "$directory" == "${GOSEC_PACKAGE_DIRS[index]}" ]]; then
+				security_error "duplicate Go package coverage row: $row"
+				return 1
+			fi
+		done
 		GOSEC_PACKAGE_IMPORTS+=("$import_path")
 		GOSEC_PACKAGE_DIRS+=("$directory")
 	done <"$output_path"
@@ -119,13 +117,18 @@ run_gosec_analysis() {
 verify_root_module_surface() {
 	local output_path="$1"
 	local -a modules=()
+	local module
 	if ! GOWORK=off go list -m all >"$output_path"; then
 		security_error "root Go module enumeration failed"
 		return 1
 	fi
-	mapfile -t modules <"$output_path"
+	while IFS= read -r module || [[ -n "$module" ]]; do
+		modules+=("$module")
+	done <"$output_path"
 	printf 'root Go module graph:\n'
-	printf '  %s\n' "${modules[@]}"
+	if ((${#modules[@]} != 0)); then
+		printf '  %s\n' "${modules[@]}"
+	fi
 	if ((${#modules[@]} != 1)) || [[ "${modules[0]:-}" != "$MAIN_MODULE" ]]; then
 		security_error "root Go module graph must contain only $MAIN_MODULE"
 		return 1


### PR DESCRIPTION
## Summary

Establish the release security-analysis gate for GoFrame ahead of
`v0.4.0-preview.1`.

This PR adds one canonical security-analysis runner and a dedicated
`Security analysis` workflow covering supported Go toolchains, target-specific
source configurations, reachable-vulnerability analysis, Staticcheck
correctness checks, advisory gosec scanning, and exact root-module dependency
integrity.

The complete analyzer policy is evaluated independently under Go `1.26.6` and
Go `1.27.0` with `GOTOOLCHAIN=local`.

Analyzer health, package coverage, report integrity, and policy execution are
fail-closed. Ordinary gosec findings remain visible and advisory.

## Security contract

The release gate covers the supported source configurations that materially
change with the selected toolchain or build target:

- Staticcheck `SA*` for ordinary and `goframe_debug` host builds;
- Staticcheck `SA*` for the Windows `amd64` cross-target;
- Staticcheck `SA*` for the production `js/wasm` `pkg/goframe` runtime;
- `govulncheck -scan=symbol` for the host module graph;
- `govulncheck -scan=symbol` for the Windows `amd64` module graph;
- `govulncheck -scan=symbol` for the browser `pkg/goframe` runtime;
- target-aware gosec package enumeration and analysis for host, Windows, and
  browser runtime surfaces;
- exact verification that the root module dependency graph contains only the
  GoFrame module.

The full target policy runs separately under each supported Go toolchain:
`1.26.6` and `1.27.0`. Other active Go versions are rejected rather than
silently changing the analyzer build configuration.

Package-enumeration failures, empty or duplicate coverage, analyzer execution
failures, missing or invalid structured reports, report-processing failures,
and source-suppression failures are blocking.

Ordinary gosec findings do not fail the gate. They are reported as advisory
diagnostics without being promoted to GitHub error annotations.

Generated GOX applications are intentionally outside the clean-checkout
whole-program analyzer contract because their compilable Go surface exists only
after `goxc` workspace materialization. The browser static-analysis boundary is
therefore the production `pkg/goframe` runtime rather than generated application
graphs.

Windows analysis is cross-target static analysis under
`GOOS=windows GOARCH=amd64 CGO_ENABLED=0`; native Windows execution remains part
of Core CI evidence.

## Validation

Hermetic runner regressions verify:

- complete host, Windows, and browser target coverage under both supported Go
  versions;
- rejection of unsupported Go versions and preservation of
  `GOTOOLCHAIN=local`;
- target propagation and isolation between host, Windows, and browser passes;
- ordinary and `goframe_debug` Staticcheck coverage;
- blocking govulncheck failures for target-specific analysis;
- fail-closed package enumeration, including empty and duplicate coverage;
- fail-closed gosec execution, report creation, and report classification;
- advisory-only treatment of ordinary gosec findings;
- exact root-module graph validation;
- argument preservation for package paths containing spaces.

The canonical runner is compatible with the stock Bash `3.2` baseline on the
supported macOS host. The existing macOS Core lane validates runner syntax and
executes the hermetic policy controls through `/bin/bash`.

The security gate complements, rather than replaces, existing native Windows,
browser smoke, package, vet, race, size-budget, and CodeQL evidence.

## Scope

This PR is limited to security-analysis policy, its regression coverage,
workflow integration, and CI documentation.

It does not change:

- runtime, GOX, `goxc`, or application behavior;
- production packages or generated application sources;
- dependencies or supported Go/TinyGo baselines;
- pinned analyzer versions;
- CodeQL configuration or policy;
- existing release rulesets or required-check names;
- broader CI topology;
- GitHub Action or downloaded-toolchain pinning planned for the next release
  hardening stage;
- fast-fail CI policy.

The existing `Security analysis` required context remains a single job; the two
supported Go toolchains execute sequentially within that contract.

## Review focus

Please focus on:

- complete security-policy coverage under both supported Go toolchains;
- build-target selection and isolation across host, Windows, and browser
  analysis;
- fail-closed analyzer/package/report health versus advisory gosec findings;
- the boundary between clean-checkout analysis and generated GOX applications;
- Bash `3.2` compatibility of the canonical local runner;
- preservation of the existing CodeQL, vet, race, native-platform, and
  release-stage contracts;
- absence of A3 Action/artifact pinning and A4 fast-fail/topology changes.

## Related

- #143
- Milestone: `v0.4.0-preview.1`