### PR TITLE
ci(tinygo): adopt 0.42.0 baseline

### DIFF
--- a/.github/workflows/ci-browser-smoke.yml
+++ b/.github/workflows/ci-browser-smoke.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  TINYGO_VERSION: 0.41.1
+  TINYGO_VERSION: 0.42.0
 
 jobs:
   browser-smoke:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -114,7 +114,7 @@ jobs:
           - '1.26.6'
 
     env:
-      TINYGO_VERSION: 0.41.1
+      TINYGO_VERSION: 0.42.0
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-wasm-size.yml
+++ b/.github/workflows/ci-wasm-size.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  TINYGO_VERSION: 0.41.1
+  TINYGO_VERSION: 0.42.0
 
 jobs:
   tinygo-size:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Adopted TinyGo `0.42.0` for the release compiler baseline, with a measured,
+  deterministic WASM size rebaseline limited to failing absolute ceilings;
+  compression ratios and production compiler flags are unchanged.
 - User-authored `goframe.json` paths now canonicalize `/`, `\`, and mixed
   separator spellings to one portable slash representation at ingestion,
   including `output` and `wasm`. Filesystem conversion is explicit at host

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,11 +47,12 @@ It checks:
 - GOX golden tests, including source-oriented error diagnostics.
 - GOX fuzz seed targets through the normal `go test ./...` seed pass.
 
-A separate focused Linux job installs TinyGo `0.41.1` under Go `1.26.6`. It
+A separate focused Linux job installs TinyGo `0.42.0` under Go `1.26.6`. It
 checks browser source-selection parity and feature-tagged TinyGo builds without
-duplicating the full package, browser, or size workflows. TinyGo `0.41.1`
-supports Go through `1.26`, so the stable Go `1.27.0` Core row does not claim
-TinyGo parity.
+duplicating the full package, browser, or size workflows. TinyGo `0.42.0`
+supports Go through `1.27`; local source-selection and build characterization
+also passes with Go `1.27.0`. The stable Go `1.27.0` Core row remains standard-Go
+evidence, without a second TinyGo matrix.
 
 The `cmd/goxc` test suite includes manifest/path/package/export/workspace
 regression tests, including root-aware symlink checks for app roots, entry
@@ -160,7 +161,7 @@ pass.
 `.github/workflows/ci-wasm-size.yml` runs on pull requests, pushes to `main`,
 and manually through `workflow_dispatch`.
 
-It installs Go `1.26.6`, TinyGo `0.41.1`, brotli, and zstd. Then it packages
+It installs Go `1.26.6`, TinyGo `0.42.0`, brotli, and zstd. Then it packages
 the counter, components, todo, dashboard, context, virtualized, multipackage,
 cmdapp, router, router-dashboard, and resource examples with TinyGo. It also
 runs a release-style package pass with `--asset-hash --preload
@@ -205,7 +206,7 @@ older `main.wasm` packages.
 `.github/workflows/ci-browser-smoke.yml` runs on pull requests, pushes to
 `main`, and manually through `workflow_dispatch` on `ubuntu-latest` only.
 
-It installs Go `1.26.6`, TinyGo `0.41.1`, Node.js `24.18.1`, Chrome, and
+It installs Go `1.26.6`, TinyGo `0.42.0`, Node.js `24.18.1`, Chrome, and
 compression tools, then runs:
 
 ```bash
@@ -294,7 +295,7 @@ The private Error Boundary fixture also covers state render transactions. Its
 standard-Go/WASM lane verifies failed initial state rollback, retry without a
 ghost slot, inert discarded setters and dispatchers, preservation and later
 replacement of a committed reducer, resource ordering, stable scenario DOM
-identity, and balanced listener cleanup. A TinyGo `0.41.1` lane verifies the
+identity, and balanced listener cleanup. A TinyGo `0.42.0` lane verifies the
 successful state, reducer, resource, and cleanup path. It does not intentionally
 panic or claim recover-based rollback under TinyGo's trap-style panic mode.
 
@@ -568,7 +569,7 @@ Local checks use:
   `1.26.6` minimum patch level;
 - Go `1.26.6` and stable Go `1.27.0` for supported full Core evidence;
 - Go `1.26.6` for the browser-smoke, TinyGo parity, and WASM-size baselines;
-- TinyGo `0.41.1` for focused source-selection parity, WASM size, and browser
+- TinyGo `0.42.0` for focused source-selection parity, WASM size, and browser
   smoke gates;
 - gzip;
 - brotli;

--- a/docs/evaluator-guide.md
+++ b/docs/evaluator-guide.md
@@ -6,11 +6,12 @@ is not a production deployment guide.
 
 ## Prerequisites
 
-The release validation baseline is:
+For the current repository checkout, use the following baseline. The published
+preview's historical validation remains recorded in its dedicated
+[release notes](release-notes-v0.3.0-preview.1.md).
 
-- Go `1.22.12`, `1.25.12`, and `1.26.5`, with Go `1.26.5` recommended for the
-  guided path;
-- TinyGo 0.41.1 for size-oriented WASM packages;
+- Go `1.26.6` and `1.27.0`, with Go `1.26.6` for the guided browser/size path;
+- TinyGo `0.42.0` for size-oriented WASM packages;
 - Node.js `24.18.1` for docs, extension, and browser smoke scripts;
 - Chrome `149` or the repository's current documented Chrome/Chromium
   equivalent for local browser smoke;

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -35,13 +35,13 @@ Symlink safety tests skip when `os.Symlink` is unavailable or restricted.
 | Compiler target | Status | Notes |
 |---|---|---|
 | Go/WASM | CI-tested for selected smoke fixtures | Current heavy browser baseline uses Go `1.26.6`. It covers recover-capable runtime error and Error Boundary scenarios. Larger bundle size is expected. |
-| TinyGo/WASM | CI-tested for packaging, size, and most browser smoke | Current heavy baseline and focused source-selection parity use Go `1.26.6` with TinyGo `0.41.1`. TinyGo `0.41.1` supports Go through `1.26`; the stable Go `1.27.0` Core lane does not claim TinyGo parity. Default package path uses `-panic=trap`. |
+| TinyGo/WASM | CI-tested for packaging, size, and most browser smoke | Current heavy baseline and focused source-selection parity use Go `1.26.6` with TinyGo `0.42.0`. TinyGo supports Go through `1.27`; local Go `1.27.0` compatibility characterization passes, but the stable Core lane remains standard-Go evidence. Default package path uses `-panic=trap`. |
 | Native Go runtime | CI-tested for pure tests | Pure runtime/compiler/tooling tests run with normal Go. Browser runtime requires `js/wasm`. |
 
 The module requires Go `1.26.6` or newer. Go `1.26.6` and stable Go `1.27.0`
 are the supported full Core toolchains. Older Go versions are outside the
 GoFrame preview support contract. The browser and size workflows use Go
-`1.26.6`, TinyGo `0.41.1`, and Node.js `24.18.1`; the Go `1.27.0` lane is
+`1.26.6`, TinyGo `0.42.0`, and Node.js `24.18.1`; the Go `1.27.0` lane is
 standard-Go Core evidence and does not duplicate the heavy browser or size
 workflows.
 

--- a/docs/public-preview-readiness.md
+++ b/docs/public-preview-readiness.md
@@ -271,7 +271,7 @@ Evidence:
 - `docs/platform-support.md`;
 - CI and local validation on Linux/Chrome and macOS/Windows for core Go/toolchain
   checks;
-- TinyGo `0.41.1` size and smoke gates;
+- TinyGo `0.42.0` size and smoke gates;
 - Go/WASM recover-capable smoke fixtures.
 
 Limitation:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -20,8 +20,8 @@ existing runtime primitives directly:
 ## Prerequisites
 
 Install Go, TinyGo, Node.js, Chrome or Chromium, gzip, brotli, and optionally
-zstd. The repository CI currently uses Go `1.24.x`, TinyGo `0.41.1`, and
-Node.js 20.
+zstd. The repository CI uses Go `1.26.6` and `1.27.0`, with Go `1.26.6` plus
+TinyGo `0.42.0` for browser and size gates, and Node.js `24.18.1`.
 
 ## Install goxc
 

--- a/docs/wasm-size-headroom-audit.md
+++ b/docs/wasm-size-headroom-audit.md
@@ -5,9 +5,15 @@
 This document began with a toolchain-sensitive dashboard size investigation.
 The historical Go `1.24.4` and Go `1.22.12` results remain below for context.
 
-The current supported release-size source of truth is Go `1.26.5` plus TinyGo
-`0.41.1` on Linux amd64. The 2026-07-30 migration reproduced the frozen base
-twice with isolated workspaces and caches. Both runs produced identical raw,
+The current supported release-size source of truth is Go `1.26.6` plus TinyGo
+`0.42.0` / LLVM `22.1.4` on Linux amd64. The 2026-09-07 adjudication below
+attributes the modest, deterministic growth principally to the shared TinyGo
+runtime/JavaScript bridge. Only fifteen failing absolute ceilings move to the
+smallest enclosing KiB boundary; all ratios and production code stay unchanged.
+
+The historical 2026-07-30 migration used Go `1.26.5` and TinyGo `0.41.1` and
+reproduced its frozen base twice with isolated workspaces and caches. Both
+runs produced identical raw,
 gzip, Brotli, and Zstandard outputs for all eleven applications. Three measured
 cells exceeded their previous limits, so only those cells were aligned to the
 new baseline.
@@ -41,8 +47,10 @@ ceiling, compression command, workflow, or application changes.
 
 - Workflow: `.github/workflows/ci-wasm-size.yml`
 - Budget script: `scripts/size-budget.sh`
-- CI Go version: `1.26.5`
-- CI TinyGo version: `0.41.1`
+- CI Go version: `1.26.6`
+- CI TinyGo version: `0.42.0` / LLVM `22.1.4`
+- Measurement host: Linux amd64
+- Measured compressors: gzip `1.14`, Brotli `1.2.0`, Zstandard `1.5.7`
 
 The workflow installs `goxc`, generates and packages every listed example with
 TinyGo, then repeats packaging with `--asset-hash --preload
@@ -64,15 +72,95 @@ If no match exists, it reports the default missing path
 | --- | ---: | ---: | ---: | ---: |
 | counter | 97280 B | 40960 B | 56320 B | 49152 B |
 | components | 107520 B | 43008 B | 56320 B | 49152 B |
-| todo | 123904 B | 40960 B | 56320 B | 49152 B |
-| dashboard | 175104 B | 53248 B | 71680 B | 61440 B |
-| context | 120832 B | 37888 B | 46080 B | 40960 B |
-| virtualized | 128000 B | 40960 B | 50176 B | 44032 B |
+| todo | 126976 B | 40960 B | 56320 B | 49152 B |
+| dashboard | 181248 B | 55296 B | 71680 B | 61440 B |
+| context | 123904 B | 38912 B | 47104 B | 41984 B |
+| virtualized | 133120 B | 43008 B | 52224 B | 46080 B |
 | multipackage | 110592 B | 43008 B | 56320 B | 49152 B |
 | cmdapp | 110592 B | 43008 B | 56320 B | 49152 B |
-| router | 119808 B | 45056 B | 58368 B | 51200 B |
-| router-dashboard | 240640 B | 79872 B | 96256 B | 84992 B |
-| resource | 162816 B | 59392 B | 70656 B | 63488 B |
+| router | 122880 B | 45056 B | 58368 B | 51200 B |
+| router-dashboard | 241664 B | 79872 B | 96256 B | 84992 B |
+| resource | 163840 B | 60416 B | 70656 B | 63488 B |
+
+## TinyGo 0.42.0 Baseline Adjudication - 2026-09-07
+
+The frozen GoFrame base is `621b4344450259e6ffabe1edf64364e1682f7a36`.
+Both official Linux amd64 compilers used physical Go `1.26.6`: TinyGo
+`0.41.1` / LLVM `20.1.1` versus TinyGo `0.42.0` / LLVM `22.1.4`.
+Both installations bundle wasm-opt `116`. Production compilation remained
+`tinygo build -target=wasm -no-debug -panic=trap` through `goxc`; no diagnostic
+compiler flags or post-build optimization were substituted for release output.
+
+Two independent runs per compiler used separate workspaces, Go/module caches,
+TinyGo/XDG caches, and package outputs. Each run generated and packaged all
+eleven applications, then repeated the complete hashed/preloaded/gzip/Brotli
+package sequence from CI. Raw SHA-256 values and all 44 size measurements were
+identical within each compiler pair. Ordinary and release-style packages were
+equivalent after normalizing only `goframe-package.json`'s `generatedAt`.
+Compression used the unchanged script commands: gzip `-c -9`, Brotli quality
+11, and Zstandard level 19, with the versions listed above.
+
+WABT `1.0.36` and V8 validated all eleven candidate production modules.
+Their 13 function imports, 17 exports, and imported/exported function signatures
+are unchanged. Initial memory remains two 64 KiB pages. Each private function
+table adds the same three finalizer-related entries. No debug/DWARF section is
+introduced; the production name sections remain available for attribution.
+
+The net TinyGo runtime, internal-task, and JavaScript bridge function-body cost
+is `2619 B` to `2704 B` across all eleven apps. This includes the newly active
+finalizer runner and pressure-GC paths: `syscall/js.makeValue` grows from
+`121 B` to `760 B`, while `runtime.alloc` shrinks by `674 B` as GC code is
+factored into separate bodies. This matches upstream's
+[finalizer implementation](https://github.com/tinygo-org/tinygo/commit/7994d2e9122c5ffef3f69ab09c2f93dea73b744e)
+and [WASM finalizer scheduling](https://github.com/tinygo-org/tinygo/pull/5545).
+[Type-specific hash/equality generation](https://github.com/tinygo-org/tinygo/pull/5359)
+and LLVM changes also affect the code. GoFrame runtime body totals decrease
+`128 B` to `316 B` across every app, counting changed generic symbol spellings
+on both sides rather than treating them as new reachability.
+
+Code-section growth ranges from `1382 B` to `3002 B`; data changes range from
+`-400 B` to `+56 B`. Dashboard's upper residual includes `206 B` of reflection
+bodies and `218 B` of other application/stdlib bodies. Resource and
+router-dashboard grow less because their existing resource-panel bodies
+shrink `838 B` and `899 B`, with data reductions of `400 B` and `385 B`.
+No unexplained application-specific growth outlier remains. Attribution is
+strong for the shared finalizer cost, but the complete delta is an official
+TinyGo/LLVM toolchain shift, not a claim that one source commit or LLVM alone
+caused every byte.
+
+Source-selection and feature-tagged build tests pass with Go `1.26.6` and
+`1.27.0`. The unchanged complete Chrome `149.0.7827.196` browser smoke passes
+under Go `1.26.6` with TinyGo `0.42.0`. Go `1.27.0` remains compatibility
+characterization, not an added TinyGo CI row. No matching upstream blocker was
+identified in the measured corpus; this is not a claim of general compiler
+correctness or WASM panic recovery support.
+
+Exactly fifteen absolute cells fail the old ceilings; the other 29 pass.
+Each moved ceiling is `ceil(measured_bytes / 1024) * 1024`:
+
+| app/format | 0.41.1 B | 0.42.0 B | delta % | old ceiling B | overage B | new ceiling B | headroom B |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| todo raw | 123568 | 126313 | 2.221 | 123904 | 2409 | 126976 | 663 |
+| dashboard raw | 177629 | 181166 | 1.991 | 178176 | 2990 | 181248 | 82 |
+| dashboard br | 54061 | 55108 | 1.937 | 54272 | 836 | 55296 | 188 |
+| context raw | 120314 | 123063 | 2.285 | 120832 | 2231 | 123904 | 841 |
+| context gzip | 45473 | 46593 | 2.463 | 46080 | 513 | 47104 | 511 |
+| context br | 37258 | 38166 | 2.437 | 37888 | 278 | 38912 | 746 |
+| context zstd | 40141 | 41191 | 2.616 | 40960 | 231 | 41984 | 793 |
+| virtualized raw | 130149 | 133081 | 2.253 | 131072 | 2009 | 133120 | 39 |
+| virtualized gzip | 50373 | 51529 | 2.295 | 51200 | 329 | 52224 | 695 |
+| virtualized br | 41208 | 42158 | 2.305 | 41984 | 174 | 43008 | 850 |
+| virtualized zstd | 44493 | 45504 | 2.272 | 45056 | 448 | 46080 | 576 |
+| router raw | 119984 | 122803 | 2.349 | 120832 | 1971 | 122880 | 77 |
+| router-dashboard raw | 240238 | 241449 | 0.504 | 240640 | 809 | 241664 | 215 |
+| resource raw | 162454 | 163408 | 0.587 | 162816 | 592 | 163840 | 432 |
+| resource br | 59218 | 59467 | 0.420 | 59392 | 75 | 60416 | 949 |
+
+Only these failing absolute ceilings move. Ratio limits remain gzip `52.00%`,
+Brotli `38.00%`, and Zstandard `46.00%`; all 33 compressed ratio cells pass.
+Compression commands, application coverage, production code, and compiler
+flags are unchanged. Earlier measurements below retain their original compiler
+identities and values.
 
 ## Supported Toolchain Baseline Migration - 2026-07-30
 

--- a/scripts/size-budget.sh
+++ b/scripts/size-budget.sh
@@ -130,14 +130,14 @@ bundle_path() {
 status=0
 check_app "counter" "$(bundle_path counter)" 97280 40960 56320 49152 || status=1
 check_app "components" "$(bundle_path components)" 107520 43008 56320 49152 || status=1
-check_app "todo" "$(bundle_path todo)" 123904 40960 56320 49152 || status=1
-check_app "dashboard" "$(bundle_path dashboard)" 178176 54272 71680 61440 || status=1
-check_app "context" "$(bundle_path context)" 120832 37888 46080 40960 || status=1
-check_app "virtualized" "$(bundle_path virtualized)" 131072 41984 51200 45056 || status=1
+check_app "todo" "$(bundle_path todo)" 126976 40960 56320 49152 || status=1
+check_app "dashboard" "$(bundle_path dashboard)" 181248 55296 71680 61440 || status=1
+check_app "context" "$(bundle_path context)" 123904 38912 47104 41984 || status=1
+check_app "virtualized" "$(bundle_path virtualized)" 133120 43008 52224 46080 || status=1
 check_app "multipackage" "$(bundle_path multipackage)" 110592 43008 56320 49152 || status=1
 check_app "cmdapp" "$(bundle_path cmdapp)" 110592 43008 56320 49152 || status=1
-check_app "router" "$(bundle_path router)" 120832 45056 58368 51200 || status=1
-check_app "routerdash" "$(bundle_path router-dashboard)" 240640 79872 96256 84992 || status=1
-check_app "resource" "$(bundle_path resource)" 162816 59392 70656 63488 || status=1
+check_app "router" "$(bundle_path router)" 122880 45056 58368 51200 || status=1
+check_app "routerdash" "$(bundle_path router-dashboard)" 241664 79872 96256 84992 || status=1
+check_app "resource" "$(bundle_path resource)" 163840 60416 70656 63488 || status=1
 
 exit "$status"


### PR DESCRIPTION
## Summary

Adopt TinyGo `0.42.0` as GoFrame's current TinyGo/WASM release baseline ahead
of `v0.4.0-preview.1`.

The upgrade was characterized against the existing TinyGo `0.41.1` baseline
before changing repository policy. The resulting WASM growth is deterministic,
bounded, and primarily attributable to the newer TinyGo/LLVM runtime and
JavaScript bridge rather than GoFrame production code.

The migration preserves the existing browser, packaging, source-selection, and
compression-ratio contracts.

## What changes

- update the active TinyGo baseline from `0.41.1` to `0.42.0` in Core, Browser
  Smoke, and WASM Size workflows;
- reconcile current CI, platform-support, tutorial, evaluator, and
  release-readiness documentation with the new baseline;
- preserve historical `0.41.1` measurements and audit evidence unchanged;
- rebaseline only the absolute WASM size ceilings exceeded by the deterministic
  `0.42.0` output;
- record the TinyGo `0.42.0` size adjudication and new release-size source of
  truth.

## WASM size adjudication

TinyGo `0.41.1` / LLVM `20.1.1` and TinyGo `0.42.0` / LLVM `22.1.4` were
compared under the same Go `1.26.6` source and packaging inputs.

Repeated isolated builds were byte-stable within each compiler baseline.

The `0.42.0` output exceeded 15 existing absolute ceilings across seven
applications. Structural analysis found a common compiler/runtime shift,
including newly reachable TinyGo finalizer and WASM scheduling paths, while
GoFrame runtime bodies generally became smaller.

The rebaseline therefore changes only those failing absolute cells, each to the
smallest enclosing KiB boundary.

Unchanged:

- gzip ratio limit: `52.00%`;
- Brotli ratio limit: `38.00%`;
- Zstandard ratio limit: `46.00%`;
- compression commands;
- production TinyGo compiler flags;
- application coverage.

## Compatibility evidence

The migration was validated against the existing release-visible TinyGo
surface:

- focused browser compiler/source-selection parity;
- feature-tagged TinyGo builds;
- the complete TinyGo package matrix;
- hashed, preloaded, gzip, and Brotli package variants;
- WASM structural validation;
- Chrome browser smoke;
- existing WASM size gates after the bounded rebaseline.

TinyGo `0.42.0` was also characterized successfully with Go `1.27.0`.
The permanent TinyGo CI baseline remains Go `1.26.6`; this PR does not add a
second TinyGo matrix.

## Scope

This PR does not change:

- GoFrame runtime, GOX, or `goxc` production behavior;
- example application source;
- TinyGo compiler flags;
- Go or Node support policy;
- Go/npm dependencies;
- compression-ratio limits;
- CI job topology or required-check names;
- GitHub Action references;
- downloaded-artifact integrity policy.

GitHub Action SHA pinning and TinyGo artifact integrity remain part of the next
release-hardening stage.

## Review focus

Please focus on:

- whether the TinyGo `0.42.0` adoption preserves the existing release contracts;
- whether the measured WASM growth justifies the bounded absolute-size
  rebaseline;
- whether only current TinyGo references were migrated while historical
  `0.41.1` evidence remains intact;
- absence of production-code, dependency, A3 supply-chain-pinning, or A4
  CI-topology changes.

## Related

- #143
- Milestone: `v0.4.0-preview.1`